### PR TITLE
added default max y-axis value on charts for all zero data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - 2021-02-08
+
+### Fixed
+
+- Added default max y-axis value for charts with all zero data
+
 ## [0.2.0] - 2021-02-03
 
 ### Changed

--- a/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
 
+import {DEFAULT_MAX_Y} from '../../../../constants';
 import {useYScale} from '../use-y-scale';
 
 jest.mock('d3-scale', () => ({
@@ -79,6 +80,37 @@ describe('useYScale', () => {
     mount(<TestComponent />);
 
     expect(domainSpy).toHaveBeenCalledWith([-89, 1000]);
+  });
+
+  it('creates a y scale with the domain maximum set to the default max y for a data set with all zero values', () => {
+    let domainSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+      scale.range = (range: any) => (range ? scale : range);
+      domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+      scale.domain = domainSpy;
+      scale.nice = () => scale;
+      return scale;
+    });
+
+    function TestComponent() {
+      useYScale({
+        drawableHeight: 400,
+        formatYAxisLabel: jest.fn(),
+        data: [
+          {rawValue: 0, label: 'test'},
+          {rawValue: 0, label: 'test'},
+          {rawValue: 0, label: 'test'},
+        ],
+      });
+
+      return null;
+    }
+
+    mount(<TestComponent />);
+
+    expect(domainSpy).toHaveBeenCalledWith([0, DEFAULT_MAX_Y]);
   });
 
   it('creates a y scale with range equal to the drawable height', () => {

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -3,6 +3,7 @@ import {scaleLinear} from 'd3-scale';
 import {Data} from 'types';
 
 import {MIN_Y_LABEL_SPACE} from '../constants';
+import {DEFAULT_MAX_Y} from '../../../constants';
 import {NumberLabelFormatter} from '../../../types';
 
 export function useYScale({
@@ -16,7 +17,8 @@ export function useYScale({
 }) {
   const {yScale, ticks} = useMemo(() => {
     const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
-    const max = Math.max(...data.map(({rawValue}) => rawValue));
+    const calculatedMax = Math.max(...data.map(({rawValue}) => rawValue));
+    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     const maxTicks = Math.max(
       1,

--- a/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
@@ -4,6 +4,7 @@ import {scaleLinear} from 'd3-scale';
 
 import {Series} from '../../types';
 import {useYScale} from '../use-y-scale';
+import {DEFAULT_MAX_Y} from '../../../../constants';
 
 jest.mock('d3-scale', () => ({
   scaleLinear: jest.fn(() => {
@@ -81,6 +82,41 @@ describe('useYScale', () => {
     mount(<TestComponent />);
 
     expect(domainSpy).toHaveBeenCalledWith([-10000, 10000]);
+  });
+
+  it('creates a y scale with the domain maiximum set to the default max y for a data set with all zero values', () => {
+    let domainSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+      scale.range = (range: any) => (range ? scale : range);
+      domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+      scale.domain = domainSpy;
+      scale.nice = () => scale;
+      return scale;
+    });
+
+    function TestComponent() {
+      useYScale({
+        drawableHeight: 250,
+        formatYAxisLabel: jest.fn(),
+        series: [
+          {
+            name: 'Test Data 1',
+            data: [{label: '1', rawValue: 0}],
+          },
+          {
+            name: 'Test Data 2',
+            data: [{label: '1', rawValue: 0}],
+          },
+        ],
+      });
+      return null;
+    }
+
+    mount(<TestComponent />);
+
+    expect(domainSpy).toHaveBeenCalledWith([0, DEFAULT_MAX_Y]);
   });
 
   it('creates a y scale with range equal to the drawable height', () => {

--- a/src/components/LineChart/utilities/y-axis-min-max.ts
+++ b/src/components/LineChart/utilities/y-axis-min-max.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_MAX_Y} from '../../../constants';
 import {Series} from '../types';
 
 export function yAxisMinMax(series: Series[]) {
@@ -10,6 +11,8 @@ export function yAxisMinMax(series: Series[]) {
       maxY = Math.max(maxY, rawValue);
     });
   });
+
+  maxY = maxY === 0 ? DEFAULT_MAX_Y : maxY;
 
   return [minY, maxY];
 }

--- a/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_MAX_Y} from '../../../constants';
 import {Series, StackSeries} from '../types';
 
 export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
@@ -9,9 +10,12 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
       Math.max(...value.map(([, endingValue]) => endingValue)),
     );
 
+    const calculatedMax = Math.max(...maxStackedValues);
+    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+
     return {
       min: Math.min(...minStackedValues),
-      max: Math.max(...maxStackedValues),
+      max,
     };
   } else {
     const groupedDataPoints = data.reduce<number[]>(
@@ -22,9 +26,12 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
       [],
     );
 
+    const calculatedMax = Math.max(...groupedDataPoints);
+    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+
     return {
       min: Math.min(...groupedDataPoints, 0),
-      max: Math.max(...groupedDataPoints),
+      max,
     };
   }
 }

--- a/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
+++ b/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
@@ -1,5 +1,6 @@
 import {Series, StackSeries} from 'components/MultiSeriesBarChart/types';
 
+import {DEFAULT_MAX_Y} from '../../../../constants';
 import {getMinMax} from '../get-min-max';
 
 const mockData: Series[] = [
@@ -35,6 +36,39 @@ const mockStackedData = [
   ],
 ] as StackSeries[];
 
+const mockZeroData: Series[] = [
+  {
+    data: [
+      {label: 'label', rawValue: 0},
+      {label: 'label', rawValue: 0},
+      {label: 'label', rawValue: 0},
+    ],
+    color: 'colorBlack',
+    name: 'LABEL1',
+  },
+  {
+    data: [
+      {label: 'label', rawValue: 0},
+      {label: 'label', rawValue: 0},
+      {label: 'label', rawValue: 0},
+    ],
+    color: 'colorBlack',
+    name: 'LABEL2',
+  },
+];
+const mockZeroStackedData = [
+  [
+    [0, 0],
+    [0, 0],
+    [0, 0],
+  ],
+  [
+    [0, 0],
+    [0, 0],
+    [0, 0],
+  ],
+] as StackSeries[];
+
 describe('get-min-max', () => {
   it('returns min and max of non stacked data when stackedValues is null', () => {
     const {min, max} = getMinMax(null, mockData);
@@ -48,5 +82,15 @@ describe('get-min-max', () => {
 
     expect(min).toStrictEqual(0);
     expect(max).toStrictEqual(33);
+  });
+
+  it('returns the default max y value for non stacked values of all zeros', () => {
+    const {max} = getMinMax(null, mockZeroData);
+    expect(max).toStrictEqual(DEFAULT_MAX_Y);
+  });
+
+  it('returns the default max y value for stacked values of all zeros', () => {
+    const {max} = getMinMax(mockZeroStackedData, mockZeroData);
+    expect(max).toStrictEqual(DEFAULT_MAX_Y);
   });
 });

--- a/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
@@ -3,6 +3,7 @@ import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
 
 import {useYScale} from '../use-y-scale';
+import {DEFAULT_MAX_Y} from '../../../../constants';
 
 jest.mock('d3-scale', () => ({
   scaleLinear: jest.fn(() => {
@@ -42,6 +43,8 @@ const mockData = [
     [0, 200],
   ],
 ];
+
+const mockZeroData = new Array(5).fill(new Array(3).fill([0, 0]));
 
 describe('useYScale', () => {
   afterEach(() => {
@@ -99,6 +102,33 @@ describe('useYScale', () => {
     mount(<TestComponent />);
 
     expect(domainSpy).toHaveBeenCalledWith([0, 3127]);
+  });
+
+  it('creates a y scale with the domain maiximum set to the default max y for a data set with all zero values', () => {
+    let domainSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+      scale.range = (range: any) => (range ? scale : range);
+      domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+      scale.domain = domainSpy;
+      scale.nice = () => scale;
+      return scale;
+    });
+
+    function TestComponent() {
+      useYScale({
+        drawableHeight: 250,
+        formatYAxisLabel: jest.fn(),
+        stackedValues: mockZeroData as any,
+      });
+
+      return null;
+    }
+
+    mount(<TestComponent />);
+
+    expect(domainSpy).toHaveBeenCalledWith([0, DEFAULT_MAX_Y]);
   });
 
   it('creates a y scale with range equal to the drawable height', () => {

--- a/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -4,7 +4,7 @@ import {Series} from 'd3-shape';
 
 import {getTextWidth} from '../../../utilities';
 import {MIN_Y_LABEL_SPACE, Spacing} from '../constants';
-import {FONT_SIZE} from '../../../constants';
+import {DEFAULT_MAX_Y, FONT_SIZE} from '../../../constants';
 import {NumberLabelFormatter} from '../../../types';
 
 export function useYScale({
@@ -28,11 +28,13 @@ export function useYScale({
       ),
     );
 
-    const maxY = Math.max(
+    const calculatedMax = Math.max(
       ...stackedValues.map((value) =>
         Math.max(...value.map(([, endingValue]) => endingValue)),
       ),
     );
+
+    const maxY = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     const maxTicks = Math.max(
       1,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const LINE_HEIGHT = 15;
 export const MAX_TEXT_BOX_HEIGHT = LINE_HEIGHT * 3;
 export const SMALL_LABEL_WIDTH = 50;
 export const LABEL_SPACE_MINUS_FIRST_AND_LAST = 0.6;
+export const DEFAULT_MAX_Y = 10;
 
 export enum Margin {
   Top = SPACING_TIGHT,


### PR DESCRIPTION
### What problem is this PR solving?

Solves: https://github.com/Shopify/core-issues/issues/21246

### Reviewers’ :tophat: instructions

Generate a line graph, bar chart, area chart and multiseries bar chart (stacked and not stacked) with all zero values.

The y-axis should now have a max value of 10 instead of a single zero value.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
