### PR TITLE
[Bar] Focus Outline Fixes

### DIFF
--- a/src/components/Bar/Bar.scss
+++ b/src/components/Bar/Bar.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.BarNoOutline {
+  @include no-outline;
+}

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -7,6 +7,8 @@ import {ScaleLinear} from 'd3-scale';
 import {getColorValue} from '../../utilities';
 import {ROUNDED_BAR_RADIUS, MIN_BAR_HEIGHT} from '../../constants';
 
+import styles from './Bar.scss';
+
 interface Props {
   color: Color;
   highlightColor: Color;
@@ -89,6 +91,7 @@ export function Bar({
       style={{
         transform: `translate(${xPosition}px, ${yPosition}px) ${rotation}`,
       }}
+      className={color === highlightColor ? undefined : styles.BarNoOutline}
     />
   );
 }

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -94,6 +94,8 @@ interface BarChartProps {
 }
 ```
 
+In order for the user to have visual feedback that a bar has been selected, it is recommended that a `highlightColor`, which is different to the `color`, is passed in for this component. If a `highlightColor` is not provided, the browser's default outline treatment will be used when the bar is focused.
+
 ### Required props
 
 #### data

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -179,6 +179,8 @@ This accepts any [Polaris Viz color](/documentation/Polaris-Viz-colors.md) value
 
 This accepts any [Polaris Viz color](/documentation/Polaris-Viz-colors.md) value, and corresponds to the color of the bar for that series when you hover over a bar group. It defaults to `primary`. The four 'prominent' Polaris Viz colors (`primaryProminent`, `secondaryProminent`, `tertiaryProminent`, `quaternaryProminent`) exist as a good option for a complimentary hover color.
 
+In order for the user to have visual feedback that a bar has been selected, it is recommended that a `highlightColor`, which is different to the `color`, is passed in in the `series` for this component. If a `highlightColor` is not provided, the browser's default outline treatment will be used when the bar is focused.
+
 ### The `RenderTooltipContentData` type
 
 The `RenderTooltipContentData` type looks very similar to the `Series` type. Its interface looks like this:

--- a/src/components/MultiSeriesBarChart/components/StackedBarGroup/StackedBarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/StackedBarGroup/StackedBarGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ScaleLinear, ScaleBand} from 'd3-scale';
 import {Color} from 'types';
+import {classNames} from '@shopify/css-utilities';
 
 import {formatAriaLabel} from '../../utilities';
 import {StackSeries} from '../../types';
@@ -58,6 +59,9 @@ export function StackedBarGroup({
 
         const ariaEnabledBar = groupIndex === 0;
 
+        const nonUniqueHighlightColor =
+          colors[groupIndex] === highlightColors[groupIndex];
+
         return (
           <g
             role={groupIndex === 0 ? 'listitem' : undefined}
@@ -65,7 +69,10 @@ export function StackedBarGroup({
             key={barIndex}
           >
             <rect
-              className={styles.Bar}
+              className={classNames(
+                styles.Bar,
+                nonUniqueHighlightColor && styles.StackNoOutline,
+              )}
               key={barIndex}
               x={xPosition}
               y={yScale(end)}

--- a/src/components/MultiSeriesBarChart/shared.scss
+++ b/src/components/MultiSeriesBarChart/shared.scss
@@ -1,5 +1,10 @@
 @import 'node_modules/@shopify/polaris-tokens/dist/index';
+@import '../../styles/common';
 
 .Bar {
   transition: fill $duration-slow;
+}
+
+.StackNoOutline {
+  @include no-outline;
 }

--- a/src/styles/shared/_accessibility.scss
+++ b/src/styles/shared/_accessibility.scss
@@ -12,3 +12,7 @@
   opacity: 0;
   // stylelint-enable declaration-no-important
 }
+
+@mixin no-outline {
+  outline: none;
+}


### PR DESCRIPTION
### What problem is this PR solving?

Current PR adds outline to Bar if focused only if highlightColour doesn't exist. This could have been done directly in the styles for the `animated.path` but to accommodate for possible future changes, I added a `.scss` file. Feel free to ask me to change that if you feel strongly about not adding it in.

| Before | After |
| -- | -- |
| ![Screen Shot 2021-03-24 at 4 15 17 PM](https://user-images.githubusercontent.com/40300265/112377509-3a03cd00-8cbc-11eb-9616-4809b82fe91e.png) | ![Screen Shot 2021-03-24 at 4 14 56 PM](https://user-images.githubusercontent.com/40300265/112377476-2fe1ce80-8cbc-11eb-9ce2-bb166a6cacae.png) |
### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->
Accessibility should break for neither BarChart nor MultiSeriesBarChart. Focus outline should only appear if there's no highlight colour passed for the given bar (currently in the playground, the multiseries bar chart does have highlightColor while the regular barChart doesn't). This should work for both tabbing and clicking, and for both the stacked and non stacked version of the MultiSeriesBarChart.
<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
