### PR TITLE
showArea → includeArea

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Components inherit their sizes from their containers, so place your component in
     <li><strong>useAnimation:</strong>
     <code>boolean</code>
     </li>
-    <li><strong>showArea:</strong>
+    <li><strong>includeArea:</strong>
     <code>boolean</code>
     </li>
     </ul></td>


### PR DESCRIPTION
### What problem is this PR solving?

The previous docs were incorrect; `showArea` should be `includeArea` for sparklines.

### Reviewers’ :tophat: instructions

N/A

### Before merging

- [ ] ~Check your changes on a variety of browsers and devices.~
- [ ] ~Update the Changelog.~
- [x] Update relevant documentation.
