### PR TITLE
[LineChart] Adding handling for empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `background`, `border`, `border-radius`, and `padding` to each `TooltipContent` styles
+- Added `emptyStateText` and empty state handling to `<LineChart />`
 
 ### Removed
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -36,6 +36,7 @@ interface Props {
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   hideXAxisLabels: boolean;
   hasSpline: boolean;
+  emptyStateText?: string;
 }
 
 export function Chart({
@@ -47,6 +48,7 @@ export function Chart({
   renderTooltipContent,
   hideXAxisLabels,
   hasSpline,
+  emptyStateText,
 }: Props) {
   const [tooltipDetails, setTooltipDetails] = useState<ActiveTooltip | null>(
     null,
@@ -56,6 +58,8 @@ export function Chart({
 
   const fontSize =
     dimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
+
+  const emptyState = series.length === 0;
 
   const {ticks: initialTicks} = useYScale({
     fontSize,
@@ -206,7 +210,7 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
-        role="table"
+        role={emptyState ? 'img' : 'table'}
         width="100%"
         height="100%"
         onMouseMove={(event) => {
@@ -219,6 +223,7 @@ export function Chart({
         }}
         onTouchEnd={() => handleInteraction(null)}
         onMouseLeave={() => handleMouseInteraction(null)}
+        aria-label={emptyState ? emptyStateText : undefined}
       >
         <g
           transform={`translate(${axisMargin},${dimensions.height -
@@ -243,7 +248,7 @@ export function Chart({
           />
         </g>
 
-        {tooltipDetails == null ? null : (
+        {tooltipDetails == null || emptyState ? null : (
           <g transform={`translate(${axisMargin},${Margin.Top})`}>
             <Crosshair
               x={xScale(tooltipDetails.index)}
@@ -252,11 +257,13 @@ export function Chart({
           </g>
         )}
 
-        <VisuallyHiddenRows
-          formatYAxisLabel={formatYAxisLabel}
-          xAxisLabels={formattedLabels}
-          series={series}
-        />
+        {emptyState ? null : (
+          <VisuallyHiddenRows
+            formatYAxisLabel={formatYAxisLabel}
+            xAxisLabels={formattedLabels}
+            series={series}
+          />
+        )}
 
         <g transform={`translate(${axisMargin},${Margin.Top})`}>
           {reversedSeries.map((singleSeries, index) => {
@@ -305,7 +312,7 @@ export function Chart({
         </g>
       </svg>
 
-      {tooltipDetails == null ? null : (
+      {tooltipDetails == null || emptyState ? null : (
         <TooltipContainer
           activePointIndex={tooltipDetails.index}
           currentX={tooltipDetails.x}

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -125,6 +125,7 @@ interface LineChartProps {
   formatYAxisLabel?(value: number): string;
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
+  emptyStateText?: string;
   hideXAxisLabels?: boolean;
 }
 ```
@@ -187,6 +188,8 @@ The lineStyle type determines if the drawn line for the series is a solid or das
 | `boolean` | `false` |
 
 The showArea type determines if a gradient area style is used for the series.
+
+If `series` may be an empty array, provide <a href="#emptyStateText">`emptyStateText`</a> to communicate the empty state to screenreaders.
 
 ### The `RenderTooltipContentData` type
 
@@ -266,11 +269,19 @@ This accepts a function that is called to render the tooltip content. By default
 
 #### skipLinkText
 
-| type     |
-| -------- |
-| `string` |
+| type     | default     |
+| -------- | ----------- |
+| `string` | `undefined` |
 
 If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.
+
+#### emptyStateText
+
+| type     | default     |
+| -------- | ----------- |
+| `string` | `undefined` |
+
+Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the series data. It is strongly recommended that this is included if the series prop could be an empty array.
 
 #### hasSpline
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -18,6 +18,7 @@ export interface LineChartProps {
   formatYAxisLabel?: NumberLabelFormatter;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
   skipLinkText?: string;
+  emptyStateText?: string;
   hasSpline?: boolean;
 }
 
@@ -29,6 +30,7 @@ export function LineChart({
   hideXAxisLabels = false,
   renderTooltipContent,
   skipLinkText,
+  emptyStateText,
   hasSpline = false,
 }: LineChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
@@ -54,10 +56,6 @@ export function LineChart({
     };
   }, [containerRef, updateDimensions]);
 
-  if (series.length === 0) {
-    return null;
-  }
-
   function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
     const formattedData = data.map(
       ({name, point: {label, value}, color, lineStyle}) => ({
@@ -82,7 +80,9 @@ export function LineChart({
 
   return (
     <React.Fragment>
-      {skipLinkText == null || skipLinkText.length === 0 ? null : (
+      {skipLinkText == null ||
+      skipLinkText.length === 0 ||
+      series.length === 0 ? null : (
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
       <div style={{width: '100%', height: '100%'}} ref={containerRef}>
@@ -100,6 +100,7 @@ export function LineChart({
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
+            emptyStateText={emptyStateText}
           />
         )}
       </div>

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -58,6 +58,17 @@ const mockProps = {
   hasSpline: false,
 };
 
+const mockEmptyStateProps = {
+  series: [],
+  xAxisLabels: [],
+  dimensions: new DOMRect(),
+  formatXAxisLabel: jest.fn((value) => value),
+  formatYAxisLabel: jest.fn((value) => value),
+  renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
+  hideXAxisLabels: false,
+  hasSpline: false,
+};
+
 describe('<Chart />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -198,6 +209,27 @@ describe('<Chart />', () => {
       series: mockProps.series,
       xAxisLabels: mockProps.xAxisLabels,
       formatYAxisLabel: mockProps.formatYAxisLabel,
+    });
+  });
+
+  describe('empty state', () => {
+    it('does not render tooltip for empty state', () => {
+      const chart = mount(<Chart {...mockEmptyStateProps} />);
+
+      expect(chart).not.toContainReactText('Mock Tooltip');
+      expect(chart).not.toContainReactComponent(TooltipContainer);
+    });
+
+    it('does not render crosshair for empty state', () => {
+      const chart = mount(<Chart {...mockEmptyStateProps} />);
+
+      expect(chart).not.toContainReactComponent(Crosshair);
+    });
+
+    it('does not render Visually Hidden Rows for empty state', () => {
+      const chart = mount(<Chart {...mockEmptyStateProps} />);
+
+      expect(chart).not.toContainReactComponent(VisuallyHiddenRows);
     });
   });
 });

--- a/src/components/LineChart/utilities/y-axis-min-max.ts
+++ b/src/components/LineChart/utilities/y-axis-min-max.ts
@@ -1,7 +1,15 @@
-import {DEFAULT_MAX_Y} from '../../../constants';
+import {
+  DEFAULT_MAX_Y,
+  EMPTY_STATE_CHART_MIN,
+  EMPTY_STATE_CHART_MAX,
+} from '../../../constants';
 import {Series} from '../types';
 
 export function yAxisMinMax(series: Series[]) {
+  if (series.length === 0) {
+    return [EMPTY_STATE_CHART_MIN, EMPTY_STATE_CHART_MAX];
+  }
+
   let minY = Infinity;
   let maxY = -Infinity;
 
@@ -13,6 +21,5 @@ export function yAxisMinMax(series: Series[]) {
   });
 
   maxY = maxY === 0 && minY === 0 ? DEFAULT_MAX_Y : maxY;
-
   return [minY, maxY];
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,8 @@ export const LABEL_SPACE_MINUS_FIRST_AND_LAST = 0.6;
 export const DEFAULT_MAX_Y = 10;
 export const ROUNDED_BAR_RADIUS = 3;
 export const MIN_BAR_HEIGHT = 5;
+export const EMPTY_STATE_CHART_MIN = 0;
+export const EMPTY_STATE_CHART_MAX = 10;
 
 export enum Margin {
   Top = SPACING_TIGHT,


### PR DESCRIPTION
### What problem is this PR solving?

Adds handling for empty state in `LineChart`, ie when series is an empty array.

| Before | After |
| -- | -- |
| ![Screen Shot 2021-04-07 at 2 36 46 PM](https://user-images.githubusercontent.com/40300265/113917102-cc24ce80-97ae-11eb-95a4-db470b5e6914.png) | ![Screen Shot 2021-04-07 at 2 36 13 PM](https://user-images.githubusercontent.com/40300265/113917097-c7f8b100-97ae-11eb-9f1b-3cc3214ee0b5.png) |

Also adds `emptyStateText` prop for `LineChart` for a11y in case of the empty state.

This PR is a part of the changes for https://github.com/Shopify/core-issues/issues/22617

### Reviewers’ :tophat: instructions

1. Pass in an empty array as `series` and `xAxisLabels` to `LineChart`, and make sure it doesn't render the Tooltip, Crosshair, or any unnecessary elements.
2. Make sure it plays well with a11y for both tabbing and screenreader support — it shouldn't render visually hidden rows if there's no data. (Or should it? What design decision makes more sense?)
3. Make sure the aria label for emptyStateText works as expected.
4. These changes should not affect how the `LineChart` normally works in case of no empty state.
5. Another question: Does it make sense to hard code [0, 10] for min and max Y axis values, or is there a better approach?

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
