### PR TITLE
Add normalized stacked chart

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,8 +3,6 @@ up:
   - node:
       yarn: v1.13.0
       version: v10.13.0 # to be kept in sync with .nvmrc and .circleci/config.yml
-  - git_hooks:
-      pre-commit: pre-commit
 
 open:
   app: http://localhost:6006/

--- a/package.json
+++ b/package.json
@@ -107,8 +107,12 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@shopify/polaris-tokens": "^2.6.0",
+    "@types/d3-array": "^2.0.0",
+    "@types/d3-scale": "^2.1.1",
     "@types/react": "^16.8.15",
     "@types/react-dom": "^16.8.4",
+    "d3-array": "^2.4.0",
+    "d3-scale": "^3.2.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "tslib": "^1.9.3"

--- a/src/components/NormalizedStackedBar/NormalizedStackedBar.style.ts
+++ b/src/components/NormalizedStackedBar/NormalizedStackedBar.style.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import {fontStackBase, spacingLoose} from '@shopify/polaris-tokens';
+
+export const Container = styled.div(({isVertical}: {isVertical: boolean}) => ({
+  fontFamily: fontStackBase,
+  fontSize: '14px',
+  display: 'flex',
+  flexDirection: isVertical ? 'row-reverse' : 'column',
+  justifyContent: isVertical ? 'flex-end' : 'normal',
+  height: isVertical ? '100%' : 'inherit',
+}));
+
+export const BarContainer = styled.div(
+  ({isVertical}: {isVertical: boolean}) => ({
+    display: 'flex',
+    flexDirection: isVertical ? 'column' : 'row',
+  }),
+);
+
+export const LabelContainer = styled.div(
+  ({isVertical}: {isVertical: boolean}) => {
+    return isVertical
+      ? {display: 'flex', flexFlow: 'column wrap', marginLeft: spacingLoose}
+      : {
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min-content, 150px))',
+        };
+  },
+);

--- a/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
+++ b/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
@@ -1,12 +1,93 @@
 import React from 'react';
-import styled from '@emotion/styled';
-import tokens from '@shopify/polaris-tokens';
+import {sum} from 'd3-array';
+import {scaleLinear} from 'd3-scale';
 
-const Bar = styled.div`
-  background: ${tokens.colorPurple};
-  color: ${tokens.colorWhite};
-`;
+import {BarSegment, BarLabel} from './components';
+import {Size, ColorScheme, Color, Data, Orientation} from './types';
+import {getColorPalette, getTokensFromColors} from './utilities';
+import {
+  Container,
+  BarContainer,
+  LabelContainer,
+} from './NormalizedStackedBar.style';
 
-export function NormalizedStackedBar() {
-  return <Bar>NormalizedStackedBar</Bar>;
+interface Props {
+  data: Data[];
+  accessibilityLabel?: string;
+  size?: Size;
+  orientation?: Orientation;
+  colors?: Color[] | ColorScheme;
+}
+
+const SIZES = {
+  small: 16,
+  medium: 36,
+  large: 56,
+};
+
+export function NormalizedStackedBar({
+  data,
+  accessibilityLabel,
+  size = 'small',
+  orientation = 'horizontal',
+  colors = 'classic',
+}: Props) {
+  const containsNegatives = data.some(({value}) => value < 0);
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  if (isDevelopment && containsNegatives) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This component is not built to handle negatives. Consider using a different component.',
+    );
+  }
+
+  if (isDevelopment && data.length > 4) {
+    throw new Error(
+      'This component displays a max of 4 data items. Please modify your data before passing it into this component.',
+    );
+  }
+
+  const slicedData = data.slice(0, 4);
+  const totalValue = sum(slicedData, ({value}) => value);
+
+  const xScale = scaleLinear()
+    .range([0, 100])
+    .domain([0, totalValue]);
+
+  const isVertical = orientation === 'vertical';
+  const colorPalette = Array.isArray(colors)
+    ? getTokensFromColors(colors)
+    : getColorPalette(colors);
+
+  return (
+    <Container
+      isVertical={isVertical}
+      aria-label={accessibilityLabel}
+      role="img"
+    >
+      <LabelContainer isVertical={isVertical}>
+        {slicedData.map(({label, formattedValue}, index) => (
+          <BarLabel
+            key={`${label}-${formattedValue}`}
+            label={label}
+            value={formattedValue}
+            color={colorPalette[index]}
+          />
+        ))}
+      </LabelContainer>
+
+      <BarContainer isVertical={isVertical}>
+        {slicedData.map(({value, label}, index) => (
+          <BarSegment
+            orientation={orientation}
+            size={SIZES[size]}
+            scale={xScale(value)}
+            key={`${label}-${value}`}
+            color={colorPalette[index]}
+          />
+        ))}
+      </BarContainer>
+    </Container>
+  );
 }

--- a/src/components/NormalizedStackedBar/components/BarLabel/BarLabel.style.ts
+++ b/src/components/NormalizedStackedBar/components/BarLabel/BarLabel.style.ts
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import {
+  spacingExtraTight,
+  spacingTight,
+  spacingExtraLoose,
+} from '@shopify/polaris-tokens';
+
+export const LabelColor = styled.div(({color}: {color: string}) => ({
+  background: color,
+  border: '1px solid transparent',
+  borderRadius: '3px',
+  height: '10px',
+  width: '10px',
+}));
+
+export const Label = styled.div(() => ({
+  flex: 1,
+  marginLeft: spacingTight,
+  wordBreak: 'break-word',
+}));
+
+export const Container = styled.div(() => ({
+  display: 'flex',
+  alignItems: 'baseline',
+  marginBottom: spacingExtraLoose,
+}));
+
+export const Value = styled.div(() => ({
+  marginTop: spacingExtraTight,
+}));
+
+export const Bold = styled.div(() => ({
+  fontWeight: 600,
+}));

--- a/src/components/NormalizedStackedBar/components/BarLabel/BarLabel.tsx
+++ b/src/components/NormalizedStackedBar/components/BarLabel/BarLabel.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import {LabelColor, Label, Container, Value, Bold} from './BarLabel.style';
+
+export interface Props {
+  label: string;
+  value: string;
+  color: string;
+}
+
+export function BarLabel({label, value, color}: Props) {
+  return (
+    <Container>
+      <LabelColor color={color} />
+      <Label>
+        <Bold>{label}</Bold>
+        <Value>{value}</Value>
+      </Label>
+    </Container>
+  );
+}

--- a/src/components/NormalizedStackedBar/components/BarLabel/index.ts
+++ b/src/components/NormalizedStackedBar/components/BarLabel/index.ts
@@ -1,0 +1,1 @@
+export {BarLabel, Props as BarLabelProps} from './BarLabel';

--- a/src/components/NormalizedStackedBar/components/BarLabel/tests/BarLabel.test.tsx
+++ b/src/components/NormalizedStackedBar/components/BarLabel/tests/BarLabel.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {BarLabel} from '../BarLabel';
+
+describe('<BarLabel />', () => {
+  describe('renders props', () => {
+    it('renders BarLabel with props', () => {
+      const barLabel = mount(
+        <BarLabel label="Google" value="200" color="rgb(255, 255, 255)" />,
+      );
+
+      expect(barLabel.text()).toContain('Google');
+      expect(barLabel.text()).toContain('200');
+    });
+  });
+});

--- a/src/components/NormalizedStackedBar/components/BarSegment/BarSegment.style.ts
+++ b/src/components/NormalizedStackedBar/components/BarSegment/BarSegment.style.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+interface Props {
+  scale: number;
+  height: number;
+  width: number;
+  background: string;
+}
+
+export const Segment = styled.div((props: Props) => ({
+  background: props.background,
+  border: '1px solid transparent',
+  flex: `${props.scale} 0 0`,
+  width: `${props.width}px`,
+  height: `${props.height}px`,
+  margin: '0 1px 1px 0',
+  '&:last-of-type': {margin: 0},
+}));

--- a/src/components/NormalizedStackedBar/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBar/components/BarSegment/BarSegment.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {Orientation} from '../../types';
+
+import {Segment} from './BarSegment.style';
+
+interface Props {
+  scale: number;
+  color: string;
+  size: number;
+  orientation: Orientation;
+}
+
+export function BarSegment({color, scale, size, orientation}: Props) {
+  const scaleNeedsRounding = scale > 0 && scale < 1.5;
+  const safeScale = scaleNeedsRounding ? 1.5 : scale;
+
+  return (
+    <Segment
+      scale={safeScale}
+      height={orientation === 'horizontal' ? size : 0}
+      width={orientation === 'vertical' ? size : 0}
+      background={color}
+    />
+  );
+}

--- a/src/components/NormalizedStackedBar/components/BarSegment/index.ts
+++ b/src/components/NormalizedStackedBar/components/BarSegment/index.ts
@@ -1,0 +1,1 @@
+export {BarSegment} from './BarSegment';

--- a/src/components/NormalizedStackedBar/components/BarSegment/tests/BarSegment.test.tsx
+++ b/src/components/NormalizedStackedBar/components/BarSegment/tests/BarSegment.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {BarSegment} from '../BarSegment';
+import {Segment} from '../BarSegment.style';
+
+describe('<BarSegment />', () => {
+  it('applies the bar size prop to the div height when the chart is horizontal', () => {
+    const barSegment = mount(
+      <BarSegment
+        scale={64}
+        color="rgb(255, 255, 255)"
+        size={10}
+        orientation="horizontal"
+      />,
+    );
+
+    expect(barSegment.find(Segment)!.props.height).toBe(10);
+  });
+
+  it('applies the bar size prop to the div width when the chart is vertical', () => {
+    const barSegment = mount(
+      <BarSegment
+        scale={64}
+        color="rgb(255, 255, 255)"
+        size={10}
+        orientation="vertical"
+      />,
+    );
+
+    expect(barSegment.find(Segment)!.props.width).toBe(10);
+  });
+
+  it('does not round up a 0 scale', () => {
+    const barSegment = mount(
+      <BarSegment
+        scale={0}
+        color="rgb(255, 255, 255)"
+        size={10}
+        orientation="horizontal"
+      />,
+    );
+
+    expect(barSegment.find(Segment)!.props.scale).toBe(0);
+  });
+
+  it('rounds up a scale above 0 and below 1.5', () => {
+    const barSegment = mount(
+      <BarSegment
+        scale={0.1}
+        color="rgb(255, 255, 255)"
+        size={10}
+        orientation="horizontal"
+      />,
+    );
+
+    expect(barSegment.find(Segment)!.props.scale).toBe(1.5);
+  });
+
+  it('does not round up a scale above 1.5', () => {
+    const barSegment = mount(
+      <BarSegment
+        scale={1.51}
+        color="rgb(255, 255, 255)"
+        size={10}
+        orientation="horizontal"
+      />,
+    );
+
+    expect(barSegment.find(Segment)!.props.scale).toBe(1.51);
+  });
+});

--- a/src/components/NormalizedStackedBar/components/index.ts
+++ b/src/components/NormalizedStackedBar/components/index.ts
@@ -1,0 +1,2 @@
+export {BarLabel} from './BarLabel';
+export {BarSegment} from './BarSegment';

--- a/src/components/NormalizedStackedBar/index.ts
+++ b/src/components/NormalizedStackedBar/index.ts
@@ -1,1 +1,2 @@
 export {NormalizedStackedBar} from './NormalizedStackedBar';
+export {Orientation, Size, ColorScheme, Color} from './types';

--- a/src/components/NormalizedStackedBar/tests/NormalizedStackedBar.test.tsx
+++ b/src/components/NormalizedStackedBar/tests/NormalizedStackedBar.test.tsx
@@ -1,11 +1,179 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+import {NormalizedStackedBar} from 'components';
 
-import {NormalizedStackedBar} from '../NormalizedStackedBar';
+import {BarSegment, BarLabel} from '../components';
 
-describe('NormalizedStackedBar', () => {
-  it('something', () => {
-    const component = mount(<NormalizedStackedBar />);
-    expect(component.text()).toBe('NormalizedStackedBar');
+describe('<NormalizedBarChart />', () => {
+  const mockProps = {
+    data: [
+      {label: 'label0', value: 993.9266809283133, formattedValue: '$993.93'},
+      {label: 'label1', value: 666.4681407384194, formattedValue: '$666.47'},
+      {label: 'label2', value: 500, formattedValue: '$500.00'},
+      {label: 'label3', value: 200, formattedValue: '$200.00'},
+    ],
+  };
+
+  describe('Bars', () => {
+    it('renders 4 bars when given 4 data items', () => {
+      const barChart = mount(<NormalizedStackedBar {...mockProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(4);
+    });
+
+    it('renders 4 bars when given more than 4 data items', () => {
+      const highEdgeProps = {
+        data: [
+          {
+            label: 'DuckDuckGo',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'Google',
+            value: 666.4681407384194,
+            formattedValue: '$666.47',
+          },
+          {label: 'Yahoo', value: 500, formattedValue: '$500.00'},
+          {label: 'Bing', value: 200, formattedValue: '$200.00'},
+          {
+            label: 'DuckDuck',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {label: 'Goog', value: 666.4681407384194, formattedValue: '$666.47'},
+          {label: 'Yah', value: 500, formattedValue: '$500.00'},
+          {label: 'Bin', value: 200, formattedValue: '$200.00'},
+        ],
+      };
+      const barChart = mount(<NormalizedStackedBar {...highEdgeProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(4);
+    });
+
+    it('renders 0 bars when given 0', () => {
+      const lowEdgeProps = {
+        data: [],
+      };
+
+      const barChart = mount(<NormalizedStackedBar {...lowEdgeProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(0);
+    });
+  });
+
+  describe('Labels', () => {
+    it('renders 4 Labels when more than 4 data items are provided', () => {
+      const highEdgeProps = {
+        data: [
+          {
+            label: 'DuckDuckGo',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo1',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo2',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo3',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo4',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo5',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+        ],
+      };
+
+      const barChart = mount(<NormalizedStackedBar {...highEdgeProps} />);
+
+      expect(barChart.findAll(BarLabel)).toHaveLength(4);
+    });
+
+    it('renders 2 BarLabels given 2 data items are provided', () => {
+      const lowEdgeProps = {
+        data: [
+          {
+            label: 'DuckDuckGo',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+          {
+            label: 'DuckDuckGo1',
+            value: 993.9266809283133,
+            formattedValue: '$993.93',
+          },
+        ],
+      };
+
+      const barChart = mount(<NormalizedStackedBar {...lowEdgeProps} />);
+
+      expect(barChart.findAll(BarLabel)).toHaveLength(2);
+    });
+  });
+
+  describe('Colors', () => {
+    it('handles arrays of color tokens', () => {
+      const barChart = mount(
+        <NormalizedStackedBar {...mockProps} colors={['colorPurple']} />,
+      );
+
+      expect(barChart.find(BarSegment)!.props.color).toBe('rgb(156, 106, 222)');
+    });
+
+    it('handles color palettes', () => {
+      const barChart = mount(
+        <NormalizedStackedBar {...mockProps} colors="classic" />,
+      );
+
+      expect(barChart.find(BarSegment)!.props.color).toBe('rgb(80, 36, 143)');
+    });
+  });
+
+  describe('Orientation', () => {
+    it('defaults to horizontal orientation and passes it to BarSegment', () => {
+      const barChart = mount(<NormalizedStackedBar {...mockProps} />);
+
+      expect(barChart.find(BarSegment)!.props.orientation).toBe('horizontal');
+    });
+
+    it('accepts vertical orientation and passes it to BarSegment', () => {
+      const barChart = mount(
+        <NormalizedStackedBar {...mockProps} orientation="vertical" />,
+      );
+
+      expect(barChart.find(BarSegment)!.props.orientation).toBe('vertical');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('sets an img role on the parent div', () => {
+      const barChart = mount(<NormalizedStackedBar {...mockProps} />);
+
+      expect(barChart.find('div')!.props.role).toBe('img');
+    });
+
+    it('adds an aria label when one is passed in', () => {
+      const label = 'A stacked bar chart showing sales by channel.';
+      const barChart = mount(
+        <NormalizedStackedBar {...mockProps} accessibilityLabel={label} />,
+      );
+
+      expect(barChart.find('div')!.props['aria-label']).toBe(label);
+    });
   });
 });

--- a/src/components/NormalizedStackedBar/tests/utilities.test.ts
+++ b/src/components/NormalizedStackedBar/tests/utilities.test.ts
@@ -1,0 +1,23 @@
+import {getColorPalette, getTokensFromColors} from '../utilities';
+
+describe('utilities', () => {
+  describe('getColorPalette', () => {
+    it('returns an array of colors', () => {
+      const actual = getColorPalette('classic');
+
+      expect(actual).toStrictEqual([
+        'rgb(80, 36, 143)',
+        'rgb(0, 111, 187)',
+        'rgb(71, 193, 191)',
+        'rgb(196, 205, 213)',
+      ]);
+    });
+  });
+
+  describe('getTokensFromColors', () => {
+    it('returns an array of colors', () => {
+      const actual = getTokensFromColors(['colorBlack', 'colorBlue']);
+      expect(actual).toStrictEqual(['rgb(0, 0, 0)', 'rgb(0, 111, 187)']);
+    });
+  });
+});

--- a/src/components/NormalizedStackedBar/types.ts
+++ b/src/components/NormalizedStackedBar/types.ts
@@ -1,0 +1,70 @@
+export type Orientation = 'horizontal' | 'vertical';
+
+export type ColorScheme = 'classic' | 'twentytwenty';
+
+export type Size = 'small' | 'medium' | 'large';
+
+export interface Data {
+  formattedValue: string;
+  value: number;
+  label: string;
+}
+
+export type Color =
+  | 'colorBlack'
+  | 'colorBlue'
+  | 'colorBlueDark'
+  | 'colorBlueDarker'
+  | 'colorBlueLight'
+  | 'colorBlueLighter'
+  | 'colorBlueText'
+  | 'colorGreen'
+  | 'colorGreenDark'
+  | 'colorGreenDarker'
+  | 'colorGreenLight'
+  | 'colorGreenLighter'
+  | 'colorGreenText'
+  | 'colorIndigo'
+  | 'colorIndigoDark'
+  | 'colorIndigoDarker'
+  | 'colorIndigoLight'
+  | 'colorIndigoLighter'
+  | 'colorIndigoText'
+  | 'colorInk'
+  | 'colorInkLight'
+  | 'colorInkLighter'
+  | 'colorInkLightest'
+  | 'colorOrange'
+  | 'colorOrangeDark'
+  | 'colorOrangeDarker'
+  | 'colorOrangeLight'
+  | 'colorOrangeLighter'
+  | 'colorOrangeText'
+  | 'colorPurple'
+  | 'colorPurpleDark'
+  | 'colorPurpleDarker'
+  | 'colorPurpleLight'
+  | 'colorPurpleLighter'
+  | 'colorPurpleText'
+  | 'colorRed'
+  | 'colorRedDark'
+  | 'colorRedDarker'
+  | 'colorRedLight'
+  | 'colorRedLighter'
+  | 'colorRedText'
+  | 'colorSky'
+  | 'colorSkyDark'
+  | 'colorSkyLight'
+  | 'colorSkyLighter'
+  | 'colorTeal'
+  | 'colorTealDark'
+  | 'colorTealDarker'
+  | 'colorTealLight'
+  | 'colorTealLighter'
+  | 'colorTealText'
+  | 'colorWhite'
+  | 'colorYellow'
+  | 'colorYellowDark'
+  | 'colorYellowDarker'
+  | 'colorYellowLight'
+  | 'colorYellowLighter';

--- a/src/components/NormalizedStackedBar/utilities.ts
+++ b/src/components/NormalizedStackedBar/utilities.ts
@@ -1,0 +1,20 @@
+import tokens, {
+  colorPurpleDark,
+  colorBlue,
+  colorTeal,
+  colorSkyDark,
+} from '@shopify/polaris-tokens';
+
+import {ColorScheme, Color} from './types';
+
+export function getColorPalette(colors: ColorScheme) {
+  const colorMap = {
+    classic: [colorPurpleDark, colorBlue, colorTeal, colorSkyDark],
+    twentytwenty: ['#009DB2', '#2B3698', '#BD227F', '#D6630F'],
+  };
+  return colorMap[colors];
+}
+
+export function getTokensFromColors(colors: Color[]) {
+  return colors.map((color) => tokens[color]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,23 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/d3-array@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-2.0.0.tgz#a0d63a296a2d8435a9ec59393dcac746c6174a96"
+  integrity sha512-rGqfPVowNDTszSFvwoZIXvrPG7s/qKzm9piCRIH6xwTTRu7pPZ3ootULFnPkTt74B6i5lN0FpLQL24qGOw1uZA==
+
+"@types/d3-scale@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-2.1.1.tgz#405e58771ec6ae7b8f7b4178ee1887620759e8f7"
+  integrity sha512-kNTkbZQ+N/Ip8oX9PByXfDLoCSaZYm+VUOasbmsa6KD850/ziMdYepg/8kLg2plHzoLANdMqPoYQbvExevLUHg==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-time@*":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-1.0.10.tgz#d338c7feac93a98a32aac875d1100f92c7b61f4f"
+  integrity sha512-aKf62rRQafDQmSiv1NylKhIMmznsjRN+MnXRXTqHoqm0U/UZzVpdrtRnSIfdiLS616OuC1soYeX1dBg2n1u8Xw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -4564,6 +4581,51 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+"d3-array@1.2.0 - 2", d3-array@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
+  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
+
+d3-color@1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.0.tgz#89c45a995ed773b13314f06460df26d60ba0ecaf"
+  integrity sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==
+
+d3-format@1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.3.tgz#4e8eb4dff3fdcb891a8489ec6e698601c41b96f1"
+  integrity sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ==
+
+d3-interpolate@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
+
+d3-scale@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.1.tgz#da1684adce7261b4bc7a76fe193d887f0e909e69"
+  integrity sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==
+  dependencies:
+    d3-array "1.2.0 - 2"
+    d3-format "1"
+    d3-interpolate "^1.2.0"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-time-format@2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.2.3.tgz#0c9a12ee28342b2037e5ea1cf0b9eb4dd75f29cb"
+  integrity sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
+  integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.5"
@@ -9964,7 +10026,7 @@ node-releases@^1.0.0-alpha.11, node-releases@^1.1.44:
   dependencies:
     semver "^6.3.0"
 
-node-sass@^4.10.0, node-sass@^4.12.0:
+node-sass@^4.10.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
   integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==


### PR DESCRIPTION
**What is this PR doing**

Adds the normalized stacked bar to the Polaris Viz repo ✨

The implementation is _mostly_ like what we have in web, with a few exceptions:
- We are using CSS in JS via [Emotion](https://emotion.sh/docs/introduction). Given the nature of these components and the amount of logic contained in the styles, it seemed like a good fit. This also helps with a complication of consuming the components in other repos and having SCSS applied properly.
- Some new props:

  - **Orientation**: the chart defaults to the horizontal orientation that we've always used before, but gives the option of a vertical orientation as well.

| Horizontal        | Vertical           | 
| ------------- |:-------------:| 
| <img width="173" alt="Screen Shot 2020-01-13 at 3 43 15 PM" src="https://user-images.githubusercontent.com/12213371/72290585-93ce2900-361b-11ea-949c-f15008eeecdd.png"> | <img width="1498" alt="Screen Shot 2020-01-13 at 3 43 01 PM" src="https://user-images.githubusercontent.com/12213371/72290586-9466bf80-361b-11ea-91f6-c245b2cc73a6.png">| 

  - **Colors**: the chart defaults to our existing color scheme, but also accepts another predefined color palette (the new master brand viz color palette) or an array of Polaris token colors. @mirualves and I have had a few discussions about the amount of flexibility this makes available and we believe this is the best approach, as long as it is accompanied with documentation explaining how to select appropriate and accessible colors.

<img width="1533" alt="Screen Shot 2020-01-13 at 3 45 44 PM" src="https://user-images.githubusercontent.com/12213371/72290688-c9731200-361b-11ea-9b10-8d9c3cc94b97.png">

  - **Size**: the chart accepts one of three enum values that correspond to the height (or width, when it's vertical) of the bar. The small and medium sizes align with our glimpse and report implementations.

| Small        | Medium           | Large           | 
| ------------- |:-------------:| :-------------:| 
|<img width="1525" alt="Screen Shot 2020-01-13 at 3 47 08 PM" src="https://user-images.githubusercontent.com/12213371/72290819-08a16300-361c-11ea-885a-a9417bbc5f3f.png"> | <img width="1535" alt="Screen Shot 2020-01-13 at 3 47 21 PM" src="https://user-images.githubusercontent.com/12213371/72290818-08a16300-361c-11ea-9327-124c68c7ca11.png">|<img width="1525" alt="Screen Shot 2020-01-13 at 3 47 32 PM" src="https://user-images.githubusercontent.com/12213371/72290817-08a16300-361c-11ea-902e-474e3d8c8749.png">| 

  - **Accessibility label**: The container of the entire chart as an `img` aria role, to tell screen readers what the elements inside represent. An optional label value can be passed in that is also used on the container to actually describe the content. Ideally, this label should actually describe the data rather than being general. I looked into implementations where the chart was described by a table of all the data, but after describing with @dpersing a better approach is to suggest users wrap their charts in a component like Tabs, and offer all users a tab view rather than a chart view if there isn't one elsewhere on the page. We will add this to our documentation later.
<img width="587" alt="Screen Shot 2020-01-13 at 3 48 39 PM" src="https://user-images.githubusercontent.com/12213371/72290874-31295d00-361c-11ea-9779-264dc8b97c3c.png">


- It looks like there's an issue in production where long labels run into each other. This component breaks words to avoid that.

🎩**Tophat**

You can use this code in `playground/Playground.tsx` and run `yarn dev` to start the server.

<details>

```
import React from 'react';

import {NormalizedStackedBar} from '../src/components';
import {
  Orientation,
  Size,
  ColorScheme,
} from '../src/components/NormalizedStackedBar';

const mockProps = {
  // size: Size.Small,
  accessibilityLabel: 'A chart showing data about something 🎉',
  data: [
    {
      label: 'Google',
      value: 100,
      formattedValue: '$100',
    },
    {
      label: 'Direct',
      value: 500,
      formattedValue: '$500',
    },
    {label: 'Facebook', value: 100, formattedValue: '$100'},
    {label: 'Twitter', value: 100, formattedValue: '$100'},
    // {label: 'a fith data item', value: 1090000, formattedValue: '$1090000'},
  ],
};

export default function Playground() {
  return (
    <div style={{height: '501px', margin: '40px'}}>
      <NormalizedStackedBar
        size="large"
        orientation="vertical"
        {...mockProps}
      />
    </div>
  );
}

```


</details>