### PR TITLE
[Point] Remove focus outline on Point

### DIFF
--- a/src/components/Point/Point.scss
+++ b/src/components/Point/Point.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.Point {
+  @include no-outline;
+}

--- a/src/components/Point/Point.tsx
+++ b/src/components/Point/Point.tsx
@@ -4,6 +4,8 @@ import {Color, ActiveTooltip} from 'types';
 
 import {getColorValue} from '../../utilities';
 
+import styles from './Point.scss';
+
 interface Props {
   active: boolean;
   cx: number;
@@ -43,6 +45,7 @@ export const Point = React.memo(function Point({
       stroke={tokens.colorWhite}
       strokeWidth={1.5}
       onFocus={handleFocus}
+      className={styles.Point}
     />
   );
 });


### PR DESCRIPTION
### What problem is this PR solving?

Removing focus outline, as it is not needed on Point (for LineChart and AreaChart) as it is already prominent enough on it's own.
| Before | After | 
| -- | -- |
| <img width="409" alt="Screen Shot 2021-03-25 at 2 36 40 PM" src="https://user-images.githubusercontent.com/40300265/112525703-8829d680-8d77-11eb-9f1a-c6b8be53d424.png"> | <img width="483" alt="Screen Shot 2021-03-25 at 2 36 17 PM" src="https://user-images.githubusercontent.com/40300265/112525714-8bbd5d80-8d77-11eb-8266-28b886c1b36d.png"> |



### Reviewers’ :tophat: instructions

Accessibility should break for neither LineChart nor AreaChart. Focus outline should not appear on point while tabbing or clicking.

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
