### PR TITLE
Fix name of prop in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Added
 
-- Added the `stacked` bolean prop to `<MultiSeriesBarChart />`
+- Added the `isStacked` bolean prop to `<MultiSeriesBarChart />`
 - Added `<StackedBarGroup />` to `<MultiSeriesBarChart />` to allow for vertically stacked bars
 
 ### [0.0.18] - 2020-10-09


### PR DESCRIPTION
Ended up going with `isStacked` not `stacked` for the boolean prop name, need to match the Changelog to what is implemented in the component