### PR TITLE
[Line chart] Add gradient option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `<LineChart/>` gradient fill style
+
 ## [0.4.0] - 2021-02-24
 
 ### Changed

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -19,7 +19,7 @@ import {TooltipContainer} from '../TooltipContainer';
 
 import {Series, RenderTooltipContentData} from './types';
 import {useYScale} from './hooks';
-import {Line} from './components';
+import {Line, GradientArea} from './components';
 import styles from './Chart.scss';
 
 interface Props {
@@ -211,7 +211,7 @@ export function Chart({
             .slice()
             .reverse()
             .map((singleSeries, index) => {
-              const {data, name} = singleSeries;
+              const {data, name, showArea} = singleSeries;
               const path = lineGenerator(data);
 
               if (path == null) {
@@ -223,17 +223,26 @@ export function Chart({
               const isFirstLine = index === series.length - 1;
 
               return (
-                <Line
-                  key={name}
-                  xScale={xScale}
-                  yScale={yScale}
-                  series={singleSeries}
-                  path={path}
-                  activePointIndex={activePointIndex}
-                  labelledBy={tooltipId.current}
-                  handleFocus={handleFocus}
-                  tabIndex={isFirstLine ? 0 : -1}
-                />
+                <React.Fragment key={name}>
+                  <Line
+                    xScale={xScale}
+                    yScale={yScale}
+                    series={singleSeries}
+                    path={path}
+                    activePointIndex={activePointIndex}
+                    labelledBy={tooltipId.current}
+                    handleFocus={handleFocus}
+                    tabIndex={isFirstLine ? 0 : -1}
+                  />
+
+                  {showArea ? (
+                    <GradientArea
+                      series={singleSeries}
+                      yScale={yScale}
+                      xScale={xScale}
+                    />
+                  ) : null}
+                </React.Fragment>
               );
             })}
         </g>

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -144,6 +144,7 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
   }[];
   color?: Color;
   lineStyle?: LineStyle;
+  showArea?: boolean;
 }
 ```
 
@@ -177,7 +178,15 @@ This accepts any [Polaris Viz color](/documentation/Polaris-Viz-colors.md) value
 | --------------------- | --------- |
 | `'solid' \| 'dashed'` | `'solid'` |
 
-The lineStype determines if the drawn line for the series is a solid or dashed line.
+The lineStyle type determines if the drawn line for the series is a solid or dashed line.
+
+#### showArea
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+The showArea type determines if a gradient area style is used for the series.
 
 ### The `RenderTooltipContentData` type
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -76,6 +76,7 @@ export function LineChart({
   const seriesWithDefaults = series.map<Required<Series>>((series, index) => ({
     color: getDefaultColor(index),
     lineStyle: 'solid',
+    showArea: false,
     ...series,
   }));
 

--- a/src/components/LineChart/components/GradientArea/GradientArea.tsx
+++ b/src/components/LineChart/components/GradientArea/GradientArea.tsx
@@ -1,0 +1,55 @@
+import React, {useMemo} from 'react';
+import {ScaleLinear} from 'd3-scale';
+import {area} from 'd3-shape';
+
+import {uniqueId, getColorValue, rgbToRgba} from '../../../../utilities';
+import {Data} from '../../../../types';
+import {Series} from '../../types';
+
+import {getGradientDetails} from './utilities/get-gradient-details';
+
+interface Props {
+  series: Series;
+  yScale: ScaleLinear<number, number>;
+  xScale: ScaleLinear<number, number>;
+}
+
+export function GradientArea({series, yScale, xScale}: Props) {
+  const id = useMemo(() => uniqueId('gradient'), []);
+  const {data, color} = series;
+
+  const areaShape = area<Data>()
+    .x((_: Data, index: number) => xScale(index))
+    .y0(yScale(0))
+    .y1(({rawValue}: {rawValue: number}) => yScale(rawValue))(data);
+
+  if (areaShape == null || color == null) {
+    return null;
+  }
+
+  const rgb = getColorValue(color);
+  const gradientStops = getGradientDetails(data);
+
+  return (
+    <React.Fragment>
+      <defs>
+        <linearGradient id={`${id}`} x1="0%" x2="0%" y1="0%" y2="100%">
+          {gradientStops.map(({percent, alpha}) => (
+            <stop
+              key={percent}
+              offset={`${percent}%`}
+              stopColor={rgbToRgba({rgb, alpha})}
+            />
+          ))}
+        </linearGradient>
+      </defs>
+
+      <path
+        d={areaShape}
+        fill={`url(#${id})`}
+        strokeWidth="0"
+        stroke={series.color}
+      />
+    </React.Fragment>
+  );
+}

--- a/src/components/LineChart/components/GradientArea/index.ts
+++ b/src/components/LineChart/components/GradientArea/index.ts
@@ -1,0 +1,1 @@
+export {GradientArea} from './GradientArea';

--- a/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
+++ b/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {scaleLinear} from 'd3-scale';
+
+import {GradientArea} from '../GradientArea';
+
+describe('<GradientArea />', () => {
+  const mockProps = {
+    series: {
+      name: 'Primary',
+      color: 'primary' as any,
+      lineStyle: 'solid' as any,
+      showArea: false,
+      data: [
+        {label: 'Jan 1', rawValue: 1500},
+        {label: 'Jan 2', rawValue: 1000},
+        {label: 'Jan 3', rawValue: 800},
+        {label: 'Jan 4', rawValue: 1300},
+      ],
+    },
+    xScale: scaleLinear(),
+    yScale: scaleLinear(),
+  };
+
+  it('renders a linear gradient', () => {
+    const actual = mount(
+      <svg>
+        <GradientArea {...mockProps} />
+      </svg>,
+    );
+    expect(actual).toContainReactComponent('linearGradient');
+  });
+
+  it('renders stops', () => {
+    const actual = mount(
+      <svg>
+        <GradientArea {...mockProps} />
+      </svg>,
+    );
+    expect(actual).toContainReactComponent('stop');
+  });
+
+  it('renders a path', () => {
+    const actual = mount(
+      <svg>
+        <GradientArea {...mockProps} />
+      </svg>,
+    );
+    expect(actual).toContainReactComponent('path');
+  });
+});

--- a/src/components/LineChart/components/GradientArea/utilities/get-gradient-details.ts
+++ b/src/components/LineChart/components/GradientArea/utilities/get-gradient-details.ts
@@ -1,0 +1,32 @@
+import {Data} from '../../../../../types';
+
+const HIGHEST_ALPHA = 0.25;
+
+export function getGradientDetails(data: Data[]) {
+  const max = Math.max(...data.map(({rawValue}) => rawValue), 0);
+  const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
+  const allNegatives = max <= 0 && min <= 0;
+  const allPositives = min === 0 && max >= 0;
+
+  if (allPositives) {
+    return [
+      {percent: 0, alpha: HIGHEST_ALPHA},
+      {percent: 100, alpha: 0},
+    ];
+  } else if (allNegatives) {
+    return [
+      {percent: 0, alpha: 0},
+      {percent: 100, alpha: HIGHEST_ALPHA},
+    ];
+  } else {
+    const range = max - min;
+    const negativeStartPercent = ((0 - min) * 100) / range;
+    const zeroPercentLine = 100 - negativeStartPercent;
+
+    return [
+      {percent: 0, alpha: HIGHEST_ALPHA},
+      {percent: zeroPercentLine, alpha: 0},
+      {percent: 100, alpha: HIGHEST_ALPHA},
+    ];
+  }
+}

--- a/src/components/LineChart/components/GradientArea/utilities/tests/get-gradient-details.test.ts
+++ b/src/components/LineChart/components/GradientArea/utilities/tests/get-gradient-details.test.ts
@@ -1,0 +1,64 @@
+import {getGradientDetails} from '../get-gradient-details';
+
+describe('getGradientDetails', () => {
+  it('returns two stop details for all positive numbers', () => {
+    const actual = getGradientDetails([
+      {label: '1', rawValue: 1},
+      {label: '2', rawValue: 2},
+      {label: '3', rawValue: 3},
+      {label: '4', rawValue: 4},
+      {label: '5', rawValue: 5},
+      {label: '6', rawValue: 6},
+      {label: '7', rawValue: 7},
+      {label: '8', rawValue: 8},
+      {label: '9', rawValue: 9},
+      {label: '10', rawValue: 10},
+    ]);
+
+    expect(actual).toStrictEqual([
+      {alpha: 0.25, percent: 0},
+      {alpha: 0, percent: 100},
+    ]);
+  });
+
+  it('returns two stop details for all negative numbers', () => {
+    const actual = getGradientDetails([
+      {label: '1', rawValue: -1},
+      {label: '2', rawValue: -2},
+      {label: '3', rawValue: -3},
+      {label: '4', rawValue: -4},
+      {label: '5', rawValue: -5},
+      {label: '6', rawValue: -6},
+      {label: '7', rawValue: -7},
+      {label: '8', rawValue: -8},
+      {label: '9', rawValue: -9},
+      {label: '10', rawValue: -10},
+    ]);
+
+    expect(actual).toStrictEqual([
+      {alpha: 0, percent: 0},
+      {alpha: 0.25, percent: 100},
+    ]);
+  });
+
+  it('returns three stop details for mixed numbers', () => {
+    const actual = getGradientDetails([
+      {label: '1', rawValue: -1},
+      {label: '2', rawValue: -2},
+      {label: '3', rawValue: -3},
+      {label: '4', rawValue: -4},
+      {label: '5', rawValue: -5},
+      {label: '6', rawValue: 6},
+      {label: '7', rawValue: 7},
+      {label: '8', rawValue: 8},
+      {label: '9', rawValue: 9},
+      {label: '10', rawValue: 10},
+    ]);
+
+    expect(actual).toStrictEqual([
+      {alpha: 0.25, percent: 0},
+      {alpha: 0, percent: 66.66666666666666},
+      {alpha: 0.25, percent: 100},
+    ]);
+  });
+});

--- a/src/components/LineChart/components/Legend/tests/Legend.test.tsx
+++ b/src/components/LineChart/components/Legend/tests/Legend.test.tsx
@@ -11,6 +11,7 @@ const mockSeries: Required<Series>[] = [
     name: 'Test series 1',
     color: 'colorGreen',
     lineStyle: 'dashed',
+    showArea: false,
   },
 ];
 

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -20,6 +20,7 @@ const mockProps = {
     ],
     color: 'primary' as 'primary',
     lineStyle: 'solid' as 'solid',
+    showArea: false,
   },
   xScale: scaleLinear(),
   yScale: scaleLinear(),

--- a/src/components/LineChart/components/index.ts
+++ b/src/components/LineChart/components/index.ts
@@ -1,3 +1,4 @@
 export {Legend} from './Legend';
 export {Line} from './Line';
+export {GradientArea} from './GradientArea';
 export {TooltipContent, TooltipContentProps} from './TooltipContent';

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -27,7 +27,7 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([Math.min(0, minY), maxY])
+      .domain([Math.min(0, minY), Math.max(0, maxY)])
       .nice(maxTicks);
 
     const ticks = yScale.ticks(maxTicks).map((value) => ({

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -9,7 +9,7 @@ import {
 
 import {Chart} from '../Chart';
 import {Series} from '../types';
-import {Line} from '../components';
+import {Line, GradientArea} from '../components';
 import {YAxis} from '../../YAxis';
 
 (global as any).DOMRect = class DOMRect {
@@ -36,6 +36,7 @@ const primarySeries: Required<Series> = {
   name: 'Primary',
   color: 'primary',
   lineStyle: 'solid',
+  showArea: false,
   data: [
     {label: 'Jan 1', rawValue: 1500},
     {label: 'Jan 2', rawValue: 1000},
@@ -132,6 +133,14 @@ describe('<Chart />', () => {
     );
 
     expect(chart).toContainReactComponentTimes(Line, 2);
+  });
+
+  it('renders a <GradientArea /> for a series when showArea is true', () => {
+    const chart = mount(
+      <Chart {...mockProps} series={[{...primarySeries, showArea: true}]} />,
+    );
+
+    expect(chart).toContainReactComponentTimes(GradientArea, 1);
   });
 
   it('renders tooltip content inside a <TooltipContainer /> if there is an active point', () => {

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -18,6 +18,7 @@ const primarySeries: Required<Series> = {
   name: 'Primary',
   color: 'primary',
   lineStyle: 'solid',
+  showArea: false,
   data: [
     {label: 'Jan 1', rawValue: 1500},
     {label: 'Jan 2', rawValue: 1000},

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -4,6 +4,7 @@ export type LineStyle = 'dashed' | 'solid';
 
 export interface Series extends DataSeries<Data> {
   lineStyle?: LineStyle;
+  showArea?: boolean;
 }
 
 interface TooltipData {

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -2,10 +2,9 @@ import React, {useMemo} from 'react';
 import {ScaleLinear} from 'd3-scale';
 import {area} from 'd3-shape';
 
-import {getColorValue, uniqueId} from '../../../../utilities';
+import {getColorValue, uniqueId, rgbToRgba} from '../../../../utilities';
 import {usePrefersReducedMotion} from '../../../../hooks';
 import {SingleSeries, Coordinates} from '../../Sparkline';
-import {rgbToRgba} from '../../utilities';
 import {LinearGradient} from '../../components';
 
 import styles from './Series.scss';

--- a/src/components/Sparkline/utilities.ts
+++ b/src/components/Sparkline/utilities.ts
@@ -4,7 +4,3 @@ export function getPathLength(element: SVGPathElement | null) {
   }
   return element.getTotalLength();
 }
-
-export function rgbToRgba({rgb, alpha}: {rgb: string; alpha: number}) {
-  return rgb.replace(')', `, ${alpha})`).replace('rgb', 'rgba');
-}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -10,3 +10,4 @@ export {degreesToRadians} from './degrees-to-radians';
 export {getBarXAxisDetails} from './get-bar-xaxis-details';
 export {getLongestLabelDetails} from './get-longest-label-details';
 export {getMaxDiagonalDetails} from './get-max-diagonal-details';
+export {rgbToRgba} from './rgb-to-rgba';

--- a/src/utilities/rgb-to-rgba.ts
+++ b/src/utilities/rgb-to-rgba.ts
@@ -1,0 +1,3 @@
+export function rgbToRgba({rgb, alpha}: {rgb: string; alpha: number}) {
+  return rgb.replace(')', `, ${alpha})`).replace('rgb', 'rgba');
+}

--- a/src/utilities/tests/rgb-to-rgba.test.ts
+++ b/src/utilities/tests/rgb-to-rgba.test.ts
@@ -1,4 +1,4 @@
-import {rgbToRgba} from './utilities';
+import {rgbToRgba} from '../rgb-to-rgba';
 
 describe('rgbToRgba', () => {
   it('returns an rgba value', () => {


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/polaris-viz/issues/214

Adds the gradient fill option for the line chart, since that is something we'd ideally like to have for the Orders project.
The reason why there is different handling for all negatives, all positives and mixed data is because we want the gradient to be based on the data itself, so it needs to respond differently to each of those situations.

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

|Gradient with negatives and positives  | Gradient with all negatives  | Gradient with all positives  |
|---|---|---|
| <img width="925" alt="Screen Shot 2021-02-23 at 10 26 10 PM" src="https://user-images.githubusercontent.com/12213371/108943226-64635b80-7626-11eb-9cf0-cf9432753222.png">  | <img width="943" alt="Screen Shot 2021-02-23 at 10 26 44 PM" src="https://user-images.githubusercontent.com/12213371/108943224-63cac500-7626-11eb-93f5-66f9c27b2183.png">  |<img width="935" alt="Screen Shot 2021-02-23 at 10 25 38 PM" src="https://user-images.githubusercontent.com/12213371/108943230-64fbf200-7626-11eb-82f6-659fe30bb872.png">|

### Reviewers’ :tophat: instructions

You can update the LineChartDemo with the code below. Change the data so you can see how the gradient looks in different cases.

<details>

```
import React from 'react';

// eslint-disable-next-line shopify/strict-component-boundaries
import {
  LineChart,
  LineChartProps,
  LineChartTooltipContent,
} from '../../src/components';

import {OUTER_CONTAINER_STYLE} from './constants';

export function LineChartDemo() {
  const innerContainerStyle = {
    width: '900px',
    background: 'white',
    padding: '2rem',
    borderRadius: '6px',
    border: '2px solid #EAECEF',
  };

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  const series = [
    {
      name: 'Apr 01–Apr 14, 2020',
      data: [
        {rawValue: 2251, label: '2020-04-01T12:00:00'},
        {rawValue: 1132.2, label: '2020-04-02T12:00:00'},
        {rawValue: 50000, label: '2020-04-03T12:00:00'},
        {rawValue: 7200, label: '2020-04-04T12:00:00'},
        {rawValue: 1500, label: '2020-04-05T12:00:00'},
        {rawValue: 6132, label: '2020-04-06T12:00:00'},
        {rawValue: 3100, label: '2020-04-07T12:00:00'},
        {rawValue: 20000, label: '2020-04-08T12:00:00'},
        {rawValue: 5103, label: '2020-04-09T12:00:00'},
        {rawValue: 40012.5, label: '2020-04-10T12:00:00'},
        {rawValue: -100000, label: '2020-04-11T12:00:00'},
        {rawValue: 6000, label: '2020-04-12T12:00:00'},
        {rawValue: 5500, label: '2020-04-13T12:00:00'},
        {rawValue: 7000, label: '2020-04-14T12:00:00'},
      ],
      color: 'primary',
      showArea: true,
    },
    {
      name: 'Mar 01–Mar 14, 2020',
      data: [
        {rawValue: 5200, label: '2020-03-01T12:00:00'},
        {rawValue: 7000, label: '2020-03-02T12:00:00'},
        {rawValue: 1000, label: '2020-03-03T12:00:00'},
        {rawValue: 2000, label: '2020-03-04T12:00:00'},
        {rawValue: 5000, label: '2020-03-05T12:00:00'},
        {rawValue: 1000, label: '2020-03-06T12:00:00'},
        {rawValue: 2000, label: '2020-03-07T12:00:00'},
        {rawValue: 5000, label: '2020-03-08T12:00:00'},
        {rawValue: 4000, label: '2020-03-09T12:00:00'},
        {rawValue: -11200, label: '2020-03-10T12:00:00'},
        {rawValue: 2000, label: '2020-03-11T12:00:00'},
        {rawValue: 3000, label: '2020-03-12T12:00:00'},
        {rawValue: 2000, label: '2020-03-13T12:00:00'},
        {rawValue: 3000, label: '2020-03-14T12:00:00'},
      ],
      color: 'pastComparison',
      lineStyle: 'dashed' as 'dashed',
    },
  ];

  const xAxisLabels = series[0].data.map(({label}) => label);

  function formatXAxisLabel(value: string) {
    return new Date(value).toLocaleDateString('en-CA', {
      day: 'numeric',
      month: 'numeric',
    });
  }

  function formatYAxisLabel(value: number) {
    return new Intl.NumberFormat('en', {
      style: 'currency',
      currency: 'CAD',
      currencyDisplay: 'symbol',
      maximumSignificantDigits: 1,
    }).format(value);
  }

  const renderTooltipContent: LineChartProps['renderTooltipContent'] = ({
    data,
  }) => {
    function formatTooltipValue(value: number) {
      return new Intl.NumberFormat('en', {
        style: 'currency',
        currency: 'CAD',
      }).format(value);
    }

    function formatTooltipLabel(value: string) {
      return new Date(value).toLocaleDateString('en-CA', {
        day: 'numeric',
        month: 'long',
        year: 'numeric',
      });
    }

    const formattedData = data.map(
      ({name, point: {label, value}, color, lineStyle}) => ({
        name,
        color,
        lineStyle,
        point: {
          value: formatTooltipValue(value),
          label: formatTooltipLabel(label),
        },
      }),
    );

    return <LineChartTooltipContent data={formattedData} />;
  };

  return (
    <div style={OUTER_CONTAINER_STYLE}>
      <div style={innerContainerStyle}>
        <LineChart
          series={series}
          chartHeight={229}
          xAxisLabels={xAxisLabels}
          formatXAxisLabel={formatXAxisLabel}
          formatYAxisLabel={formatYAxisLabel}
          renderTooltipContent={renderTooltipContent}
          skipLinkText="Skip line chart content"
        />
      </div>
    </div>
  );
}

```

</details>

### Before merging

I'll update these after a review.

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
