### PR TITLE
[Line chart] Spacing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `<LineChart/>` gradient fill style
 
+### Fixed
+
+- `<LineChart/>` spacing of the axis labels and legend
+
 ## [0.4.0] - 2021-02-24
 
 ### Changed

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -58,7 +58,7 @@ export function Chart({
     chartDimensions: dimensions,
     formatXAxisLabel,
     formatYAxisLabel,
-    xAxisLabels: xAxisLabels == null ? [] : xAxisLabels,
+    xAxisLabels: xAxisLabels == null || hideXAxisLabels ? [] : xAxisLabels,
   });
 
   const marginBottom =
@@ -71,6 +71,7 @@ export function Chart({
   const formattedLabels = xAxisLabels.map(formatXAxisLabel);
 
   const {axisMargin, ticks, yScale} = useYScale({
+    fontSize,
     drawableHeight,
     series,
     formatYAxisLabel,

--- a/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
@@ -38,6 +38,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         series: [],
+        fontSize: 12,
       });
 
       return null;
@@ -74,6 +75,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         series: [deeplyNegative, highlyPositive],
+        fontSize: 12,
       });
 
       return null;
@@ -98,6 +100,7 @@ describe('useYScale', () => {
 
     function TestComponent() {
       useYScale({
+        fontSize: 12,
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         series: [
@@ -133,6 +136,7 @@ describe('useYScale', () => {
 
     function TestComponent() {
       useYScale({
+        fontSize: 12,
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         series: [],
@@ -158,6 +162,7 @@ describe('useYScale', () => {
 
     function TestComponent() {
       const {ticks} = useYScale({
+        fontSize: 12,
         drawableHeight: 250,
         formatYAxisLabel: jest.fn((value) => `Formatted value: ${value}`),
         series: [],

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -2,7 +2,7 @@ import {useMemo, useEffect, useState} from 'react';
 import {scaleLinear} from 'd3-scale';
 
 import {yAxisMinMax} from '../utilities';
-import {MIN_Y_LABEL_SPACE, SPACING_LOOSE} from '../constants';
+import {MIN_Y_LABEL_SPACE, SPACING} from '../constants';
 import {Series} from '../types';
 import {NumberLabelFormatter} from '../../../types';
 
@@ -10,7 +10,9 @@ export function useYScale({
   drawableHeight,
   series,
   formatYAxisLabel,
+  fontSize,
 }: {
+  fontSize: number;
   drawableHeight: number;
   series: Series[];
   formatYAxisLabel: NumberLabelFormatter;
@@ -43,7 +45,7 @@ export function useYScale({
     let currentMaxTickLength = 0;
 
     const tick = document.createElement('p');
-    tick.style.fontSize = '12px';
+    tick.style.fontSize = `${fontSize}px`;
     tick.style.display = 'inline-block';
     tick.style.visibility = 'hidden';
     document.body.appendChild(tick);
@@ -57,10 +59,9 @@ export function useYScale({
     document.body.removeChild(tick);
 
     setMaxTickLength(currentMaxTickLength);
-  }, [ticks, maxTickLength]);
+  }, [ticks, maxTickLength, fontSize]);
 
-  const axisMargin =
-    maxTickLength == null ? null : maxTickLength + SPACING_LOOSE;
+  const axisMargin = maxTickLength == null ? null : maxTickLength + SPACING;
 
   return {yScale, ticks, axisMargin};
 }

--- a/src/styles/shared/_legends.scss
+++ b/src/styles/shared/_legends.scss
@@ -5,6 +5,7 @@
   color: $color-ink-light;
   font-size: 12px;
   font-weight: 500;
+  margin: 0;
 }
 
 @mixin legend-container {


### PR DESCRIPTION
### What problem is this PR solving?
The main issue this PR fixes is a spacing regression caused by adding accessibility handling to the line chart. When we added properly accessibility handling, we needed to make the xAxis labels mandatory, however we didn't update the check for the xAxis label measurement to check for the new prop `hideXAxisLabels`. The result was that charts without xAxis labels still had extra space at the bottom of the graph to account for the labels.

Additionally, this PR fixes some other spacing issues by:
- checking the right yAxis font size when we measure the yAxis width
- using the correct spacing when we measure the yAxis width
- removing margin from the legend text, in case the legend text wraps

| Before      | After           | 
| ------------- |:-------------:|
| <img width="328" alt="Screen Shot 2021-02-25 at 10 37 44 AM" src="https://user-images.githubusercontent.com/12213371/109178819-41849480-7757-11eb-979b-6d4318cbf73d.png">  | <img width="339" alt="Screen Shot 2021-02-25 at 10 00 01 AM" src="https://user-images.githubusercontent.com/12213371/109178808-3f223a80-7757-11eb-90e7-e59193179562.png"> |


### Reviewers’ :tophat: instructions
You can use the following code in the LineChartDemo to represent the kind of scenario we have on the marketing and products glimpses

<details>

```
import React from 'react';

// eslint-disable-next-line shopify/strict-component-boundaries
import {
  LineChart,
  LineChartProps,
  LineChartTooltipContent,
} from '../../src/components';

import {OUTER_CONTAINER_STYLE} from './constants';

export function LineChartDemo() {
  const innerContainerStyle = {
    width: '325px',
    background: 'white',
    // padding: '2rem',
    borderRadius: '6px',
    border: '2px solid #EAECEF',
  };

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  const series = [
    {
      name: 'Apr 01–Apr 14, 2020',
      data: [
        {rawValue: 2251, label: '2020-04-01T12:00:00'},
        {rawValue: 12132.2, label: '2020-04-02T12:00:00'},
        {rawValue: 5000, label: '2020-04-03T12:00:00'},
        {rawValue: 7200, label: '2020-04-04T12:00:00'},
        {rawValue: 1500, label: '2020-04-05T12:00:00'},
        {rawValue: 6132, label: '2020-04-06T12:00:00'},
        {rawValue: 3100, label: '2020-04-07T12:00:00'},
        {rawValue: 2200, label: '2020-04-08T12:00:00'},
        {rawValue: 5103, label: '2020-04-09T12:00:00'},
        {rawValue: 2112.5, label: '2020-04-10T12:00:00'},
        {rawValue: 4004, label: '2020-04-11T12:00:00'},
        {rawValue: 6000, label: '2020-04-12T12:00:00'},
        {rawValue: 5500, label: '2020-04-13T12:00:00'},
        {rawValue: 7000, label: '2020-04-14T12:00:00'},
      ],
      color: 'primary',
    },
    {
      name: 'Mar 01–Mar 14, 2020',
      data: [
        {rawValue: 5200, label: '2020-03-01T12:00:00'},
        {rawValue: 7000, label: '2020-03-02T12:00:00'},
        {rawValue: 1000, label: '2020-03-03T12:00:00'},
        {rawValue: 2000, label: '2020-03-04T12:00:00'},
        {rawValue: 5000, label: '2020-03-05T12:00:00'},
        {rawValue: 1000, label: '2020-03-06T12:00:00'},
        {rawValue: 2000, label: '2020-03-07T12:00:00'},
        {rawValue: 5000, label: '2020-03-08T12:00:00'},
        {rawValue: 4000, label: '2020-03-09T12:00:00'},
        {rawValue: 11200, label: '2020-03-10T12:00:00'},
        {rawValue: 2000, label: '2020-03-11T12:00:00'},
        {rawValue: 3000, label: '2020-03-12T12:00:00'},
        {rawValue: 2000, label: '2020-03-13T12:00:00'},
        {rawValue: 3000, label: '2020-03-14T12:00:00'},
      ],
      color: 'pastComparison',
      lineStyle: 'dashed' as 'dashed',
    },
  ];

  const xAxisLabels = series[0].data.map(({label}) => label);

  function formatXAxisLabel(value: string) {
    return new Date(value).toLocaleDateString('en-CA', {
      day: 'numeric',
      month: 'numeric',
    });
  }

  function formatYAxisLabel(value: number) {
    return new Intl.NumberFormat('en', {
      style: 'currency',
      currency: 'CAD',
      currencyDisplay: 'symbol',
      maximumSignificantDigits: 1,
    }).format(value);
  }

  const renderTooltipContent: LineChartProps['renderTooltipContent'] = ({
    data,
  }) => {
    function formatTooltipValue(value: number) {
      return new Intl.NumberFormat('en', {
        style: 'currency',
        currency: 'CAD',
      }).format(value);
    }

    function formatTooltipLabel(value: string) {
      return new Date(value).toLocaleDateString('en-CA', {
        day: 'numeric',
        month: 'long',
        year: 'numeric',
      });
    }

    const formattedData = data.map(
      ({name, point: {label, value}, color, lineStyle}) => ({
        name,
        color,
        lineStyle,
        point: {
          value: formatTooltipValue(value),
          label: formatTooltipLabel(label),
        },
      }),
    );

    return <LineChartTooltipContent data={formattedData} />;
  };

  return (
    <div style={OUTER_CONTAINER_STYLE}>
      <div style={innerContainerStyle}>
        <LineChart
          hideXAxisLabels
          series={series}
          chartHeight={229}
          xAxisLabels={xAxisLabels}
          formatXAxisLabel={formatXAxisLabel}
          formatYAxisLabel={formatYAxisLabel}
          renderTooltipContent={renderTooltipContent}
          skipLinkText="Skip line chart content"
        />
      </div>
    </div>
  );
}

```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
