### PR TITLE
Add playground dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ node_modules
 /styles.scss
 /styles
 /sandbox
+/playground
 .DS_Store
 *.scss.d.ts


### PR DESCRIPTION
### What problem is this PR solving?

Adds the `playground` directory back to the `.gitignore` 

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
