### PR TITLE
[Bar chart] Add minimal x axis labels option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Ability to show point at the end of a `<Sparkline />` series
+- `emptyStateText` and empty state handling to `<MultiSeriesBarChart />`
+- `useMinimalLabels` option added to the `<BarChart />` `xAxisOptions` prop
 
 ### Changed
 
@@ -13,10 +15,6 @@
 ### Removed
 
 - The timeseries prop has been removed from bar charts, in favour of using that label handling by default (when there is not enough room for all diagonal labels, some will be dropped).
-
-### Added
-
-- `emptyStateText` and empty state handling to `<MultiSeriesBarChart />`
 
 ## [0.8.1] — 2021-04-20
 

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -100,6 +100,7 @@ interface BarChartProps {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
     showTicks?: boolean;
     labelColor?: string;
+    useMinimalLabels?: boolean;
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
@@ -229,6 +230,14 @@ This accepts a function that is called to format the labels when the chart draws
 | `string` | `'rgb(223, 227, 232)'` |
 
 The color used for axis labels.
+
+##### useMinimalLabels
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+If set to true, a chart with more than three xAxis labels will show a maximum of three labels. This option is useful when timeseries data is displayed.
 
 ##### showTicks
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -89,6 +89,7 @@ export function BarChart({
     labelFormatter: (value: string) => value,
     showTicks: true,
     labelColor: DEFAULT_GREY_LABEL,
+    useMinimalLabels: false,
     ...xAxisOptions,
   };
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -88,6 +88,11 @@ export function Chart({
     [fontSize, initialTicks],
   );
 
+  const minimalLabelIndexes =
+    xAxisOptions.useMinimalLabels && data.length > 3
+      ? [0, Math.floor(data.length / 2), data.length - 1]
+      : null;
+
   const xAxisDetails = useMemo(
     () =>
       getBarXAxisDetails({
@@ -96,6 +101,7 @@ export function Chart({
         xLabels: data.map(({label}) => xAxisOptions.labelFormatter(label)),
         chartDimensions,
         padding: barOptions.margin,
+        minimalLabelIndexes,
       }),
     [
       approxYAxisLabelWidth,
@@ -103,6 +109,7 @@ export function Chart({
       data,
       chartDimensions,
       barOptions.margin,
+      minimalLabelIndexes,
       xAxisOptions,
     ],
   );
@@ -203,11 +210,11 @@ export function Chart({
             labels={xAxisLabels}
             xScale={xScale}
             fontSize={fontSize}
-            showFewerLabels={xAxisDetails.needsDiagonalLabels}
             xAxisDetails={xAxisDetails}
             textColor={xAxisOptions.labelColor}
             gridColor={gridOptions.color}
             showTicks={xAxisOptions.showTicks}
+            minimalLabelIndexes={minimalLabelIndexes}
           />
         </g>
 

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -42,6 +42,7 @@ describe('Chart />', () => {
       labelFormatter: (value: string) => value.toString(),
       showTicks: true,
       labelColor: 'red',
+      useMinimalLabels: false,
     },
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
@@ -56,9 +57,51 @@ describe('Chart />', () => {
     expect(barChart).toContainReactComponent('svg');
   });
 
-  it('renders an xAxis', () => {
-    const barChart = mount(<Chart {...mockProps} />);
-    expect(barChart).toContainReactComponent(BarChartXAxis);
+  describe('<BarChartXAxis />', () => {
+    it('renders', () => {
+      const barChart = mount(<Chart {...mockProps} />);
+      expect(barChart).toContainReactComponent(BarChartXAxis);
+    });
+
+    it('is passed three minimalLabelIndexes if useMinimalLabels is true and there are more than three data items', () => {
+      const barChart = mount(
+        <Chart
+          {...mockProps}
+          data={[
+            {rawValue: 10, label: 'data'},
+            {rawValue: 20, label: 'data 2'},
+            {rawValue: 20, label: 'data 3'},
+            {rawValue: 20, label: 'data 4'},
+          ]}
+          xAxisOptions={{
+            labelFormatter: (value: string) => value.toString(),
+            showTicks: true,
+            labelColor: 'red',
+            useMinimalLabels: true,
+          }}
+        />,
+      );
+      expect(barChart).toContainReactComponent(BarChartXAxis, {
+        minimalLabelIndexes: [0, 2, 3],
+      });
+    });
+
+    it('is passed null minimalLabelIndexes if useMinimalLabels is true but there are less than three bars', () => {
+      const barChart = mount(
+        <Chart
+          {...mockProps}
+          xAxisOptions={{
+            labelFormatter: (value: string) => value.toString(),
+            showTicks: true,
+            labelColor: 'red',
+            useMinimalLabels: true,
+          }}
+        />,
+      );
+      expect(barChart).toContainReactComponent(BarChartXAxis, {
+        minimalLabelIndexes: null,
+      });
+    });
   });
 
   it('renders an yAxis', () => {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -28,6 +28,7 @@ export interface XAxisOptions {
   labelFormatter: StringLabelFormatter;
   showTicks: boolean;
   labelColor: string;
+  useMinimalLabels: boolean;
 }
 
 export interface YAxisOptions {

--- a/src/components/BarChartXAxis/BarChartXAxis.scss
+++ b/src/components/BarChartXAxis/BarChartXAxis.scss
@@ -7,7 +7,6 @@
 }
 
 .DiagonalText {
-  text-align: right;
   @include ellipsis-overflow;
   line-height: 1;
 }

--- a/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
+++ b/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
@@ -27,7 +27,6 @@ describe('<BarChartXAxis/>', () => {
       {value: 'Label', xOffset: 20},
     ],
     xScale: scaleBand(),
-    showFewerLabels: false,
     xAxisDetails: {
       needsDiagonalLabels: false,
       maxXLabelHeight: 40,
@@ -72,12 +71,11 @@ describe('<BarChartXAxis/>', () => {
     expect(axis).toContainReactComponentTimes('foreignObject', 2);
   });
 
-  it('hides elements if showFewerLabels is true and there is not enough room', () => {
+  it('hides elements if needsDiagonalLabels is true and there is not enough room', () => {
     const axis = mount(
       <svg>
         <BarChartXAxis
           {...mockProps}
-          showFewerLabels
           xAxisDetails={{
             ...mockProps.xAxisDetails,
             needsDiagonalLabels: true,
@@ -115,5 +113,68 @@ describe('<BarChartXAxis/>', () => {
 
     const foreignObjectTransform = axis.find('foreignObject')!.props.transform;
     expect(foreignObjectTransform).toContain('rotate');
+  });
+
+  it('displays minimal labels if minimalLabelIndexes is true', () => {
+    const axis = mount(
+      <svg>
+        <BarChartXAxis
+          {...mockProps}
+          minimalLabelIndexes={[0, 3, 6]}
+          labels={[
+            {value: '0', xOffset: 10},
+            {value: '1', xOffset: 10},
+            {value: '2', xOffset: 20},
+            {value: '3', xOffset: 20},
+            {value: '4', xOffset: 20},
+            {value: '5', xOffset: 20},
+            {value: '6', xOffset: 20},
+          ]}
+        />
+        ,
+      </svg>,
+    );
+
+    const styleProps = {fontSize: 10, color: 'red'};
+
+    expect(axis).toContainReactComponent('div', {
+      children: '0',
+      style: {...styleProps, textAlign: 'left'},
+    });
+
+    expect(axis).toContainReactComponent('div', {
+      children: '3',
+      style: {...styleProps, textAlign: 'center'},
+    });
+
+    expect(axis).toContainReactComponent('div', {
+      children: '6',
+      style: {...styleProps, textAlign: 'right'},
+    });
+  });
+
+  it('uses modified positions for minimal xAxis labels', () => {
+    const axis = mount(
+      <svg>
+        <BarChartXAxis
+          {...mockProps}
+          minimalLabelIndexes={[0, 3, 6]}
+          labels={[
+            {value: '0', xOffset: 10},
+            {value: '1', xOffset: 10},
+            {value: '2', xOffset: 20},
+            {value: '3', xOffset: 20},
+            {value: '4', xOffset: 20},
+            {value: '5', xOffset: 20},
+            {value: '6', xOffset: 20},
+          ]}
+        />
+        ,
+      </svg>,
+    );
+
+    expect(axis).toContainReactComponent('g', {
+      transform: 'translate(5, 8)',
+    });
   });
 });

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -214,7 +214,6 @@ export function Chart({
             labels={xAxisLabels}
             xScale={xScale}
             xAxisDetails={xAxisDetails}
-            showFewerLabels={xAxisDetails.needsDiagonalLabels}
             fontSize={fontSize}
             textColor={xAxisOptions.labelColor}
             gridColor={gridOptions.color}

--- a/src/utilities/tests/get-bar-xaxis-details.test.ts
+++ b/src/utilities/tests/get-bar-xaxis-details.test.ts
@@ -15,20 +15,20 @@ jest.mock('../../utilities/get-text-container-height', () => ({
 }));
 
 describe('getBarXAxisDetails', () => {
-  it('returns xAxis details when diagonal labels are needed', () => {
-    const manyDataPoints = [
-      {rawValue: 10, label: 'Value 1'},
-      {rawValue: 0, label: 'Value 2'},
-      {rawValue: 10, label: 'Value 1'},
-      {rawValue: 0, label: 'Value 2'},
-      {rawValue: 10, label: 'Value 1'},
-      {rawValue: 0, label: 'Value 2'},
-      {rawValue: 10, label: 'Value 1'},
-      {rawValue: 0, label: 'Value 2'},
-      {rawValue: 10, label: 'Value 1'},
-      {rawValue: 0, label: 'Value 2'},
-    ];
+  const manyDataPoints = [
+    {rawValue: 10, label: 'Value 1'},
+    {rawValue: 0, label: 'Value 2'},
+    {rawValue: 10, label: 'Value 1'},
+    {rawValue: 0, label: 'Value 2'},
+    {rawValue: 10, label: 'Value 1'},
+    {rawValue: 0, label: 'Value 2'},
+    {rawValue: 10, label: 'Value 1'},
+    {rawValue: 0, label: 'Value 2'},
+    {rawValue: 10, label: 'Value 1'},
+    {rawValue: 0, label: 'Value 2'},
+  ];
 
+  it('returns xAxis details when diagonal labels are needed', () => {
     const actual = getBarXAxisDetails({
       yAxisLabelWidth: 100,
       xLabels: manyDataPoints.map(({label}) => label),
@@ -59,5 +59,25 @@ describe('getBarXAxisDetails', () => {
     });
 
     expect(actual).toMatchObject({needsDiagonalLabels: false});
+  });
+
+  it('returns xAxis details when minimalLabelIndexes are provided', () => {
+    const actual = getBarXAxisDetails({
+      yAxisLabelWidth: 10,
+      xLabels: manyDataPoints.map(({label}) => label),
+      fontSize: 10,
+      minimalLabelIndexes: [0, 4, 9],
+      chartDimensions: {
+        height: 100,
+        width: 100,
+      } as any,
+    });
+
+    expect(actual).toMatchObject({
+      maxXLabelHeight: 10.656565315951458,
+      maxDiagonalLabelLength: 16.57867257451994,
+      needsDiagonalLabels: true,
+      maxWidth: 18,
+    });
   });
 });


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/23743

Adds an option to the bar chart API to allow for minimal xAxis labels (the first, middle and third) label, when the bar chart has more than  3 bars.

| Design  |  Component |
|---|---|
| <img width="1099" alt="Screen Shot 2021-04-22 at 8 45 18 AM" src="https://user-images.githubusercontent.com/12213371/115716505-3d37ba80-a347-11eb-87fe-a9fc30adb4f0.png"> | <img width="1513" alt="Screen Shot 2021-04-22 at 8 49 45 AM" src="https://user-images.githubusercontent.com/12213371/115717129-e088cf80-a347-11eb-98f9-7de4c48338ec.png">  | 


### Reviewers’ :tophat: instructions
Add the `useMinimalLabels` boolean to the `xAxisOptions` object of the BarChart, like this:

```
          xAxisOptions={{
            useMinimalLabels: true,
          }}

```

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
