### PR TITLE
Use DOMRect for chart dimensions

### DIFF
--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -3,7 +3,7 @@ import {line} from 'd3-shape';
 import {scaleLinear} from 'd3-scale';
 
 import {Margin, Y_SCALE_PADDING} from './constants';
-import {ChartDimensions, Series} from './types';
+import {Series} from './types';
 import {yAxisMinMax} from './utilities';
 import {Line, XAxis, YAxis} from './components';
 
@@ -18,18 +18,12 @@ export function LineChart({
   xAxisLabels,
   formatYAxisValue = (value) => `${value}`,
 }: Props) {
-  const [svgDimensions, setSvgDimensions] = useState<ChartDimensions>({
-    width: 0,
-    height: 0,
-  });
+  const [svgDimensions, setSvgDimensions] = useState<DOMRect>(new DOMRect());
   const containerRef = useRef<SVGSVGElement | null>(null);
 
   function updateDimensions() {
     if (containerRef.current != null) {
-      setSvgDimensions({
-        height: containerRef.current.clientHeight,
-        width: containerRef.current.clientWidth,
-      });
+      setSvgDimensions(containerRef.current.getBoundingClientRect());
     }
   }
 

--- a/src/components/LineChart/components/XAxis/XAxis.tsx
+++ b/src/components/LineChart/components/XAxis/XAxis.tsx
@@ -7,12 +7,11 @@ import {
 } from '@shopify/polaris-tokens';
 
 import {Margin} from '../../constants';
-import {ChartDimensions} from '../../types';
 
 interface Props {
   xScale: ScaleLinear<number, number>;
   labels: string[];
-  dimensions: ChartDimensions;
+  dimensions: DOMRect;
 }
 
 const TICK_SIZE = 6;

--- a/src/components/LineChart/components/YAxis/YAxis.tsx
+++ b/src/components/LineChart/components/YAxis/YAxis.tsx
@@ -8,12 +8,11 @@ import {
 } from '@shopify/polaris-tokens';
 
 import {Margin} from '../../constants';
-import {ChartDimensions} from '../../types';
 
 interface Props {
   yScale: ScaleLinear<number, number>;
   formatYAxisValue(value: number): string;
-  dimensions: ChartDimensions;
+  dimensions: DOMRect;
 }
 
 const MIN_LABEL_SPACE = 80;

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -12,8 +12,3 @@ export interface Series {
     lineStyle: 'dashed' | 'solid';
   }>;
 }
-
-export interface ChartDimensions {
-  height: number;
-  width: number;
-}


### PR DESCRIPTION
### What problem is this PR solving?

Part of #30

Instead of using a custom type for chart dimensions, we can use the whole bounding rect, represented by the native `DOMRect` object. This will later allow us to access other information about the bounding rect, like `left`/`top`

### Reviewers’ :tophat: instructions

Everything should function exactly as before since `DOMRect` is a superset of the previous type

<details>
<summary>Playground</summary>

```tsx
import './Playground.scss';
import React from 'react';
import {colorTeal} from '@shopify/polaris-tokens';

import {LineChart} from '../src/components';
import {Series} from '../src/components/LineChart/types';

const formatDate = new Intl.DateTimeFormat('en', {
  month: 'short',
  day: 'numeric',
}).format;
const formatNumber = new Intl.NumberFormat('en', {
  style: 'currency',
  currency: 'USD',
  maximumFractionDigits: 0,
  minimumFractionDigits: 0,
}).format;

function generateData() {
  return Array(6)
    .fill(null)
    .map((_, index) => ({
      x: formatDate(new Date(2020, 0, index + 1)),
      y: Math.random() > 0.5 ? Math.random() * 1000 : Math.random() * -1000,
    }));
}

const DATA = [
  {x: formatDate(new Date(2020, 0, 5)), y: 100},
  {x: formatDate(new Date(2020, 0, 6)), y: -40},
  {x: formatDate(new Date(2020, 0, 7)), y: -20},
  {x: formatDate(new Date(2020, 0, 8)), y: -40},
  {x: formatDate(new Date(2020, 0, 9)), y: 250},
  {x: formatDate(new Date(2020, 0, 10)), y: 100},
];

export default function Playground() {
  const series: Series[] = [
    {data: DATA, name: 'Data 1', style: {color: 'colorTeal'}},
    {data: generateData(), name: 'Data 2', style: {lineStyle: 'dashed'}},
    {
      data: generateData(),
      name: 'Data 3',
      style: {color: 'colorBlue', lineStyle: 'dashed'},
    },
    {
      data: generateData(),
      name: 'Data 4',
      style: {color: 'colorOrange', lineStyle: 'dashed'},
    },
  ];

  return (
    <div style={{marginTop: 150, marginBottom: 150}}>
      <h4>Line chart!</h4>
      <div style={{height: '250px', maxWidth: 600, margin: 'auto'}}>
        <LineChart
          series={series}
          xAxisLabels={series[0].data.map(({x}) => x)}
          formatYAxisValue={formatNumber}
        />
      </div>
    </div>
  );
}
```
</details>


### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [x] Update the Changelog.
- [x] Update relevant documentation.
