### PR TITLE
Only show chart once container has been measured

### DIFF
--- a/src/components/LineChart/Chart.scss
+++ b/src/components/LineChart/Chart.scss
@@ -1,0 +1,6 @@
+.Container {
+  position: relative;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+}

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -1,0 +1,139 @@
+import React, {useState} from 'react';
+import {line} from 'd3-shape';
+import {scaleLinear} from 'd3-scale';
+
+import {yAxisMinMax, eventPoint} from './utilities';
+import {Series} from './types';
+import {Margin, Y_SCALE_PADDING} from './constants';
+import {Crosshair, Line, Tooltip, XAxis, YAxis} from './components';
+import * as styles from './Chart.scss';
+
+interface Props {
+  series: Series[];
+  xAxisLabels: string[];
+  formatYAxisValue(value: number): string;
+  dimensions: DOMRect;
+}
+
+export function Chart({
+  series,
+  dimensions,
+  xAxisLabels,
+  formatYAxisValue,
+}: Props) {
+  const [activePointIndex, setActivePointIndex] = useState<number | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const longestSeriesLength = series.reduce<number>(
+    (max, currentSeries) => Math.max(max, currentSeries.data.length - 1),
+    0,
+  );
+
+  const [minY, maxY] = yAxisMinMax(series);
+
+  const xScale = scaleLinear()
+    .range([0, dimensions.width - Margin.Left - Margin.Right])
+    .domain([0, longestSeriesLength]);
+
+  const yScale = scaleLinear()
+    .range([dimensions.height - (Margin.Top + Margin.Bottom), 0])
+    .domain([Math.min(0, minY), maxY * Y_SCALE_PADDING])
+    .nice();
+
+  const lineGenerator = line<{x: string; y: number}>()
+    .x((_, index) => xScale(index))
+    .y(({y}) => yScale(y));
+
+  function handleInteraction(
+    event: React.MouseEvent<SVGSVGElement> | React.TouchEvent<SVGSVGElement>,
+  ) {
+    const point = eventPoint(event);
+    if (point == null) {
+      return;
+    }
+
+    const {svgX, clientX, clientY} = point;
+    if (svgX < Margin.Left) {
+      return;
+    }
+
+    const closestIndex = Math.round(xScale.invert(svgX - Margin.Left));
+    setActivePointIndex(Math.min(longestSeriesLength, closestIndex));
+    setTooltipPosition({
+      x: clientX - dimensions.left,
+      y: clientY - dimensions.top,
+    });
+  }
+
+  return (
+    <div className={styles.Container}>
+      <svg
+        width="100%"
+        height="100%"
+        onMouseMove={handleInteraction}
+        onTouchMove={handleInteraction}
+        onTouchEnd={() => setActivePointIndex(null)}
+        onMouseLeave={() => setActivePointIndex(null)}
+      >
+        <g transform={`translate(0,${dimensions.height - Margin.Bottom})`}>
+          <XAxis xScale={xScale} labels={xAxisLabels} dimensions={dimensions} />
+        </g>
+
+        <g transform={`translate(${Margin.Left},${Margin.Top})`}>
+          <YAxis
+            yScale={yScale}
+            formatYAxisValue={formatYAxisValue}
+            dimensions={dimensions}
+          />
+        </g>
+
+        {activePointIndex == null ? null : (
+          <g transform={`translate(${Margin.Left},${Margin.Top})`}>
+            <Crosshair x={xScale(activePointIndex)} dimensions={dimensions} />
+          </g>
+        )}
+
+        <g transform={`translate(${Margin.Left},${Margin.Top})`}>
+          {series
+            .slice()
+            .reverse()
+            .map((singleSeries) => {
+              const {data, name} = singleSeries;
+              const path = lineGenerator(data);
+
+              if (path == null) {
+                throw new Error(
+                  `Could not generate line path for series ${name}`,
+                );
+              }
+
+              return (
+                <Line
+                  key={name}
+                  xScale={xScale}
+                  yScale={yScale}
+                  series={singleSeries}
+                  path={path}
+                  activePointIndex={activePointIndex}
+                />
+              );
+            })}
+        </g>
+      </svg>
+
+      {tooltipPosition == null || activePointIndex == null ? null : (
+        <Tooltip
+          activePointIndex={activePointIndex}
+          currentX={tooltipPosition.x}
+          currentY={tooltipPosition.y}
+          formatYAxisValue={formatYAxisValue}
+          series={series}
+          chartDimensions={dimensions}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/LineChart/LineChart.scss
+++ b/src/components/LineChart/LineChart.scss
@@ -1,6 +1,0 @@
-@import 'node_modules/@shopify/polaris-tokens/dist/index';
-
-.Container {
-  position: relative;
-  overflow: hidden;
-}

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,13 +1,9 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {line} from 'd3-shape';
-import {scaleLinear} from 'd3-scale';
 import {useDebouncedCallback} from 'use-debounce';
 
-import {Margin, Y_SCALE_PADDING} from './constants';
+import {Chart} from './Chart';
 import {Series} from './types';
-import {eventPoint, yAxisMinMax} from './utilities';
-import {Crosshair, Legend, Line, Tooltip, XAxis, YAxis} from './components';
-import * as styles from './LineChart.scss';
+import {Legend} from './components';
 
 interface Props {
   series: Series[];
@@ -22,15 +18,8 @@ export function LineChart({
   chartHeight = 250,
   formatYAxisValue = (value) => `${value}`,
 }: Props) {
-  const [chartDimensions, setChartDimensions] = useState<DOMRect>(
-    new DOMRect(),
-  );
+  const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [activePointIndex, setActivePointIndex] = useState<number | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
 
   const [updateDimensions] = useDebouncedCallback(() => {
     if (containerRef.current != null) {
@@ -50,125 +39,15 @@ export function LineChart({
     };
   }, [containerRef, updateDimensions]);
 
-  const longestSeriesLength = series.reduce<number>(
-    (max, currentSeries) => Math.max(max, currentSeries.data.length - 1),
-    0,
-  );
-
-  const [minY, maxY] = yAxisMinMax(series);
-
-  const xScale = scaleLinear()
-    .range([0, chartDimensions.width - Margin.Left - Margin.Right])
-    .domain([0, longestSeriesLength]);
-
-  const yScale = scaleLinear()
-    .range([chartDimensions.height - (Margin.Top + Margin.Bottom), 0])
-    .domain([Math.min(0, minY), maxY * Y_SCALE_PADDING])
-    .nice();
-
-  const lineGenerator = line<{x: string; y: number}>()
-    .x((_, index) => xScale(index))
-    .y(({y}) => yScale(y));
-
-  function handleInteraction(
-    event: React.MouseEvent<SVGSVGElement> | React.TouchEvent<SVGSVGElement>,
-  ) {
-    const point = eventPoint(event);
-    if (point == null) {
-      return;
-    }
-
-    const {svgX, clientX, clientY} = point;
-    if (svgX < Margin.Left) {
-      return;
-    }
-
-    const closestIndex = Math.round(xScale.invert(svgX - Margin.Left));
-    setActivePointIndex(Math.min(longestSeriesLength, closestIndex));
-    setTooltipPosition({
-      x: clientX - chartDimensions.left,
-      y: clientY - chartDimensions.top,
-    });
-  }
-
   return (
     <React.Fragment>
-      <div
-        className={styles.Container}
-        style={{height: chartHeight}}
-        ref={containerRef}
-      >
-        <svg
-          width="100%"
-          height="100%"
-          onMouseMove={handleInteraction}
-          onTouchMove={handleInteraction}
-          onTouchEnd={() => setActivePointIndex(null)}
-          onMouseLeave={() => setActivePointIndex(null)}
-        >
-          <g
-            transform={`translate(0,${chartDimensions.height - Margin.Bottom})`}
-          >
-            <XAxis
-              xScale={xScale}
-              labels={xAxisLabels}
-              dimensions={chartDimensions}
-            />
-          </g>
-
-          <g transform={`translate(${Margin.Left},${Margin.Top})`}>
-            <YAxis
-              yScale={yScale}
-              formatYAxisValue={formatYAxisValue}
-              dimensions={chartDimensions}
-            />
-          </g>
-
-          {activePointIndex == null ? null : (
-            <g transform={`translate(${Margin.Left},${Margin.Top})`}>
-              <Crosshair
-                x={xScale(activePointIndex)}
-                dimensions={chartDimensions}
-              />
-            </g>
-          )}
-
-          <g transform={`translate(${Margin.Left},${Margin.Top})`}>
-            {series
-              .slice()
-              .reverse()
-              .map((singleSeries) => {
-                const {data, name} = singleSeries;
-                const path = lineGenerator(data);
-
-                if (path == null) {
-                  throw new Error(
-                    `Could not generate line path for series ${name}`,
-                  );
-                }
-
-                return (
-                  <Line
-                    key={name}
-                    xScale={xScale}
-                    yScale={yScale}
-                    series={singleSeries}
-                    path={path}
-                    activePointIndex={activePointIndex}
-                  />
-                );
-              })}
-          </g>
-        </svg>
-
-        {tooltipPosition == null || activePointIndex == null ? null : (
-          <Tooltip
-            activePointIndex={activePointIndex}
-            currentX={tooltipPosition.x}
-            currentY={tooltipPosition.y}
-            formatYAxisValue={formatYAxisValue}
+      <div style={{height: chartHeight}} ref={containerRef}>
+        {chartDimensions == null ? null : (
+          <Chart
             series={series}
-            chartDimensions={chartDimensions}
+            xAxisLabels={xAxisLabels}
+            formatYAxisValue={formatYAxisValue}
+            dimensions={chartDimensions}
           />
         )}
       </div>

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {Chart} from '../Chart';
+import {Series} from '../types';
+import {Crosshair, Line, Tooltip, XAxis, YAxis} from '../components';
+
+(global as any).DOMRect = class DOMRect {
+  width = 500;
+  height = 250;
+  top = 100;
+  left = 100;
+};
+
+const fakeSVGEvent = {
+  currentTarget: {
+    getScreenCTM: () => ({
+      inverse: () => ({x: 100, y: 100}),
+    }),
+    createSVGPoint: () => ({
+      x: 100,
+      y: 100,
+      matrixTransform: () => ({x: 100, y: 100}),
+    }),
+  },
+};
+
+const primarySeries: Series = {
+  name: 'Primary',
+  data: [
+    {x: 'Jan 1', y: 1500},
+    {x: 'Jan 2', y: 1000},
+    {x: 'Jan 3', y: 800},
+    {x: 'Jan 4', y: 1300},
+  ],
+};
+
+const mockProps = {
+  series: [primarySeries],
+  xAxisLabels: ['Jan 1'],
+  dimensions: new DOMRect(),
+  formatYAxisValue: jest.fn(),
+};
+
+describe('<Chart />', () => {
+  it('renders an svg element', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    expect(chart).toContainReactComponent('svg');
+  });
+
+  it('sets an active point and tooltip position on svg mouse or touch interaction', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    const svg = chart.find('svg')!;
+
+    chart.act(() => {
+      svg.trigger('onMouseMove', fakeSVGEvent);
+    });
+
+    expect(chart).toContainReactComponent(Line, {activePointIndex: 0});
+  });
+
+  it('renders an <XAxis />', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    expect(chart).toContainReactComponent(XAxis, {
+      labels: ['Jan 1'],
+    });
+  });
+
+  it('creates an x scale with a domain corresponding to the longest series', () => {
+    const longSeries: Series = {
+      name: 'Long series',
+      data: [
+        {x: '1', y: 1},
+        {x: '2', y: 2},
+        {x: '3', y: 3},
+        {x: '4', y: 4},
+        {x: '5', y: 5},
+        {x: '6', y: 6},
+        {x: '7', y: 7},
+        {x: '8', y: 8},
+        {x: '9', y: 9},
+        {x: '10', y: 10},
+      ],
+    };
+    const lineChart = mount(
+      <Chart {...mockProps} series={[primarySeries, longSeries]} />,
+    );
+
+    expect(
+      lineChart
+        .find(XAxis)!
+        .prop('xScale')
+        .domain(),
+    ).toStrictEqual([0, 9]);
+  });
+
+  it('creates an x scale with range from 0 to the width of the chart, minus margins', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    expect(
+      chart
+        .find(XAxis)!
+        .prop('xScale')
+        .range(),
+    ).toStrictEqual([0, 420]);
+  });
+
+  it('renders a <YAxis />', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    expect(chart).toContainReactComponent(YAxis);
+  });
+
+  it('creates a y scale with a domain corresponding to the minimum and maximum values in the data set, plus some padding', () => {
+    const deeplyNegative: Series = {
+      name: 'Deeply negative',
+      data: [{x: '1', y: -10000}],
+    };
+    const highlyPositive: Series = {
+      name: 'Highly positive',
+      data: [{x: '1', y: 10000}],
+    };
+    const lineChart = mount(
+      <Chart {...mockProps} series={[deeplyNegative, highlyPositive]} />,
+    );
+
+    // We expect the Y_SCALE_PADDING to be 1.2, so the max will be 12,000
+    expect(
+      lineChart
+        .find(YAxis)!
+        .prop('yScale')
+        .domain(),
+    ).toStrictEqual([-10000, 12000]);
+  });
+
+  it('creates a y scale with range from the height of the chart, minus margins to 0', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    expect(
+      chart
+        .find(YAxis)!
+        .prop('yScale')
+        .range(),
+    ).toStrictEqual([205, 0]);
+  });
+
+  it('renders a <Crosshair /> if there is an active point', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    // No crosshair if there is no active point
+    expect(chart).not.toContainReactComponent(Crosshair);
+
+    // create an active point
+    const svg = chart.find('svg')!;
+    svg.trigger('onMouseMove', fakeSVGEvent);
+
+    expect(chart).toContainReactComponent(Crosshair);
+  });
+
+  it('renders a <Line /> for each series', () => {
+    const chart = mount(
+      <Chart
+        {...mockProps}
+        series={[primarySeries, {...primarySeries, name: 'A second series'}]}
+      />,
+    );
+
+    expect(chart).toContainReactComponentTimes(Line, 2);
+  });
+
+  it('renders a <Tooltip /> if there is an active point', () => {
+    const chart = mount(<Chart {...mockProps} />);
+
+    // No tooltip if there is no active point
+    expect(chart).not.toContainReactComponent(Tooltip);
+
+    // create an active point
+    const svg = chart.find('svg')!;
+    svg.trigger('onMouseMove', fakeSVGEvent);
+
+    expect(chart).toContainReactComponent(Tooltip);
+  });
+});

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -2,27 +2,15 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {LineChart} from '../LineChart';
+import {Chart} from '../Chart';
 import {Series} from '../types';
-import {Crosshair, Legend, Line, Tooltip, XAxis, YAxis} from '../components';
+import {Legend} from '../components';
 
 (global as any).DOMRect = class DOMRect {
   width = 500;
   height = 250;
   top = 100;
   left = 100;
-};
-
-const fakeSVGEvent = {
-  currentTarget: {
-    getScreenCTM: () => ({
-      inverse: () => ({x: 100, y: 100}),
-    }),
-    createSVGPoint: () => ({
-      x: 100,
-      y: 100,
-      matrixTransform: () => ({x: 100, y: 100}),
-    }),
-  },
 };
 
 const primarySeries: Series = {
@@ -36,167 +24,26 @@ const primarySeries: Series = {
 };
 
 describe('<LineChart />', () => {
-  it('renders an svg element', () => {
+  it('renders a <Chart /> if container dimensions have been measured', () => {
+    jest.useFakeTimers();
     const lineChart = mount(
       <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
     );
-
-    expect(lineChart).toContainReactComponent('svg');
-  });
-
-  it('sets an active point and tooltip position on svg mouse or touch interaction', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    const svg = lineChart.find('svg')!;
 
     lineChart.act(() => {
-      svg.trigger('onMouseMove', fakeSVGEvent);
+      jest.runAllTimers();
     });
 
-    expect(lineChart).toContainReactComponent(Line, {activePointIndex: 0});
+    expect(lineChart).toContainReactComponent(Chart);
+    jest.useRealTimers();
   });
 
-  it('renders an <XAxis />', () => {
+  it('does not render a <Chart /> if container dimensions have not been measured', () => {
     const lineChart = mount(
       <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
     );
 
-    expect(lineChart).toContainReactComponent(XAxis, {
-      labels: ['Jan 1'],
-    });
-  });
-
-  it('creates an x scale with a domain corresponding to the longest series', () => {
-    const longSeries: Series = {
-      name: 'Long series',
-      data: [
-        {x: '1', y: 1},
-        {x: '2', y: 2},
-        {x: '3', y: 3},
-        {x: '4', y: 4},
-        {x: '5', y: 5},
-        {x: '6', y: 6},
-        {x: '7', y: 7},
-        {x: '8', y: 8},
-        {x: '9', y: 9},
-        {x: '10', y: 10},
-      ],
-    };
-    const lineChart = mount(
-      <LineChart
-        series={[primarySeries, longSeries]}
-        xAxisLabels={['Jan 1']}
-      />,
-    );
-
-    expect(
-      lineChart
-        .find(XAxis)!
-        .prop('xScale')
-        .domain(),
-    ).toStrictEqual([0, 9]);
-  });
-
-  it('creates an x scale with range from 0 to the width of the chart, minus margins', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    expect(
-      lineChart
-        .find(XAxis)!
-        .prop('xScale')
-        .range(),
-    ).toStrictEqual([0, 420]);
-  });
-
-  it('renders a <YAxis />', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    expect(lineChart).toContainReactComponent(YAxis);
-  });
-
-  it('creates a y scale with a domain corresponding to the minimum and maximum values in the data set, plus some padding', () => {
-    const deeplyNegative: Series = {
-      name: 'Deeply negative',
-      data: [{x: '1', y: -10000}],
-    };
-    const highlyPositive: Series = {
-      name: 'Highly positive',
-      data: [{x: '1', y: 10000}],
-    };
-    const lineChart = mount(
-      <LineChart
-        series={[deeplyNegative, highlyPositive]}
-        xAxisLabels={['Jan 1']}
-      />,
-    );
-
-    // We expect the Y_SCALE_PADDING to be 1.2, so the max will be 12,000
-    expect(
-      lineChart
-        .find(YAxis)!
-        .prop('yScale')
-        .domain(),
-    ).toStrictEqual([-10000, 12000]);
-  });
-
-  it('creates a y scale with range from the height of the chart, minus margins to 0', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    expect(
-      lineChart
-        .find(YAxis)!
-        .prop('yScale')
-        .range(),
-    ).toStrictEqual([205, 0]);
-  });
-
-  it('renders a <Crosshair /> if there is an active point', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    // No crosshair if there is no active point
-    expect(lineChart).not.toContainReactComponent(Crosshair);
-
-    // create an active point
-    const svg = lineChart.find('svg')!;
-    svg.trigger('onMouseMove', fakeSVGEvent);
-
-    expect(lineChart).toContainReactComponent(Crosshair);
-  });
-
-  it('renders a <Line /> for each series', () => {
-    const lineChart = mount(
-      <LineChart
-        series={[primarySeries, {...primarySeries, name: 'A second series'}]}
-        xAxisLabels={['Jan 1']}
-      />,
-    );
-
-    expect(lineChart).toContainReactComponentTimes(Line, 2);
-  });
-
-  it('renders a <Tooltip /> if there is an active point', () => {
-    const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
-    );
-
-    // No tooltip if there is no active point
-    expect(lineChart).not.toContainReactComponent(Tooltip);
-
-    // create an active point
-    const svg = lineChart.find('svg')!;
-    svg.trigger('onMouseMove', fakeSVGEvent);
-
-    expect(lineChart).toContainReactComponent(Tooltip);
+    expect(lineChart).not.toContainReactComponent(Chart);
   });
 
   it('renders a Legend', () => {


### PR DESCRIPTION
### What problem is this PR solving?

Part of #30

There is often a flash of the chart rendering before the chart container is properly measured, making it appear like there is a tiny version of the chart before rendering the real chart. This PR ensures the chart doesn't render unless we have measurements for the container by putting it in a subcomponent that can be conditionally rendered.

### Reviewers’ :tophat: instructions

Make sure you can't reproduce the flash of unstyled content and that, in general, the chart isn't super broken because of the code moving around

<details>
<summary>Playground</summary>

```tsx
import React, {useState} from 'react';
import {colorSky, colorSkyDark, colorBlue} from '@shopify/polaris-tokens';

import {LineChart} from '../src/components';

const formatMoney = new Intl.NumberFormat('en', {
  currency: 'USD',
  style: 'currency',
}).format;
const formatNumber = new Intl.NumberFormat('en').format;
const formatDate = new Intl.DateTimeFormat('en', {
  month: 'short',
  day: 'numeric',
}).format;

function generateData(numPoints, min = 5, max = 15) {
  return Array.from(Array(numPoints))
    .fill(null)
    .map((_, index) => {
      return {x: `${index}`, y: min + Math.floor(Math.random() * max)};
    });
}

const OVERVIEW_DASHBOARD_STYLE = [
  {name: 'Apr–Apr 30, 2020 was a good month', data: generateData(30)},
  {
    name: 'Mar 1–Mar 31, 2020',
    data: generateData(31),
    style: {
      color: 'colorSkyDark',
      lineStyle: 'dashed',
    },
  },
];

const LOTS_OF_DATA = [
  {
    data: [
      {x: '5', y: 100},
      {x: '6', y: -40},
      {x: '7', y: -20},
      {x: '8', y: -40},
      {x: '9', y: 250},
      {x: '10', y: 100},
      {x: '11', y: 100},
      {x: '12', y: -40},
      {x: '13', y: -20},
      {x: '14', y: -40},
      {x: '15', y: 250},
      {x: '16', y: 100},
    ],
    name: 'Data 1',
    style: {color: 'colorTeal'},
  },
  {
    data: generateData(8, 0, 1000),
    name: 'Data 2',
    style: {lineStyle: 'dashed'},
  },
  {
    data: generateData(10, 0, 1000),
    name: 'Data 3',
    style: {color: 'colorBlue'},
  },
  {
    data: generateData(8, 0, 1000),
    name: 'Data 4',
    style: {color: 'colorOrange', lineStyle: 'dashed'},
  },
];

export default function Playground() {
  const [dataSet, setDataSet] = useState('OVERVIEW_DASHBOARD');

  const series =
    dataSet === 'OVERVIEW_DASHBOARD' ? OVERVIEW_DASHBOARD_STYLE : LOTS_OF_DATA;

  function handleChangeDataSet() {
    setDataSet(
      dataSet === 'OVERVIEW_DASHBOARD' ? 'LOTS_OF_DATA' : 'OVERVIEW_DASHBOARD',
    );
  }

  return (
    <div
      style={{
        margin: '150px 0',
        fontFamily:
          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
      }}
    >
      <div
        style={{
          maxWidth: 800,
          margin: 'auto',
          background: 'white',
          padding: 12,
          borderRadius: 6,
          border: `1px solid ${colorSky}`,
        }}
      >
        <LineChart
          xAxisLabels={series[0].data.map(({x}) =>
            formatDate(new Date(2020, 3, parseInt(x, 10) + 1)),
          )}
          formatYAxisValue={formatNumber}
          series={series}
        />

        <br />
        <hr style={{border: 0, height: 1, background: colorSkyDark}} />
        <br />

        <div style={{textAlign: 'left'}}>
          <button
            style={{
              border: `2px solid ${colorBlue}`,
              fontSize: 13,
              borderRadius: 8,
              color: colorBlue,
              padding: '7px 18px',
              fontWeight: 600,
              cursor: 'pointer',
              outline: 'none',
            }}
            onClick={() => handleChangeDataSet()}
          >
            Change data set
          </button>
        </div>
      </div>
    </div>
  );
}
```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [ ] ~Update the Changelog.~
- [ ] ~Update relevant documentation.~