### PR TITLE
[Bar chart] Rename histogram

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -3,11 +3,11 @@ import {useDebouncedCallback} from 'use-debounce';
 import {Color} from 'types';
 
 import {Chart} from './Chart';
-import {BarData} from './types';
+import {BarData, BarMargin} from './types';
 
 interface Props {
   data: BarData[];
-  histogram?: boolean;
+  barMargin?: keyof typeof BarMargin;
   accessibilityLabel?: string;
   color?: Color;
   highlightColor?: Color;
@@ -19,7 +19,7 @@ export function BarChart({
   data,
   highlightColor,
   accessibilityLabel,
-  histogram = false,
+  barMargin = 'Medium',
   color = 'colorPurple',
   formatYValue = (value) => value.toString(),
   formatXAxisLabel = (value) => value.toString(),
@@ -56,7 +56,7 @@ export function BarChart({
         <Chart
           data={data}
           chartDimensions={chartDimensions}
-          histogram={histogram}
+          barMargin={BarMargin[barMargin]}
           color={color}
           highlightColor={highlightColor}
           formatYValue={formatYValue}

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -21,7 +21,7 @@ import styles from './Chart.scss';
 interface Props {
   data: BarData[];
   chartDimensions: DOMRect;
-  histogram: boolean;
+  barMargin: number;
   color: Color;
   highlightColor?: Color;
   formatYValue(value: number): string;
@@ -31,7 +31,7 @@ interface Props {
 export function Chart({
   data,
   chartDimensions,
-  histogram,
+  barMargin,
   color,
   highlightColor,
   formatYValue,
@@ -54,7 +54,7 @@ export function Chart({
 
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
-    histogram,
+    barMargin,
     data,
     fontSize,
     formatXAxisLabel,

--- a/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
@@ -23,14 +23,14 @@ describe('useXScale', () => {
       rangeSpy = jest.fn(() => scale);
       scale.rangeRound = rangeSpy;
       scale.bandwidth = () => 10;
-      scale.padding = () => scale;
+      scale.paddingInner = () => scale;
       return scale;
     });
 
     function TestComponent() {
       useXScale({
         drawableWidth: 200,
-        histogram: false,
+        barMargin: 0,
         data: [{rawValue: 10, label: ''}],
         fontSize: 12,
         formatXAxisLabel: () => '',
@@ -51,7 +51,7 @@ describe('useXScale', () => {
       scale.range = (range: any) => range;
       scale.rangeRound = () => scale;
       scale.bandwidth = () => 10;
-      scale.padding = () => scale;
+      scale.paddingInner = () => scale;
       domainSpy = jest.fn(() => scale);
       scale.domain = domainSpy;
       return scale;
@@ -60,7 +60,7 @@ describe('useXScale', () => {
     function TestComponent() {
       useXScale({
         drawableWidth: 200,
-        histogram: false,
+        barMargin: 0,
         data: [
           {rawValue: 0, label: ''},
           {rawValue: 1000, label: ''},
@@ -83,7 +83,7 @@ describe('useXScale', () => {
       scale.range = () => scale;
       scale.rangeRound = () => scale;
       scale.bandwidth = () => 10;
-      scale.padding = () => scale;
+      scale.paddingInner = () => scale;
       scale.domain = () => scale;
       return scale;
     });
@@ -91,7 +91,7 @@ describe('useXScale', () => {
     function TestComponent() {
       const {xAxisLabels} = useXScale({
         drawableWidth: 200,
-        histogram: false,
+        barMargin: 0,
         data: [{rawValue: 0, label: 'Test 1'}],
         fontSize: 12,
         formatXAxisLabel: (val: string) => `${val}!`,

--- a/src/components/BarChart/hooks/use-x-scale.ts
+++ b/src/components/BarChart/hooks/use-x-scale.ts
@@ -6,20 +6,20 @@ import {wrapLabel} from '../../../utilities';
 
 export function useXScale({
   drawableWidth,
-  histogram,
+  barMargin,
   data,
   fontSize,
   formatXAxisLabel,
 }: {
   drawableWidth: number;
-  histogram: boolean;
+  barMargin: number;
   data: BarData[];
   fontSize: number;
   formatXAxisLabel(value: string, index: number): string;
 }) {
   const xScale = scaleBand()
     .rangeRound([0, drawableWidth])
-    .padding(histogram ? 0 : 0.1)
+    .paddingInner(barMargin)
     .domain(data.map((_, index) => index.toString()));
 
   const barWidthOffset = xScale.bandwidth() / 2;

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -37,6 +37,7 @@ describe('Chart />', () => {
     color: 'colorPurple' as Color,
     formatYValue: (value: number) => value.toString(),
     formatXAxisLabel: (value: string) => value,
+    barMargin: 0,
   };
 
   it('renders an SVG element', () => {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -2,3 +2,10 @@ export interface BarData {
   rawValue: number;
   label: string;
 }
+
+export enum BarMargin {
+  Small = 0.05,
+  Medium = 0.1,
+  Large = 0.3,
+  None = 0,
+}


### PR DESCRIPTION
### What problem is this PR solving?
Part of https://github.com/Shopify/polaris-viz/issues/53

tldr: I went down a real rabbit hole about histograms and I came out the other side thinking we should just rename the prop.

<details>
<summary>Open if you would like to see my rant</summary>

A real, good, histogram should have some features that are a bit of a departure from the bar chart. For example, it should really use a linear scale rather than the scaleband, to allow us to have a label on either side of each bar to indicate the range of the bucket. I [experimented](https://github.com/Shopify/polaris-viz/pull/65/files) with what would be required for this and while it is probably possible with this component, I think it would just be better as a separate component if we see the demand. The experiment draft PR includes conditionally calling hooks, which obviously isn't an option. It also presents an issue of using our current data props to determine what a proper label would be when the data is histogram-style data. If you have ideas on how to make this work, I'd be happy to revisit it. Here's how this looks:
<img width="830" alt="Screen Shot 2020-06-25 at 5 25 05 PM" src="https://user-images.githubusercontent.com/12213371/85796932-c6229d00-b708-11ea-86d7-8cf5b41cb1a7.png">


Or here is a less drastic [solution](https://github.com/Shopify/polaris-viz/pull/67). However, the two problems with it are: 1) we sacrifice showing the labels in the tooltips because when it comes to the bars representing a range, the xAxis labels no longer really transfer to the tooltip labels 2) we can't provide a label for the last bar. Here's how that looks:

<img width="832" alt="Screen Shot 2020-06-25 at 5 17 54 PM" src="https://user-images.githubusercontent.com/12213371/85796805-8eb3f080-b708-11ea-90a9-b1933a06f91e.png">


</details>

A histogram-like style can be achieved with our bar chart by removing the space between the bars and providing labels that indicate the range each label is displaying. I just think we should tone down the prop name so it doesn't shout "I'm a histogram" when really it is just a bit like a histogram. We can explain the nuances in the docs and explain how to achieve something like this: 
<img width="844" alt="Screen Shot 2020-06-25 at 5 27 00 PM" src="https://user-images.githubusercontent.com/12213371/85797150-14d03700-b709-11ea-9285-db36307bd9c5.png">


This PR just renames the prop.

### Reviewers’ :tophat: instructions
N/A

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
