### PR TITLE
[MultiSeriesBarChart] add stacked bar tests

### DIFF
--- a/src/components/GroupedBarChart/components/StackedBarGroup/tests/StackedBarGroup.test.tsx
+++ b/src/components/GroupedBarChart/components/StackedBarGroup/tests/StackedBarGroup.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {scaleBand, scaleLinear} from 'd3-scale';
+import {Color} from 'types';
+import {StackSeries} from 'components/GroupedBarChart/types';
+
+import {StackedBarGroup} from '../StackedBarGroup';
+
+jest.mock('d3-scale', () => ({
+  scaleLinear: jest.fn(() => jest.fn((value) => value)),
+  scaleBand: jest.fn(() => {
+    const scale = (value: any) => value;
+    scale.bandwidth = () => 500;
+    return scale;
+  }),
+}));
+
+describe('<StackedBarGroup/>', () => {
+  const stackedValues = [
+    [0, 1],
+    [0, 2],
+    [0, 3],
+  ] as StackSeries;
+
+  const mockProps = {
+    groupIndex: 1,
+    data: stackedValues,
+    yScale: scaleLinear() as any,
+    xScale: scaleBand() as any,
+    colors: ['primary', 'secondary'] as Color[],
+    highlightColors: ['primaryProminent', 'secondaryProminent'] as Color[],
+    activeBarGroup: null,
+  };
+
+  it('renders a rect for each data item', () => {
+    const wrapper = mount(
+      <svg>
+        <StackedBarGroup {...mockProps} />
+      </svg>,
+    );
+
+    expect(wrapper).toContainReactComponentTimes('rect', mockProps.data.length);
+  });
+
+  it('renders bar stack with colors from series props', () => {
+    const wrapper = mount(
+      <svg>
+        <StackedBarGroup {...mockProps} />
+      </svg>,
+    );
+
+    expect(wrapper).toContainReactComponent('rect', {
+      fill: 'rgb(41,35,112)',
+    });
+  });
+
+  it('renders bar stack with highlightColors from series prop when it is the activeBarGroup', () => {
+    const wrapper = mount(
+      <svg>
+        <StackedBarGroup {...mockProps} activeBarGroup={1} />
+      </svg>,
+    );
+
+    expect(wrapper).toContainReactComponent('rect', {
+      fill: 'rgb(9, 6, 37)',
+    });
+  });
+
+  it('renders a bar with height', () => {
+    const wrapper = mount(
+      <svg>
+        <StackedBarGroup {...mockProps} />
+      </svg>,
+    );
+
+    const rects = wrapper.findAll('rect');
+    const firstRect = rects[0];
+
+    expect(firstRect).toHaveReactProps({
+      height: 1,
+    });
+  });
+});

--- a/src/components/GroupedBarChart/tests/Chart.test.tsx
+++ b/src/components/GroupedBarChart/tests/Chart.test.tsx
@@ -4,7 +4,7 @@ import {Color} from 'types';
 import {YAxis, TooltipContainer} from 'components';
 
 import {Chart} from '../Chart';
-import {XAxis, Tooltip, BarGroup} from '../components';
+import {XAxis, Tooltip, BarGroup, StackedBarGroup} from '../components';
 
 (global as any).DOMRect = class DOMRect {
   width = 500;
@@ -80,54 +80,122 @@ describe('Chart />', () => {
     expect(chart).toContainReactComponent(Tooltip);
   });
 
-  it('renders a BarGroup for each data item', () => {
-    const chart = mount(<Chart {...mockProps} />);
+  describe('<BarGroup />', () => {
+    it('renders a BarGroup for each data item', () => {
+      const chart = mount(<Chart {...mockProps} />);
 
-    expect(chart).toContainReactComponentTimes(BarGroup, 3);
-  });
+      expect(chart).toContainReactComponentTimes(BarGroup, 3);
+    });
 
-  it('passes active props to the BarGroup that is being hovered on', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    it('passes active props to the BarGroup that is being hovered', () => {
+      const chart = mount(<Chart {...mockProps} />);
 
-    const svg = chart.find('svg')!;
-    svg.trigger('onMouseMove', fakeSVGEvent);
+      const svg = chart.find('svg')!;
+      svg.trigger('onMouseMove', fakeSVGEvent);
 
-    expect(chart).toContainReactComponent(BarGroup, {
-      isActive: true,
+      expect(chart).toContainReactComponent(BarGroup, {
+        isActive: true,
+      });
+    });
+
+    it('passes highlightColors with default colors to barGroup when no highlightColors are provided', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(BarGroup, {
+        highlightColors: ['colorBlack', 'colorRed'],
+      });
+    });
+
+    it('passes highlightColors barGroup', () => {
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          series={[
+            {
+              data: [10, 20, 30],
+              color: 'colorBlack' as Color,
+              highlightColor: 'primary' as Color,
+              label: 'LABEL1',
+            },
+            {
+              data: [10, 20, 30],
+              color: 'colorRed' as Color,
+              highlightColor: 'secondary' as Color,
+              label: 'LABEL2',
+            },
+          ]}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(BarGroup, {
+        highlightColors: ['primary', 'secondary'],
+      });
+    });
+
+    it('does not render BarGroup is stacked is true', () => {
+      const chart = mount(<Chart {...mockProps} stacked />);
+
+      expect(chart).not.toContainReactComponent(BarGroup);
     });
   });
 
-  it('passes highlightColors with default colors to barGroup when no highlightColor is defined', () => {
-    const chart = mount(<Chart {...mockProps} />);
+  describe('<StackedBarGroup />', () => {
+    it('renders StackedBarGroup if stacked is true', () => {
+      const chart = mount(<Chart {...mockProps} stacked />);
 
-    expect(chart).toContainReactComponent(BarGroup, {
-      highlightColors: ['colorBlack', 'colorRed'],
+      expect(chart).toContainReactComponent(StackedBarGroup);
     });
-  });
 
-  it('passes highlightColors to barGroup', () => {
-    const chart = mount(
-      <Chart
-        {...mockProps}
-        series={[
-          {
-            data: [10, 20, 30],
-            color: 'colorBlack' as Color,
-            highlightColor: 'primary' as Color,
-            label: 'LABEL1',
-          },
-          {
-            data: [10, 20, 30],
-            color: 'colorRed' as Color,
-            highlightColor: 'secondary' as Color,
-            label: 'LABEL2',
-          },
-        ]}
-      />,
-    );
+    it('renders a StackedBarGroup for each stacked data item', () => {
+      const chart = mount(<Chart {...mockProps} stacked />);
 
-    expect(chart).toContainReactComponent(BarGroup, {
-      highlightColors: ['primary', 'secondary'],
+      expect(chart).toContainReactComponentTimes(StackedBarGroup, 2);
+    });
+
+    it('passes highlightColors StackedBarGroup', () => {
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          series={[
+            {
+              data: [10, 20, 30],
+              color: 'colorBlack' as Color,
+              highlightColor: 'primary' as Color,
+              label: 'LABEL1',
+            },
+            {
+              data: [10, 20, 30],
+              color: 'colorRed' as Color,
+              highlightColor: 'secondary' as Color,
+              label: 'LABEL2',
+            },
+          ]}
+          stacked
+        />,
+      );
+
+      expect(chart).toContainReactComponent(StackedBarGroup, {
+        highlightColors: ['primary', 'secondary'],
+      });
+    });
+
+    it('passes highlightColors with default colors to StackedBarGroup when no highlightColors are provided', () => {
+      const chart = mount(<Chart {...mockProps} stacked />);
+
+      expect(chart).toContainReactComponent(StackedBarGroup, {
+        highlightColors: ['colorBlack', 'colorRed'],
+      });
+    });
+
+    it('passes active props to the BarGroup that is being hovered', () => {
+      const chart = mount(<Chart {...mockProps} stacked />);
+
+      const svg = chart.find('svg')!;
+      svg.trigger('onMouseMove', fakeSVGEvent);
+
+      expect(chart).toContainReactComponent(StackedBarGroup, {
+        activeBarGroup: 0,
+      });
     });
   });
 });

--- a/src/components/GroupedBarChart/tests/GroupedBarChart.test.tsx
+++ b/src/components/GroupedBarChart/tests/GroupedBarChart.test.tsx
@@ -6,7 +6,7 @@ import {GroupedBarChart} from '../GroupedBarChart';
 import {Chart} from '../Chart';
 import {Legend} from '../components';
 
-describe('GroupedBarChart />', () => {
+describe('<GroupedBarChart />', () => {
   const mockProps = {
     series: [
       {data: [10, 20, 30], color: 'colorBlack' as Color, label: 'LABEL1'},

--- a/src/components/GroupedBarChart/utilities/tests/get-min-max.test.tsx
+++ b/src/components/GroupedBarChart/utilities/tests/get-min-max.test.tsx
@@ -1,0 +1,36 @@
+import {Data, StackSeries} from 'components/GroupedBarChart/types';
+
+import {getMinMax} from '../get-min-max';
+
+const mockData: Data[] = [
+  {data: [10, 20, 30], color: 'colorBlack', label: 'LABEL1'},
+  {data: [1, 2, 3], color: 'colorBlack', label: 'LABEL2'},
+];
+const mockStackedData = [
+  [
+    [0, 10],
+    [0, 20],
+    [0, 30],
+  ],
+  [
+    [10, 11],
+    [20, 22],
+    [30, 33],
+  ],
+] as StackSeries[];
+
+describe('get-min-max', () => {
+  it('returns min and max of non stacked data when stackedValues is null', () => {
+    const {min, max} = getMinMax(null, mockData);
+
+    expect(min).toStrictEqual(0);
+    expect(max).toStrictEqual(30);
+  });
+
+  it('returns min and max of stacked values when stackedValues is not null', () => {
+    const {min, max} = getMinMax(mockStackedData, mockData);
+
+    expect(min).toStrictEqual(0);
+    expect(max).toStrictEqual(33);
+  });
+});

--- a/src/components/GroupedBarChart/utilities/tests/get-stacked-values.test.tsx
+++ b/src/components/GroupedBarChart/utilities/tests/get-stacked-values.test.tsx
@@ -1,0 +1,68 @@
+import {Data} from 'components/GroupedBarChart/types';
+import {stack} from 'd3-shape';
+
+import {getStackedValues} from '../get-stacked-values';
+
+const mockData: Data[] = [
+  {data: [10, 20, 30], color: 'colorBlack', label: 'LABEL1'},
+  {data: [1, 2, 3], color: 'colorBlack', label: 'LABEL2'},
+  {data: [5, 7, 10], color: 'colorBlack', label: 'LABEL3'},
+];
+const labels: string[] = ['one', 'two', 'three'];
+
+jest.mock('d3-shape', () => ({
+  stack: jest.fn(() => {
+    const generator = (value: any) => value;
+    generator.offset = () => generator;
+    generator.keys = () => generator;
+    return generator;
+  }),
+}));
+
+describe('get-stacked-values', () => {
+  it('makes a call to stack()', () => {
+    (stack as jest.Mock).mockImplementation(() => {
+      const stack = () => (value: any) => value;
+      stack.offset = () => stack;
+      stack.keys = () => stack;
+      return stack;
+    });
+
+    getStackedValues(mockData, labels);
+
+    expect(stack).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the offset to the stackedData', () => {
+    let offsetSpy = jest.fn();
+
+    (stack as jest.Mock).mockImplementation(() => {
+      const stack = () => (value: any) => value;
+      offsetSpy = jest.fn((offset: any) => (offset ? offset : stack));
+      stack.offset = offsetSpy;
+      stack.keys = (keys: any) => (keys ? stack : keys);
+      return stack;
+    });
+
+    getStackedValues(mockData, labels);
+
+    expect(offsetSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the keys to the stackedData', () => {
+    let keySpy = jest.fn();
+
+    (stack as jest.Mock).mockImplementation(() => {
+      const stack = () => (value: any) => value;
+      stack.offset = (offset: any) => (offset ? offset : stack);
+
+      keySpy = jest.fn(() => stack);
+      stack.keys = () => keySpy;
+      return stack;
+    });
+
+    getStackedValues(mockData, labels);
+
+    expect(keySpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### What problem is this PR solving?

Adds tests to all components and utilities used to create the Stacked Bar Chart

**Notes**
When Adding tests to `get-y-scale` it was found that without unique labels, the `y scale` used for the stacked data is incorrect. [Issue here](https://github.com/Shopify/polaris-viz/issues/153)

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

No tophatting needed, but feel free to change my test descriptions 😛 .

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
