### PR TITLE
[Unify Chart Interfaces] Updated StackedAreaChart

### DIFF
--- a/documentation/code/StackedAreaChartDemo.tsx
+++ b/documentation/code/StackedAreaChartDemo.tsx
@@ -24,13 +24,29 @@ export function StackedAreaChartDemo() {
 
   const series = [
     {
-      label: 'First-time',
-      data: [4237, 5024, 5730, 5587, 5303, 5634, 3238],
+      name: 'First-time',
+      data: [
+        {label: 'January', rawValue: 4237},
+        {label: 'February', rawValue: 5024},
+        {label: 'March', rawValue: 5730},
+        {label: 'April', rawValue: 5587},
+        {label: 'May', rawValue: 5303},
+        {label: 'June', rawValue: 5634},
+        {label: 'July', rawValue: 3238},
+      ],
       color: 'primary',
     },
     {
-      label: 'Returning',
-      data: [5663, 7349, 9795, 7396, 7028, 12484, 4878],
+      name: 'Returning',
+      data: [
+        {label: 'January', rawValue: 5663},
+        {label: 'February', rawValue: 7349},
+        {label: 'March', rawValue: 9795},
+        {label: 'April', rawValue: 7396},
+        {label: 'May', rawValue: 7028},
+        {label: 'June', rawValue: 12484},
+        {label: 'July', rawValue: 4878},
+      ],
       color: 'secondary',
     },
   ];

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -45,7 +45,7 @@ export function Chart({
   const areaStack = useMemo(
     () =>
       stack()
-        .keys(series.map(({label}) => label))
+        .keys(series.map(({name}) => name))
         .order(stackOrderReverse)
         .offset(stackOffsetNone),
     [series],
@@ -54,10 +54,10 @@ export function Chart({
   const formattedData = useMemo(
     () =>
       xAxisLabels.map((_, labelIndex) =>
-        series.reduce((acc, {label, data}) => {
-          const value = data[labelIndex];
+        series.reduce((acc, {name, data}) => {
+          const {rawValue} = data[labelIndex];
 
-          const dataPoint = {[label]: value};
+          const dataPoint = {[name]: rawValue};
           return Object.assign(acc, dataPoint);
         }, {}),
       ),
@@ -96,13 +96,13 @@ export function Chart({
     }
 
     const data = series.reduce<RenderTooltipContentData['data']>(
-      function removeNullsAndFormatData(tooltipData, {color, label, data}) {
-        const value = data[activePointIndex];
-        if (value == null) {
+      function removeNullsAndFormatData(tooltipData, {color, name, data}) {
+        const {rawValue} = data[activePointIndex];
+        if (rawValue == null) {
           return tooltipData;
         }
 
-        tooltipData.push({color, label, value});
+        tooltipData.push({color, label: name, value: rawValue});
         return tooltipData;
       },
       [],

--- a/src/components/StackedAreaChart/StackedAreaChart.md
+++ b/src/components/StackedAreaChart/StackedAreaChart.md
@@ -9,13 +9,29 @@ Used to compare multiple series of data and display the total value. This chart 
 ```tsx
 const series = [
   {
-    label: 'First-time',
-    data: [4237, 5024, 5730, 5587, 5303, 5634, 3238],
+    name: 'First-time',
+    data: [
+      {label: 'January', rawValue: 4237},
+      {label: 'February', rawValue: 5024},
+      {label: 'March', rawValue: 5730},
+      {label: 'April', rawValue: 5587},
+      {label: 'May', rawValue: 5303},
+      {label: 'June', rawValue: 5634},
+      {label: 'July', rawValue: 3238},
+    ],
     color: 'primary',
   },
   {
-    label: 'Returning',
-    data: [5663, 7349, 9795, 7396, 7028, 12484, 4878],
+    name: 'Returning',
+    data: [
+      {label: 'January', rawValue: 5663},
+      {label: 'February', rawValue: 7349},
+      {label: 'March', rawValue: 9795},
+      {label: 'April', rawValue: 7396},
+      {label: 'May', rawValue: 7028},
+      {label: 'June', rawValue: 12484},
+      {label: 'July', rawValue: 4878},
+    ],
     color: 'secondary',
   },
 ];
@@ -90,30 +106,34 @@ This component derives its size from its parent container and fills the width of
 The `Series` type allows the user to define the color of each series. Its interface looks like this:
 
 ```typescript
-{
-  label: string;
-  data: Data[];
+interface Series {
+  name: string;
+  data: {label: string; rawValue: number | null}[];
   color: Color;
 }
 ```
 
-#### data
-
-| type               |
-| ------------------ |
-| `number \| null[]` |
-
-The array that the chart uses to plot the area. Null values are not displayed.
-
-#### label
+#### name
 
 | type     |
 | -------- |
 | `string` |
 
-The label for the series. This appears in the chart legend and tooltip.
+The name for the series. This appears in the chart legend and tooltip.
+
+#### data
+
+| type                                          |
+| --------------------------------------------- |
+| `{label: string, rawValue: number \| null}[]` |
+
+The array that the chart uses to plot the area. Null values are not displayed.
 
 #### color
+
+| type    |
+| ------- |
+| `Color` |
 
 It allows you to pass any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md) for the `color` value.
 
@@ -142,7 +162,7 @@ The distinction between the `RenderTooltipContentData` and series `Data` types i
 | ---------- |
 | `Series[]` |
 
-The prop to determine the chart's drawn area. Each `Series` object corresponds to an area drawn on the chart, and is explained in greater detail above.
+The prop to determine the chart's drawn area. Each `Series` object corresponds to an area drawn on the chart, and is explained in greater detail [above](#series).
 
 ### Optional Props
 

--- a/src/components/StackedAreaChart/components/Legend/Legend.tsx
+++ b/src/components/StackedAreaChart/components/Legend/Legend.tsx
@@ -12,11 +12,11 @@ interface Props {
 export function Legend({series}: Props) {
   return (
     <div className={styles.Container}>
-      {series.map(({label, color}) => {
+      {series.map(({name, color}) => {
         return (
-          <div className={styles.Series} key={label}>
+          <div className={styles.Series} key={name}>
             <SquareColorPreview color={color} />
-            <p className={styles.SeriesName}>{label}</p>
+            <p className={styles.SeriesName}>{name}</p>
           </div>
         );
       })}

--- a/src/components/StackedAreaChart/components/Legend/tests/Legend.test.tsx
+++ b/src/components/StackedAreaChart/components/Legend/tests/Legend.test.tsx
@@ -8,13 +8,29 @@ import {SquareColorPreview} from '../../../../SquareColorPreview';
 describe('<Legend/>', () => {
   const mockData = [
     {
-      label: 'Asia',
-      data: [502, 1000, 2000, 1000, 100, 1000, 5000],
+      name: 'Asia',
+      data: [
+        {label: '1', rawValue: 502},
+        {label: '2', rawValue: 1000},
+        {label: '3', rawValue: 2000},
+        {label: '4', rawValue: 1000},
+        {label: '5', rawValue: 100},
+        {label: '6', rawValue: 1000},
+        {label: '7', rawValue: 5000},
+      ],
       color: 'colorPurple' as Color,
     },
     {
-      label: 'Africa',
-      data: [106, 107, 111, 133, 100, 767, 1766],
+      name: 'Africa',
+      data: [
+        {label: '1', rawValue: 106},
+        {label: '2', rawValue: 107},
+        {label: '3', rawValue: 111},
+        {label: '4', rawValue: 133},
+        {label: '5', rawValue: 100},
+        {label: '6', rawValue: 767},
+        {label: '7', rawValue: 1766},
+      ],
       color: 'colorTeal' as Color,
     },
   ];

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -48,13 +48,29 @@ describe('<Chart />', () => {
   const mockProps = {
     series: [
       {
-        label: 'Asia',
-        data: [502, 1000, 2000, 1000, 100, 1000, 5000],
+        name: 'Asia',
+        data: [
+          {label: '1', rawValue: 502},
+          {label: '2', rawValue: 1000},
+          {label: '3', rawValue: 2000},
+          {label: '4', rawValue: 1000},
+          {label: '5', rawValue: 100},
+          {label: '6', rawValue: 1000},
+          {label: '7', rawValue: 5000},
+        ],
         color: 'colorPurple' as Color,
       },
       {
-        label: 'Africa',
-        data: [106, 107, 111, 133, 100, 767, 1766],
+        name: 'Africa',
+        data: [
+          {label: '1', rawValue: 106},
+          {label: '2', rawValue: 107},
+          {label: '3', rawValue: 111},
+          {label: '4', rawValue: 133},
+          {label: '5', rawValue: 100},
+          {label: '6', rawValue: 767},
+          {label: '7', rawValue: 1766},
+        ],
         color: 'colorTeal' as Color,
       },
     ],

--- a/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
+++ b/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
@@ -15,13 +15,29 @@ import {Legend} from '../components';
 
 const mockData = [
   {
-    label: 'Asia',
-    data: [502, 1000, 2000, 1000, 100, 1000, 5000],
+    name: 'Asia',
+    data: [
+      {label: '1', rawValue: 502},
+      {label: '2', rawValue: 1000},
+      {label: '3', rawValue: 2000},
+      {label: '4', rawValue: 1000},
+      {label: '5', rawValue: 100},
+      {label: '6', rawValue: 1000},
+      {label: '7', rawValue: 5000},
+    ],
     color: 'colorPurple' as Color,
   },
   {
-    label: 'Africa',
-    data: [106, 107, 111, 133, 100, 767, 1766],
+    name: 'Africa',
+    data: [
+      {label: '1', rawValue: 106},
+      {label: '2', rawValue: 107},
+      {label: '3', rawValue: 111},
+      {label: '4', rawValue: 133},
+      {label: '5', rawValue: 100},
+      {label: '6', rawValue: 767},
+      {label: '7', rawValue: 1766},
+    ],
     color: 'colorTeal' as Color,
   },
 ];

--- a/src/components/StackedAreaChart/types.ts
+++ b/src/components/StackedAreaChart/types.ts
@@ -1,9 +1,12 @@
 import {Color} from 'types';
 
-type Data = number | null;
+export interface Data {
+  label: string;
+  rawValue: number | null;
+}
 
 export interface Series {
-  label: string;
+  name: string;
   data: Data[];
   color: Color;
 }


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

This is a step towards addressing https://github.com/Shopify/polaris-viz/issues/166 by migrating the `<StackedAreaChart />` interface to align more closely with https://github.com/Shopify/polaris-viz/issues/166. The `<StackedAreaChart />` series interface now looks like this:

```tsx
interface Series {
  name: string;
  data: {rawValue: number | null, label: string}[];
  color?: Color;
}
```

Notably, this does _not_ utilize the `Data`/`DataSeries` interface introduced in #183. The `Data` type does not allow `null` values. In order to prevent a regression, I kept the `<StackedAreaChart />` forked for now. I plan to address `null` values as a part of https://github.com/Shopify/core-issues/issues/20789. This PR will be merged into a feature branch (#184).

### Reviewers’ :tophat: instructions

**1. Compare the documentation for the data type with the actual declaration of the types:**

[Stacked Area Chart docs](https://github.com/Shopify/polaris-viz/blob/interfaces-stackedareachart/src/components/StackedAreaChart/StackedAreaChart.md) vs [Stacked Area Chart types](https://github.com/Shopify/polaris-viz/blob/interfaces-stackedareachart/src/components/StackedAreaChart/types.ts)

**2. Tophat the `<StackedAreaChart />` to make sure that it is working properly**

<details>

```tsx
import React from 'react';

import {
  StackedAreaChartDemo,
} from '../documentation/code';

export default function Playground() {
  return (
    <StackedAreaChartDemo />
  );
}

```
</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

~- [ ] Update the Changelog.~ N/A

- [x] Update relevant documentation.
