### PR TITLE
[LineChart] Adding option for dotted line to LineChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `dotted` lineStyle to `LineChart`
+
 ## [0.8.0] — 2021-04-14
 
 ### Added

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -175,9 +175,9 @@ This accepts any [Polaris Viz color](/documentation/Polaris-Viz-colors.md) value
 
 #### lineStyle
 
-| type                  | default   |
-| --------------------- | --------- |
-| `'solid' \| 'dashed'` | `'solid'` |
+| type                              | default   |
+| --------------------------------- | --------- |
+| `'solid' \| 'dashed' \| 'dotted'` | `'solid'` |
 
 The lineStyle type determines if the drawn line for the series is a solid or dashed line.
 

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -5,6 +5,8 @@ import {ScaleLinear} from 'd3-scale';
 import {getColorValue} from '../../../../utilities';
 import {Series} from '../../types';
 
+import {StrokeDasharray} from './constants';
+
 interface Props {
   series: Required<Series>;
   xScale: ScaleLinear<number, number>;
@@ -41,7 +43,7 @@ export const Line = React.memo(function Shape({
       stroke={getColorValue(series.color)}
       strokeLinejoin="round"
       strokeLinecap="round"
-      strokeDasharray={series.lineStyle === 'dashed' ? '2 4' : 'unset'}
+      strokeDasharray={StrokeDasharray[series.lineStyle]}
     />
   );
 });

--- a/src/components/LineChart/components/Line/constants.ts
+++ b/src/components/LineChart/components/Line/constants.ts
@@ -1,0 +1,5 @@
+export const StrokeDasharray = {
+  dotted: '0.1 8',
+  dashed: '2 4',
+  solid: 'unset',
+};

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -37,7 +37,26 @@ const mockProps = {
 
 describe('<Line />', () => {
   describe('Line', () => {
-    it('renders a line with the series styles', () => {
+    it('renders a line with the series style solid', () => {
+      const actual = mount(
+        <svg>
+          <Line
+            {...mockProps}
+            series={{
+              ...mockProps.series,
+              lineStyle: 'solid',
+            }}
+          />
+        </svg>,
+      );
+
+      expect(actual).toContainReactComponent('path', {
+        strokeDasharray: 'unset',
+        stroke: getColorValue('primary'),
+      });
+    });
+
+    it('renders a line with the series style dashed', () => {
       const actual = mount(
         <svg>
           <Line
@@ -52,6 +71,25 @@ describe('<Line />', () => {
 
       expect(actual).toContainReactComponent('path', {
         strokeDasharray: '2 4',
+        stroke: getColorValue('primary'),
+      });
+    });
+
+    it('renders a line with the series style dotted', () => {
+      const actual = mount(
+        <svg>
+          <Line
+            {...mockProps}
+            series={{
+              ...mockProps.series,
+              lineStyle: 'dotted',
+            }}
+          />
+        </svg>,
+      );
+
+      expect(actual).toContainReactComponent('path', {
+        strokeDasharray: '0.1 8',
         stroke: getColorValue('primary'),
       });
     });

--- a/src/components/LinePreview/LinePreview.tsx
+++ b/src/components/LinePreview/LinePreview.tsx
@@ -4,6 +4,12 @@ import {Color} from 'types';
 import {getColorValue} from '../../utilities';
 import {LineStyle} from '../../types';
 
+import {
+  DOTTED_LINE_PREVIEW_CY,
+  DOTTED_LINE_PREVIEW_RADIUS,
+  DOT_SPACING,
+} from './constants';
+
 interface Props {
   color: Color;
   lineStyle: LineStyle;
@@ -13,13 +19,46 @@ export function LinePreview({color, lineStyle}: Props) {
   return (
     <div>
       <svg width="15px" height="5px">
-        <path
-          d="M0,0L100,0"
-          stroke={getColorValue(color)}
-          strokeWidth="4"
-          strokeDasharray={lineStyle === 'dashed' ? '3 2' : 'unset'}
-        />
+        {getLinePreview(color, lineStyle)}
       </svg>
     </div>
   );
+}
+
+function getLinePreview(color: Color, lineStyle: LineStyle) {
+  const linePreviewColor = getColorValue(color);
+  const solidLine = (
+    <path d="M0,0L100,0" stroke={linePreviewColor} strokeWidth="4" />
+  );
+  const dashedLine = (
+    <path
+      d="M0,0L100,0"
+      stroke={linePreviewColor}
+      strokeWidth="4"
+      strokeDasharray="3 2"
+    />
+  );
+  const dottedLine = (
+    <g fill={linePreviewColor}>
+      {[...Array(3)].map((_, index) => {
+        return (
+          <circle
+            key={index}
+            cx={1 + index * DOT_SPACING}
+            cy={DOTTED_LINE_PREVIEW_CY}
+            r={DOTTED_LINE_PREVIEW_RADIUS}
+          />
+        );
+      })}
+    </g>
+  );
+
+  switch (lineStyle) {
+    case 'dashed':
+      return dashedLine;
+    case 'dotted':
+      return dottedLine;
+    default:
+      return solidLine;
+  }
 }

--- a/src/components/LinePreview/constants.ts
+++ b/src/components/LinePreview/constants.ts
@@ -1,0 +1,3 @@
+export const DOTTED_LINE_PREVIEW_CY = 1;
+export const DOTTED_LINE_PREVIEW_RADIUS = 1;
+export const DOT_SPACING = 5;

--- a/src/components/LinePreview/tests/LinePreview.test.tsx
+++ b/src/components/LinePreview/tests/LinePreview.test.tsx
@@ -28,8 +28,14 @@ describe('<LinePreview />', () => {
       <LinePreview color="colorBlue" lineStyle="solid" />,
     );
 
-    expect(linePreview).toContainReactComponent('path', {
-      strokeDasharray: 'unset',
-    });
+    expect(linePreview).toContainReactComponent('path');
+  });
+
+  it('renders a dotted path if lineStyle is dotted', () => {
+    const linePreview = mount(
+      <LinePreview color="colorBlue" lineStyle="dotted" />,
+    );
+
+    expect(linePreview).toContainReactComponentTimes('circle', 3);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface NullableData {
   rawValue: number | null;
 }
 
-export type LineStyle = 'dashed' | 'solid';
+export type LineStyle = 'dashed' | 'solid' | 'dotted';
 
 export interface DataSeries<T> {
   name: string;


### PR DESCRIPTION
### What problem is this PR solving?

Resolves [this issue](https://app.zenhub.com/workspaces/insights-analytical-standards-6035163ff10573001475dba4/issues/shopify/core-issues/23564).

Adds a dotted `lineStyle` option to `LineChart`.
![Screen Shot 2021-04-14 at 11 58 17 AM](https://user-images.githubusercontent.com/40300265/114741391-b9fbe080-9d18-11eb-88ad-be7fd9c627ae.png)


### Reviewers’ :tophat: instructions

1. Change the `lineStyle` in `LineChartDemo` to dotted.
2. Make sure it visually is accurate on the graph.
3. Make sure the previews below and in the tooltip are accurate.
4. Make sure tests pass for the component.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
