### PR TITLE
Add optional title prop to LineChartTooltipContent

### DIFF
--- a/src/components/LineChart/components/TooltipContent/TooltipContent.scss
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.scss
@@ -21,3 +21,9 @@
   column-gap: $spacing-tight;
   row-gap: $spacing-tight;
 }
+
+.Title {
+  @include tooltip-emphasis;
+  grid-column: 1 / span 3;
+  margin-bottom: $spacing-extra-tight;
+}

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -18,11 +18,13 @@ interface TooltipData {
 
 export interface TooltipContentProps {
   data: TooltipData[];
+  title?: string;
 }
 
-export function TooltipContent({data}: TooltipContentProps) {
+export function TooltipContent({data, title}: TooltipContentProps) {
   return (
     <div className={styles.Container}>
+      {title == null ? null : <div className={styles.Title}>{title}</div>}
       {data.map(({name, point: {label, value}, color, lineStyle}) => {
         return (
           <React.Fragment key={name}>

--- a/src/components/TooltipContent/TooltipContent.md
+++ b/src/components/TooltipContent/TooltipContent.md
@@ -143,6 +143,7 @@ interface LineChartTooltipContentProps {
       lineStyle?: LineStyle;
     };
   }[];
+  title?: string;
 }
 ```
 
@@ -175,6 +176,14 @@ The values to display for the given data point.
 | `{color?: Color; lineStyle?: LineStyle}` | `undefined` |
 
 This sets the style for the line drawn next to the point label. `color` accepts any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md) and defaults to `colorPurple`. `lineStyle` accepts `solid` and `dashed`, and defaults to `solid`.
+
+##### title
+
+| type     |
+| -------- |
+| `string` |
+
+The title to display at the top of the tooltip.
 
 ### BarChartTooltipContent
 


### PR DESCRIPTION
### What problem is this PR solving?

This PR allows the `LineChartTooltipContent` to accept an optional `title` prop which when provided, renders a title above the tooltip content (similar to the regular `TooltipContent` component).

### Reviewers’ :tophat: instructions

Try the following code in the playground:

<details>

```tsx
import React from 'react';

import {
  LineChartTooltipContent,
  LineChartTooltipContentProps,
} from '../src/components';

const lineChartTooltipContentData: LineChartTooltipContentProps['data'] = [
  {
    name: 'Hot Dogs',
    point: {
      label: 'January 1st, 2021',
      value: '10',
    },
    color: 'primary',
    lineStyle: 'solid',
  },
  {
    name: 'Burgers',
    point: {
      label: 'December 1st, 2020',
      value: '12',
    },
    color: 'pastComparison',
    lineStyle: 'dashed',
  },
];

export default function Playground() {
  return (
    <div style={{width: '200px', margin: '50px'}}>
      <LineChartTooltipContent
        data={lineChartTooltipContentData}
        title="Hello world title"
      />
    </div>
  );
}
```

</details>

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
