### PR TITLE
Allow non-unique line chart series

### DIFF
--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -224,7 +224,7 @@ export function Chart({
               const isFirstLine = index === series.length - 1;
 
               return (
-                <React.Fragment key={name}>
+                <React.Fragment key={`${name}-${index}`}>
                   <Line
                     xScale={xScale}
                     yScale={yScale}

--- a/src/components/LineChart/components/Legend/Legend.tsx
+++ b/src/components/LineChart/components/Legend/Legend.tsx
@@ -12,9 +12,9 @@ interface Props {
 export function Legend({series}: Props) {
   return (
     <div className={styles.Container} aria-hidden>
-      {series.map(({name, color, lineStyle}) => {
+      {series.map(({name, color, lineStyle}, index) => {
         return (
-          <div className={styles.Series} key={name}>
+          <div className={styles.Series} key={`${name}-${index}`}>
             <LinePreview color={color} lineStyle={lineStyle} />
             <p className={styles.SeriesName}>{name}</p>
           </div>

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -23,9 +23,9 @@ export interface TooltipContentProps {
 export function TooltipContent({data}: TooltipContentProps) {
   return (
     <div className={styles.Container}>
-      {data.map(({name, point: {label, value}, color, lineStyle}) => {
+      {data.map(({name, point: {label, value}, color, lineStyle}, index) => {
         return (
-          <React.Fragment key={name}>
+          <React.Fragment key={`${name}-${index}`}>
             <LinePreview color={color} lineStyle={lineStyle} />
             <p className={styles.Name}>{label}</p>
             <p className={styles.Value}>{value}</p>

--- a/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
+++ b/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
@@ -24,11 +24,11 @@ export function VisuallyHiddenRows({
     <React.Fragment>
       <g role="row">
         <text role="rowheader" />
-        {xAxisLabels.map((xAxisLabel) => {
+        {xAxisLabels.map((xAxisLabel, index) => {
           return (
             <text
               className={styles.VisuallyHidden}
-              key={`a11y-${xAxisLabel}`}
+              key={`a11y-${xAxisLabel}-${index}`}
               role="columnheader"
             >
               {xAxisLabel}


### PR DESCRIPTION
### What problem is this PR solving?
I noticed while using the Playground that we get a key error on the line chart (and area chart) if we provide a duplicated xAxis label. It's kind of an edge case, but we shouldn't throw a key error when it happens. This PR fixes that.

### Reviewers’ :tophat: instructions

If you want to see the fix, duplicate the first series being provided to the line chart in the LineChartDemo. (This data is being used to populate the xAxis labels). There should be no key error.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
