### PR TITLE
Export Props Interfaces

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -8,7 +8,7 @@ import {TooltipContent} from './components';
 import {Chart} from './Chart';
 import {BarData, BarMargin, RenderTooltipContentData} from './types';
 
-interface Props {
+export interface BarChartProps {
   data: BarData[];
   barMargin?: keyof typeof BarMargin;
   accessibilityLabel?: string;
@@ -30,7 +30,7 @@ export function BarChart({
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
-}: Props) {
+}: BarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/components/BarChart/index.ts
+++ b/src/components/BarChart/index.ts
@@ -1,2 +1,2 @@
-export {BarChart} from './BarChart';
+export {BarChart, BarChartProps} from './BarChart';
 export {TooltipContent as BarChartTooltipContent} from './components';

--- a/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
+++ b/src/components/NormalizedStackedBar/NormalizedStackedBar.tsx
@@ -10,7 +10,7 @@ import {BarSegment, BarLabel} from './components';
 import {Size, Data, Orientation} from './types';
 import styles from './NormalizedStackedBar.scss';
 
-interface Props {
+export interface NormalizedStackedBarProps {
   data: Data[];
   accessibilityLabel?: string;
   size?: Size;
@@ -24,7 +24,7 @@ export function NormalizedStackedBar({
   size = 'small',
   orientation = 'horizontal',
   colors = ['colorPurpleDark', 'colorBlue', 'colorTeal', 'colorSkyDark'],
-}: Props) {
+}: NormalizedStackedBarProps) {
   const containsNegatives = data.some(({value}) => value < 0);
   const isDevelopment = process.env.NODE_ENV === 'development';
 

--- a/src/components/NormalizedStackedBar/index.ts
+++ b/src/components/NormalizedStackedBar/index.ts
@@ -1,2 +1,5 @@
-export {NormalizedStackedBar} from './NormalizedStackedBar';
+export {
+  NormalizedStackedBar,
+  NormalizedStackedBarProps,
+} from './NormalizedStackedBar';
 export {Orientation, Size} from './types';

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -28,7 +28,7 @@ interface Coordinates {
   y: number;
 }
 
-interface Props {
+export interface SparklineProps {
   data: Coordinates[];
   color?: Color;
   isAnimated?: boolean;
@@ -42,7 +42,7 @@ export function Sparkline({
   color = 'colorTeal',
   isAnimated = false,
   areaFillStyle = 'none',
-}: Props) {
+}: SparklineProps) {
   const pathRef = useRef<SVGPathElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});

--- a/src/components/Sparkline/index.ts
+++ b/src/components/Sparkline/index.ts
@@ -1,1 +1,1 @@
-export {Sparkline} from './Sparkline';
+export {Sparkline, SparklineProps} from './Sparkline';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,12 @@
 export {Point} from './Point';
 export {Crosshair} from './Crosshair';
-export {BarChart, BarChartTooltipContent} from './BarChart';
+export {BarChart, BarChartProps, BarChartTooltipContent} from './BarChart';
 export {LineChart, LineChartProps, LineChartTooltipContent} from './LineChart';
-export {NormalizedStackedBar} from './NormalizedStackedBar';
-export {Sparkline} from './Sparkline';
+export {
+  NormalizedStackedBar,
+  NormalizedStackedBarProps,
+} from './NormalizedStackedBar';
+export {Sparkline, SparklineProps} from './Sparkline';
 export {YAxis} from './YAxis';
 export {TooltipContainer} from './TooltipContainer';
 export {SquareColorPreview} from './SquareColorPreview';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 export {
   Sparkline,
+  SparklineProps,
   NormalizedStackedBar,
+  NormalizedStackedBarProps,
   BarChart,
+  BarChartProps,
   BarChartTooltipContent,
   LineChart,
   LineChartProps,


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This resolves the second to-do of https://github.com/Shopify/polaris-viz/pull/167 (`Make sure that all the props types are exported`) by exporting all of the props types from the components. 

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

Because this is a typescript-only change, I think that as long as CI passes, we don't need to test this with sandbox code.

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~ N/A

~- [ ] Update the Changelog.~ N/A

~- [ ] Update relevant documentation.~ N/A
