### PR TITLE
Small label tweaks

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -29,7 +29,7 @@ export function BarChart({
   barMargin = 'Medium',
   timeSeries = false,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
+  formatYAxisLabel = (value) => Math.round(value).toString(),
   renderTooltipContent,
   skipLinkText,
 }: BarChartProps) {

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -16,7 +16,6 @@ import {
   FONT_SIZE,
   SMALL_SCREEN,
   SPACING,
-  SPACING_LOOSE,
 } from './constants';
 import styles from './Chart.scss';
 
@@ -65,7 +64,7 @@ export function Chart({
   const xAxisDetails = useMemo(
     () =>
       getBarXAxisDetails({
-        yAxisLabelWidth: approxYAxisLabelWidth + SPACING_LOOSE,
+        yAxisLabelWidth: approxYAxisLabelWidth,
         fontSize,
         xLabels: data.map(({label}) => formatXAxisLabel(label)),
         chartDimensions,

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -18,7 +18,8 @@ export function useYScale({
   const {yScale, ticks} = useMemo(() => {
     const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
     const calculatedMax = Math.max(...data.map(({rawValue}) => rawValue));
-    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+    const max =
+      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     const maxTicks = Math.max(
       1,

--- a/src/components/BarChartXAxis/BarChartXAxis.scss
+++ b/src/components/BarChartXAxis/BarChartXAxis.scss
@@ -3,7 +3,7 @@
 .Text {
   text-align: center;
   @include axis-text;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .DiagonalText {

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -50,11 +50,13 @@ export function BarChartXAxis({
 
   const transform = needsDiagonalLabels
     ? `translate(${-diagonalLabelOffset -
-        SPACING_BASE_TIGHT} ${maxXLabelHeight +
-        SPACING_EXTRA_TIGHT}) rotate(${DIAGONAL_ANGLE})`
+        SPACING_BASE_TIGHT / 2} ${maxXLabelHeight +
+        SPACING_EXTRA_TIGHT / 2}) rotate(${DIAGONAL_ANGLE})`
     : `translate(-${maxWidth / 2} ${SPACING_TIGHT})`;
 
-  const textHeight = needsDiagonalLabels ? LINE_HEIGHT : maxXLabelHeight;
+  const textHeight = needsDiagonalLabels
+    ? LINE_HEIGHT
+    : maxXLabelHeight + SPACING_EXTRA_TIGHT;
   const textWidth = needsDiagonalLabels ? maxDiagonalLabelLength : maxWidth;
   const textContainerClassName = needsDiagonalLabels
     ? styles.DiagonalText

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -26,7 +26,7 @@ export function LineChart({
   xAxisLabels,
   chartHeight = 250,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
+  formatYAxisLabel = (value) => Math.round(value).toString(),
   hideXAxisLabels = false,
   renderTooltipContent,
   skipLinkText,

--- a/src/components/LineChart/utilities/y-axis-min-max.ts
+++ b/src/components/LineChart/utilities/y-axis-min-max.ts
@@ -12,7 +12,7 @@ export function yAxisMinMax(series: Series[]) {
     });
   });
 
-  maxY = maxY === 0 ? DEFAULT_MAX_Y : maxY;
+  maxY = maxY === 0 && minY === 0 ? DEFAULT_MAX_Y : maxY;
 
   return [minY, maxY];
 }

--- a/src/components/LinearXAxis/LinearXAxis.scss
+++ b/src/components/LinearXAxis/LinearXAxis.scss
@@ -2,7 +2,7 @@
 
 .Text {
   @include axis-text;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .DiagonalText {

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -30,7 +30,7 @@ export function MultiSeriesBarChart({
   accessibilityLabel,
   chartHeight = DEFAULT_HEIGHT,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
+  formatYAxisLabel = (value) => Math.round(value).toString(),
   renderTooltipContent,
 }: MultiSeriesBarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);

--- a/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
@@ -11,10 +11,12 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     );
 
     const calculatedMax = Math.max(...maxStackedValues);
-    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+    const min = Math.min(...minStackedValues);
+    const max =
+      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     return {
-      min: Math.min(...minStackedValues),
+      min,
       max,
     };
   } else {
@@ -27,10 +29,12 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     );
 
     const calculatedMax = Math.max(...groupedDataPoints);
-    const max = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+    const min = Math.min(...groupedDataPoints, 0);
+    const max =
+      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     return {
-      min: Math.min(...groupedDataPoints, 0),
+      min,
       max,
     };
   }

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -27,7 +27,7 @@ export function StackedAreaChart({
   series,
   chartHeight = 250,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
+  formatYAxisLabel = (value) => Math.round(value).toString(),
   renderTooltipContent,
   opacity = 1,
   isAnimated = false,

--- a/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -36,7 +36,8 @@ export function useYScale({
       ),
     );
 
-    const maxY = calculatedMax === 0 ? DEFAULT_MAX_Y : calculatedMax;
+    const maxY =
+      calculatedMax === 0 && minY === 0 ? DEFAULT_MAX_Y : calculatedMax;
 
     const maxTicks = Math.max(
       1,

--- a/src/styles/shared/_axes.scss
+++ b/src/styles/shared/_axes.scss
@@ -9,6 +9,7 @@ $axis-color: rgb(223, 227, 232);
 
 @mixin axis-text {
   color: $label-color;
+  line-height: 1;
 }
 
 @mixin axis-label {

--- a/src/utilities/get-text-container-height.ts
+++ b/src/utilities/get-text-container-height.ts
@@ -12,7 +12,8 @@ export function getTextContainerHeight({
   container.style.display = 'inline-block';
   container.style.visibility = 'hidden';
   container.style.width = `${containerWidth}px`;
-  container.style.wordBreak = 'break-all';
+  container.style.wordBreak = 'break-word';
+  container.style.lineHeight = '1';
   document.body.appendChild(container);
   container.innerText = text;
   const height = container.clientHeight;


### PR DESCRIPTION
### What problem is this PR solving?
Fixes a few bugs I discovered as part of https://github.com/Shopify/core-issues/issues/22447

- when no yAxis label formatting function is provided and the input values have many decimals, our yAxis label calculations can be off
- we were adding spacing to the bar chart yAxis label space calculation when we shouldn't have been, which was throwing things off
- we have a concept of `DEFAULT_MAX_Y` which fixes the issue of a 0 value chart showing only 0 on the yAxis. The way the checks were, this was also getting applied to an all negative scenario, which it wasn't intended to. That in turn made the yScale not ideal and also messed up some label calculations.
- no longer breaks strings at any place, only breaks them at the word or when absolutely necessary. This just looked better
- tweaks the spacing for diagonal labels and slightly increases the height for horizontal labels, to account for characters like `y`

### Reviewers’ :tophat: instructions
You can look at the Playground as it is and modify the BarChart labels and width to see the changes in action.

Alternatively, to tophat the changes in web, you can use web branch `product-trends-graph`. dev up in web, then in Polaris Viz run `yarn build-consumer web` then run `dev server`. Navigate to https://shop1.myshopify.io/admin/reports/product_trends to see the bar graph.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

~- [ ] Update relevant documentation.~
