### PR TITLE
Add Render Tooltip to MultiSeriesBarChart

### DIFF
--- a/documentation/code/MultiSeriesBarChartDemo.tsx
+++ b/documentation/code/MultiSeriesBarChartDemo.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
-import {MultiSeriesBarChart} from '../../src/components';
+import {
+  MultiSeriesBarChart,
+  MultiSeriesBarChartProps,
+  TooltipContent,
+} from '../../src/components';
 
 import {OUTER_CONTAINER_STYLE} from './constants';
 
@@ -59,6 +63,33 @@ export function MultiSeriesBarChartDemo({isStacked = false}: Props) {
       maximumSignificantDigits: 3,
     }).format(val);
 
+  const renderTooltipContent: MultiSeriesBarChartProps['renderTooltipContent'] = ({
+    data,
+    title,
+  }) => {
+    const formatTooltipValue = (val: number) =>
+      new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: 'CAD',
+      }).format(val);
+
+    const formattedData = data.map(({label, value, color}) => ({
+      color,
+      label,
+      value: formatTooltipValue(value),
+    }));
+
+    const total = data.reduce((totalValue, {value}) => totalValue + value, 0);
+
+    return (
+      <TooltipContent
+        title={title}
+        data={formattedData}
+        total={{label: 'Total', value: formatTooltipValue(total)}}
+      />
+    );
+  };
+
   return (
     <div style={OUTER_CONTAINER_STYLE}>
       <div style={innerContainerStyle}>
@@ -68,6 +99,7 @@ export function MultiSeriesBarChartDemo({isStacked = false}: Props) {
           series={series}
           chartHeight={253}
           isStacked={isStacked}
+          renderTooltipContent={renderTooltipContent}
         />
       </div>
     </div>

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -1,12 +1,12 @@
 import React, {useState, useMemo} from 'react';
 
-import {TooltipContent, TooltipContainer} from '../../components';
+import {TooltipContainer} from '../../components';
 import {eventPoint, getTextWidth} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 
 import {getStackedValues} from './utilities';
-import {Data} from './types';
+import {Data, RenderTooltipContentData} from './types';
 import {XAxis, BarGroup, StackedBarGroup} from './components';
 import {useYScale, useXScale} from './hooks';
 import {
@@ -26,6 +26,7 @@ interface Props {
   chartDimensions: DOMRect;
   formatXAxisLabel: StringLabelFormatter;
   formatYAxisLabel: NumberLabelFormatter;
+  renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   timeSeries: boolean;
   isStacked: boolean;
 }
@@ -36,6 +37,7 @@ export function Chart({
   labels,
   formatXAxisLabel,
   formatYAxisLabel,
+  renderTooltipContent,
   timeSeries,
   isStacked,
 }: Props) {
@@ -99,7 +101,7 @@ export function Chart({
     highlightColor != null ? highlightColor : barColors[index],
   );
 
-  const tooltipMarkup = useMemo(() => {
+  const tooltipContentMarkup = useMemo(() => {
     if (activeBarGroup == null) {
       return null;
     }
@@ -108,12 +110,15 @@ export function Chart({
       return {
         label,
         color,
-        value: formatYAxisLabel(data[activeBarGroup]),
+        value: data[activeBarGroup],
       };
     });
 
-    return <TooltipContent data={data} />;
-  }, [activeBarGroup, formatYAxisLabel, series]);
+    return renderTooltipContent({
+      data,
+      title: labels[activeBarGroup],
+    });
+  }, [activeBarGroup, labels, renderTooltipContent, series]);
 
   return (
     <div
@@ -192,7 +197,7 @@ export function Chart({
           margin={MARGIN}
           position="center"
         >
-          {tooltipMarkup}
+          {tooltipContentMarkup}
         </TooltipContainer>
       ) : null}
     </div>

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -2,19 +2,21 @@ import React, {useState, useLayoutEffect, useRef} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
+import {TooltipContent} from '../../components';
 
 import {Chart} from './Chart';
-import {Data} from './types';
+import {Data, RenderTooltipContentData} from './types';
 import {Legend} from './components';
 import {DEFAULT_HEIGHT} from './constants';
 
-interface Props {
+export interface MultiSeriesBarChartProps {
   series: Data[];
   labels: string[];
   timeSeries?: boolean;
   accessibilityLabel?: string;
   formatXAxisLabel?: StringLabelFormatter;
   formatYAxisLabel?: NumberLabelFormatter;
+  renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
   chartHeight?: number;
   isStacked?: boolean;
 }
@@ -28,7 +30,8 @@ export function MultiSeriesBarChart({
   chartHeight = DEFAULT_HEIGHT,
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
-}: Props) {
+  renderTooltipContent,
+}: MultiSeriesBarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -50,6 +53,16 @@ export function MultiSeriesBarChart({
     };
   }, [containerRef, updateDimensions]);
 
+  function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
+    const formattedData = data.map(({label, value, color}) => ({
+      color,
+      label,
+      value: formatYAxisLabel(value),
+    }));
+
+    return <TooltipContent data={formattedData} />;
+  }
+
   return (
     <div aria-label={accessibilityLabel} role="img">
       <div style={{height: chartHeight}} ref={containerRef}>
@@ -60,6 +73,11 @@ export function MultiSeriesBarChart({
             chartDimensions={chartDimensions}
             formatXAxisLabel={formatXAxisLabel}
             formatYAxisLabel={formatYAxisLabel}
+            renderTooltipContent={
+              renderTooltipContent != null
+                ? renderTooltipContent
+                : renderDefaultTooltipContent
+            }
             timeSeries={timeSeries}
             isStacked={isStacked}
           />

--- a/src/components/MultiSeriesBarChart/index.ts
+++ b/src/components/MultiSeriesBarChart/index.ts
@@ -1,1 +1,4 @@
-export {MultiSeriesBarChart} from './MultiSeriesBarChart';
+export {
+  MultiSeriesBarChart,
+  MultiSeriesBarChartProps,
+} from './MultiSeriesBarChart';

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
-import {YAxis, TooltipContainer, TooltipContent} from 'components';
+import {YAxis, TooltipContainer} from 'components';
 
 import {Chart} from '../Chart';
 import {XAxis, BarGroup, StackedBarGroup} from '../components';
@@ -36,6 +36,8 @@ describe('Chart />', () => {
     jest.useRealTimers();
   });
 
+  const renderTooltipContent = () => <p>Mock Tooltip</p>;
+
   const mockProps = {
     series: [
       {data: [10, 20, 30], color: 'colorBlack' as Color, label: 'LABEL1'},
@@ -47,6 +49,7 @@ describe('Chart />', () => {
     formatXAxisLabel: jest.fn((value: string) => value),
     formatYAxisLabel: (value: number) => value.toString(),
     timeSeries: false,
+    renderTooltipContent,
   };
 
   it('renders an SVG element', () => {
@@ -70,21 +73,21 @@ describe('Chart />', () => {
     expect(mockProps.formatXAxisLabel).toHaveBeenCalledTimes(3);
   });
 
-  it('does not render <TooltipContent /> or <TooltipContainer /> if there is no active point', () => {
+  it('does not render <TooltipContainer /> if there is no active point', () => {
     const chart = mount(<Chart {...mockProps} />);
 
     expect(chart).not.toContainReactComponent(TooltipContainer);
-    expect(chart).not.toContainReactComponent(TooltipContent);
   });
 
-  it('renders <TooltipContent /> and <TooltipContainer /> if there is an active point', () => {
+  it('renders tooltip content inside a <TooltipContainer /> if there is an active point', () => {
     const chart = mount(<Chart {...mockProps} />);
     const svg = chart.find('svg')!;
 
     svg.trigger('onMouseMove', fakeSVGEvent);
 
-    expect(chart).toContainReactComponent(TooltipContainer);
-    expect(chart).toContainReactComponent(TooltipContent);
+    const tooltipContainer = chart.find(TooltipContainer)!;
+
+    expect(tooltipContainer).toContainReactText('Mock Tooltip');
   });
 
   describe('<BarGroup />', () => {

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -14,3 +14,12 @@ export type StackSeries = Series<
   },
   string
 >;
+
+export interface RenderTooltipContentData {
+  data: {
+    color: Color;
+    label: string;
+    value: number;
+  }[];
+  title: string;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,5 +9,8 @@ export {TooltipContainer} from './TooltipContainer';
 export {SquareColorPreview} from './SquareColorPreview';
 export {StackedAreaChart} from './StackedAreaChart';
 export {LinearXAxis} from './LinearXAxis';
-export {MultiSeriesBarChart} from './MultiSeriesBarChart';
+export {
+  MultiSeriesBarChart,
+  MultiSeriesBarChartProps,
+} from './MultiSeriesBarChart';
 export {TooltipContent, TooltipContentProps} from './TooltipContent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,7 @@ export {
   LineChartTooltipContent,
   StackedAreaChart,
   MultiSeriesBarChart,
+  MultiSeriesBarChartProps,
+  TooltipContent,
+  TooltipContentProps,
 } from './components';


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This refactors the Multi-Series Bar Chart to expose a `renderTooltip` function to the client, as well as provide a default render function in the case that the consumer doesn't provide a function to call back to. This is part of the work reflected in https://github.com/Shopify/polaris-viz/pull/160.

I'm merging this into a feature branch and will use that to merge to master (https://github.com/Shopify/polaris-viz/pull/167).

This PR is very similar to https://github.com/Shopify/polaris-viz/pull/165. If you don't have context on the approach I'm taking with this PR, I would read through the discussion there.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

Playground code for 🎩 ing 👀 
<details>

```tsx
import React from 'react';

import {
  MultiSeriesBarChart,
  MultiSeriesBarChartProps,
  TooltipContent,
} from '../src/components';

export default function Playground() {
  const innerContainerStyle = {
    width: '900px',
    background: 'white',
    padding: '2rem',
    borderRadius: '6px',
    border: '2px solid #EAECEF',
  };

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  const series = [
    {
      color: 'primary',
      highlightColor: 'primaryProminent',
      label: 'Breakfast',
      data: [3, 7, 4, 8, 10, 0, 1],
    },
    {
      color: 'secondary',
      highlightColor: 'secondaryProminent',
      label: 'Lunch',
      data: [4, 3, 5, 15, 8, 10, 2],
    },
    {
      color: 'tertiary',
      highlightColor: 'tertiaryProminent',
      label: 'Dinner',
      data: [7, 2, 6, 12, 10, 5, 3],
    },
  ];

  const labels = [
    'Monday',
    'Tuesday',
    'Wednesday',
    'Thursday',
    'Friday',
    'Saturday',
    'Sunday',
  ];

  const formatYAxisLabel = (val: number) =>
    new Intl.NumberFormat('en-CA', {
      style: 'currency',
      currency: 'CAD',
      maximumSignificantDigits: 3,
    }).format(val);

  const renderTooltipContent: MultiSeriesBarChartProps['renderTooltipContent'] = ({
    data,
    title,
  }) => {
    const formatTooltipValue = (val: number) =>
      new Intl.NumberFormat('en-CA', {
        style: 'currency',
        currency: 'CAD',
      }).format(val);

    const formattedData = data.map(({label, value, color}) => ({
      color,
      label,
      value: formatTooltipValue(value),
    }));

    const total = data.reduce((totalValue, {value}) => totalValue + value, 0);

    return (
      <TooltipContent
        title={title}
        data={formattedData}
        total={{label: 'Total', value: formatTooltipValue(total)}}
      />
    );
  };

  return (
    <div style={innerContainerStyle}>
      <MultiSeriesBarChart
        formatYAxisLabel={formatYAxisLabel}
        labels={labels}
        series={series}
        chartHeight={253}
        isStacked={false}
        renderTooltipContent={renderTooltipContent}
      />
    </div>
  );
}

```
</details>


### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~ Will be addressed in https://github.com/Shopify/polaris-viz/pull/167

~- [ ] Update the Changelog.~ N/A

- [x] Update relevant documentation.
