### PR TITLE
[Unify Data Interfaces] Introduce Data and DataSeries type, Bar chart

### DIFF
--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -64,7 +64,7 @@ return (
     color="primary"
     formatXAxisLabel={formatXAxisLabel}
     formatYAxisLabel={formatYAxisLabel}
-    renderTooltipContent={renderTooltip}
+    renderTooltipContent={renderTooltipContent}
   />
 );
 ```

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -1,15 +1,15 @@
 import React, {useState, useLayoutEffect, useRef} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
-import {Color} from 'types';
+import {Color, Data} from 'types';
 
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 
 import {TooltipContent} from './components';
 import {Chart} from './Chart';
-import {BarData, BarMargin, RenderTooltipContentData} from './types';
+import {BarMargin, RenderTooltipContentData} from './types';
 
 export interface BarChartProps {
-  data: BarData[];
+  data: Data[];
   barMargin?: keyof typeof BarMargin;
   accessibilityLabel?: string;
   color?: Color;

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -1,12 +1,12 @@
 import React, {useState, useMemo} from 'react';
-import {Color} from 'types';
+import {Color, Data} from 'types';
 
 import {eventPoint, getTextWidth} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {TooltipContainer} from '../TooltipContainer';
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 
-import {BarData, RenderTooltipContentData} from './types';
+import {RenderTooltipContentData} from './types';
 import {XAxis, Bar} from './components';
 import {useYScale, useXScale} from './hooks';
 import {
@@ -21,7 +21,7 @@ import {
 import styles from './Chart.scss';
 
 interface Props {
-  data: BarData[];
+  data: Data[];
   chartDimensions: DOMRect;
   barMargin: number;
   color: Color;

--- a/src/components/BarChart/hooks/use-x-scale.ts
+++ b/src/components/BarChart/hooks/use-x-scale.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import {scaleBand} from 'd3-scale';
+import {Data} from 'types';
 
-import {BarData} from '../types';
 import {StringLabelFormatter} from '../../../types';
 
 export function useXScale({
@@ -12,7 +12,7 @@ export function useXScale({
 }: {
   drawableWidth: number;
   barMargin: number;
-  data: BarData[];
+  data: Data[];
   formatXAxisLabel: StringLabelFormatter;
 }) {
   const xScale = scaleBand()

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
+import {Data} from 'types';
 
-import {BarData} from '../types';
 import {MIN_Y_LABEL_SPACE} from '../constants';
 import {NumberLabelFormatter} from '../../../types';
 
@@ -11,7 +11,7 @@ export function useYScale({
   formatYAxisLabel,
 }: {
   drawableHeight: number;
-  data: BarData[];
+  data: Data[];
   formatYAxisLabel: NumberLabelFormatter;
 }) {
   const {yScale, ticks} = useMemo(() => {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,8 +1,3 @@
-export interface BarData {
-  rawValue: number;
-  label: string;
-}
-
 export enum BarMargin {
   Small = 0.05,
   Medium = 0.1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,13 @@
+export interface Data {
+  label: string;
+  rawValue: number;
+}
+
+export interface DataSeries {
+  name: string;
+  data: Data[];
+}
+
 export type Color = TokensColor | VizPaletteColor;
 
 export type TokensColor =


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This is a step towards addressing https://github.com/Shopify/polaris-viz/issues/166 by introducing a `Data` and `DataSeries` type to be used within Polaris Viz:

```tsx
export interface Data {
  label: string;
  rawValue: number;
}

export interface DataSeries {
  name: string;
  data: Data[];
}
```

It also replaces the `BarData` type on `<BarChart />` with the `Data` type. This PR will be merged into a feature branch.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

**1. Compare the documentation for the data type with the actual declaration of the types:**

[Bar Chart docs](https://github.com/Shopify/polaris-viz/blob/interfaces-type-and-barchart/src/components/BarChart/BarChart.md) vs [Bar Chart types](https://github.com/Shopify/polaris-viz/blob/interfaces-type-and-barchart/src/components/BarChart/Chart.tsx) (basically just note that `Data` is being explained in the docs)

**2. Tophat the `<BarChart />` to make sure that it is working properly**

<details>

```tsx
import React from 'react';

import {
  BarChartDemo,
} from '../documentation/code';

export default function Playground() {
  return (
    <BarChartDemo />
  );
}

```
</details>

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

~- [ ] Update the Changelog.~ N/A

- [x] Update relevant documentation.
