### PR TITLE
[Bar Chart] Adding A11y to BarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - Removed the `accessibilityLabel` prop from `<LineChart/>` in favour of a more complete accessibility approach
 - `<LineChart/>` now requires `xAxisLabels`
+- Removed the accessibilityLabel from [`<BarChart/>`](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/BarChart.md)
 
 ### Added
 
 - `skipLinkText` and `hideXAxisLabels` prop to `<LineChart/>`
+- `skipLinkText` prop to [`<BarChart/>`](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/BarChart.md)
 
 ## [0.3.0] - 2021-02-10
 

--- a/documentation/code/BarChartDemo.tsx
+++ b/documentation/code/BarChartDemo.tsx
@@ -86,6 +86,7 @@ export function BarChartDemo() {
           formatXAxisLabel={formatXAxisLabel}
           formatYAxisLabel={formatYAxisLabel}
           renderTooltipContent={renderTooltipContent}
+          skipLinkText="Skip chart content"
         />
       </div>
     </div>

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -65,6 +65,7 @@ return (
     formatXAxisLabel={formatXAxisLabel}
     formatYAxisLabel={formatYAxisLabel}
     renderTooltipContent={renderTooltipContent}
+    skipLinkText="Skip chart content"
   />
 );
 ```
@@ -90,6 +91,7 @@ interface BarChartProps {
   }): React.ReactNode;
   highlightColor?: Color;
   timeSeries?: boolean;
+  skipLinkText?: string;
 }
 ```
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -2,8 +2,9 @@ import React, {useState, useLayoutEffect, useRef} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {Color, Data} from 'types';
 
+import {SkipLink} from '../SkipLink';
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
-import {getDefaultColor} from '../../utilities';
+import {getDefaultColor, uniqueId} from '../../utilities';
 
 import {TooltipContent} from './components';
 import {Chart} from './Chart';
@@ -12,18 +13,17 @@ import {BarMargin, RenderTooltipContentData} from './types';
 export interface BarChartProps {
   data: Data[];
   barMargin?: keyof typeof BarMargin;
-  accessibilityLabel?: string;
   color?: Color;
   highlightColor?: Color;
   formatXAxisLabel?: StringLabelFormatter;
   formatYAxisLabel?: NumberLabelFormatter;
   timeSeries?: boolean;
+  skipLinkText?: string;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
 }
 
 export function BarChart({
   data,
-  accessibilityLabel,
   color = getDefaultColor(),
   highlightColor = getDefaultColor(),
   barMargin = 'Medium',
@@ -31,9 +31,12 @@ export function BarChart({
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
+  skipLinkText,
 }: BarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const skipLinkAnchorId = useRef(uniqueId('barChart'));
 
   const [updateDimensions] = useDebouncedCallback(() => {
     if (containerRef.current != null) {
@@ -64,28 +67,33 @@ export function BarChart({
   }
 
   return (
-    <div
-      aria-label={accessibilityLabel}
-      role="img"
-      style={{width: '100%', height: '100%'}}
-      ref={containerRef}
-    >
+    <div style={{width: '100%', height: '100%'}} ref={containerRef}>
       {chartDimensions == null ? null : (
-        <Chart
-          data={data}
-          chartDimensions={chartDimensions}
-          barMargin={BarMargin[barMargin]}
-          color={color}
-          highlightColor={highlightColor}
-          formatXAxisLabel={formatXAxisLabel}
-          formatYAxisLabel={formatYAxisLabel}
-          timeSeries={timeSeries}
-          renderTooltipContent={
-            renderTooltipContent != null
-              ? renderTooltipContent
-              : renderDefaultTooltipContent
-          }
-        />
+        <React.Fragment>
+          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+            <SkipLink anchorId={skipLinkAnchorId.current}>
+              {skipLinkText}
+            </SkipLink>
+          )}
+          <Chart
+            data={data}
+            chartDimensions={chartDimensions}
+            barMargin={BarMargin[barMargin]}
+            color={color}
+            highlightColor={highlightColor}
+            formatXAxisLabel={formatXAxisLabel}
+            formatYAxisLabel={formatYAxisLabel}
+            timeSeries={timeSeries}
+            renderTooltipContent={
+              renderTooltipContent != null
+                ? renderTooltipContent
+                : renderDefaultTooltipContent
+            }
+          />
+          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+            <SkipLink.Anchor id={skipLinkAnchorId.current} />
+          )}
+        </React.Fragment>
       )}
     </div>
   );

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -105,6 +105,8 @@ export function Chart({
     formatXAxisLabel,
   });
 
+  const barWidth = xScale.bandwidth();
+
   const tooltipMarkup = useMemo(() => {
     if (activeBar == null) {
       return null;
@@ -136,6 +138,7 @@ export function Chart({
           transform={`translate(${axisMargin},${chartDimensions.height -
             MARGIN.Bottom -
             xAxisDetails.maxXLabelHeight})`}
+          aria-hidden="true"
         >
           <BarChartXAxis
             labels={xAxisLabels}
@@ -150,25 +153,34 @@ export function Chart({
           transform={`translate(${axisMargin + SPACING_EXTRA_TIGHT},${
             MARGIN.Top
           })`}
+          aria-hidden="true"
         >
           <YAxis ticks={ticks} drawableWidth={drawableWidth} />
         </g>
 
-        <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
+        <g transform={`translate(${axisMargin},${MARGIN.Top})`} role="list">
           {data.map(({rawValue}, index) => {
             const xPosition = xScale(index.toString());
+            const ariaLabel = `${formatXAxisLabel(
+              data[index].label,
+            )}: ${formatYAxisLabel(data[index].rawValue)}`;
 
             return (
-              <Bar
-                key={index}
-                x={xPosition == null ? 0 : xPosition}
-                yScale={yScale}
-                rawValue={rawValue}
-                width={xScale.bandwidth()}
-                isSelected={index === activeBar}
-                color={color}
-                highlightColor={highlightColor}
-              />
+              <g role="listitem" key={index}>
+                <Bar
+                  key={index}
+                  x={xPosition == null ? 0 : xPosition}
+                  yScale={yScale}
+                  rawValue={rawValue}
+                  width={barWidth}
+                  isSelected={index === activeBar}
+                  color={color}
+                  highlightColor={highlightColor}
+                  onFocus={handleFocus}
+                  index={index}
+                  ariaLabel={ariaLabel}
+                />
+              </g>
             );
           })}
         </g>
@@ -188,6 +200,23 @@ export function Chart({
       ) : null}
     </div>
   );
+
+  function handleFocus({
+    index,
+    cx,
+    cy,
+  }: {
+    index: number;
+    cx: number;
+    cy: number;
+  }) {
+    if (index == null) return;
+    setActiveBar(index);
+    setTooltipPosition({
+      x: cx + axisMargin + xScale.bandwidth() / 2,
+      y: cy,
+    });
+  }
 
   function handleInteraction(
     event: React.MouseEvent<SVGSVGElement> | React.TouchEvent<SVGSVGElement>,

--- a/src/components/BarChart/components/Bar/Bar.tsx
+++ b/src/components/BarChart/components/Bar/Bar.tsx
@@ -15,6 +15,9 @@ interface Props {
   yScale: ScaleLinear<number, number>;
   rawValue: number;
   width: number;
+  index: number;
+  onFocus: ({index, cx, cy}: {index: number; cx: number; cy: number}) => any;
+  ariaLabel?: string;
 }
 
 export function Bar({
@@ -25,6 +28,9 @@ export function Bar({
   rawValue,
   yScale,
   width,
+  onFocus,
+  index,
+  ariaLabel,
 }: Props) {
   const currentColor = isSelected
     ? getColorValue(highlightColor)
@@ -47,6 +53,10 @@ export function Bar({
     ? modifiedYPosition
     : yScale(Math.max(0, rawValue));
 
+  const handleFocus = () => {
+    onFocus({index, cx: x, cy: yPosition});
+  };
+
   return (
     <animated.rect
       x={x}
@@ -54,6 +64,10 @@ export function Bar({
       fill={animation.color}
       width={width}
       height={height}
+      aria-label={ariaLabel}
+      onFocus={handleFocus}
+      tabIndex={0}
+      role="img"
     />
   );
 }

--- a/src/components/BarChart/components/Bar/tests/Bar.test.tsx
+++ b/src/components/BarChart/components/Bar/tests/Bar.test.tsx
@@ -21,6 +21,8 @@ describe('<Bar/>', () => {
           rawValue={1000}
           width={100}
           yScale={scaleBand() as any}
+          index={1}
+          onFocus={jest.fn()}
         />
         ,
       </svg>,
@@ -46,6 +48,8 @@ describe('<Bar/>', () => {
           rawValue={1}
           width={100}
           yScale={scaleBand() as any}
+          index={1}
+          onFocus={jest.fn()}
         />
         ,
       </svg>,
@@ -67,6 +71,8 @@ describe('<Bar/>', () => {
           rawValue={0}
           width={100}
           yScale={scaleBand() as any}
+          index={1}
+          onFocus={jest.fn()}
         />
         ,
       </svg>,
@@ -88,6 +94,8 @@ describe('<Bar/>', () => {
           rawValue={1}
           width={100}
           yScale={scaleBand() as any}
+          index={1}
+          onFocus={jest.fn()}
         />
         ,
       </svg>,

--- a/src/components/BarChart/tests/BarChart.test.tsx
+++ b/src/components/BarChart/tests/BarChart.test.tsx
@@ -3,25 +3,34 @@ import {mount} from '@shopify/react-testing';
 
 import {BarChart} from '../BarChart';
 import {Chart} from '../Chart';
+import {SkipLink} from '../../SkipLink';
 
 describe('BarChart />', () => {
   const mockProps = {data: [{rawValue: 10, label: 'data'}]};
-
-  it('renders accessibility props', () => {
-    const label = 'A bar chart showing sales data';
-    const barChart = mount(
-      <BarChart {...mockProps} accessibilityLabel={label} />,
-    );
-
-    expect(barChart).toContainReactComponent('div', {
-      'aria-label': label,
-      role: 'img',
-    });
-  });
 
   it('renders a <Chart />', () => {
     const barChart = mount(<BarChart {...mockProps} />);
 
     expect(barChart).toContainReactComponent(Chart);
+  });
+});
+
+describe('skipLinkText', () => {
+  const mockProps = {data: [{rawValue: 10, label: 'data'}]};
+
+  it('renders an anchor tag that allows skipping the chart content', () => {
+    const barChart = mount(
+      <BarChart {...mockProps} skipLinkText="Skip chart content" />,
+    );
+
+    expect(barChart).toContainReactComponent(SkipLink, {
+      children: 'Skip chart content',
+    });
+  });
+
+  it('does not render an anchor tag if empty', () => {
+    const barChart = mount(<BarChart {...mockProps} skipLinkText="" />);
+
+    expect(barChart).not.toContainReactComponent(SkipLink.Anchor);
   });
 });

--- a/src/components/TooltipContainer/TooltipContainer.tsx
+++ b/src/components/TooltipContainer/TooltipContainer.tsx
@@ -124,6 +124,7 @@ export function TooltipContainer({
         ),
       }}
       ref={tooltipRef}
+      aria-hidden="true"
     >
       {children}
     </animated.div>


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://shopify-retail.atlassian.net/browse/ORV-22
Resolves https://github.com/Shopify/core-issues/issues/21091

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<details>
<summary>Paste the following code in the `Playground.tsx` file:</summary>

```
import React from 'react';

import {BarChartDemo} from '../documentation/code';

export default function Playground() {
  return (
    <div>
      <BarChartDemo />
    </div>
  );
}

```

</details>

- Tabbing in the page should display the skip link. If clicked, it should should skip all bar chart datapoints.
- Tabbing multiple times should go through the points in the first data series
- Turn Voice Over on (command + f5/in system settings):
	- Tab once to move the focus to the skip link and enter the web content
	- Ctrl + Option + Shift + ➡️: Move into the list. It should read the commands to navigate in the list, and correctly read out tooltip content for each bar.

| | |
|--|--|
| ![Screen Shot 2021-02-16 at 4 02 06 PM](https://user-images.githubusercontent.com/40300265/108121441-d3faa900-7070-11eb-94a5-210713016615.png) | <img width="496" alt="Screen Shot 2021-02-16 at 4 04 42 PM" src="https://user-images.githubusercontent.com/40300265/108121510-e83ea600-7070-11eb-8ef3-75d3bc9c7d79.png"> |
| ![Screen Shot 2021-02-16 at 4 05 08 PM](https://user-images.githubusercontent.com/40300265/108121496-e4ab1f00-7070-11eb-9c60-d26a77c3a0b7.png) | <img width="498" alt="Screen Shot 2021-02-16 at 4 04 30 PM" src="https://user-images.githubusercontent.com/40300265/108121445-d4933f80-7070-11eb-8ce5-55b49462a6a5.png"> |




### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
