### PR TITLE
[NormalizedStackedBarChart] Adding A11y to NormalizedStackedBarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed the `accessibilityLabel` prop from `<LineChart/>` and `<BarChart/>` in favour of a more complete accessibility approach
 - `<LineChart/>` now requires `xAxisLabels`
 - `<Sparkline />` now accepts a `series` prop instead of `data` and universal styling props, so that multiple data series can be displayed and individually configured
+- Removed the accessibilityLabel from `<NormalizedStackedBarChart/>`, component is accessible by default.
 
 ### Added
 

--- a/documentation/code/NormalizedStackedBarChartDemo.tsx
+++ b/documentation/code/NormalizedStackedBarChartDemo.tsx
@@ -47,7 +47,6 @@ export function NormalizedStackedBarChartDemo() {
               formattedValue: '$20',
             },
           ]}
-          accessibilityLabel="A chart showing the breakdown of ad revenue"
           colors={['primary', 'secondary', 'tertiary', 'quaternary']}
           orientation="horizontal"
           size="large"

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
@@ -12,7 +12,6 @@ import styles from './NormalizedStackedBarChart.scss';
 
 export interface NormalizedStackedBarChartProps {
   data: Data[];
-  accessibilityLabel?: string;
   size?: Size;
   orientation?: Orientation;
   colors?: Color[];
@@ -20,7 +19,6 @@ export interface NormalizedStackedBarChartProps {
 
 export function NormalizedStackedBarChart({
   data,
-  accessibilityLabel,
   size = 'small',
   orientation = 'horizontal',
   colors = ['colorPurpleDark', 'colorBlue', 'colorTeal', 'colorSkyDark'],
@@ -57,10 +55,8 @@ export function NormalizedStackedBarChart({
         styles.Container,
         isVertical ? styles.VerticalContainer : styles.HorizontalContainer,
       )}
-      aria-label={accessibilityLabel}
-      role="img"
     >
-      <div
+      <ul
         className={
           isVertical
             ? styles.VerticalLabelContainer
@@ -75,7 +71,7 @@ export function NormalizedStackedBarChart({
             color={colorPalette[index]}
           />
         ))}
-      </div>
+      </ul>
 
       <div
         className={classNames(

--- a/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
@@ -10,12 +10,12 @@ export interface Props {
 
 export function BarLabel({label, value, color}: Props) {
   return (
-    <div className={styles.Container}>
+    <li className={styles.Container}>
       <div style={{background: color}} className={styles.LabelColor} />
       <div className={styles.Label}>
         <strong>{label}</strong>
         <div className={styles.Value}>{value}</div>
       </div>
-    </div>
+    </li>
   );
 }

--- a/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
+++ b/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
@@ -164,21 +164,4 @@ describe('<NormalizedBarChart />', () => {
       expect(barChart.find(BarSegment)!.props.orientation).toBe('vertical');
     });
   });
-
-  describe('Accessibility', () => {
-    it('sets an img role on the parent div', () => {
-      const barChart = mount(<NormalizedStackedBarChart {...mockProps} />);
-
-      expect(barChart.find('div')!.props.role).toBe('img');
-    });
-
-    it('adds an aria label when one is passed in', () => {
-      const label = 'A stacked bar chart showing sales by channel.';
-      const barChart = mount(
-        <NormalizedStackedBarChart {...mockProps} accessibilityLabel={label} />,
-      );
-
-      expect(barChart.find('div')!.props['aria-label']).toBe(label);
-    });
-  });
 });


### PR DESCRIPTION
### What problem is this PR solving?

Adds screen reader accessibility to NormalizedStackedBarChart.

cc; @carysmills 

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<details>
<summary>Paste the following code in the `Playground.tsx` file:</summary>

```
import React from 'react';

import {NormalizedStackedBarChartDemo} from '../documentation/code';

export default function Playground() {
  return (
    <div>
      <NormalizedStackedBarChartDemo />
    </div>
  );
}

```

</details>

- Since there are no interactive elements in NormalizedStackedBarChart, there's no accessibility needed for mouse/keyboard users.
- Turn Voice Over on (command + f5/in system settings/command + start key thrice in succession):
	- Tab once to move the focus to the list (div which contains all `BarLabel` elements)
	- Ctrl + Option + Shift + ➡️: Move into the list. It should read the commands to navigate in the list, and correctly read out information content for each label.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
