### PR TITLE
[NormalizedStackedBar] Better handle long strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Horizontal `<NormalizedStackedBar />` does not prematurely wrap label text
+
 ## [0.0.20] - 2020-12-08
 
 ### Added

--- a/src/components/NormalizedStackedBar/NormalizedStackedBar.scss
+++ b/src/components/NormalizedStackedBar/NormalizedStackedBar.scss
@@ -37,5 +37,5 @@
 
 .HorizontailLabelContainer {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min-content, 150px));
+  grid-template-columns: repeat(auto-fit, minmax(150px, max-content));
 }


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/143

Allows long strings not to wrap for labels or values when there is enough room to display them. Note: when there is not enough space, the label/value will still wrap, but this is an improvement over the previous handling which meant labels wrapped when they were greater than 150px.

| Before  | After  | 
|---|---|
| <img width="1186" alt="before-long" src="https://user-images.githubusercontent.com/12213371/103694995-d34aff00-4f69-11eb-8adb-f5e0227e472e.png">  | <img width="1172" alt="after-long" src="https://user-images.githubusercontent.com/12213371/103695015-d9d97680-4f69-11eb-8da8-ac989fa3924e.png">  | 
| <img width="1178" alt="before-short" src="https://user-images.githubusercontent.com/12213371/103695033-e1008480-4f69-11eb-957d-e81d1d49ce9f.png"> | <img width="1172" alt="after-short" src="https://user-images.githubusercontent.com/12213371/103695058-e9f15600-4f69-11eb-8938-b21862c923fe.png"> |  

### Reviewers’ :tophat: instructions

The default playground has this component. Try increasing the formatted label or value being provided to the chart and make sure it looks good.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
