### PR TITLE
[MultiSeriesBarChart] Adding a11y to MultiSeriesBarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 ### Fixed
 
 - Barcharts with many bars use a better range and no longer have a tooltip bug.
+- Removed the `accessibilityLabel` prop from `<MultiSeriesBarChart/>` in favour of a more complete accessibility approach
+
+### Added
+
+- `skipLinkText` to `<MultiSeriesBarChart/>`
 
 ## [0.5.3] - 2021-03-10
 

--- a/documentation/code/MultiSeriesBarChartDemo.tsx
+++ b/documentation/code/MultiSeriesBarChartDemo.tsx
@@ -122,6 +122,7 @@ export function MultiSeriesBarChartDemo({isStacked = false}: Props) {
           series={series}
           isStacked={isStacked}
           renderTooltipContent={renderTooltipContent}
+          skipLinkText="Skip chart content"
         />
       </div>
 

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -77,7 +77,6 @@ The bar chart interface looks like this:
 ```typescript
 interface BarChartProps {
   data: {rawValue: number; label: string}[];
-  accessibilityLabel?: string;
   barMargin?: 'Small' | 'Medium' | 'Large' | 'None';
   color?: Color;
   formatXAxisLabel?(value: string, index?: number, data?: string[]): string;

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -105,6 +105,7 @@ return (
     series={series}
     isStacked={isStacked}
     renderTooltipContent={renderTooltipContent}
+    skipLinkText="Skip chart content"
   />
 );
 ```
@@ -117,12 +118,12 @@ The mult-series bar chart interface looks like this:
 interface MultiSeriesBarChartProps {
   series: Series[];
   labels: string[];
-  accessibilityLabel?: string;
   timeSeries?: boolean;
   isStacked?: boolean;
   formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
   formatYAxisLabel?(value: number): string;
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
+  skipLinkText?: string;
 }
 ```
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -1,9 +1,10 @@
 import React, {useState, useLayoutEffect, useRef} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
+import {SkipLink} from '../SkipLink';
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 import {TooltipContent} from '../TooltipContent';
-import {getDefaultColor} from '../../utilities';
+import {getDefaultColor, uniqueId} from '../../utilities';
 
 import {Chart} from './Chart';
 import {Series, RenderTooltipContentData} from './types';
@@ -12,11 +13,11 @@ export interface MultiSeriesBarChartProps {
   series: Series[];
   labels: string[];
   timeSeries?: boolean;
-  accessibilityLabel?: string;
   formatXAxisLabel?: StringLabelFormatter;
   formatYAxisLabel?: NumberLabelFormatter;
   renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
   isStacked?: boolean;
+  skipLinkText?: string;
 }
 
 export function MultiSeriesBarChart({
@@ -24,13 +25,14 @@ export function MultiSeriesBarChart({
   series,
   isStacked = false,
   timeSeries = false,
-  accessibilityLabel,
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
+  skipLinkText,
 }: MultiSeriesBarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const skipLinkAnchorId = useRef(uniqueId('multiSeriesBarChart'));
 
   const [updateDimensions] = useDebouncedCallback(() => {
     if (containerRef.current != null) {
@@ -67,27 +69,32 @@ export function MultiSeriesBarChart({
   }));
 
   return (
-    <div
-      aria-label={accessibilityLabel}
-      role="img"
-      style={{height: '100%', width: '100%'}}
-      ref={containerRef}
-    >
+    <div style={{height: '100%', width: '100%'}} ref={containerRef}>
       {chartDimensions == null ? null : (
-        <Chart
-          series={seriesWithDefaults}
-          labels={labels}
-          chartDimensions={chartDimensions}
-          formatXAxisLabel={formatXAxisLabel}
-          formatYAxisLabel={formatYAxisLabel}
-          renderTooltipContent={
-            renderTooltipContent != null
-              ? renderTooltipContent
-              : renderDefaultTooltipContent
-          }
-          timeSeries={timeSeries}
-          isStacked={isStacked}
-        />
+        <React.Fragment>
+          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+            <SkipLink anchorId={skipLinkAnchorId.current}>
+              {skipLinkText}
+            </SkipLink>
+          )}
+          <Chart
+            series={seriesWithDefaults}
+            labels={labels}
+            chartDimensions={chartDimensions}
+            formatXAxisLabel={formatXAxisLabel}
+            formatYAxisLabel={formatYAxisLabel}
+            renderTooltipContent={
+              renderTooltipContent != null
+                ? renderTooltipContent
+                : renderDefaultTooltipContent
+            }
+            timeSeries={timeSeries}
+            isStacked={isStacked}
+          />
+          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+            <SkipLink.Anchor id={skipLinkAnchorId.current} />
+          )}
+        </React.Fragment>
       )}
     </div>
   );

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -14,6 +14,9 @@ interface Props {
   colors: Color[];
   highlightColors: Color[];
   isActive: boolean;
+  barGroupIndex: number;
+  ariaLabel: string;
+  onFocus: (index: number) => void;
 }
 
 export function BarGroup({
@@ -24,6 +27,9 @@ export function BarGroup({
   colors,
   isActive,
   highlightColors,
+  onFocus,
+  barGroupIndex,
+  ariaLabel,
 }: Props) {
   const barWidth = width / data.length - BAR_SPACING;
 
@@ -45,16 +51,32 @@ export function BarGroup({
           ? getColorValue(highlightColors[index])
           : getColorValue(colors[index]);
 
+        const handleFocus = () => {
+          onFocus(barGroupIndex);
+        };
+
+        const ariaEnabledBar = index === 0;
+
         return (
-          <rect
-            className={styles.Bar}
+          <g
+            role={index === 0 ? 'listitem' : undefined}
+            aria-hidden={!ariaEnabledBar}
             key={index}
-            x={xPosition}
-            y={yPosition}
-            fill={fillColor}
-            width={barWidth}
-            height={height}
-          />
+          >
+            <rect
+              className={styles.Bar}
+              key={index}
+              x={xPosition}
+              y={yPosition}
+              fill={fillColor}
+              width={barWidth}
+              height={height}
+              tabIndex={ariaEnabledBar ? 0 : -1}
+              onFocus={handleFocus}
+              role={ariaEnabledBar ? 'img' : undefined}
+              aria-label={ariaEnabledBar ? ariaLabel : undefined}
+            />
+          </g>
         );
       })}
     </React.Fragment>

--- a/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -25,6 +25,9 @@ describe('<Bar/>', () => {
     ] as Color[],
     isActive: false,
     hasActiveGroup: false,
+    onFocus: jest.fn(),
+    barGroupIndex: 0,
+    ariaLabel: 'Aria Label',
   };
 
   it('renders a rect for each data item', () => {

--- a/src/components/MultiSeriesBarChart/components/StackedBarGroup/StackedBarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/StackedBarGroup/StackedBarGroup.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {ScaleLinear, ScaleBand} from 'd3-scale';
 import {Color} from 'types';
 
+import {formatAriaLabel} from '../../utilities';
 import {StackSeries} from '../../types';
 import {BAR_SPACING} from '../../constants';
 import {getColorValue} from '../../../../utilities';
@@ -15,6 +16,14 @@ interface Props {
   colors: Color[];
   highlightColors: Color[];
   activeBarGroup: number | null;
+  accessibilityData: {
+    title: string;
+    data: {
+      label: string;
+      value: string;
+    }[];
+  }[];
+  onFocus: (index: number) => void;
 }
 
 export function StackedBarGroup({
@@ -25,6 +34,8 @@ export function StackedBarGroup({
   colors,
   highlightColors,
   activeBarGroup,
+  onFocus,
+  accessibilityData,
 }: Props) {
   const barWidth = xScale.bandwidth() - BAR_SPACING;
 
@@ -38,16 +49,35 @@ export function StackedBarGroup({
             ? getColorValue(highlightColors[groupIndex])
             : getColorValue(colors[groupIndex]);
 
+        const handleFocus = () => {
+          onFocus(barIndex);
+        };
+
+        const ariaLabel = formatAriaLabel(accessibilityData[barIndex]);
+        const height = Math.abs(yScale(end) - yScale(start));
+
+        const ariaEnabledBar = groupIndex === 0;
+
         return (
-          <rect
-            className={styles.Bar}
+          <g
+            role={groupIndex === 0 ? 'listitem' : undefined}
+            aria-hidden={!ariaEnabledBar}
             key={barIndex}
-            x={xPosition}
-            y={yScale(end)}
-            height={Math.abs(yScale(end) - yScale(start))}
-            width={barWidth}
-            fill={fillColor}
-          />
+          >
+            <rect
+              className={styles.Bar}
+              key={barIndex}
+              x={xPosition}
+              y={yScale(end)}
+              height={height}
+              width={barWidth}
+              fill={fillColor}
+              tabIndex={ariaEnabledBar ? 0 : -1}
+              onFocus={handleFocus}
+              role={ariaEnabledBar ? 'img' : undefined}
+              aria-label={ariaEnabledBar ? ariaLabel : undefined}
+            />
+          </g>
         );
       })}
     </g>

--- a/src/components/MultiSeriesBarChart/components/StackedBarGroup/tests/StackedBarGroup.test.tsx
+++ b/src/components/MultiSeriesBarChart/components/StackedBarGroup/tests/StackedBarGroup.test.tsx
@@ -30,6 +30,48 @@ describe('<StackedBarGroup/>', () => {
     colors: ['primary', 'secondary'] as Color[],
     highlightColors: ['primaryProminent', 'secondaryProminent'] as Color[],
     activeBarGroup: null,
+    onFocus: jest.fn(),
+    accessibilityData: [
+      {
+        title: 'title1',
+        data: [
+          {
+            label: 'label',
+            value: 'value',
+          },
+          {
+            label: 'label2',
+            value: 'value2',
+          },
+        ],
+      },
+      {
+        title: 'title2',
+        data: [
+          {
+            label: 'label',
+            value: 'value',
+          },
+          {
+            label: 'label2',
+            value: 'value2',
+          },
+        ],
+      },
+      {
+        title: 'title3',
+        data: [
+          {
+            label: 'label',
+            value: 'value',
+          },
+          {
+            label: 'label2',
+            value: 'value2',
+          },
+        ],
+      },
+    ],
   };
 
   it('renders a rect for each data item', () => {

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -21,18 +21,6 @@ describe('<MultiSeriesBarChart />', () => {
     labels: ['Something', 'Another', 'Thing'],
   };
 
-  it('renders accessibility props', () => {
-    const label = 'A bar chart showing sales data';
-    const multiSeriesBarChart = mount(
-      <MultiSeriesBarChart {...mockProps} accessibilityLabel={label} />,
-    );
-
-    expect(multiSeriesBarChart).toContainReactComponent('div', {
-      'aria-label': label,
-      role: 'img',
-    });
-  });
-
   it('renders a <Chart />', () => {
     const multiSeriesBarChart = mount(<MultiSeriesBarChart {...mockProps} />);
 

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -21,3 +21,11 @@ export interface RenderTooltipContentData {
   }[];
   title: string;
 }
+
+export interface AccessibilitySeries {
+  title: string;
+  data: {
+    label: string;
+    value: string;
+  }[];
+}

--- a/src/components/MultiSeriesBarChart/utilities/format-aria-label.ts
+++ b/src/components/MultiSeriesBarChart/utilities/format-aria-label.ts
@@ -1,0 +1,7 @@
+import {AccessibilitySeries} from '../types';
+
+export function formatAriaLabel(series: AccessibilitySeries) {
+  return `${series.title}: ${series.data.map(
+    ({label, value}) => `${label} ${value}`,
+  )}`;
+}

--- a/src/components/MultiSeriesBarChart/utilities/index.ts
+++ b/src/components/MultiSeriesBarChart/utilities/index.ts
@@ -1,2 +1,3 @@
 export {getStackedValues} from './get-stacked-values';
 export {getMinMax} from './get-min-max';
+export {formatAriaLabel} from './format-aria-label';

--- a/src/components/MultiSeriesBarChart/utilities/tests/format-aria-labels.test.tsx
+++ b/src/components/MultiSeriesBarChart/utilities/tests/format-aria-labels.test.tsx
@@ -1,0 +1,30 @@
+import {formatAriaLabel} from '../format-aria-label';
+import {AccessibilitySeries} from '../../types';
+
+const mockData: AccessibilitySeries = {
+  title: 'title1',
+  data: [
+    {
+      label: 'label',
+      value: 'value',
+    },
+    {
+      label: 'label2',
+      value: 'value2',
+    },
+    {
+      label: 'label3',
+      value: 'value3',
+    },
+  ],
+};
+
+describe('format-aria-label', () => {
+  it('returns formatted aria label string', () => {
+    const ariaLabel = formatAriaLabel(mockData);
+
+    expect(ariaLabel).toStrictEqual(
+      'title1: label value,label2 value2,label3 value3',
+    );
+  });
+});


### PR DESCRIPTION
### What problem is this PR solving?

Adds a11y to `MultiSeriesBarChart`

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->
In the Playground, we want to check for accessibility for keyboard users and screenreader support.

1. `Skip Chart Content` should be displayed in each case, and if clicked, user should exit the chart.
2. For keyboard accessibility, tabbing through the chart should select a bar out of each group, and display a Tooltip. This should **not** happen for each bar in the group, only the first.
3. For screenreader accessibility, you should be able to Control+Option+Right Arrow Key / tabbing and get information about each bar group
4. Make sure to check this for when the chart is stacked, and non-stacked. (add prop isStacked to the MultiSeriesBarChart in the playground/demos)

| | |
| -- | -- |
| ![Screen Shot 2021-03-11 at 2 23 52 PM](https://user-images.githubusercontent.com/40300265/110843571-7247ec00-8276-11eb-91bc-4917706834eb.png) | ![Screen Shot 2021-03-11 at 2 24 20 PM](https://user-images.githubusercontent.com/40300265/110843585-770ca000-8276-11eb-8ace-b80b5c927d98.png) |

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
