### PR TITLE
Add spline option to line chart and sparkline

### DIFF
--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -35,6 +35,7 @@ interface Props {
   dimensions: DOMRect;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   hideXAxisLabels: boolean;
+  hasSpline: boolean;
 }
 
 export function Chart({
@@ -45,6 +46,7 @@ export function Chart({
   formatYAxisLabel,
   renderTooltipContent,
   hideXAxisLabels,
+  hasSpline,
 }: Props) {
   const [tooltipDetails, setTooltipDetails] = useState<ActiveTooltip | null>(
     null,
@@ -254,7 +256,12 @@ export function Chart({
 
             return (
               <React.Fragment key={`${name}-${index}`}>
-                <Line series={singleSeries} xScale={xScale} yScale={yScale} />
+                <Line
+                  series={singleSeries}
+                  xScale={xScale}
+                  yScale={yScale}
+                  hasSpline={hasSpline}
+                />
 
                 {data.map(({rawValue}, dataIndex) => {
                   const activeIndex =
@@ -280,6 +287,7 @@ export function Chart({
                     series={singleSeries}
                     yScale={yScale}
                     xScale={xScale}
+                    hasSpline={hasSpline}
                   />
                 ) : null}
               </React.Fragment>

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -271,3 +271,11 @@ This accepts a function that is called to render the tooltip content. By default
 | `string` |
 
 If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.
+
+#### hasSpline
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to curve the line between points.

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -18,6 +18,7 @@ export interface LineChartProps {
   formatYAxisLabel?: NumberLabelFormatter;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
   skipLinkText?: string;
+  hasSpline?: boolean;
 }
 
 export function LineChart({
@@ -28,6 +29,7 @@ export function LineChart({
   hideXAxisLabels = false,
   renderTooltipContent,
   skipLinkText,
+  hasSpline = false,
 }: LineChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -92,6 +94,7 @@ export function LineChart({
             formatYAxisLabel={formatYAxisLabel}
             dimensions={chartDimensions}
             hideXAxisLabels={hideXAxisLabels}
+            hasSpline={hasSpline}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent

--- a/src/components/LineChart/components/GradientArea/GradientArea.tsx
+++ b/src/components/LineChart/components/GradientArea/GradientArea.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import {ScaleLinear} from 'd3-scale';
-import {area} from 'd3-shape';
+import {area, curveMonotoneX} from 'd3-shape';
 
 import {uniqueId, getColorValue, rgbToRgba} from '../../../../utilities';
 import {Data} from '../../../../types';
@@ -12,16 +12,23 @@ interface Props {
   series: Series;
   yScale: ScaleLinear<number, number>;
   xScale: ScaleLinear<number, number>;
+  hasSpline: boolean;
 }
 
-export function GradientArea({series, yScale, xScale}: Props) {
+export function GradientArea({series, yScale, xScale, hasSpline}: Props) {
   const id = useMemo(() => uniqueId('gradient'), []);
   const {data, color} = series;
 
-  const areaShape = area<Data>()
+  const areaGenerator = area<Data>()
     .x((_: Data, index: number) => xScale(index))
     .y0(yScale(0))
-    .y1(({rawValue}: {rawValue: number}) => yScale(rawValue))(data);
+    .y1(({rawValue}: {rawValue: number}) => yScale(rawValue));
+
+  if (hasSpline) {
+    areaGenerator.curve(curveMonotoneX);
+  }
+
+  const areaShape = areaGenerator(data);
 
   if (areaShape == null || color == null) {
     return null;

--- a/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
+++ b/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
+import {area} from 'd3-shape';
 
 import {GradientArea} from '../GradientArea';
+
+jest.mock('d3-shape', () => ({
+  area: jest.fn(() => {
+    const shape = (value: any) => value;
+    shape.x = () => shape;
+    shape.y0 = () => shape;
+    shape.y1 = () => shape;
+    return shape;
+  }),
+}));
 
 describe('<GradientArea />', () => {
   const mockProps = {
@@ -20,6 +31,7 @@ describe('<GradientArea />', () => {
     },
     xScale: scaleLinear(),
     yScale: scaleLinear(),
+    hasSpline: false,
   };
 
   it('renders a linear gradient', () => {
@@ -47,5 +59,25 @@ describe('<GradientArea />', () => {
       </svg>,
     );
     expect(actual).toContainReactComponent('path');
+  });
+
+  it('calls the d3 curve method when hasSpline is true', () => {
+    const curveSpy = jest.fn();
+    (area as jest.Mock).mockImplementationOnce(() => {
+      const shape = (value: any) => value;
+      shape.x = () => shape;
+      shape.y0 = () => shape;
+      shape.y1 = () => shape;
+      shape.curve = curveSpy;
+      return shape;
+    });
+
+    mount(
+      <svg>
+        <GradientArea {...mockProps} hasSpline />
+      </svg>,
+    );
+
+    expect(curveSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {line} from 'd3-shape';
+import {line, curveMonotoneX} from 'd3-shape';
 import {ScaleLinear} from 'd3-scale';
 
 import {getColorValue} from '../../../../utilities';
@@ -9,12 +9,22 @@ interface Props {
   series: Required<Series>;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
+  hasSpline: boolean;
 }
 
-export const Line = React.memo(function Shape({series, xScale, yScale}: Props) {
+export const Line = React.memo(function Shape({
+  hasSpline,
+  series,
+  xScale,
+  yScale,
+}: Props) {
   const lineGenerator = line<{rawValue: number}>()
     .x((_, index) => xScale(index))
     .y(({rawValue}) => yScale(rawValue));
+
+  if (hasSpline) {
+    lineGenerator.curve(curveMonotoneX);
+  }
 
   const path = lineGenerator(series.data);
 

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+import {line} from 'd3-shape';
 import {scaleLinear} from 'd3-scale';
 
 import {getColorValue} from '../../../../../utilities';
@@ -7,6 +8,15 @@ import {Line} from '../Line';
 
 jest.mock('d3-scale', () => ({
   scaleLinear: jest.fn(() => jest.fn(() => 250)),
+}));
+
+jest.mock('d3-shape', () => ({
+  line: jest.fn(() => {
+    const shape = (value: any) => value;
+    shape.x = () => shape;
+    shape.y = () => shape;
+    return shape;
+  }),
 }));
 
 const mockProps = {
@@ -22,12 +32,13 @@ const mockProps = {
   },
   xScale: scaleLinear(),
   yScale: scaleLinear(),
+  hasSpline: false,
 };
 
 describe('<Line />', () => {
   describe('Line', () => {
     it('renders a line with the series styles', () => {
-      const line = mount(
+      const actual = mount(
         <svg>
           <Line
             {...mockProps}
@@ -39,10 +50,29 @@ describe('<Line />', () => {
         </svg>,
       );
 
-      expect(line).toContainReactComponent('path', {
+      expect(actual).toContainReactComponent('path', {
         strokeDasharray: '2 4',
         stroke: getColorValue('primary'),
       });
+    });
+
+    it('calls the d3 curve method when hasSpline is true', () => {
+      const curveSpy = jest.fn();
+      (line as jest.Mock).mockImplementationOnce(() => {
+        const shape = (value: any) => value;
+        shape.x = () => shape;
+        shape.y = () => shape;
+        shape.curve = curveSpy;
+        return shape;
+      });
+
+      mount(
+        <svg>
+          <Line {...mockProps} hasSpline />
+        </svg>,
+      );
+
+      expect(curveSpy).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -55,6 +55,7 @@ const mockProps = {
   formatYAxisLabel: jest.fn((value) => value),
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
   hideXAxisLabels: false,
+  hasSpline: false,
 };
 
 describe('<Chart />', () => {

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -133,3 +133,11 @@ Visually hidden text for screen readers.
 | `boolean` | `false` |
 
 Determines whether to animate the chart on state changes.
+
+#### hasSpline
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to curve the line between points.

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -25,14 +25,16 @@ export interface SingleSeries {
 
 export interface SparklineProps {
   series: SingleSeries[];
-  isAnimated?: boolean;
   accessibilityLabel?: string;
+  isAnimated?: boolean;
+  hasSpline?: boolean;
 }
 
 export function Sparkline({
   series,
   accessibilityLabel,
-  isAnimated,
+  isAnimated = false,
+  hasSpline = false,
 }: SparklineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
@@ -95,6 +97,7 @@ export function Sparkline({
                 series={singleSeries}
                 isAnimated={isAnimated}
                 height={height}
+                hasSpline={hasSpline}
               />
             </g>
           );

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
+import {area} from 'd3-shape';
 
 import {Series} from '../Series';
 import {LinearGradient} from '../../LinearGradient';
+
+jest.mock('d3-shape', () => ({
+  area: jest.fn(() => {
+    const shape = (value: any) => value;
+    shape.x = () => shape;
+    shape.y = () => shape;
+    shape.y0 = () => shape;
+    shape.y1 = () => shape;
+    shape.curve = () => shape;
+    return shape;
+  }),
+}));
 
 const mockSeries = {
   color: 'colorRed' as any,
@@ -29,6 +42,7 @@ const mockProps = {
   series: mockSeries,
   isAnimated: false,
   height: 250,
+  hasSpline: false,
 };
 
 jest.mock('utilities/unique-id', () => ({
@@ -111,5 +125,26 @@ describe('Series', () => {
     );
 
     expect(actual).toContainReactComponent(LinearGradient);
+  });
+
+  it('calls the d3 curve method when hasSpline is true', () => {
+    const curveSpy = jest.fn();
+    (area as jest.Mock).mockImplementationOnce(() => {
+      const shape = (value: any) => value;
+      shape.x = () => shape;
+      shape.y = () => shape;
+      shape.y0 = () => shape;
+      shape.y1 = () => shape;
+      shape.curve = curveSpy;
+      return shape;
+    });
+
+    mount(
+      <svg>
+        <Series {...mockProps} hasSpline />
+      </svg>,
+    );
+
+    expect(curveSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### What problem is this PR solving?
Adds the spline option to the line chart and sparkline, as discussed for the Orders project

<img width="260" alt="Screen Shot 2021-03-18 at 2 14 46 PM" src="https://user-images.githubusercontent.com/12213371/111676186-4f788300-87f4-11eb-9075-d00bb01b0f9e.png">

<img width="1460" alt="Screen Shot 2021-03-18 at 2 14 00 PM" src="https://user-images.githubusercontent.com/12213371/111676139-425b9400-87f4-11eb-9bd9-d8fb7fc21847.png">

### Reviewers’ :tophat: instructions
In the `LineChartDemo` and `SparklineDemo` add `spline` as a top level prop to the chart.

Some things I'd like feedback on:
- do you think monotoneX was the right choice for the type of curve? I picked it because it seems the closest to a straight line as possible: it goes through the correct points and does not deviate too much from where a straight line would go on the chart. Some other options I considered were `curveBasis`, `curveCardinal` or `curveCatmullRom`. You can see some explanations of the different curves [here](https://subscription.packtpub.com/book/web_development/9781838645571/7/ch07lvl1sec52/curve-functions) and [here](https://github.com/d3/d3-shape). There is also an interactive explorer [here](http://bl.ocks.org/d3indepth/b6d4845973089bc1012dec1674d3aff8). @mirualves looked at this with me, and we agreed on the monotoneX option, but I'm open to other ideas.
- should I add any tests?

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
