### PR TITLE
Improve responsiveness of line chart on touch devices

### DIFF
--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -155,44 +155,53 @@ export function Chart({
     return null;
   }
 
-  const handleInteraction = throttle(
+  const handleMouseInteraction = throttle(
     (
       event:
         | React.MouseEvent<SVGSVGElement>
         | React.TouchEvent<SVGSVGElement>
         | null,
     ) => {
-      if (axisMargin == null || xScale == null) {
-        return;
-      }
-
-      if (event === null) {
-        setTooltipDetails(null);
-        return;
-      }
-
-      const point = eventPoint(event);
-
-      if (point == null) {
-        return;
-      }
-
-      const {svgX, svgY} = point;
-      if (svgX < axisMargin) {
-        return;
-      }
-
-      const closestIndex = Math.round(xScale.invert(svgX - axisMargin));
-
-      setTooltipDetails({
-        x: svgX,
-        y: svgY,
-        index: Math.min(longestSeriesLength, closestIndex),
-      });
+      handleInteraction(event);
     },
     50,
     {leading: true},
   );
+
+  function handleInteraction(
+    event:
+      | React.MouseEvent<SVGSVGElement>
+      | React.TouchEvent<SVGSVGElement>
+      | null,
+  ) {
+    if (axisMargin == null || xScale == null) {
+      return;
+    }
+
+    if (event === null) {
+      setTooltipDetails(null);
+      return;
+    }
+
+    const point = eventPoint(event);
+
+    if (point == null) {
+      return;
+    }
+
+    const {svgX, svgY} = point;
+    if (svgX < axisMargin) {
+      return;
+    }
+
+    const closestIndex = Math.round(xScale.invert(svgX - axisMargin));
+
+    setTooltipDetails({
+      x: svgX,
+      y: svgY,
+      index: Math.min(longestSeriesLength, closestIndex),
+    });
+  }
 
   return (
     <div className={styles.Container}>
@@ -202,14 +211,14 @@ export function Chart({
         height="100%"
         onMouseMove={(event) => {
           event.persist();
-          handleInteraction(event);
+          handleMouseInteraction(event);
         }}
         onTouchMove={(event) => {
           event.persist();
           handleInteraction(event);
         }}
         onTouchEnd={() => handleInteraction(null)}
-        onMouseLeave={() => handleInteraction(null)}
+        onMouseLeave={() => handleMouseInteraction(null)}
       >
         <g
           transform={`translate(${axisMargin},${dimensions.height -


### PR DESCRIPTION
### What problem is this PR solving?
I noticed that the line chart is not very responsive to touch events on mobile and then I realized it was because of the throttling added as part of performance improvements.

My approach is to keep the throttling for mouse events, but for touch events not to throttle them. I think this is okay as it seems likely there would be significantly less touch events being fired than mouse events, with a regular interaction.

It's a little difficult to capture in a video, but I tried my best!

|  Before | After  |
|---|---|
| ![Mar-24-2021 16-50-42](https://user-images.githubusercontent.com/12213371/112381554-17c07e00-8cc1-11eb-8103-c38eb05e9331.gif) | ![Mar-24-2021 16-45-53](https://user-images.githubusercontent.com/12213371/112381224-b8626e00-8cc0-11eb-8a6e-472da3146ead.gif) | 

### Reviewers’ :tophat: instructions
You can look at the regular playground. I looked at it in iOS simulator as I can't get my SimpleProxy working at the moment.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
