### PR TITLE
Add basic line chart animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `dotted` lineStyle to `LineChart`
 - Added `emptyStateText` and empty state handling to `<BarChart />`
+- `isAnimated` prop to `LineChart` for line onload animation
 
 ## [0.8.0] — 2021-04-14
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -37,6 +37,7 @@ interface Props {
   hideXAxisLabels: boolean;
   hasSpline: boolean;
   emptyStateText?: string;
+  isAnimated: boolean;
 }
 
 export function Chart({
@@ -49,6 +50,7 @@ export function Chart({
   hideXAxisLabels,
   hasSpline,
   emptyStateText,
+  isAnimated,
 }: Props) {
   const [tooltipDetails, setTooltipDetails] = useState<ActiveTooltip | null>(
     null,
@@ -277,6 +279,8 @@ export function Chart({
                   xScale={xScale}
                   yScale={yScale}
                   hasSpline={hasSpline}
+                  isAnimated={isAnimated}
+                  index={index}
                 />
 
                 {data.map(({rawValue}, dataIndex) => {
@@ -304,6 +308,8 @@ export function Chart({
                     yScale={yScale}
                     xScale={xScale}
                     hasSpline={hasSpline}
+                    isAnimated={isAnimated}
+                    index={index}
                   />
                 ) : null}
               </React.Fragment>

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -290,3 +290,11 @@ Used to indicate to screenreaders that a chart with no data has been rendered, i
 | `boolean` | `false` |
 
 Whether to curve the line between points.
+
+#### isAnimated
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to animate the lines and gradient when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -4,6 +4,7 @@ import {useDebouncedCallback} from 'use-debounce';
 import {getDefaultColor, uniqueId} from '../../utilities';
 import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 import {SkipLink} from '../SkipLink';
+import {usePrefersReducedMotion} from '../../hooks';
 
 import {Chart} from './Chart';
 import {Series, RenderTooltipContentData} from './types';
@@ -20,6 +21,7 @@ export interface LineChartProps {
   skipLinkText?: string;
   emptyStateText?: string;
   hasSpline?: boolean;
+  isAnimated?: boolean;
 }
 
 export function LineChart({
@@ -32,9 +34,11 @@ export function LineChart({
   skipLinkText,
   emptyStateText,
   hasSpline = false,
+  isAnimated = false,
 }: LineChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const {prefersReducedMotion} = usePrefersReducedMotion();
 
   const skipLinkAnchorId = useRef(uniqueId('lineChart'));
 
@@ -95,6 +99,7 @@ export function LineChart({
             dimensions={chartDimensions}
             hideXAxisLabels={hideXAxisLabels}
             hasSpline={hasSpline}
+            isAnimated={isAnimated && !prefersReducedMotion}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent

--- a/src/components/LineChart/components/GradientArea/GradientArea.scss
+++ b/src/components/LineChart/components/GradientArea/GradientArea.scss
@@ -1,0 +1,10 @@
+.FadeInArea {
+  opacity: 0;
+  animation: fadeIn 0.5s ease-in-out forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}

--- a/src/components/LineChart/components/GradientArea/GradientArea.tsx
+++ b/src/components/LineChart/components/GradientArea/GradientArea.tsx
@@ -3,19 +3,30 @@ import {ScaleLinear} from 'd3-scale';
 import {area, curveMonotoneX} from 'd3-shape';
 
 import {uniqueId, getColorValue, rgbToRgba} from '../../../../utilities';
+import {ANIMATION_DELAY, SLOW_DURATION, FAST_DURATION} from '../../constants';
 import {Data} from '../../../../types';
 import {Series} from '../../types';
 
 import {getGradientDetails} from './utilities/get-gradient-details';
+import styles from './GradientArea.scss';
 
 interface Props {
   series: Series;
   yScale: ScaleLinear<number, number>;
   xScale: ScaleLinear<number, number>;
   hasSpline: boolean;
+  isAnimated: boolean;
+  index: number;
 }
 
-export function GradientArea({series, yScale, xScale, hasSpline}: Props) {
+export function GradientArea({
+  series,
+  yScale,
+  xScale,
+  hasSpline,
+  isAnimated,
+  index,
+}: Props) {
   const id = useMemo(() => uniqueId('gradient'), []);
   const {data, color} = series;
 
@@ -36,6 +47,10 @@ export function GradientArea({series, yScale, xScale, hasSpline}: Props) {
 
   const rgb = getColorValue(color);
   const gradientStops = getGradientDetails(data);
+  const animationDelay =
+    data.length > 1000
+      ? index * ANIMATION_DELAY + SLOW_DURATION
+      : index * ANIMATION_DELAY + FAST_DURATION;
 
   return (
     <React.Fragment>
@@ -53,9 +68,13 @@ export function GradientArea({series, yScale, xScale, hasSpline}: Props) {
 
       <path
         d={areaShape}
+        style={{
+          animationDelay: `${animationDelay}s`,
+        }}
         fill={`url(#${id})`}
         strokeWidth="0"
         stroke={series.color}
+        className={isAnimated ? styles.FadeInArea : null}
       />
     </React.Fragment>
   );

--- a/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
+++ b/src/components/LineChart/components/GradientArea/tests/GradientArea.test.tsx
@@ -32,6 +32,8 @@ describe('<GradientArea />', () => {
     xScale: scaleLinear(),
     yScale: scaleLinear(),
     hasSpline: false,
+    isAnimated: false,
+    index: 0,
   };
 
   it('renders a linear gradient', () => {

--- a/src/components/LineChart/components/Line/Line.scss
+++ b/src/components/LineChart/components/Line/Line.scss
@@ -1,0 +1,18 @@
+@import '../../../../styles/common';
+
+.AnimatedPath {
+  animation: reveal ease-in-out both;
+}
+
+@keyframes reveal {
+  // clip-path margin is to prevent the top and bottom of the path from being cut off
+  0% {
+    clip-path: inset($clip-path-margin 100% $clip-path-margin 0);
+  }
+  99% {
+    clip-path: inset($clip-path-margin 0% $clip-path-margin 0);
+  }
+  100% {
+    clip-path: unset;
+  }
+}

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -4,7 +4,9 @@ import {ScaleLinear} from 'd3-scale';
 
 import {getColorValue} from '../../../../utilities';
 import {Series} from '../../types';
+import {ANIMATION_DELAY, FAST_DURATION, SLOW_DURATION} from '../../constants';
 
+import styles from './Line.scss';
 import {StrokeDasharray} from './constants';
 
 interface Props {
@@ -12,6 +14,8 @@ interface Props {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   hasSpline: boolean;
+  isAnimated: boolean;
+  index: number;
 }
 
 export const Line = React.memo(function Shape({
@@ -19,6 +23,8 @@ export const Line = React.memo(function Shape({
   series,
   xScale,
   yScale,
+  isAnimated,
+  index,
 }: Props) {
   const lineGenerator = line<{rawValue: number}>()
     .x((_, index) => xScale(index))
@@ -30,6 +36,10 @@ export const Line = React.memo(function Shape({
 
   const path = lineGenerator(series.data);
 
+  const animationDelay = index * ANIMATION_DELAY;
+  const animationDuration =
+    series.data.length > 1000 ? SLOW_DURATION : FAST_DURATION;
+
   if (path == null) {
     return null;
   }
@@ -37,6 +47,10 @@ export const Line = React.memo(function Shape({
   return (
     <path
       d={path}
+      style={{
+        animationDelay: `${animationDelay}s`,
+        animationDuration: `${animationDuration}s`,
+      }}
       fill="none"
       strokeWidth="2px"
       paintOrder="stroke"
@@ -44,6 +58,7 @@ export const Line = React.memo(function Shape({
       strokeLinejoin="round"
       strokeLinecap="round"
       strokeDasharray={StrokeDasharray[series.lineStyle]}
+      className={isAnimated ? styles.AnimatedPath : null}
     />
   );
 });

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -33,6 +33,8 @@ const mockProps = {
   xScale: scaleLinear(),
   yScale: scaleLinear(),
   hasSpline: false,
+  isAnimated: false,
+  index: 0,
 };
 
 describe('<Line />', () => {

--- a/src/components/LineChart/constants.ts
+++ b/src/components/LineChart/constants.ts
@@ -7,3 +7,6 @@ export const SMALL_WIDTH = 300;
 export const MIN_LABEL_SPACE = 100;
 export const TICK_SIZE = 6;
 export const FONT_SIZE = 12;
+export const ANIMATION_DELAY = 0.25;
+export const SLOW_DURATION = 1;
+export const FAST_DURATION = 0.5;

--- a/src/components/LineChart/stories/LineChart.stories.scss
+++ b/src/components/LineChart/stories/LineChart.stories.scss
@@ -1,0 +1,11 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+.Container {
+  background: white;
+  padding: 20px;
+  box-sizing: border-box;
+  height: 400px;
+  overflow: hidden;
+}

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {Story, Meta} from '@storybook/react';
+
+import {LineChart, LineChartProps} from '../LineChart';
+import styles from './LineChart.stories.scss';
+import {
+  series,
+  xAxisLabels,
+  formatXAxisLabel,
+  formatYAxisLabel,
+  renderTooltipContent,
+} from './utils.stories';
+
+export default {
+  title: 'LineChart',
+  component: LineChart,
+  decorators: [
+    (Story: any) => <div className={styles.Container}>{Story()}</div>,
+  ],
+  argTypes: {
+    // Render the prop documentation but without a control.
+    formatXAxisLabel: {
+      control: false,
+    },
+    formatYAxisLabel: {
+      control: false,
+    },
+    renderTooltipContent: {
+      control: false,
+    },
+  },
+} as Meta;
+
+const Template: Story<LineChartProps> = (args: LineChartProps) => {
+  return <LineChart {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  series,
+  xAxisLabels,
+  formatXAxisLabel,
+  formatYAxisLabel,
+  renderTooltipContent,
+};

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import {TooltipContent} from '../components/TooltipContent/TooltipContent';
+import {LineChartProps} from '../LineChart';
+
+export const series = [
+  {
+    name: 'Apr 01–Apr 14, 2020',
+    data: [
+      {rawValue: 333, label: '2020-04-01T12:00:00'},
+      {rawValue: 897, label: '2020-04-02T12:00:00'},
+      {rawValue: 234, label: '2020-04-03T12:00:00'},
+      {rawValue: 534, label: '2020-04-04T12:00:00'},
+      {rawValue: 132, label: '2020-04-05T12:00:00'},
+      {rawValue: 159, label: '2020-04-06T12:00:00'},
+      {rawValue: 239, label: '2020-04-07T12:00:00'},
+      {rawValue: 908, label: '2020-04-08T12:00:00'},
+      {rawValue: 234, label: '2020-04-09T12:00:00'},
+      {rawValue: 645, label: '2020-04-10T12:00:00'},
+      {rawValue: 543, label: '2020-04-11T12:00:00'},
+      {rawValue: 89, label: '2020-04-12T12:00:00'},
+      {rawValue: 809, label: '2020-04-13T12:00:00'},
+      {rawValue: 129, label: '2020-04-14T12:00:00'},
+    ],
+    color: 'primary' as 'primary',
+    lineStyle: 'solid' as 'solid',
+    showArea: true,
+  },
+  {
+    name: 'Mar 01–Mar 14, 2020',
+    data: [
+      {rawValue: 809, label: '2020-03-02T12:00:00'},
+      {rawValue: 238, label: '2020-03-01T12:00:00'},
+      {rawValue: 190, label: '2020-03-03T12:00:00'},
+      {rawValue: 90, label: '2020-03-04T12:00:00'},
+      {rawValue: 237, label: '2020-03-05T12:00:00'},
+      {rawValue: 580, label: '2020-03-07T12:00:00'},
+      {rawValue: 172, label: '2020-03-06T12:00:00'},
+      {rawValue: 12, label: '2020-03-08T12:00:00'},
+      {rawValue: 390, label: '2020-03-09T12:00:00'},
+      {rawValue: 43, label: '2020-03-10T12:00:00'},
+      {rawValue: 997, label: '2020-03-11T12:00:00'},
+      {rawValue: 791, label: '2020-03-12T12:00:00'},
+      {rawValue: 623, label: '2020-03-13T12:00:00'},
+      {rawValue: 21, label: '2020-03-14T12:00:00'},
+    ],
+    color: 'pastComparison' as 'pastComparison',
+    lineStyle: 'dashed' as 'dashed',
+  },
+];
+
+export const xAxisLabels = series[0].data.map(({label}) => label);
+
+export function formatXAxisLabel(value: string) {
+  return new Date(value).toLocaleDateString('en-CA', {
+    day: 'numeric',
+    month: 'numeric',
+  });
+}
+
+export function formatYAxisLabel(value: number) {
+  return new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: 'CAD',
+    currencyDisplay: 'symbol',
+    maximumSignificantDigits: 1,
+  }).format(value);
+}
+
+export const renderTooltipContent: LineChartProps['renderTooltipContent'] = ({
+  data,
+}) => {
+  function formatTooltipValue(value: number) {
+    return new Intl.NumberFormat('en', {
+      style: 'currency',
+      currency: 'CAD',
+    }).format(value);
+  }
+
+  function formatTooltipLabel(value: string) {
+    return new Date(value).toLocaleDateString('en-CA', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
+  const formattedData = data.map(
+    ({name, point: {label, value}, color, lineStyle}) => ({
+      name,
+      color,
+      lineStyle,
+      point: {
+        value: formatTooltipValue(value),
+        label: formatTooltipLabel(label),
+      },
+    }),
+  );
+
+  return <TooltipContent data={formattedData} />;
+};

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -56,6 +56,7 @@ const mockProps = {
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
   hideXAxisLabels: false,
   hasSpline: false,
+  isAnimated: false,
 };
 
 const mockEmptyStateProps = {
@@ -67,11 +68,20 @@ const mockEmptyStateProps = {
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
   hideXAxisLabels: false,
   hasSpline: false,
+  isAnimated: false,
 };
 
 describe('<Chart />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
+  });
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: jest.fn(() => {
+        return {matches: false};
+      }),
+    });
   });
 
   afterEach(() => {

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -27,6 +27,14 @@ const primarySeries: Required<Series> = {
 };
 
 describe('<LineChart />', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: jest.fn(() => {
+        return {matches: false};
+      }),
+    });
+  });
+
   it('renders a <Chart />', () => {
     const lineChart = mount(
       <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -1,7 +1,11 @@
 import React, {useState, useMemo, useRef} from 'react';
 import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
 
-import {useLinearXAxisDetails, useLinearXScale} from '../../hooks';
+import {
+  useLinearXAxisDetails,
+  useLinearXScale,
+  usePrefersReducedMotion,
+} from '../../hooks';
 import {
   SMALL_SCREEN,
   SMALL_FONT_SIZE,
@@ -48,6 +52,8 @@ export function Chart({
   opacity,
   isAnimated,
 }: Props) {
+  const {prefersReducedMotion} = usePrefersReducedMotion();
+
   const [activePointIndex, setActivePointIndex] = useState<number | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<{
     x: number;
@@ -207,7 +213,7 @@ export function Chart({
           yScale={yScale}
           colors={colors}
           opacity={opacity}
-          isAnimated={isAnimated}
+          isAnimated={isAnimated && !prefersReducedMotion}
         />
 
         {activePointIndex == null ? null : (

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -6,7 +6,6 @@ import {Color} from 'types';
 import {ScaleLinear} from 'd3-scale';
 
 import {getColorValue, uniqueId} from '../../../../utilities';
-import {usePrefersReducedMotion} from '../../../../hooks';
 
 import {usePrevious} from './hooks';
 
@@ -40,7 +39,6 @@ export function Areas({
   opacity,
   isAnimated,
 }: Props) {
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const prevstackedValues = usePrevious(stackedValues);
   const valuesHaveNotUpdated = isEqual(prevstackedValues, stackedValues);
 
@@ -50,7 +48,7 @@ export function Areas({
     from: {
       width: 0,
     },
-    immediate: prefersReducedMotion || !isAnimated || valuesHaveNotUpdated,
+    immediate: !isAnimated || valuesHaveNotUpdated,
     reset: true,
   });
 

--- a/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -14,14 +14,6 @@ jest.mock('utilities/unique-id', () => ({
 }));
 
 describe('<StackedAreas />', () => {
-  beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      value: jest.fn(() => {
-        return {matches: false};
-      }),
-    });
-  });
-
   const mockProps = {
     width: 100,
     height: 50,

--- a/src/styles/shared/_variables.scss
+++ b/src/styles/shared/_variables.scss
@@ -1,3 +1,4 @@
 $button-drop-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
 $border-radius-base: 0.4rem;
 $border-subdued: rgba(186, 191, 195, 1);
+$clip-path-margin: -5px;


### PR DESCRIPTION
### What problem is this PR solving?
Part 1 of https://github.com/Shopify/core-issues/issues/23491

I think my [original PR](https://github.com/Shopify/polaris-viz/pull/268) for line chart animations is getting a bit out of hand. I think it'd be a good idea to separate the animations for the line (this PR), then have my other PR focus on animating the points.  

If all looks good here, I will update `<Sparkline />` animations to match in a future PR.

### Reviewers’ :tophat: instructions

* Run Storybook `yarn storybook`, or view [here](https://6062ad4a2d14cd0021539c1b-kwtzilezex.chromatic.com/)
* Go to `http://localhost:6006/?path=/docs/linechart--default`, scroll down and set `isAnimated` to true
* Interact with the chart, make sure the animations for the line and points load
* On your computer, go to `System Preferences > Accessibility > Display`
   ![image](https://user-images.githubusercontent.com/30587540/113627638-cd7cbc80-9631-11eb-9c9f-6d3c1751d2b9.png)
* Refresh storybook, go back to `Docs` and turn on animations again
* Make sure that the animations don't load
* Confirm tabbing/screenreader still works

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
