### PR TITLE
Component spacing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- `<LineChart/>` spacing of the axis labels and legend
+- `<LineChart/>`, `<BarChart/>`, `<StackedAreaChart/>` and `<MultiSeriesBarChart />` spacing of the axis labels and legends
 
 ## [0.4.0] - 2021-02-24
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -15,8 +15,8 @@ import {
   SMALL_FONT_SIZE,
   FONT_SIZE,
   SMALL_SCREEN,
+  SPACING,
   SPACING_LOOSE,
-  SPACING_EXTRA_TIGHT,
 } from './constants';
 import styles from './Chart.scss';
 
@@ -95,7 +95,7 @@ export function Chart({
     [fontSize, ticks],
   );
 
-  const axisMargin = SPACING_LOOSE + yAxisLabelWidth;
+  const axisMargin = SPACING + yAxisLabelWidth;
   const drawableWidth = chartDimensions.width - MARGIN.Right - axisMargin;
 
   const {xScale, xAxisLabels} = useXScale({
@@ -150,12 +150,14 @@ export function Chart({
         </g>
 
         <g
-          transform={`translate(${axisMargin + SPACING_EXTRA_TIGHT},${
-            MARGIN.Top
-          })`}
+          transform={`translate(${axisMargin},${MARGIN.Top})`}
           aria-hidden="true"
         >
-          <YAxis ticks={ticks} drawableWidth={drawableWidth} />
+          <YAxis
+            ticks={ticks}
+            drawableWidth={drawableWidth}
+            fontSize={fontSize}
+          />
         </g>
 
         <g transform={`translate(${axisMargin},${MARGIN.Top})`} role="list">

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -15,7 +15,7 @@ import {
   FONT_SIZE,
   SMALL_WIDTH,
   SMALL_FONT_SIZE,
-  SPACING_LOOSE,
+  SPACING,
   INNER_PADDING,
 } from './constants';
 import styles from './Chart.scss';
@@ -47,6 +47,9 @@ export function Chart({
     y: number;
   } | null>(null);
 
+  const fontSize =
+    chartDimensions.width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
+
   const yAxisLabelWidth = useMemo(
     () =>
       series
@@ -54,19 +57,16 @@ export function Chart({
           data.map(({rawValue}) =>
             getTextWidth({
               text: formatYAxisLabel(rawValue),
-              fontSize: FONT_SIZE,
+              fontSize,
             }),
           ),
         )
         .reduce((acc, currentValue) => acc.concat(currentValue), [])
         .reduce((acc, currentValue) => Math.max(acc, currentValue)),
-    [formatYAxisLabel, series],
+    [fontSize, formatYAxisLabel, series],
   );
 
-  const axisMargin = SPACING_LOOSE + yAxisLabelWidth;
-
-  const fontSize =
-    chartDimensions.width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
+  const axisMargin = SPACING + yAxisLabelWidth;
 
   const formattedXAxisLabels = useMemo(() => labels.map(formatXAxisLabel), [
     formatXAxisLabel,
@@ -167,7 +167,11 @@ export function Chart({
         </g>
 
         <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
-          <YAxis ticks={ticks} drawableWidth={drawableWidth} />
+          <YAxis
+            ticks={ticks}
+            drawableWidth={drawableWidth}
+            fontSize={fontSize}
+          />
         </g>
         <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
           {stackedValues != null

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -103,6 +103,7 @@ export function Chart({
   const drawableHeight = dimensions.height - Margin.Top - marginBottom;
 
   const {axisMargin, ticks, yScale} = useYScale({
+    fontSize,
     drawableHeight,
     stackedValues,
     formatYAxisLabel,
@@ -173,7 +174,11 @@ export function Chart({
         </g>
 
         <g transform={`translate(${axisMargin},${Margin.Top})`}>
-          <YAxis ticks={ticks} drawableWidth={drawableWidth} />
+          <YAxis
+            ticks={ticks}
+            drawableWidth={drawableWidth}
+            fontSize={fontSize}
+          />
         </g>
 
         <VisuallyHiddenRows

--- a/src/components/StackedAreaChart/constants.ts
+++ b/src/components/StackedAreaChart/constants.ts
@@ -2,6 +2,7 @@ export const MIN_Y_LABEL_SPACE = 80;
 export const AREA_OPACITY = 0.8;
 
 export enum Spacing {
+  Base = 16,
   Tight = 8,
   Loose = 20,
   ExtraTight = 4,

--- a/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
@@ -67,6 +67,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         stackedValues: mockData as any,
+        fontSize: 12,
       });
 
       return null;
@@ -94,6 +95,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         stackedValues: mockData as any,
+        fontSize: 12,
       });
 
       return null;
@@ -121,6 +123,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         stackedValues: mockZeroData as any,
+        fontSize: 12,
       });
 
       return null;
@@ -148,6 +151,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: jest.fn(),
         stackedValues: mockData as any,
+        fontSize: 12,
       });
 
       return null;
@@ -173,6 +177,7 @@ describe('useYScale', () => {
         drawableHeight: 250,
         formatYAxisLabel: (value) => `Formatted: ${value}`,
         stackedValues: mockData as any,
+        fontSize: 12,
       });
 
       const {formattedValue} = ticks[0];

--- a/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -4,14 +4,16 @@ import {Series} from 'd3-shape';
 
 import {getTextWidth} from '../../../utilities';
 import {MIN_Y_LABEL_SPACE, Spacing} from '../constants';
-import {DEFAULT_MAX_Y, FONT_SIZE} from '../../../constants';
+import {DEFAULT_MAX_Y} from '../../../constants';
 import {NumberLabelFormatter} from '../../../types';
 
 export function useYScale({
+  fontSize,
   drawableHeight,
   stackedValues,
   formatYAxisLabel,
 }: {
+  fontSize: number;
   drawableHeight: number;
   stackedValues: Series<
     {
@@ -54,14 +56,14 @@ export function useYScale({
 
     const maxTickWidth = Math.max(
       ...ticks.map(({formattedValue}) =>
-        getTextWidth({fontSize: FONT_SIZE, text: formattedValue}),
+        getTextWidth({fontSize, text: formattedValue}),
       ),
     );
 
-    const axisMargin = maxTickWidth + Spacing.Loose + Spacing.ExtraTight;
+    const axisMargin = maxTickWidth + Spacing.Base;
 
     return {yScale, ticks, axisMargin};
-  }, [formatYAxisLabel, drawableHeight, stackedValues]);
+  }, [stackedValues, drawableHeight, formatYAxisLabel, fontSize]);
 
   return {yScale, ticks, axisMargin};
 }

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -106,7 +106,7 @@ describe('<Chart />', () => {
         horizontalLabelWidth: 26.523076923076925,
       },
       fontSize: 12,
-      drawableWidth: 472,
+      drawableWidth: 480,
     });
   });
 
@@ -129,16 +129,16 @@ describe('<Chart />', () => {
         {value: 1000, formattedValue: '1000', yOffset: 115},
         {value: 2000, formattedValue: '2000', yOffset: 0},
       ],
-      drawableWidth: 472,
+      drawableWidth: 480,
     });
   });
 
   it('renders a StackedAreas', () => {
     const chart = mount(<Chart {...mockProps} />);
     expect(chart).toContainReactComponent(StackedAreas, {
-      width: 472,
+      width: 480,
       height: 230,
-      transform: 'translate(24,8)',
+      transform: 'translate(16,8)',
       colors: ['colorPurple', 'colorTeal'],
       opacity: 1,
       isAnimated: true,


### PR DESCRIPTION
### What problem is this PR solving?
Makes the yAxis labels of the bar charts and area chart flush left so they are properly aligned with whatever other content is on the page.

This is the same approach taken in https://github.com/Shopify/polaris-viz/pull/221, just for the other charts

### Reviewers’ :tophat: instructions
For the demo components changed in this PR (regular bar chart, multiseries bar chart and area chart) remove the padding from their container. Ensure that the longest yAxis label is aligned left, all the way to the SVG's outermost edge. Example:

<img width="240" alt="Screen Shot 2021-02-25 at 2 09 58 PM" src="https://user-images.githubusercontent.com/12213371/109204297-2aec3680-7773-11eb-96dc-a45085db79d7.png">


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

~- [ ] Update relevant documentation.~
