### PR TITLE
[NormalizedStackedBar] Do not render bar for 0 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `<LineChart />` yScale improvements
+- `<NormalizedStackedBar />` do not show bar for 0 values
 
 ## [0.0.13] - 2020-08-05
 

--- a/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
+++ b/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
@@ -86,15 +86,17 @@ export function NormalizedStackedBar({
             : styles.HorizontalBarContainer,
         )}
       >
-        {slicedData.map(({value, label}, index) => (
-          <BarSegment
-            orientation={orientation}
-            size={size}
-            scale={xScale(value)}
-            key={`${label}-${value}`}
-            color={colorPalette[index]}
-          />
-        ))}
+        {slicedData.map(({value, label}, index) =>
+          value === 0 ? null : (
+            <BarSegment
+              orientation={orientation}
+              size={size}
+              scale={xScale(value)}
+              key={`${label}-${value}`}
+              color={colorPalette[index]}
+            />
+          ),
+        )}
       </div>
     </div>
   );

--- a/src/components/NormalizedStackedBar/tests/NormalizedStackedBar.test.tsx
+++ b/src/components/NormalizedStackedBar/tests/NormalizedStackedBar.test.tsx
@@ -60,6 +60,19 @@ describe('<NormalizedBarChart />', () => {
 
       expect(barChart.findAll(BarSegment)).toHaveLength(0);
     });
+
+    it('does not render a bar for 0 values', () => {
+      const barChart = mount(
+        <NormalizedStackedBar
+          data={[
+            {label: 'Bin', value: 200, formattedValue: '$200.00'},
+            {label: 'Stuff', value: 0, formattedValue: '$0.00'},
+          ]}
+        />,
+      );
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(1);
+    });
   });
 
   describe('Labels', () => {


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/87

It came up when speaking to @alenaiouguina that we should not be showing a bar on this chart if the value is 0. So this PR removes bars when they have a 0 value.

| Before  | After  | 
|---|---|
| <img width="1050" alt="Screen Shot 2020-08-06 at 3 46 01 PM" src="https://user-images.githubusercontent.com/12213371/89575489-d778c200-d7fb-11ea-96a9-16b758618b11.png"> | <img width="1036" alt="Screen Shot 2020-08-06 at 3 45 40 PM" src="https://user-images.githubusercontent.com/12213371/89575490-d778c200-d7fb-11ea-8c16-e39c2e8db0c2.png">|

### Reviewers’ :tophat: instructions
Check that the chart looks as expected when there is a bar with a 0 value

- `dev clone polaris-viz`
- checkout branch
- `dev up && dev server`
- navigate to your localhost port where the Playground is
- Use the code below in the Playground.tsx file and modify the data as you like

<details>

```
import React from 'react';

import {NormalizedStackedBar} from '../src/components';
import {
  Orientation,
  Size,
  ColorScheme,
} from '../src/components/NormalizedStackedBar';

const mockProps = {
  // size: Size.Small,
  accessibilityLabel: 'A chart showing data about something 🎉',
  data: [
    {
      label: 'Google',
      value: 0,
      formattedValue: '$0',
    },
    {
      label: 'Direct',
      value: 500,
      formattedValue: '$500',
    },
    {label: 'Facebook', value: 100, formattedValue: '$100'},
    {label: 'Twitter', value: 100, formattedValue: '$100'},
    // {label: 'a fith data item', value: 1090000, formattedValue: '$1090000'},
  ],
};

export default function Playground() {
  return (
    <div style={{height: '501px', margin: '40px'}}>
      <NormalizedStackedBar
        size="large"
        // orientation="vertical"
        {...mockProps}
      />
    </div>
  );
}

```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
