### PR TITLE
[LinearXAxis] Make ariaHidden prop required

### DIFF
--- a/src/components/LinearXAxis/LinearXAxis.tsx
+++ b/src/components/LinearXAxis/LinearXAxis.tsx
@@ -28,7 +28,7 @@ interface Props {
   fontSize: number;
   xAxisDetails: XAxisDetails;
   drawableHeight: number;
-  ariaHidden?: boolean;
+  ariaHidden: boolean;
 }
 
 function getTextAlign({
@@ -56,7 +56,7 @@ function Axis({
   fontSize,
   drawableWidth,
   drawableHeight,
-  ariaHidden = false,
+  ariaHidden,
 }: Props) {
   const {
     maxDiagonalLabelLength,

--- a/src/components/LinearXAxis/tests/LinearXAxis.test.tsx
+++ b/src/components/LinearXAxis/tests/LinearXAxis.test.tsx
@@ -30,6 +30,7 @@ const mockProps = {
     ticks: [0, 1, 2],
     horizontalLabelWidth: 30,
   },
+  ariaHidden: false,
 };
 
 describe('<LinearXAxis />', () => {


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/polaris-viz/issues/206 now that both LineChart and StackedAreaChart have a11y added to them.

### Reviewers’ :tophat: instructions

- Both `LineChart` and `StackedAreaChart` should would with no issues (especially with accessibility), all tests should pass.

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
