### PR TITLE
Fix all-negative handling

### DIFF
--- a/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
@@ -82,6 +82,37 @@ describe('useYScale', () => {
     expect(domainSpy).toHaveBeenCalledWith([-89, 1000]);
   });
 
+  it('creates a y scale with 0 as the max value if all input values are negative', () => {
+    let domainSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+      scale.range = (range: any) => (range ? scale : range);
+      domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+      scale.domain = domainSpy;
+      scale.nice = () => scale;
+      return scale;
+    });
+
+    function TestComponent() {
+      useYScale({
+        drawableHeight: 400,
+        formatYAxisLabel: jest.fn(),
+        data: [
+          {rawValue: -1000, label: 'test'},
+          {rawValue: -89, label: 'test'},
+          {rawValue: -300, label: 'test'},
+        ],
+      });
+
+      return null;
+    }
+
+    mount(<TestComponent />);
+
+    expect(domainSpy).toHaveBeenCalledWith([-1000, 0]);
+  });
+
   it('creates a y scale with the domain maximum set to the default max y for a data set with all zero values', () => {
     let domainSpy = jest.fn();
     (scaleLinear as jest.Mock).mockImplementation(() => {

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -19,7 +19,9 @@ export function useYScale({
     const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
     const calculatedMax = Math.max(...data.map(({rawValue}) => rawValue));
     const max =
-      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
+      calculatedMax === 0 && min === 0
+        ? DEFAULT_MAX_Y
+        : Math.max(calculatedMax, 0);
 
     const maxTicks = Math.max(
       1,

--- a/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
@@ -13,7 +13,9 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     const calculatedMax = Math.max(...maxStackedValues);
     const min = Math.min(...minStackedValues);
     const max =
-      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
+      calculatedMax === 0 && min === 0
+        ? DEFAULT_MAX_Y
+        : Math.max(0, calculatedMax);
 
     return {
       min,
@@ -31,7 +33,9 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     const calculatedMax = Math.max(...groupedDataPoints);
     const min = Math.min(...groupedDataPoints, 0);
     const max =
-      calculatedMax === 0 && min === 0 ? DEFAULT_MAX_Y : calculatedMax;
+      calculatedMax === 0 && min === 0
+        ? DEFAULT_MAX_Y
+        : Math.max(0, calculatedMax);
 
     return {
       min,

--- a/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
+++ b/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
@@ -69,6 +69,52 @@ const mockZeroStackedData = [
   ],
 ] as StackSeries[];
 
+const mockNegativeStackedData = [
+  [
+    [-3, 0],
+    [-7, 0],
+  ],
+  [
+    [-7, -3],
+    [-10, -7],
+  ],
+  [
+    [-14, -7],
+    [-12, -10],
+  ],
+] as StackSeries[];
+
+const mockNegativeSeries: Series[] = [
+  {
+    color: 'colorPurple',
+    name: 'Breakfast',
+    data: [
+      {
+        label: 'Monday',
+        rawValue: -3,
+      },
+      {
+        label: 'Tuesday',
+        rawValue: -7,
+      },
+    ],
+  },
+  {
+    color: 'colorRed',
+    name: 'Lunch',
+    data: [
+      {
+        label: 'Monday',
+        rawValue: -4,
+      },
+      {
+        label: 'Tuesday',
+        rawValue: -3,
+      },
+    ],
+  },
+];
+
 describe('get-min-max', () => {
   it('returns min and max of non stacked data when stackedValues is null', () => {
     const {min, max} = getMinMax(null, mockData);
@@ -92,5 +138,15 @@ describe('get-min-max', () => {
   it('returns the default max y value for stacked values of all zeros', () => {
     const {max} = getMinMax(mockZeroStackedData, mockZeroData);
     expect(max).toStrictEqual(DEFAULT_MAX_Y);
+  });
+
+  it('returns 0 as the max when all stacked values are negative', () => {
+    const {max} = getMinMax(mockNegativeStackedData, mockNegativeSeries);
+    expect(max).toStrictEqual(0);
+  });
+
+  it('returns 0 as the max when all non-stacked values are negative', () => {
+    const {max} = getMinMax(null, mockNegativeSeries);
+    expect(max).toStrictEqual(0);
   });
 });

--- a/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/StackedAreaChart/hooks/tests/use-y-scale.test.tsx
@@ -106,6 +106,43 @@ describe('useYScale', () => {
     expect(domainSpy).toHaveBeenCalledWith([0, 3127]);
   });
 
+  it('creates a y scale with max of 0 when all values are negative', () => {
+    let domainSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+      scale.range = (range: any) => (range ? scale : range);
+      domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+      scale.domain = domainSpy;
+      scale.nice = () => scale;
+      return scale;
+    });
+
+    function TestComponent() {
+      useYScale({
+        drawableHeight: 250,
+        formatYAxisLabel: jest.fn(),
+        stackedValues: [
+          [
+            [-649, -1151],
+            [-820, -1820],
+          ],
+          [
+            [-543, -649],
+            [-713, -820],
+          ],
+        ] as any,
+        fontSize: 12,
+      });
+
+      return null;
+    }
+
+    mount(<TestComponent />);
+
+    expect(domainSpy).toHaveBeenCalledWith([-1820, 0]);
+  });
+
   it('creates a y scale with the domain maiximum set to the default max y for a data set with all zero values', () => {
     let domainSpy = jest.fn();
     (scaleLinear as jest.Mock).mockImplementation(() => {

--- a/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -25,14 +25,22 @@ export function useYScale({
 }) {
   const {yScale, ticks, axisMargin} = useMemo(() => {
     const minY = Math.min(
-      ...stackedValues.map((value) =>
-        Math.min(...value.map(([startingValue]) => startingValue)),
-      ),
+      ...stackedValues.map((value) => {
+        return Math.min(
+          ...value.map(([startingValue, endingValue]) =>
+            Math.min(startingValue, endingValue),
+          ),
+        );
+      }),
     );
 
     const calculatedMax = Math.max(
       ...stackedValues.map((value) =>
-        Math.max(...value.map(([, endingValue]) => endingValue)),
+        Math.max(
+          ...value.map(([startingValue, endingValue]) =>
+            Math.max(startingValue, endingValue),
+          ),
+        ),
       ),
     );
 
@@ -46,7 +54,7 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([Math.min(0, minY), maxY])
+      .domain([Math.min(0, minY), Math.max(0, maxY)])
       .nice(maxTicks);
 
     const ticks = yScale.ticks(maxTicks).map((value) => ({


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/22622

For the most part, this PR ensures that in the case of all negatives, the max value on the graph is 0 rather than a negative number. We do the same thing for min numbers, but we hadn't added all the right handling for the inverse.

| Before  | After  | 
|---|---|
| <img width="1500" alt="Screen Shot 2021-03-16 at 11 02 37 AM" src="https://user-images.githubusercontent.com/12213371/111332015-cfadb580-8647-11eb-8695-e54609cbb26b.png">  | <img width="1459" alt="Screen Shot 2021-03-16 at 11 08 39 AM" src="https://user-images.githubusercontent.com/12213371/111332255-008dea80-8648-11eb-8024-7f5f7faf73ee.png">  | 

Additionally, I noticed a bug on the area chart for an all-negative scenario, which I fixed on this PR. Our logic to get the min and max values was not working correctly when the chart shows entirely negatives.

| Before  | After  | 
|---|---|
| <img width="1458" alt="Screen Shot 2021-03-16 at 11 07 19 AM" src="https://user-images.githubusercontent.com/12213371/111331995-cc1a2e80-8647-11eb-891e-9fce385d2950.png">  | <img width="1475" alt="Screen Shot 2021-03-16 at 11 08 50 AM" src="https://user-images.githubusercontent.com/12213371/111332309-0c79ac80-8648-11eb-8df8-825a52258828.png"> | 

Most of the diff is updating and adding tests.

### Reviewers’ :tophat: instructions
`git fetch --all --prune`
`git cherry-pick db4f12176f45c2cae089c89b4b8f3bce155edac7`

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
