### PR TITLE
Use "strict" without exceptions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,7 @@
     "declarationDir": "types",
     "declarationMap": false,
     "jsx": "react-native",
-    // strictFunctionTypes & strictPropertyInitialization are implictly
-    // enabled by strict mode but we're not yet compliant, so disable for now
-    "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
+    "strict": true,
     "importHelpers": true,
     "skipLibCheck": false
   },


### PR DESCRIPTION
### What problem is this PR solving?

Trying to clean up some of the repo config; I noticed these rules were disabled, but it seems like it must have been because of things that exist in `polaris` but not `polaris-viz`. This PR uses full TS strict-mode.

### Reviewers’ :tophat: instructions

Make sure CI passes and the build still works

### Before merging

- [ ] ~Check your changes on a variety of browsers and devices.~
- [ ] ~Update the Changelog.~
- [ ] ~Update relevant documentation.~
