### PR TITLE
[Linechart] Performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/d3-shape": "^1.3.2",
     "@types/jest": "24.0.19",
     "@types/lodash.isequal": "^4.5.5",
+    "@types/lodash.throttle": "^4.1.6",
     "@types/node": "^12.7.5",
     "@types/react": "^16.8.15",
     "@types/react-dom": "^16.8.4",
@@ -126,6 +127,7 @@
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.7",
     "lodash.isequal": "^4.5.0",
+    "lodash.throttle": "^4.1.1",
     "react-spring": "^8.0.27",
     "use-debounce": "^3.3.0"
   }

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -1,69 +1,37 @@
 import React from 'react';
+import {line} from 'd3-shape';
 import {ScaleLinear} from 'd3-scale';
 
-import {Point} from '../../../Point';
 import {getColorValue} from '../../../../utilities';
 import {Series} from '../../types';
 
 interface Props {
-  path: string;
   series: Required<Series>;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  activePointIndex: number | null;
-  labelledBy: string;
-  tabIndex: number;
-  handleFocus: ({
-    index,
-    cx,
-    cy,
-  }: {
-    index?: number;
-    cx: number;
-    cy: number;
-  }) => void;
 }
 
-export function Line({
-  path,
-  series,
-  xScale,
-  yScale,
-  activePointIndex,
-  labelledBy,
-  handleFocus,
-  tabIndex,
-}: Props) {
-  const {color, lineStyle, data} = series;
+export const Line = React.memo(function Shape({series, xScale, yScale}: Props) {
+  const lineGenerator = line<{rawValue: number}>()
+    .x((_, index) => xScale(index))
+    .y(({rawValue}) => yScale(rawValue));
+
+  const path = lineGenerator(series.data);
+
+  if (path == null) {
+    return null;
+  }
 
   return (
-    <React.Fragment>
-      <path
-        d={path}
-        fill="none"
-        strokeWidth="2px"
-        paintOrder="stroke"
-        stroke={getColorValue(color)}
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        strokeDasharray={lineStyle === 'dashed' ? '2 4' : 'unset'}
-      />
-
-      {data.map(({rawValue}, index) => {
-        return (
-          <Point
-            key={index}
-            color={color}
-            cx={xScale(index)}
-            cy={yScale(rawValue)}
-            active={index === activePointIndex}
-            onFocus={handleFocus}
-            index={index}
-            tabIndex={tabIndex}
-            ariaLabelledby={labelledBy}
-          />
-        );
-      })}
-    </React.Fragment>
+    <path
+      d={path}
+      fill="none"
+      strokeWidth="2px"
+      paintOrder="stroke"
+      stroke={getColorValue(series.color)}
+      strokeLinejoin="round"
+      strokeLinecap="round"
+      strokeDasharray={series.lineStyle === 'dashed' ? '2 4' : 'unset'}
+    />
   );
-}
+});

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
-import {Point} from 'components';
 
 import {getColorValue} from '../../../../../utilities';
 import {Line} from '../Line';
@@ -11,7 +10,6 @@ jest.mock('d3-scale', () => ({
 }));
 
 const mockProps = {
-  path: 'M0,0L10,10',
   series: {
     name: 'Test series',
     data: [
@@ -24,25 +22,10 @@ const mockProps = {
   },
   xScale: scaleLinear(),
   yScale: scaleLinear(),
-  activePointIndex: null,
-  labelledBy: 'someId',
-  tabIndex: 0,
-  handleFocus: jest.fn(),
 };
 
 describe('<Line />', () => {
   describe('Line', () => {
-    it('renders a path element with the given path', () => {
-      const line = mount(
-        <svg>
-          <Line {...mockProps} />
-        </svg>,
-      );
-
-      // eslint-disable-next-line id-length
-      expect(line).toContainReactComponent('path', {d: 'M0,0L10,10'});
-    });
-
     it('renders a line with the series styles', () => {
       const line = mount(
         <svg>
@@ -59,53 +42,6 @@ describe('<Line />', () => {
       expect(line).toContainReactComponent('path', {
         strokeDasharray: '2 4',
         stroke: getColorValue('primary'),
-      });
-    });
-  });
-
-  describe('Points', () => {
-    it('renders a point for each data point in the series', () => {
-      const line = mount(
-        <svg>
-          <Line {...mockProps} />
-        </svg>,
-      );
-
-      expect(line).toContainReactComponentTimes(Point, 2);
-    });
-
-    it('calculates the x and y position using the given x and y scales', () => {
-      mount(
-        <svg>
-          <Line {...mockProps} />
-        </svg>,
-      );
-
-      expect(mockProps.xScale).toHaveBeenCalledWith(0);
-      expect(mockProps.yScale).toHaveBeenCalledWith(
-        mockProps.series.data[0].rawValue,
-      );
-    });
-
-    it('renders with active: true if the point index matches the activePointIndex', () => {
-      const line = mount(
-        <svg>
-          <Line {...mockProps} activePointIndex={1} />
-        </svg>,
-      );
-
-      expect(line).toContainReactComponentTimes(Point, 1, {active: true});
-    });
-
-    it('renders with the provided series color', () => {
-      const line = mount(
-        <svg>
-          <Line {...mockProps} />
-        </svg>,
-      );
-
-      expect(line).toContainReactComponent(Point, {
-        color: 'primary',
       });
     });
   });

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -5,6 +5,7 @@ import {
   LinearXAxis,
   TooltipContainer,
   VisuallyHiddenRows,
+  Point,
 } from 'components';
 
 import {Chart} from '../Chart';
@@ -20,6 +21,7 @@ import {YAxis} from '../../YAxis';
 };
 
 const fakeSVGEvent = {
+  persist: jest.fn(),
   currentTarget: {
     getScreenCTM: () => ({
       inverse: () => ({x: 100, y: 100}),
@@ -79,7 +81,7 @@ describe('<Chart />', () => {
       svg.trigger('onMouseMove', fakeSVGEvent);
     });
 
-    expect(chart).toContainReactComponent(Line, {activePointIndex: 1});
+    expect(chart).toContainReactComponent(Point, {active: true});
   });
 
   describe('<LinearAxis />', () => {
@@ -133,6 +135,35 @@ describe('<Chart />', () => {
     );
 
     expect(chart).toContainReactComponentTimes(Line, 2);
+  });
+
+  it('renders a <Point /> for each data item in each series', () => {
+    const chart = mount(
+      <Chart
+        {...mockProps}
+        series={[primarySeries, {...primarySeries, name: 'A second series'}]}
+      />,
+    );
+
+    expect(chart).toContainReactComponentTimes(Point, 8);
+  });
+
+  it('passes props to <Point />', () => {
+    const chart = mount(
+      <Chart
+        {...mockProps}
+        series={[primarySeries, {...primarySeries, name: 'A second series'}]}
+      />,
+    );
+
+    expect(chart).toContainReactComponent(Point, {
+      color: 'primary',
+      cx: 0,
+      cy: 0,
+      active: false,
+      index: 0,
+      tabIndex: -1,
+    });
   });
 
   it('renders a <GradientArea /> for a series when showArea is true', () => {

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -5,7 +5,7 @@ export interface Series extends DataSeries<Data> {
   lineStyle?: LineStyle;
 }
 
-interface TooltipData {
+export interface TooltipData {
   name: string;
   point: {
     label: string;

--- a/src/components/Point/Point.tsx
+++ b/src/components/Point/Point.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import tokens from '@shopify/polaris-tokens';
-import {Color} from 'types';
+import {Color, ActiveTooltip} from 'types';
 
 import {getColorValue} from '../../utilities';
 
@@ -9,13 +9,13 @@ interface Props {
   cx: number;
   cy: number;
   color: Color;
-  index?: number;
-  onFocus?: ({index, cx, cy}: {index?: number; cx: number; cy: number}) => any;
+  index: number;
+  onFocus?: ({index, x, y}: ActiveTooltip) => void;
   tabIndex?: number;
   ariaLabelledby?: string;
 }
 
-export function Point({
+export const Point = React.memo(function Point({
   cx,
   cy,
   active,
@@ -27,7 +27,7 @@ export function Point({
 }: Props) {
   const handleFocus = () => {
     if (onFocus != null) {
-      onFocus({index, cx, cy});
+      onFocus({index, x: cx, y: cy});
     }
   };
 
@@ -45,4 +45,4 @@ export function Point({
       onFocus={handleFocus}
     />
   );
-}
+});

--- a/src/components/Point/tests/Point.test.tsx
+++ b/src/components/Point/tests/Point.test.tsx
@@ -9,6 +9,7 @@ const mockProps = {
   cy: 100,
   active: false,
   color: 'colorPurple' as Color,
+  index: 0,
 };
 
 describe('<Point />', () => {

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -15,7 +15,11 @@ import {Crosshair} from '../Crosshair';
 import {Point} from '../Point';
 import {LinearXAxis} from '../LinearXAxis';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
-import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
+import {
+  StringLabelFormatter,
+  NumberLabelFormatter,
+  ActiveTooltip,
+} from '../../types';
 
 import {Margin} from './constants';
 import {useYScale} from './hooks';
@@ -249,20 +253,12 @@ export function Chart({
     </div>
   );
 
-  function handleFocus({
-    index,
-    cx,
-    cy,
-  }: {
-    index?: number;
-    cx: number;
-    cy: number;
-  }) {
+  function handleFocus({index, x, y}: ActiveTooltip) {
     if (index == null) return;
     setActivePointIndex(index);
     setTooltipPosition({
-      x: cx + axisMargin,
-      y: cy,
+      x: x + axisMargin,
+      y,
     });
   }
 

--- a/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
+++ b/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
@@ -15,7 +15,7 @@ interface Props {
   formatYAxisLabel: NumberLabelFormatter;
 }
 
-export function VisuallyHiddenRows({
+export const VisuallyHiddenRows = React.memo(function Rows({
   series,
   xAxisLabels,
   formatYAxisLabel,
@@ -58,4 +58,4 @@ export function VisuallyHiddenRows({
       })}
     </React.Fragment>
   );
-}
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,3 +97,9 @@ export type StringLabelFormatter = (
 ) => string;
 
 export type NumberLabelFormatter = (value: number) => string;
+
+export interface ActiveTooltip {
+  x: number;
+  y: number;
+  index: number;
+}

--- a/src/utilities/event-point.ts
+++ b/src/utilities/event-point.ts
@@ -8,6 +8,10 @@ export function eventPoint(
 ) {
   const svgNode = event.currentTarget;
 
+  if (svgNode == null) {
+    return;
+  }
+
   const screenCTM = svgNode.getScreenCTM();
 
   if (screenCTM == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.throttle@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"
+  integrity sha512-/UIH96i/sIRYGC60NoY72jGkCJtFN5KVPhEMMMTjol65effe1gPn0tycJqV5tlSwMTzX8FqzB5yAj0rfGHTPNg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.161"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"


### PR DESCRIPTION
### What problem is this PR solving?

I noticed on the notebooks project that our line chart component wasn't performing well with large amounts of data. This PR does several things to improve the performance, but before I get to the juicy details I will show you what the improvements are, using 12,000 datapoints unless otherwise stated.

**Here's an example of a typical update after a mouse event**
Notice only chart updates now, and the render duration is much shorter.

| Before        | After           | 
| ------------- |:-------------:|
|useYScale takes 260ms + 68ms |useYScale takes 3.8ms |   
|Typical mouseover performance (5,000 datapoints): <img width="1019" alt="Screen Shot 2021-03-15 at 9 40 01 AM" src="https://user-images.githubusercontent.com/12213371/111162349-745dc380-8572-11eb-8403-55efd4e086a3.png"> |<img width="1029" alt="Screen Shot 2021-03-15 at 10 02 44 AM" src="https://user-images.githubusercontent.com/12213371/111166035-1632df80-8576-11eb-895f-9b59caf24351.png">|   

**With thousands of datapoints, the chart took a noticeable amount of time to load before and then mouse over events were sluggish**

| Before        | After           | 
| ------------- |:-------------:|
|![before](https://user-images.githubusercontent.com/12213371/111159794-dbc64400-856f-11eb-8dfe-f4b4fe21789c.gif) |![after](https://user-images.githubusercontent.com/12213371/111166819-e46e4880-8576-11eb-8258-3b8d66d961b1.gif)|

**Using React's profiler tool, we can see that every mouseover event was causing many subcomponents to rerender, including Line and each Point**

| Before        | After           | 
| ------------- |:-------------:|
|![before-updates](https://user-images.githubusercontent.com/12213371/111159861-ea146000-856f-11eb-9cc3-781be72a03c6.gif)| ![after-updates](https://user-images.githubusercontent.com/12213371/111167247-4af36680-8577-11eb-8c6b-ba27a2fcb1c3.gif) |

### Code change details

## Throttling

- introduces throttle so that we can reduce the number of event listeners firing. I was a bit hesitant to add another lodash package, but it is small and it seems like the best way forward. Open to adding our own throttle if people think that's better.
- use the same handler for mouse out and mouse over. This means their throttle handling is the same.
- event.persist() is required, since we are now throttling the events

## Limiting state updates
- combine the current index and the coordinates into one state object, to avoid multiple calls to update state
- useYScale does not need state to do its job. Removing it reduces complexity and means less updates to the Chart component.

## Classics: useMemo, React.memo and useCallback
- memoize everything expensive in the Chart component, since this code is rerendered every time the chart is rerendered, which is every time the mouse coordinates or active index change
- use useCallback for the handleFocus function, to avoid the Point component thinking the prop has updated when it hasn't
- use React.memo on simple subcomponents that typically do not need to rerender every time Chart does.

## Better component structure to avoid unnecessary re-renders
- move the line shape calculation to the Line component, so it is not recalculated on every render of Chart
- remove Point from Line, so that we aren't having to drill props down, which causes the whole tree to update. Not passing down the activeIndex also means Line and Point do not need to update every time a new index become active, but rather just when the Point itself becomes active.

## Fun tidbit
- use `reduce` over chained array methods, when the data calculation cannot be memoized. Read [here]
- (https://www.freecodecamp.org/news/beware-of-chaining-array-methods-in-javascript-ef3983b60fbc/) and [here](https://kentcdodds.com/blog/array-reduce-vs-chaining-vs-for-loop) about the performance of chained array methods. In our case in the tooltip, this did seem to make a performance difference.

### Reviewers’ :tophat: instructions

 - Check the line chart as it currently is in the Playground, to make sure I haven't broken anything.

 - Then, to check 12,000 points on the graph, grab this commit. You can change the 12,000 number in LineChartDemo to see different amounts:

`git fetch --all --prune`
`git cherry-pick 6633b090d56c6b1f0d96199335e5addc5df7a6f1`

**Note: there definitely are some further things we could do to improve the experience of the tooltip with this amount of data, but for this PR I wanted to focus on performance enhancements, since that gets us a long way.**

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
