### PR TITLE
[Sparkline] Fix resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `<Sparkline />` animation on resize
+
 ## [0.0.12] - 2020-07-27
 
 ### Added


### PR DESCRIPTION
### What problem is this PR solving?
Fixes a bug where resizing the window from smaller to bigger caused the Sparkline to animate in a strange way

The problem was that the resize and measuring functions were getting out of sync, so the solution is to have them in the same `useLayoutEffect` and to debounce them together  

**Before**
![before](https://user-images.githubusercontent.com/12213371/89301735-ffb7c380-d637-11ea-9a71-245511e78073.gif)

**After**
![after](https://user-images.githubusercontent.com/12213371/89301924-32fa5280-d638-11ea-80e8-b5bdf0921d0d.gif)


### Reviewers’ :tophat: instructions

Resize your window with the Sparkline in it to be larger and smaller, make sure the animation works as expected

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<details>

```
import React, {useState} from 'react';
import {colorSky, colorSkyDark, colorBlue} from '@shopify/polaris-tokens';

import {LineChart, Sparkline} from '../src/components';

const formatMoney = new Intl.NumberFormat('en', {
  currency: 'USD',
  style: 'currency',
}).format;
const formatNumber = new Intl.NumberFormat('en').format;

const formatDate = (date: Date) =>
  date.toLocaleDateString('en-GB', {
    day: 'numeric',
    month: 'numeric',
    year: 'numeric',
  });

function generateData(numPoints, min = 50, max = 50) {
  return Array.from(Array(numPoints))
    .fill(null)
    .map((_, index) => {
      return {x: `${index}`, y: min + Math.floor(Math.random() * max)};
    });
}

const OVERVIEW_DASHBOARD_STYLE = [
  {name: 'Apr–Apr 30, 2020 was a good month', data: generateData(30)},
  {
    name: 'Mar 1–Mar 31, 2020',
    data: generateData(31),
    style: {
      color: 'colorSkyDark',
      lineStyle: 'dashed',
    },
  },
];

const LOTS_OF_DATA = [
  {
    data: [
      {x: '1', y: 10},
      {x: '2', y: -4},
      {x: '3', y: -2},
      {x: '4', y: -4},
      {x: '5', y: 25},
      {x: '6', y: 10},
      {x: '7', y: 10},
      {x: '8', y: -4},
      {x: '9', y: -2},
      {x: '10', y: -4},
      {x: '11', y: 25},
      {x: '12', y: 10},
      {x: '13', y: 10},
      {x: '15', y: -4},
      {x: '16', y: -2},
      {x: '17', y: -4},
      {x: '18', y: 25},
      {x: '19', y: 10},
      {x: '7', y: 10},
      {x: '20', y: -4},
      {x: '21', y: -2},
      {x: '22', y: -4},
      {x: '23', y: 25},
      {x: '24', y: 10},
      {x: '25', y: 10},
      {x: '26', y: -4},
      {x: '27', y: -2},
      {x: '28', y: -4},
      {x: '29', y: 25},
      {x: '30', y: 10},
      {x: '31', y: 10},
      {x: '32', y: -4},
      {x: '33', y: -2},
      {x: '34', y: -4},
      {x: '35', y: 25},
      {x: '36', y: 10},
      {x: '37', y: 10},
      {x: '38', y: -4},
      {x: '39', y: -2},
      {x: '40', y: -4},
      {x: '41', y: 25},
      {x: '42', y: 10},
      {x: '43', y: 10},
      {x: '44', y: -4},
      {x: '45', y: -2},
      {x: '46', y: -4},
      {x: '47', y: 25},
      {x: '48', y: 10},
      {x: '49', y: 25},
      {x: '50', y: 10},
      {x: '51', y: 10},
      // {x: '52', y: 250},
      // {x: '53', y: 100},
    ],
    name: 'Data 1',
    style: {color: 'colorTeal'},
  },
  {
    data: generateData(8, 0, 10),
    name: 'Data 2',
    style: {lineStyle: 'dashed'},
  },
  {
    data: generateData(10, 0, 10),
    name: 'Data 3',
    style: {color: 'colorBlue'},
  },
  {
    data: generateData(8, 0, 10),
    name: 'Data 4',
    style: {color: 'colorOrange', lineStyle: 'dashed'},
  },
];

export default function Playground() {
  const [dataSet, setDataSet] = useState('OVERVIEW_DASHBOARD');

  const series =
    dataSet === 'OVERVIEW_DASHBOARD' ? OVERVIEW_DASHBOARD_STYLE : LOTS_OF_DATA;

  function handleChangeDataSet() {
    setDataSet(
      dataSet === 'OVERVIEW_DASHBOARD' ? 'LOTS_OF_DATA' : 'OVERVIEW_DASHBOARD',
    );
  }

  return (
    <div
      style={{
        margin: '150px 0',
        fontFamily:
          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif",
      }}
    >
      <Sparkline
        color="colorPurple"
        useAnimation={true}
        includeArea={true}
        accessibilityLabel="hi"
        data={[
          {x: 0, y: 1000},
          {x: 1, y: 2000},
          {x: 2, y: 3000},
          {x: 3, y: 400},
          {x: 4, y: 50},
          {x: 5, y: 10000},
          {x: 6, y: 1000},
          {x: 7, y: 800},
          {x: 8, y: 900},
          {x: 9, y: 100},
          {x: 10, y: 11000},
        ]}
      />
      <div
        style={{
          // maxWidth: 800,
          margin: 'auto',
          background: 'white',
          padding: 12,
          borderRadius: 6,
          border: `1px solid ${colorSky}`,
        }}
      >
        <LineChart
          xAxisLabels={series[0].data.map(
            ({x}) =>
              `longggg ${formatDate(new Date(2020, 3, parseInt(x, 10) + 1))}`,
          )}
          formatYAxisValue={formatNumber}
          series={series}
        />

        <br />
        <hr style={{border: 0, height: 1, background: colorSkyDark}} />
        <br />

        <div style={{textAlign: 'left'}}>
          <button
            style={{
              border: `2px solid ${colorBlue}`,
              fontSize: 13,
              borderRadius: 8,
              color: colorBlue,
              padding: '7px 18px',
              fontWeight: 600,
              cursor: 'pointer',
              outline: 'none',
            }}
            onClick={() => handleChangeDataSet()}
          >
            Change data set
          </button>
        </div>
      </div>
    </div>
  );
}

```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
