### PR TITLE
Use range instead of rangeround on barcharts

### DIFF
--- a/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
@@ -21,7 +21,7 @@ describe('useXScale', () => {
       const scale = (value: any) => value;
       scale.domain = () => scale;
       rangeSpy = jest.fn(() => scale);
-      scale.rangeRound = rangeSpy;
+      scale.range = rangeSpy;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       return scale;
@@ -48,7 +48,7 @@ describe('useXScale', () => {
     (scaleBand as jest.Mock).mockImplementation(() => {
       const scale = (value: any) => value;
       scale.range = (range: any) => range;
-      scale.rangeRound = () => scale;
+      scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       domainSpy = jest.fn(() => scale);
@@ -79,7 +79,7 @@ describe('useXScale', () => {
     (scaleBand as jest.Mock).mockImplementation(() => {
       const scale = (value: any) => value;
       scale.range = () => scale;
-      scale.rangeRound = () => scale;
+      scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       scale.domain = () => scale;

--- a/src/components/BarChart/hooks/use-x-scale.ts
+++ b/src/components/BarChart/hooks/use-x-scale.ts
@@ -16,7 +16,7 @@ export function useXScale({
   formatXAxisLabel: StringLabelFormatter;
 }) {
   const xScale = scaleBand()
-    .rangeRound([0, drawableWidth])
+    .range([0, drawableWidth])
     .paddingInner(barMargin)
     .domain(data.map((_, index) => index.toString()));
 

--- a/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
@@ -21,7 +21,7 @@ describe('useXScale', () => {
       const scale = (value: any) => value;
       scale.domain = () => scale;
       rangeSpy = jest.fn(() => scale);
-      scale.rangeRound = rangeSpy;
+      scale.range = rangeSpy;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       return scale;
@@ -50,7 +50,7 @@ describe('useXScale', () => {
     (scaleBand as jest.Mock).mockImplementation(() => {
       const scale = (value: any) => value;
       scale.range = (range: any) => range;
-      scale.rangeRound = () => scale;
+      scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       domainSpy = jest.fn(() => scale);
@@ -79,7 +79,7 @@ describe('useXScale', () => {
     (scaleBand as jest.Mock).mockImplementation(() => {
       const scale = (value: any) => value;
       scale.range = () => scale;
-      scale.rangeRound = () => scale;
+      scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       scale.domain = () => scale;

--- a/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
@@ -13,7 +13,7 @@ export function useXScale({
   labels: string[];
 }) {
   const xScale = scaleBand()
-    .rangeRound([0, drawableWidth])
+    .range([0, drawableWidth])
     .paddingInner(INNER_PADDING)
     .domain(data.map((_, index) => index.toString()));
 


### PR DESCRIPTION
### What problem is this PR solving?

It's a bit hard to see in the screenshots, but while testing the labels on a bar chart with _many_ bars, I noticed that the first bar could sometimes not start at 0 and would rather start around 9px in. As well as taking up unnecessary, precious space, this meant that our tooltip calculations were off and hovering over a bar would trigger the wrong content in the tooltip.This was because we were using `rangeRound` rather than `range`.

| Before        | After  |
| ------------- |:-------------:|
|<img width="1449" alt="Screen Shot 2021-03-11 at 2 03 17 PM" src="https://user-images.githubusercontent.com/12213371/110840492-c6e96800-8272-11eb-93c5-da33a731000c.png">| <img width="1442" alt="Screen Shot 2021-03-11 at 2 03 37 PM" src="https://user-images.githubusercontent.com/12213371/110840490-c650d180-8272-11eb-8024-5f0276abaa8a.png"> | 

### Reviewers’ :tophat: instructions
You can have a look at the existing BarChart in the Playground. You won't notice a difference unless you have _many_ data points. If you want to try that out, here's some code that you can paste into BarChartDemo.tsx.

<details>

```
import React from 'react';

// eslint-disable-next-line shopify/strict-component-boundaries
import {BarChart, BarChartTooltipContent} from '../../src/components';

import {OUTER_CONTAINER_STYLE} from './constants';

export function BarChartDemo() {
  const innerContainerStyle = {
    width: '100%',
    height: '300px',
    // background: 'white',
    // padding: '2rem',
    // borderRadius: '6px',
    border: '2px solid #EAECEF',
    // display: 'grid',
    // placeItems: 'center',
  };

  document.body.style.fontFamily =
    "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";

  const data = [
    {rawValue: 0.000009, label: 'Hi'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
    {rawValue: 0.000009, label: '2020-01-01T12:00:00Z'},
    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
    {
      rawValue: 25.6,
      label: '2020-01-04T12:00:00Z',
    },
    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
  ];

  function formatXAxisLabel(value: string) {
    return new Date(value).toLocaleDateString('en-CA', {
      day: 'numeric',
      month: 'short',
    });
  }

  function formatYAxisLabel(value: number) {
    return new Intl.NumberFormat('en-CA', {
      style: 'currency',
      currency: 'CAD',
      maximumSignificantDigits: 2,
    }).format(value);
  }

  function renderTooltipContent({
    label,
    value,
  }: {
    label: string;
    value: number;
  }) {
    function formatTooltipLabel(value: string) {
      return new Date(value).toLocaleDateString('en-CA', {
        day: 'numeric',
        month: 'long',
        year: 'numeric',
      });
    }

    function formatTooltipValue(value: number) {
      return new Intl.NumberFormat('en-CA', {
        style: 'currency',
        currency: 'CAD',
      }).format(value);
    }

    const formattedLabel = formatTooltipLabel(label);
    const formattedValue = formatTooltipValue(value);

    return (
      <BarChartTooltipContent label={formattedLabel} value={formattedValue} />
    );
  }

  return (
    // <div style={OUTER_CONTAINER_STYLE}>
    <div style={innerContainerStyle}>
      <BarChart
        data={data}
        color="primary"
        timeSeries
        // formatXAxisLabel={formatXAxisLabel}
        // formatYAxisLabel={formatYAxisLabel}
        renderTooltipContent={renderTooltipContent}
        skipLinkText="Skip chart content"
      />
    </div>
    // </div>
  );
}

```

</details>

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

~- [ ] Update relevant documentation.~
