### PR TITLE
Use series-specific y-value formatter when provided

### DIFF
--- a/src/components/LineChart/components/Tooltip/Tooltip.tsx
+++ b/src/components/LineChart/components/Tooltip/Tooltip.tsx
@@ -53,7 +53,7 @@ export function Tooltip({
       }}
       ref={tooltipRef}
     >
-      {series.map(({name, data, style = {}}) => {
+      {series.map(({name, data, formatY, style = {}}) => {
         const point = data[activePointIndex];
 
         if (point == null) {
@@ -61,12 +61,14 @@ export function Tooltip({
         }
 
         const {color = 'colorPurple', lineStyle = 'solid'} = style;
+        const formattedYValue =
+          formatY == null ? formatYAxisValue(point.y) : formatY(point.y);
 
         return (
           <React.Fragment key={name}>
             <LinePreview color={color} lineStyle={lineStyle} />
             <p className={styles.SeriesName}>{name}</p>
-            <p className={styles.Value}>{formatYAxisValue(point.y)}</p>
+            <p className={styles.Value}>{formattedYValue}</p>
           </React.Fragment>
         );
       })}


### PR DESCRIPTION
### What problem is this PR solving?

Part of #30

Fixes a bug I noticed while making the docs where I wasn't using the y-value formatter that can be provided on each series. 

This formatter is useful in scenarios like if you are plotting sales over time and sessions over time on the same chart and want to format the tooltip with both currency and plain numeric values

### Reviewers’ :tophat: instructions

The following playground renders a line chart with 2 series ("retail sales" and "retail visits"). The sales series is rendered with currency values; the visits series without currency.

<details>
<summary><strong>Playground</strong></summary>

```tsx
import './Playground.scss';
import React from 'react';

import {LineChart} from '../src/components';

const formatMoney = new Intl.NumberFormat('en', {
  currency: 'USD',
  style: 'currency',
}).format;

const formatNumber = new Intl.NumberFormat('en').format;

export default function Playground() {
  return (
    <div
      style={{
        height: '501px',
        margin: '40px',
        fontFamily:
          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
      }}
    >
      <LineChart
        xAxisLabels={[
          'May 1',
          'May 2',
          'May 3',
          'May 4',
          'May 5',
          'May 6',
          'May 7',
          'May 8',
          'May 9',
          'May 10',
        ]}
        formatYAxisValue={formatMoney}
        series={[
          {
            name: 'Retail sales 2020',
            data: [
              {x: 'May 1, 2020', y: 1000},
              {x: 'May 2, 2020', y: 1750},
              {x: 'May 3, 2020', y: 1880},
              {x: 'May 4, 2020', y: 700},
              {x: 'May 5, 2020', y: 1300},
              {x: 'May 6, 2020', y: 800},
              {x: 'May 7, 2020', y: 2500},
              {x: 'May 8, 2020', y: 3500},
              {x: 'May 9, 2020', y: 4000},
              {x: 'May 10, 2020', y: 2500},
            ],
          },
          {
            name: 'Retail visits 2020',
            data: [
              {x: 'May 1, 2019', y: 1500},
              {x: 'May 2, 2019', y: 2000},
              {x: 'May 3, 2019', y: 2200},
              {x: 'May 4, 2019', y: 1500},
              {x: 'May 5, 2019', y: 1000},
              {x: 'May 6, 2019', y: 800},
              {x: 'May 7, 2019', y: 1000},
              {x: 'May 8, 2019', y: 1500},
              {x: 'May 9, 2019', y: 2500},
              {x: 'May 10, 2019', y: 2000},
            ],
            formatY: formatNumber,
            style: {
              color: 'colorTeal',
              lineStyle: 'dashed',
            },
          },
        ]}
      />
    </div>
  );
}
```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [ ] ~Update the Changelog.~
- [ ] ~Update relevant documentation.~
