### PR TITLE
Use initial height to get ticks for yAxis label calculations

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -29,7 +29,7 @@ export function BarChart({
   barMargin = 'Medium',
   timeSeries = false,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => Math.round(value).toString(),
+  formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
   skipLinkText,
 }: BarChartProps) {

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useMemo} from 'react';
 import {Color, Data} from 'types';
 
+import {LINE_HEIGHT} from '../../constants';
 import {eventPoint, getTextWidth, getBarXAxisDetails} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
@@ -51,14 +52,21 @@ export function Chart({
   const fontSize =
     chartDimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
+  const {ticks: initialTicks} = useYScale({
+    drawableHeight:
+      chartDimensions.height - MARGIN.Top - MARGIN.Bottom - LINE_HEIGHT,
+    data,
+    formatYAxisLabel,
+  });
+
   const approxYAxisLabelWidth = useMemo(
     () =>
       Math.max(
-        ...data.map(({rawValue}) =>
-          getTextWidth({text: formatYAxisLabel(rawValue), fontSize}),
+        ...initialTicks.map(({formattedValue}) =>
+          getTextWidth({text: formattedValue, fontSize}),
         ),
       ),
-    [data, fontSize, formatYAxisLabel],
+    [fontSize, initialTicks],
   );
 
   const xAxisDetails = useMemo(

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -52,12 +52,19 @@ export function Chart({
   const fontSize =
     dimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
+  const {ticks: initialTicks} = useYScale({
+    fontSize,
+    drawableHeight: dimensions.height - Margin.Top,
+    series,
+    formatYAxisLabel,
+  });
+
   const xAxisDetails = useLinearXAxisDetails({
     series,
     fontSize,
     chartDimensions: dimensions,
     formatXAxisLabel,
-    formatYAxisLabel,
+    initialTicks,
     xAxisLabels: xAxisLabels == null || hideXAxisLabels ? [] : xAxisLabels,
   });
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -24,7 +24,7 @@ export function LineChart({
   series,
   xAxisLabels,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => Math.round(value).toString(),
+  formatYAxisLabel = (value) => value.toString(),
   hideXAxisLabels = false,
   renderTooltipContent,
   skipLinkText,

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -50,20 +50,26 @@ export function Chart({
   const fontSize =
     chartDimensions.width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
 
+  const stackedValues = isStacked ? getStackedValues(series, labels) : null;
+
+  const {ticks: initialTicks} = useYScale({
+    drawableHeight: chartDimensions.height - MARGIN.Top - MARGIN.Bottom,
+    data: series,
+    formatYAxisLabel,
+    stackedValues,
+  });
+
   const yAxisLabelWidth = useMemo(
     () =>
-      series
-        .map(({data}) =>
-          data.map(({rawValue}) =>
-            getTextWidth({
-              text: formatYAxisLabel(rawValue),
-              fontSize,
-            }),
-          ),
-        )
-        .reduce((acc, currentValue) => acc.concat(currentValue), [])
-        .reduce((acc, currentValue) => Math.max(acc, currentValue)),
-    [fontSize, formatYAxisLabel, series],
+      Math.max(
+        ...initialTicks.map(({formattedValue}) =>
+          getTextWidth({
+            text: formattedValue,
+            fontSize,
+          }),
+        ),
+      ),
+    [fontSize, initialTicks],
   );
 
   const axisMargin = SPACING + yAxisLabelWidth;
@@ -104,8 +110,6 @@ export function Chart({
     MARGIN.Top -
     MARGIN.Bottom -
     xAxisDetails.maxXLabelHeight;
-
-  const stackedValues = isStacked ? getStackedValues(series, labels) : null;
 
   const {yScale, ticks} = useYScale({
     drawableHeight,

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -26,7 +26,7 @@ export function MultiSeriesBarChart({
   timeSeries = false,
   accessibilityLabel,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => Math.round(value).toString(),
+  formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
 }: MultiSeriesBarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -77,21 +77,28 @@ export function Chart({
   const fontSize =
     dimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
+  const stackedValues = useMemo(() => areaStack(formattedData), [
+    areaStack,
+    formattedData,
+  ]);
+
+  const {ticks: initialTicks} = useYScale({
+    fontSize,
+    drawableHeight: dimensions.height - Margin.Top,
+    stackedValues,
+    formatYAxisLabel,
+  });
+
   const xAxisDetails = useLinearXAxisDetails({
     series,
     fontSize,
     chartDimensions: dimensions,
     formatXAxisLabel,
-    formatYAxisLabel,
+    initialTicks,
     xAxisLabels: xAxisLabels == null ? [] : xAxisLabels,
   });
 
   const formattedXAxisLabels = xAxisLabels.map(formatXAxisLabel);
-
-  const stackedValues = useMemo(() => areaStack(formattedData), [
-    areaStack,
-    formattedData,
-  ]);
 
   const colors = useMemo(() => series.map(({color}) => color), [series]);
 

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -24,7 +24,7 @@ export function StackedAreaChart({
   xAxisLabels,
   series,
   formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => Math.round(value).toString(),
+  formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
   opacity = 1,
   isAnimated = false,

--- a/src/hooks/tests/useLinearXAxisDetails.test.tsx
+++ b/src/hooks/tests/useLinearXAxisDetails.test.tsx
@@ -44,7 +44,7 @@ describe('useLinearXAxisDetails', () => {
     fontSize: 14,
     chartDimensions: {width: 200} as any,
     formatXAxisLabel: (label: string) => label,
-    formatYAxisLabel: (label: number) => label.toString(),
+    initialTicks: [{value: 10, formattedValue: '$10', yOffset: 100}],
     xAxisLabels: [
       'A really really long label A really really long label',
       'Another really really long label',


### PR DESCRIPTION
### What problem is this PR solving?

The whole description I posted below is _still_ true, but I actually found an example of where we need this fix in production, after merging the orders over time viz. The data below is from the average units orders column.

| Before  | After |  
|---|---|
| <img width="232" alt="Screen Shot 2021-03-16 at 9 36 12 AM" src="https://user-images.githubusercontent.com/12213371/111319117-0d0c4600-863c-11eb-9f49-e454e25e16b1.png">  | <img width="208" alt="Screen Shot 2021-03-16 at 9 44 22 AM" src="https://user-images.githubusercontent.com/12213371/111319310-3dec7b00-863c-11eb-9f64-ed442dc83b89.png">|  

_*note, once we actually format the labels, they should not go diagonal like that and reveal no relevant information... or if we want to tweak the diagonal label handling later we can do that._

In [this PR](https://github.com/Shopify/polaris-viz/pull/235), I _sort of_ fixed an issue where the xAxis labels could get cut off when going diagonal. The reason for the particular bug was that if you provided a number like 0.354534 as one of your datapoints, we were using the longest data point to estimate how wide the yAxis width could be. But in reality, most of the time having a number like that does not mean that d3's ticks method will give us a number that long, meaning that the yAxis width ends up being shorter and then our calculations for the xAxis label diagonal cutoff can be wrong. The *old* "fix" in the linked PR was to use a formatYAxisLabel function that rounds by default, if no other formatting function is provided. 

I think this would work most of the time, but it leaves us vulnerable to less predictable situations where there is a mismatch between the chart's data and the ticks provided by d3. The new solution on this PR is to use `useYScale` twice in the component: once where we already had it once we've calculated the actual height, knowing how much space the xAxis labels will take up, but once right at the beginning when we have an estimate of the drawable height but we don't know how tall the labels will be. We only use the ticks returned from the hook the first time to estimate the yAxis width. Although the height could change once we've calculated the xAxis label height, therefore impacting the ticks, it should be minimal and would not drastically change the length of the ticks, and even if they do roll over to one more digit we have enough wiggle room for that.

### Reviewers’ :tophat: instructions

Make sure the xAxis diagonal labels do not get cut off and that other label calculations look ✨good✨

To tophat, you can do the following (the cherry-pick commit provides decimal numbers for all modified graphs in the Playground): 

`git fetch --all --prune`
`git cherry-pick 464095d8d24f480de2f3f66aaa020489ba45ff7c`

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
