### PR TITLE
[Unify Data Interfaces] Update Line Chart

### DIFF
--- a/documentation/code/LineChartDemo.tsx
+++ b/documentation/code/LineChartDemo.tsx
@@ -40,9 +40,7 @@ export function LineChartDemo() {
         {rawValue: 5500, label: '2020-04-13T12:00:00'},
         {rawValue: 7000, label: '2020-04-14T12:00:00'},
       ],
-      style: {
-        color: 'primary',
-      },
+      color: 'primary',
     },
     {
       name: 'Mar 01–Mar 14, 2020',
@@ -62,10 +60,8 @@ export function LineChartDemo() {
         {rawValue: 2000, label: '2020-03-13T12:00:00'},
         {rawValue: 3000, label: '2020-03-14T12:00:00'},
       ],
-      style: {
-        color: 'pastComparison',
-        lineStyle: 'dashed' as 'dashed',
-      },
+      color: 'pastComparison',
+      lineStyle: 'dashed' as 'dashed',
     },
   ];
 
@@ -105,14 +101,17 @@ export function LineChartDemo() {
       });
     }
 
-    const formattedData = data.map(({name, point: {label, value}, style}) => ({
-      name,
-      style,
-      point: {
-        value: formatTooltipValue(value),
-        label: formatTooltipLabel(label),
-      },
-    }));
+    const formattedData = data.map(
+      ({name, point: {label, value}, color, lineStyle}) => ({
+        name,
+        color,
+        lineStyle,
+        point: {
+          value: formatTooltipValue(value),
+          label: formatTooltipLabel(label),
+        },
+      }),
+    );
 
     return <LineChartTooltipContent data={formattedData} />;
   };

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -67,13 +67,14 @@ export function Chart({
       .filter(function removeEmptyDataPoints({data}) {
         return data[activePointIndex] != null;
       })
-      .map(({name, data, style}) => ({
+      .map(({name, data, color, lineStyle}) => ({
         point: {
           label: data[activePointIndex].label,
           value: data[activePointIndex].rawValue,
         },
         name,
-        style,
+        color,
+        lineStyle,
       }));
 
     return renderTooltipContent({data});

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -26,9 +26,7 @@ const series = [
       {rawValue: 5500, label: '2020-04-13T12:00:00'},
       {rawValue: 7000, label: '2020-04-14T12:00:00'},
     ],
-    style: {
-      color: 'primary',
-    },
+    color: 'primary',
   },
   {
     name: 'Mar 01–Mar 14, 2020',
@@ -48,10 +46,8 @@ const series = [
       {rawValue: 2000, label: '2020-03-13T12:00:00'},
       {rawValue: 3000, label: '2020-03-14T12:00:00'},
     ],
-    style: {
-      color: 'pastComparison',
-      lineStyle: 'dashed' as 'dashed',
-    },
+    color: 'pastComparison',
+    lineStyle: 'dashed' as 'dashed',
   },
 ];
 
@@ -144,10 +140,8 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
     label: string;
     rawValue: number;
   }[];
-  style?: {
-    color?: Color;
-    lineStyle?: LineStyle;
-  };
+  color?: Color;
+  lineStyle?: LineStyle;
 }
 ```
 
@@ -167,13 +161,21 @@ The name of the series. This appears in the chart legend.
 
 The array of objects that the chart uses to plot the line.
 
-#### style
+#### color
 
-| type                                               | default                                      |
-| -------------------------------------------------- | -------------------------------------------- |
-| `{color?: Color, lineStyle?: 'dashed' \| 'solid'}` | `{color: 'colorPurple', lineStyle: 'solid'}` |
+| type    | default       |
+| ------- | ------------- |
+| `Color` | `colorPurple` |
 
-The `style` prop accepts an object to configure the given series' style. It allows you to pass any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md) for the `color` value.
+This accepts any [Polaris Viz color](/documentation/Polaris-Viz-colors.md) value.
+
+#### lineStyle
+
+| type                  | default   |
+| --------------------- | --------- |
+| `'solid' \| 'dashed'` | `'solid'` |
+
+The lineStype determines if the drawn line for the series is a solid or dashed line.
 
 ### The `RenderTooltipContentData` type
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -52,14 +52,17 @@ export function LineChart({
   }
 
   function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
-    const formattedData = data.map(({name, point: {label, value}, style}) => ({
-      name,
-      style,
-      point: {
-        value: formatYAxisLabel(value),
-        label,
-      },
-    }));
+    const formattedData = data.map(
+      ({name, point: {label, value}, color, lineStyle}) => ({
+        name,
+        color,
+        lineStyle,
+        point: {
+          value: formatYAxisLabel(value),
+          label,
+        },
+      }),
+    );
     return <TooltipContent data={formattedData} />;
   }
 

--- a/src/components/LineChart/components/Legend/Legend.tsx
+++ b/src/components/LineChart/components/Legend/Legend.tsx
@@ -12,9 +12,7 @@ interface Props {
 export function Legend({series}: Props) {
   return (
     <div className={styles.Container}>
-      {series.map(({name, style = {}}) => {
-        const {color = 'colorPurple', lineStyle = 'solid'} = style;
-
+      {series.map(({name, color = 'colorPurple', lineStyle = 'solid'}) => {
         return (
           <div className={styles.Series} key={name}>
             <LinePreview color={color} lineStyle={lineStyle} />

--- a/src/components/LineChart/components/Legend/tests/Legend.test.tsx
+++ b/src/components/LineChart/components/Legend/tests/Legend.test.tsx
@@ -8,7 +8,8 @@ import {Legend} from '../Legend';
 const mockSeriesWithStyles: Series = {
   data: [],
   name: 'Test series 1',
-  style: {color: 'colorGreen', lineStyle: 'dashed'},
+  color: 'colorGreen',
+  lineStyle: 'dashed',
 };
 const mockSeriesWithoutStyles: Series = {data: [], name: 'Test series 2'};
 const allMockSeries = [mockSeriesWithStyles, mockSeriesWithoutStyles];
@@ -31,8 +32,8 @@ describe('<Legend />', () => {
     const legend = mount(<Legend series={[mockSeriesWithStyles]} />);
 
     expect(legend).toContainReactComponent(LinePreview, {
-      color: mockSeriesWithStyles.style!.color,
-      lineStyle: mockSeriesWithStyles.style!.lineStyle,
+      color: mockSeriesWithStyles.color,
+      lineStyle: mockSeriesWithStyles.lineStyle,
     });
   });
 

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -14,8 +14,7 @@ interface Props {
 }
 
 export function Line({path, series, xScale, yScale, activePointIndex}: Props) {
-  const {style = {}, data} = series;
-  const {color = 'colorPurple', lineStyle = 'solid'} = style;
+  const {color = 'colorPurple', lineStyle = 'solid', data} = series;
 
   return (
     <React.Fragment>

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -57,7 +57,8 @@ describe('<Line />', () => {
             {...mockProps}
             series={{
               ...mockProps.series,
-              style: {color: 'colorGreen', lineStyle: 'dashed'},
+              color: 'colorGreen',
+              lineStyle: 'dashed',
             }}
           />
         </svg>,
@@ -123,7 +124,7 @@ describe('<Line />', () => {
             {...mockProps}
             series={{
               ...mockProps.series,
-              style: {color: 'colorGreen'},
+              color: 'colorGreen',
             }}
           />
         </svg>,

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import {Color} from 'types';
 
-import {LineChartStyle} from '../../types';
+import {LineStyle} from '../../types';
 import {LinePreview} from '../LinePreview';
 
 import styles from './TooltipContent.scss';
@@ -11,7 +12,8 @@ interface TooltipData {
     label: string;
     value: string;
   };
-  style?: Partial<LineChartStyle>;
+  color?: Color;
+  lineStyle?: LineStyle;
 }
 
 export interface TooltipContentProps {
@@ -21,17 +23,22 @@ export interface TooltipContentProps {
 export function TooltipContent({data}: TooltipContentProps) {
   return (
     <div className={styles.Container}>
-      {data.map(({name, point: {label, value}, style = {}}) => {
-        const {color = 'colorPurple', lineStyle = 'solid'} = style;
-
-        return (
-          <React.Fragment key={name}>
-            <LinePreview color={color} lineStyle={lineStyle} />
-            <p className={styles.Name}>{label}</p>
-            <p className={styles.Value}>{value}</p>
-          </React.Fragment>
-        );
-      })}
+      {data.map(
+        ({
+          name,
+          point: {label, value},
+          color = 'colorPurple',
+          lineStyle = 'solid',
+        }) => {
+          return (
+            <React.Fragment key={name}>
+              <LinePreview color={color} lineStyle={lineStyle} />
+              <p className={styles.Name}>{label}</p>
+              <p className={styles.Value}>{value}</p>
+            </React.Fragment>
+          );
+        },
+      )}
     </div>
   );
 }

--- a/src/components/LineChart/components/TooltipContent/tests/TooltipContent.test.tsx
+++ b/src/components/LineChart/components/TooltipContent/tests/TooltipContent.test.tsx
@@ -12,9 +12,7 @@ const mockProps = {
         label: 'Apr 1, 2020',
         value: 'CA$1,240.55',
       },
-      style: {
-        color: 'primary' as 'primary',
-      },
+      color: 'primary' as 'primary',
     },
     {
       name: 'March',
@@ -22,10 +20,8 @@ const mockProps = {
         label: 'Mar 1, 2020',
         value: 'CA$926.22',
       },
-      style: {
-        color: 'pastComparison' as 'pastComparison',
-        lineStyle: 'dashed' as 'dashed',
-      },
+      color: 'pastComparison' as 'pastComparison',
+      lineStyle: 'dashed' as 'dashed',
     },
   ],
 };

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -1,19 +1,10 @@
-import {Color} from 'types';
+import {Color, DataSeries} from 'types';
 
 export type LineStyle = 'dashed' | 'solid';
 
-export interface LineChartStyle {
-  color: Color;
-  lineStyle: LineStyle;
-}
-
-export interface Series {
-  name: string;
-  data: {
-    label: string;
-    rawValue: number;
-  }[];
-  style?: Partial<LineChartStyle>;
+export interface Series extends DataSeries {
+  color?: Color;
+  lineStyle?: LineStyle;
 }
 
 interface TooltipData {
@@ -22,7 +13,8 @@ interface TooltipData {
     label: string;
     value: number;
   };
-  style?: Partial<LineChartStyle>;
+  color?: Color;
+  lineStyle?: LineStyle;
 }
 
 export interface RenderTooltipContentData {


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This is a step towards addressing https://github.com/Shopify/polaris-viz/issues/166 by migrating the `<LineChart />` interface to utilize the `Data`/`DataSeries` interface introduced in #183. The `<LineChart />` series interface now looks like this:

```tsx
interface Series {
  name: string;
  data: {rawValue: number, label: string}[];
  color?: Color;
  lineStyle?: LineStyle;
}
```

This moves `color` and `lineStyle` out of the `style` object (initially proposed here: https://github.com/Shopify/polaris-viz/issues/166#issue-762805265). This PR will be merged into a feature branch (#184).

### Reviewers’ :tophat: instructions

**1. Compare the documentation for the data type with the actual declaration of the types:**

[Line Chart docs](https://github.com/Shopify/polaris-viz/blob/interfaces-line-chart/src/components/LineChart/LineChart.md) vs [Line Chart types](https://github.com/Shopify/polaris-viz/blob/interfaces-line-chart/src/components/LineChart/types.ts)

**2. Tophat the `<LineChart />` to make sure that it is working properly**

<details>

```tsx
import React from 'react';

import {
  LineChartDemo,
} from '../documentation/code';

export default function Playground() {
  return (
    <LineChartDemo />
  );
}

```
</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

~- [ ] Update the Changelog.~ N/A

- [x] Update relevant documentation.
