### PR TITLE
Make x-axis labels optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Components inherit their sizes from their containers, so place your component in
     </td>
     <td>
     <ul>
-    <li><strong>xAxisLabels (required):</strong> <code>string[]</code></li>
     <li>
     <strong>series (required):</strong> <code>Series[]</code>
     <ul>
     <li><strong>data (required):</strong> <code>{x: string, y: number}[]</code>
     </li>
     <li><strong>name (required):</strong> <code>string</code></li>
+    <li><strong>xAxisLabels:</strong> <code>string[]</code></li>
     <li><strong>formatY:</strong> <code>(value: number): string;</code></li>
     <li>
     <strong>style (all properties optional):</strong>

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -3,14 +3,14 @@ import {line} from 'd3-shape';
 
 import {eventPoint} from './utilities';
 import {Series} from './types';
-import {Margin} from './constants';
+import {Margin, SPACING_TIGHT} from './constants';
 import {useXScale, useYScale} from './hooks';
 import {Crosshair, Line, Tooltip, XAxis, YAxis} from './components';
 import styles from './Chart.scss';
 
 interface Props {
   series: Series[];
-  xAxisLabels: string[];
+  xAxisLabels?: string[];
   formatYAxisValue(value: number): string;
   dimensions: DOMRect;
 }
@@ -27,7 +27,8 @@ export function Chart({
     y: number;
   } | null>(null);
 
-  const drawableHeight = dimensions.height - Margin.Top - Margin.Bottom;
+  const marginBottom = xAxisLabels == null ? SPACING_TIGHT : Margin.Bottom;
+  const drawableHeight = dimensions.height - Margin.Top - marginBottom;
 
   const {axisMargin, ticks, yScale} = useYScale({
     drawableHeight,
@@ -89,7 +90,7 @@ export function Chart({
       >
         <g
           transform={`translate(${axisMargin},${dimensions.height -
-            Margin.Bottom})`}
+            marginBottom})`}
         >
           <XAxis
             xScale={xScale}

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -7,7 +7,7 @@ import {Legend} from './components';
 
 interface Props {
   series: Series[];
-  xAxisLabels: string[];
+  xAxisLabels?: string[];
   chartHeight?: number;
   accessibilityLabel?: string;
   formatYAxisValue?(value: number): string;

--- a/src/components/LineChart/components/XAxis/XAxis.tsx
+++ b/src/components/LineChart/components/XAxis/XAxis.tsx
@@ -4,7 +4,7 @@ import {colorSky, colorInkLighter, spacingLoose} from '@shopify/polaris-tokens';
 
 interface Props {
   xScale: ScaleLinear<number, number>;
-  labels: string[];
+  labels?: string[];
   dimensions: DOMRect;
   drawableHeight: number;
 }
@@ -14,6 +14,10 @@ const MIN_LABEL_SPACE = 100;
 
 export function XAxis({xScale, labels, dimensions, drawableHeight}: Props) {
   const ticks = useMemo(() => {
+    if (labels == null) {
+      return [];
+    }
+
     const maxTicks = Math.max(
       1,
       Math.floor(dimensions.width / MIN_LABEL_SPACE),

--- a/src/components/LineChart/components/XAxis/tests/XAxis.test.tsx
+++ b/src/components/LineChart/components/XAxis/tests/XAxis.test.tsx
@@ -110,4 +110,20 @@ describe('<XAxis />', () => {
 
     expect(textContent).toStrictEqual(labels);
   });
+
+  it('does not render any labels if the labels prop is not provided', () => {
+    const axis = mount(
+      <svg>
+        <XAxis
+          xScale={scaleLinear()}
+          dimensions={new DOMRect()}
+          drawableHeight={150}
+        />
+      </svg>,
+    );
+
+    const text = axis.findAll('text')!;
+
+    expect(text).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
### What problem is this PR solving?

Part of #30 

Make the x-axis labels optional

### Reviewers’ :tophat: instructions

Using the following playground, switching between data sets should hide or show the labels. You should see the spacing above the legend remain consistent

<details>
<summary>Playground</summary>

```tsx
import React, {useState} from 'react';
import {colorSky, colorSkyDark, colorBlue} from '@shopify/polaris-tokens';

import {LineChart} from '../src/components';

const formatMoney = new Intl.NumberFormat('en', {
  currency: 'USD',
  style: 'currency',
}).format;
const formatNumber = new Intl.NumberFormat('en').format;
const formatDate = new Intl.DateTimeFormat('en', {
  month: 'short',
  day: 'numeric',
}).format;

function generateData(numPoints, min = 5, max = 15) {
  return Array.from(Array(numPoints))
    .fill(null)
    .map((_, index) => {
      return {x: `${index}`, y: min + Math.floor(Math.random() * max)};
    });
}

const OVERVIEW_DASHBOARD_STYLE = [
  {
    name: 'Apr–Apr 30, 2020 was a good month',
    data: generateData(30, 0, 2000000),
  },
  {
    name: 'Mar 1–Mar 31, 2020',
    data: generateData(31, 0, 2000000),
    style: {
      color: 'colorSkyDark',
      lineStyle: 'dashed',
    },
  },
];

const LOTS_OF_DATA = [
  {
    data: [
      {x: '5', y: 100},
      {x: '6', y: -40},
      {x: '7', y: -20},
      {x: '8', y: -40},
      {x: '9', y: 250},
      {x: '10', y: 100},
      {x: '11', y: 100},
      {x: '12', y: -40},
      {x: '13', y: -20},
      {x: '14', y: -40},
      {x: '15', y: 250},
      {x: '16', y: 100},
    ],
    name: 'Data 1',
    style: {color: 'colorTeal'},
  },
  {
    data: generateData(8, 0, 1000),
    name: 'Data 2',
    style: {lineStyle: 'dashed'},
  },
  {
    data: generateData(10, 0, 1000),
    name: 'Data 3',
    style: {color: 'colorBlue'},
  },
  {
    data: generateData(8, 0, 1000),
    name: 'Data 4',
    style: {color: 'colorOrange', lineStyle: 'dashed'},
  },
];

export default function Playground() {
  const [dataSet, setDataSet] = useState('OVERVIEW_DASHBOARD');

  const series =
    dataSet === 'OVERVIEW_DASHBOARD' ? OVERVIEW_DASHBOARD_STYLE : LOTS_OF_DATA;

  function handleChangeDataSet() {
    setDataSet(
      dataSet === 'OVERVIEW_DASHBOARD' ? 'LOTS_OF_DATA' : 'OVERVIEW_DASHBOARD',
    );
  }

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  return (
    <div
      style={{
        margin: '150px 0',
      }}
    >
      <div
        style={{
          maxWidth: 800,
          margin: 'auto',
          background: 'white',
          padding: 12,
          borderRadius: 6,
          border: `1px solid ${colorSky}`,
        }}
      >
        <LineChart
          xAxisLabels={
            dataSet === 'OVERVIEW_DASHBOARD'
              ? undefined
              : series[0].data.map(({x}) =>
                  formatDate(new Date(2020, 3, parseInt(x, 10) + 1)),
                )
          }
          formatYAxisValue={formatNumber}
          series={series}
        />

        <br />
        <hr style={{border: 0, height: 1, background: colorSkyDark}} />
        <br />

        <div style={{textAlign: 'left'}}>
          <button
            style={{
              border: `2px solid ${colorBlue}`,
              fontSize: 13,
              borderRadius: 8,
              color: colorBlue,
              padding: '7px 18px',
              fontWeight: 600,
              cursor: 'pointer',
              outline: 'none',
            }}
            onClick={() => handleChangeDataSet()}
          >
            Change data set
          </button>
        </div>
      </div>
    </div>
  );
}
```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [ ] ~Update the Changelog.~
- [x] Update relevant documentation.
