### PR TITLE
[BarChart] Fixing Unlabelled Image on Bar Chart

### DIFF
--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -148,6 +148,7 @@ export function Chart({
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBar(null)}
         onTouchEnd={() => setActiveBar(null)}
+        role="list"
       >
         <g
           transform={`translate(${axisMargin},${chartDimensions.height -
@@ -175,7 +176,7 @@ export function Chart({
           />
         </g>
 
-        <g transform={`translate(${axisMargin},${MARGIN.Top})`} role="list">
+        <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
           {data.map(({rawValue}, index) => {
             const xPosition = xScale(index.toString());
             const ariaLabel = `${formatXAxisLabel(


### PR DESCRIPTION
### What problem is this PR solving?

Removing the problem of having the svg being read out as an 'Unlabelled Image' in a11y.

| | |
| -- | -- |
| <img width="1772" alt="Screen Shot 2021-03-23 at 2 26 44 PM" src="https://user-images.githubusercontent.com/40300265/112198848-eaea6900-8be3-11eb-94c3-3a74c14af868.png"> | <img width="1768" alt="Screen Shot 2021-03-23 at 2 26 03 PM" src="https://user-images.githubusercontent.com/40300265/112198859-ef168680-8be3-11eb-9b56-032a2a9bfc1b.png"> |


### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->
Turn on screenreading (accessibility settings / cmd+start key 3 times), and control+option+arrow into the `BarChart`, it should show the chart as "Unlabelled Image". Everything else in the accessibility should be working as normal.

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
