### PR TITLE
Add Render Tooltip to StackedAreaChart

### DIFF
--- a/documentation/code/StackedAreaChartDemo.tsx
+++ b/documentation/code/StackedAreaChartDemo.tsx
@@ -1,20 +1,15 @@
 import React from 'react';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
-import {StackedAreaChart} from '../../src/components';
+import {
+  StackedAreaChart,
+  StackedAreaChartProps,
+  TooltipContent,
+} from '../../src/components';
 
 import {OUTER_CONTAINER_STYLE} from './constants';
 
 export function StackedAreaChartDemo() {
-  const formatYAxisLabel = (value?: number) => {
-    const formatter = new Intl.NumberFormat('en').format;
-    if (value == null) {
-      return '-';
-    }
-
-    return formatter(value);
-  };
-
   const innerContainerStyle = {
     width: '900px',
     height: '300px',
@@ -39,22 +34,58 @@ export function StackedAreaChartDemo() {
       color: 'secondary',
     },
   ];
+
+  const labels = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+  ];
+
+  const formatYAxisLabel = (value?: number) => {
+    const formatter = new Intl.NumberFormat('en').format;
+    if (value == null) {
+      return '-';
+    }
+
+    return formatter(value);
+  };
+
+  const renderTooltipContent: StackedAreaChartProps['renderTooltipContent'] = ({
+    data,
+    title,
+  }) => {
+    const formatTooltipValue = (val: number) =>
+      new Intl.NumberFormat('en').format(val);
+
+    const formattedData = data.map(({label, value, color}) => ({
+      color,
+      label,
+      value: formatTooltipValue(value),
+    }));
+
+    const total = data.reduce((totalValue, {value}) => totalValue + value, 0);
+
+    return (
+      <TooltipContent
+        title={title}
+        data={formattedData}
+        total={{label: 'Total', value: formatTooltipValue(total)}}
+      />
+    );
+  };
+
   return (
     <div style={OUTER_CONTAINER_STYLE}>
       <div style={innerContainerStyle}>
         <StackedAreaChart
-          formatYAxisLabel={formatYAxisLabel}
-          xAxisLabels={[
-            'January',
-            'February',
-            'March',
-            'April',
-            'May',
-            'June',
-            'July',
-          ]}
           series={series}
-          tooltipSumDescriptor="Total"
+          xAxisLabels={labels}
+          formatYAxisLabel={formatYAxisLabel}
+          renderTooltipContent={renderTooltipContent}
         />
       </div>
     </div>

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -1,11 +1,7 @@
 import React, {useState, useMemo} from 'react';
 import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
 
-import {
-  TooltipContainer,
-  TooltipContent,
-  TooltipContentProps,
-} from '../../components';
+import {TooltipContainer} from '../../components';
 import {eventPoint} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {Crosshair} from '../Crosshair';
@@ -17,15 +13,15 @@ import {Margin, Spacing} from './constants';
 import {useXScale, useYScale} from './hooks';
 import {StackedAreas} from './components';
 import styles from './Chart.scss';
-import {Series} from './types';
+import {Series, RenderTooltipContentData} from './types';
 
 interface Props {
   xAxisLabels: string[];
   series: Series[];
   formatXAxisLabel: StringLabelFormatter;
   formatYAxisLabel: NumberLabelFormatter;
+  renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   dimensions: DOMRect;
-  tooltipSumDescriptor?: string;
   opacity: number;
   isAnimated: boolean;
 }
@@ -36,7 +32,7 @@ export function Chart({
   dimensions,
   formatXAxisLabel,
   formatYAxisLabel,
-  tooltipSumDescriptor,
+  renderTooltipContent,
   opacity,
   isAnimated,
 }: Props) {
@@ -99,44 +95,26 @@ export function Chart({
       return null;
     }
 
-    const data = series.reduce<TooltipContentProps['data']>(
+    const data = series.reduce<RenderTooltipContentData['data']>(
       function removeNullsAndFormatData(tooltipData, {color, label, data}) {
         const value = data[activePointIndex];
         if (value == null) {
           return tooltipData;
         }
 
-        tooltipData.push({color, label, value: formatYAxisLabel(value)});
+        tooltipData.push({color, label, value});
         return tooltipData;
       },
       [],
     );
 
-    const total = series.reduce((totalValue, {data}) => {
-      const value = data[activePointIndex];
-      if (value == null) {
-        return totalValue;
-      }
+    const title = xAxisLabels[activePointIndex];
 
-      return totalValue + value;
-    }, 0);
-
-    const formattedTotal = formatYAxisLabel(total);
-
-    return (
-      <TooltipContent
-        data={data}
-        total={
-          tooltipSumDescriptor != null
-            ? {
-                label: tooltipSumDescriptor,
-                value: formattedTotal,
-              }
-            : null
-        }
-      />
-    );
-  }, [activePointIndex, formatYAxisLabel, series, tooltipSumDescriptor]);
+    return renderTooltipContent({
+      data,
+      title,
+    });
+  }, [activePointIndex, series, xAxisLabels, renderTooltipContent]);
 
   if (xScale == null || drawableWidth == null || axisMargin == null) {
     return null;

--- a/src/components/StackedAreaChart/StackedAreaChart.md
+++ b/src/components/StackedAreaChart/StackedAreaChart.md
@@ -20,15 +20,7 @@ const series = [
   },
 ];
 
-const xAxisLabels = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-];
+const labels = ['January', 'February', 'March', 'April', 'May', 'June', 'July'];
 
 const formatYAxisLabel = (value?: number) => {
   const formatter = new Intl.NumberFormat('en').format;
@@ -39,11 +31,36 @@ const formatYAxisLabel = (value?: number) => {
   return formatter(value);
 };
 
+const renderTooltipContent: StackedAreaChartProps['renderTooltipContent'] = ({
+  data,
+  title,
+}) => {
+  const formatTooltipValue = (val: number) =>
+    new Intl.NumberFormat('en').format(val);
+
+  const formattedData = data.map(({label, value, color}) => ({
+    color,
+    label,
+    value: formatTooltipValue(value),
+  }));
+
+  const total = data.reduce((totalValue, {value}) => totalValue + value, 0);
+
+  return (
+    <TooltipContent
+      title={title}
+      data={formattedData}
+      total={{label: 'Total', value: formatTooltipValue(total)}}
+    />
+  );
+};
+
 return (
   <StackedAreaChart
-    formatYAxisLabel={formatYAxisLabel}
-    xAxisLabels={xAxisLabels}
     series={series}
+    xAxisLabels={labels}
+    formatYAxisLabel={formatYAxisLabel}
+    renderTooltipContent={renderTooltipContent}
   />
 );
 ```
@@ -58,11 +75,11 @@ The stacked area chart interface looks like this:
   series: Series[];
   chartHeight?: number;
   accessibilityLabel?: string;
-  formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
-  formatYAxisLabel?(value: number): string;
-  tooltipSumDescriptor?: string;
   opacity?: number;
   isAnimated?: boolean;
+  formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
+  formatYAxisLabel?(value: number): string;
+  renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
 }
 ```
 
@@ -96,9 +113,26 @@ The array that the chart uses to plot the area. Null values are not displayed.
 
 The label for the series. This appears in the chart legend and tooltip.
 
-### color
+#### color
 
 It allows you to pass any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md) for the `color` value.
+
+### The `RenderTooltipContentData` type
+
+The `RenderTooltipContentData` type looks very similar to the `Series` type. Its interface looks like this:
+
+```tsx
+interface RenderTooltipContentData {
+  data: {
+    color: Color;
+    label: string;
+    value: number;
+  }[];
+  title: string;
+}
+```
+
+The distinction between the `RenderTooltipContentData` and series `Data` types is that `RenderTooltipContentData` is for a single data point, instead of an entire series of data.
 
 ### Required Props
 
@@ -152,14 +186,6 @@ Determines the height of the chart.
 
 The labels to display on the x axis of the chart. If no labels are passed, there are no labels rendered on the x axis of the chart.
 
-### tooltipSumDescriptor
-
-| type     | default     |
-| -------- | ----------- |
-| `string` | `undefined` |
-
-The text used to describe the total value of all series at a given point. If a descriptor isn't given, the total will not be displayed in the tooltip.
-
 ### opacity
 
 | type     | default |
@@ -175,3 +201,11 @@ Determines the opacity of all area shapes. Consider reducing the opacity below 1
 | `boolean` | `false` |
 
 Whether to animate the chart when it is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.
+
+#### renderTooltipContent
+
+| type                                                 |
+| ---------------------------------------------------- |
+| `(data: RenderTooltipContentData): React.ReactNode;` |
+
+This accepts a function that is called to render the tooltip content. By default it calls `formatYAxisLabel` to format the the tooltip value and passes it to `<TooltipContent />`.

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -2,19 +2,20 @@ import React, {useLayoutEffect, useRef, useState} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
+import {TooltipContent} from '../../components';
 
 import {Chart} from './Chart';
 import {Legend} from './components';
-import {Series} from './types';
+import {Series, RenderTooltipContentData} from './types';
 
-interface Props {
+export interface StackedAreaChartProps {
   chartHeight?: number;
   accessibilityLabel?: string;
   formatXAxisLabel?: StringLabelFormatter;
   formatYAxisLabel?: NumberLabelFormatter;
+  renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
   xAxisLabels: string[];
   series: Series[];
-  tooltipSumDescriptor?: string;
   opacity?: number;
   isAnimated?: boolean;
 }
@@ -22,14 +23,14 @@ interface Props {
 export function StackedAreaChart({
   xAxisLabels,
   series,
-  tooltipSumDescriptor,
   chartHeight = 250,
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
   accessibilityLabel,
+  renderTooltipContent,
   opacity = 1,
   isAnimated = false,
-}: Props) {
+}: StackedAreaChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -55,6 +56,19 @@ export function StackedAreaChart({
     return null;
   }
 
+  function renderDefaultTooltipContent({
+    title,
+    data,
+  }: RenderTooltipContentData) {
+    const formattedData = data.map(({label, value, color}) => ({
+      color,
+      label,
+      value: formatYAxisLabel(value),
+    }));
+
+    return <TooltipContent title={title} data={formattedData} />;
+  }
+
   return (
     <div aria-label={accessibilityLabel} role="img">
       <div style={{height: chartHeight}} ref={containerRef}>
@@ -65,7 +79,11 @@ export function StackedAreaChart({
             formatXAxisLabel={formatXAxisLabel}
             formatYAxisLabel={formatYAxisLabel}
             dimensions={chartDimensions}
-            tooltipSumDescriptor={tooltipSumDescriptor}
+            renderTooltipContent={
+              renderTooltipContent != null
+                ? renderTooltipContent
+                : renderDefaultTooltipContent
+            }
             opacity={opacity}
             isAnimated={isAnimated}
           />

--- a/src/components/StackedAreaChart/index.ts
+++ b/src/components/StackedAreaChart/index.ts
@@ -1,1 +1,1 @@
-export {StackedAreaChart} from './StackedAreaChart';
+export {StackedAreaChart, StackedAreaChartProps} from './StackedAreaChart';

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -3,7 +3,7 @@ import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
 import {LinearXAxis} from 'components/LinearXAxis';
 import {YAxis} from 'components/YAxis';
-import {Point, Crosshair, TooltipContainer, TooltipContent} from 'components';
+import {Point, Crosshair, TooltipContainer} from 'components';
 
 import {StackedAreas} from '../components';
 import {Chart} from '../Chart';
@@ -46,13 +46,6 @@ describe('<Chart />', () => {
   };
 
   const mockProps = {
-    xAxisLabels: ['Day 1', 'Day 2'],
-    formatXAxisLabel: (val: string) => val,
-    formatYAxisLabel: (val: number) => val.toString(),
-    dimensions: new DOMRect(),
-    opacity: 1,
-    isAnimated: true,
-    totalMesage: 'Total',
     series: [
       {
         label: 'Asia',
@@ -65,6 +58,13 @@ describe('<Chart />', () => {
         color: 'colorTeal' as Color,
       },
     ],
+    xAxisLabels: ['Day 1', 'Day 2'],
+    dimensions: new DOMRect(),
+    opacity: 1,
+    isAnimated: true,
+    formatXAxisLabel: (val: string) => val,
+    formatYAxisLabel: (val: number) => val.toString(),
+    renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
   };
 
   it('renders an SVG', () => {
@@ -183,14 +183,13 @@ describe('<Chart />', () => {
     expect(chart).toContainReactComponent(TooltipContainer);
   });
 
-  it('renders <TooltipContent /> inside a <TooltipContainer /> if there is an active point', () => {
+  it('renders tooltip content inside a <TooltipContainer /> if there is an active point', () => {
     const chart = mount(<Chart {...mockProps} />);
 
     const svg = chart.find('svg')!;
     svg.trigger('onMouseMove', fakeSVGEvent);
 
     const tooltipContainer = chart.find(TooltipContainer)!;
-
-    expect(tooltipContainer).toContainReactComponent(TooltipContent);
+    expect(tooltipContainer).toContainReactText('Mock Tooltip Content');
   });
 });

--- a/src/components/StackedAreaChart/types.ts
+++ b/src/components/StackedAreaChart/types.ts
@@ -7,3 +7,12 @@ export interface Series {
   data: Data[];
   color: Color;
 }
+
+export interface RenderTooltipContentData {
+  title: string;
+  data: {
+    color: Color;
+    label: string;
+    value: number;
+  }[];
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,7 +7,7 @@ export {Sparkline} from './Sparkline';
 export {YAxis} from './YAxis';
 export {TooltipContainer} from './TooltipContainer';
 export {SquareColorPreview} from './SquareColorPreview';
-export {StackedAreaChart} from './StackedAreaChart';
+export {StackedAreaChart, StackedAreaChartProps} from './StackedAreaChart';
 export {LinearXAxis} from './LinearXAxis';
 export {
   MultiSeriesBarChart,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   LineChartProps,
   LineChartTooltipContent,
   StackedAreaChart,
+  StackedAreaChartProps,
   MultiSeriesBarChart,
   MultiSeriesBarChartProps,
   TooltipContent,


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This refactors the Multi-Series Bar Chart to expose a `renderTooltip` function to the client, as well as provide a default render function in the case that the consumer doesn't provide a function to call back to. This is part of the work reflected in https://github.com/Shopify/polaris-viz/pull/160.

I'm merging this into a feature branch and will use that to merge to master (https://github.com/Shopify/polaris-viz/pull/167).

This PR is very similar to https://github.com/Shopify/polaris-viz/pull/165. If you don't have context on the approach I'm taking with this PR, I would read through the discussion there.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

Playground code to 🎩  with 👀 
<details>

```tsx
import React from 'react';
import {
  StackedAreaChart,
  StackedAreaChartProps,
  TooltipContent,
} from '../src/components';

export default function Playground() {
  const innerContainerStyle = {
    width: '900px',
    height: '300px',
    background: 'white',
    padding: '2rem',
    borderRadius: '6px',
    border: '2px solid #EAECEF',
  };

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  const series = [
    {
      label: 'First-time',
      data: [4237, 5024, 5730, 5587, 5303, 5634, 3238],
      color: 'primary',
    },
    {
      label: 'Returning',
      data: [5663, 7349, 9795, 7396, 7028, 12484, 4878],
      color: 'secondary',
    },
  ];

  const labels = [
    'January',
    'February',
    'March',
    'April',
    'May',
    'June',
    'July',
  ];

  const formatYAxisLabel = (value?: number) => {
    const formatter = new Intl.NumberFormat('en').format;
    if (value == null) {
      return '-';
    }

    return formatter(value);
  };

  const renderTooltipContent: StackedAreaChartProps['renderTooltipContent'] = ({
    data,
    title,
  }) => {
    const formatTooltipValue = (val: number) =>
      new Intl.NumberFormat('en').format(val);

    const formattedData = data.map(({label, value, color}) => ({
      color,
      label,
      value: formatTooltipValue(value),
    }));

    const total = data.reduce((totalValue, {value}) => totalValue + value, 0);

    return (
      <TooltipContent
        title={title}
        data={formattedData}
        total={{label: 'Total', value: formatTooltipValue(total)}}
      />
    );
  };

  return (
    <div style={innerContainerStyle}>
      <StackedAreaChart
        series={series}
        xAxisLabels={labels}
        formatYAxisLabel={formatYAxisLabel}
        renderTooltipContent={renderTooltipContent}
      />
    </div>
  );
}

```
</details>


### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~ Will be addressed in #167

~- [ ] Update the Changelog.~ N/A

- [x] Update relevant documentation.
