### PR TITLE
Improve tooltip bounds

### DIFF
--- a/src/components/LineChart/components/Tooltip/Tooltip.scss
+++ b/src/components/LineChart/components/Tooltip/Tooltip.scss
@@ -18,6 +18,7 @@
   font-size: 13px;
   font-weight: 600;
   margin: 0;
+  white-space: nowrap;
 }
 
 .Value {

--- a/src/components/LineChart/components/Tooltip/Tooltip.tsx
+++ b/src/components/LineChart/components/Tooltip/Tooltip.tsx
@@ -29,6 +29,9 @@ export function Tooltip({
   const rightOfCursorPosition = currentX + 10;
 
   const spring = useSpring({
+    config: {
+      duration: 0,
+    },
     top: Math.max(Margin.Top, currentY - tooltipDimensions.height - 10),
     left:
       leftOfCursorPosition < Margin.Left


### PR DESCRIPTION
### What problem is this PR solving?

This PR prevents the tooltip from exiting the bounds of the chart [as reported here](https://github.com/Shopify/polaris-viz/pull/45#pullrequestreview-415632124). There are 2 changes:

1. **Set the animation duration to 0**. The slight lag was kind of fun, but supporting it was difficult; maybe it could be re-added in the future, but for now it didn't seem worth the amount of work that would be needed
2. **Prevent text from wrapping**. Even though the tooltip remained in-bounds, it was possible to get it to collapse the label text; this PR prevents that.

### Reviewers’ :tophat: instructions

Use the following playground on lots of screen sizes to mouse around the tooltip, especially near the bounds.

<details>
<summary><strong>Playground</strong></summary>

```tsx
import './Playground.scss';
import React from 'react';

import {LineChart} from '../src/components';

const formatMoney = new Intl.NumberFormat('en', {
  currency: 'USD',
  style: 'currency',
}).format;

const formatNumber = new Intl.NumberFormat('en').format;

export default function Playground() {
  return (
    <div
      style={{
        height: '501px',
        margin: '40px',
        fontFamily:
          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
      }}
    >
      <LineChart
        xAxisLabels={[
          'May 1',
          'May 2',
          'May 3',
          'May 4',
          'May 5',
          'May 6',
          'May 7',
          'May 8',
          'May 9',
          'May 10',
        ]}
        formatYAxisValue={formatMoney}
        series={[
          {
            name: 'Retail sales 2020',
            data: [
              {x: 'May 1, 2020', y: 1000},
              {x: 'May 2, 2020', y: 1750},
              {x: 'May 3, 2020', y: 1880},
              {x: 'May 4, 2020', y: 700},
              {x: 'May 5, 2020', y: 1300},
              {x: 'May 6, 2020', y: 800},
              {x: 'May 7, 2020', y: 2500},
              {x: 'May 8, 2020', y: 3500},
              {x: 'May 9, 2020', y: 4000},
              {x: 'May 10, 2020', y: 2500},
            ],
          },
          {
            name: 'Retail visits 2020',
            data: [
              {x: 'May 1, 2019', y: 1500},
              {x: 'May 2, 2019', y: 2000},
              {x: 'May 3, 2019', y: 2200},
              {x: 'May 4, 2019', y: 1500},
              {x: 'May 5, 2019', y: 1000},
              {x: 'May 6, 2019', y: 800},
              {x: 'May 7, 2019', y: 1000},
              {x: 'May 8, 2019', y: 1500},
              {x: 'May 9, 2019', y: 2500},
              {x: 'May 10, 2019', y: 2000},
            ],
            formatY: formatNumber,
            style: {
              color: 'colorTeal',
              lineStyle: 'dashed',
            },
          },
        ]}
      />
    </div>
  );
}
```

</details>


### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [ ] ~Update the Changelog.~
- [ ] ~Update relevant documentation.~