### PR TITLE
[Line Chart] Make API more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `emptyStateText` and empty state handling to `<BarChart />`
 - `isAnimated` prop to `LineChart`, `BarChart` and `MultiSeriesBarChart`
 
+### Changed
+
+- The line chart API now allows for custom configuration of chart element colors and widths. Some top-level props are now nested within more specific object props to configure the appearance of the chart.
+
 ## [0.8.0] — 2021-04-14
 
 ### Added

--- a/documentation/code/LineChartDemo.tsx
+++ b/documentation/code/LineChartDemo.tsx
@@ -121,9 +121,12 @@ export function LineChartDemo() {
       <div style={innerContainerStyle}>
         <LineChart
           series={series}
-          xAxisLabels={xAxisLabels}
-          formatXAxisLabel={formatXAxisLabel}
-          formatYAxisLabel={formatYAxisLabel}
+          xAxisOptions={{
+            xAxisLabels,
+            labelFormatter: formatXAxisLabel,
+            showTicks: true,
+          }}
+          yAxisOptions={{labelFormatter: formatYAxisLabel}}
           renderTooltipContent={renderTooltipContent}
           skipLinkText="Skip line chart content"
         />

--- a/src/components/Crosshair/Crosshair.scss
+++ b/src/components/Crosshair/Crosshair.scss
@@ -1,5 +1,0 @@
-@import '../../styles/common';
-
-.Crosshair {
-  @include axis-crosshair;
-}

--- a/src/components/Crosshair/Crosshair.tsx
+++ b/src/components/Crosshair/Crosshair.tsx
@@ -1,25 +1,31 @@
 import React from 'react';
 
-import {CROSSHAIR_WIDTH} from '../../constants';
-
-import styles from './Crosshair.scss';
+import {CROSSHAIR_WIDTH, DEFAULT_CROSSHAIR_COLOR} from '../../constants';
 
 interface Props {
   x: number;
   height: number;
   opacity?: number;
+  fill?: string;
+  width?: number;
 }
 
-export function Crosshair({x, height, opacity = 1}: Props) {
+export function Crosshair({
+  x,
+  height,
+  opacity = 1,
+  width = CROSSHAIR_WIDTH,
+  fill = DEFAULT_CROSSHAIR_COLOR,
+}: Props) {
   return (
     <rect
-      x={x - CROSSHAIR_WIDTH / 2}
-      width={CROSSHAIR_WIDTH}
+      x={x - width / 2}
+      width={width}
       height={height}
       stroke="none"
-      className={styles.Crosshair}
       style={{
         opacity,
+        fill,
       }}
     />
   );

--- a/src/components/Crosshair/tests/Crosshair.test.tsx
+++ b/src/components/Crosshair/tests/Crosshair.test.tsx
@@ -31,7 +31,9 @@ describe('<Crosshair />', () => {
       </svg>,
     );
 
-    expect(crosshair).toContainReactComponent('rect', {style: {opacity: 1}});
+    expect(crosshair).toContainReactComponent('rect', {
+      style: {opacity: 1, fill: 'rgb(223, 227, 232)'},
+    });
   });
 
   it('applies opacity from props to the rect', () => {
@@ -41,6 +43,32 @@ describe('<Crosshair />', () => {
       </svg>,
     );
 
-    expect(crosshair).toContainReactComponent('rect', {style: {opacity: 0.8}});
+    expect(crosshair).toContainReactComponent('rect', {
+      style: {opacity: 0.8, fill: 'rgb(223, 227, 232)'},
+    });
+  });
+
+  it('applies color from props to the rect', () => {
+    const crosshair = mount(
+      <svg>
+        <Crosshair x={50} height={500} fill="red" />
+      </svg>,
+    );
+
+    expect(crosshair).toContainReactComponent('rect', {
+      style: {opacity: 1, fill: 'red'},
+    });
+  });
+
+  it('applies width from props to the rect', () => {
+    const crosshair = mount(
+      <svg>
+        <Crosshair x={50} height={500} width={100} />
+      </svg>,
+    );
+
+    expect(crosshair).toContainReactComponent('rect', {
+      width: 100,
+    });
   });
 });

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -104,9 +104,11 @@ const renderTooltipContent: LineChartProps['renderTooltipContent'] = ({
 return (
   <LineChart
     series={series}
-    xAxisLabels={xAxisLabels}
-    formatXAxisLabel={formatXAxisLabel}
-    formatYAxisLabel={formatYAxisLabel}
+    xAxisOptions={{
+      xAxisLabels,
+      labelFormatter: formatXAxisLabel,
+    }}
+    yAxisOptions={{labelFormatter: formatYAxisLabel}}
     renderTooltipContent={renderTooltipContent}
     skipLinkText="Skip chart content"
   />
@@ -120,13 +122,35 @@ The line chart interface looks like this:
 ```typescript
 interface LineChartProps {
   series: Series[];
-  xAxisLabels: string[];
-  formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
-  formatYAxisLabel?(value: number): string;
+  isAnimated?: boolean;
+  lineOptions?: {
+    hasSpline?: boolean;
+    width?: number;
+  };
+  xAxisOptions: {
+    xAxisLabels: string[];
+    labelFormatter?(value: string, index?: number, data?: string[]): string;
+    hideXAxisLabels?: boolean;
+    showTicks?: boolean;
+    labelColor: string;
+  };
+  yAxisOptions?: {
+    labelFormatter?(value: number): string;
+    labelColor: string;
+  }
+  gridOptions?: {
+    showVerticalLines?: boolean;
+    showHorizontalLines?: boolean;
+    color?: string;
+  }
+  crossHairOptions?: {
+    width?: number;
+    color?: string;
+    opacity?: number;
+  }
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
   emptyStateText?: string;
-  hideXAxisLabels?: boolean;
 }
 ```
 
@@ -223,7 +247,7 @@ The distinction between the `RenderTooltipContentData` and `Series` types is tha
 
 The prop to determine the chart's drawn area. Each `Series` object corresponds to a line drawn on the chart, and is explained in greater detail above.
 
-#### xAxisLabels
+#### xAxisOptions: xAxisLabels
 
 | type       | default |
 | ---------- | ------- |
@@ -233,31 +257,13 @@ The labels to display on the x axis of the chart and in a data table used for sc
 
 ### Optional props
 
-Determines the height of the chart.
-
-#### hideXAxisLabels
+#### isAnimated
 
 | type      | default |
 | --------- | ------- |
-| `boolean` | false   |
+| `boolean` | `false` |
 
-Whether to visually hide the x axis labels on the chart. The labels will still be displayed to screenreaders.
-
-#### formatXAxisLabel
-
-| type                                                        | default                       |
-| ----------------------------------------------------------- | ----------------------------- |
-| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
-
-This accepts a function that is called to format the labels when the chart draws its X axis.
-
-#### formatYAxisLabel
-
-| type                       | default                       |
-| -------------------------- | ----------------------------- |
-| `(value: number): string;` | `(value) => value.toString()` |
-
-This utilty function is called to format the labels for every y axis value when the chart is laid out.
+Whether to animate the lines and gradient when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.
 
 #### renderTooltipContent
 
@@ -283,18 +289,136 @@ If provided, renders a `<SkipLink/>` button with the string. Use this for charts
 
 Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the series data. It is strongly recommended that this is included if the series prop could be an empty array.
 
-#### hasSpline
+#### xAxisOptions
+
+An object including the following proprties that define the appearance of the xAxis. Only xAxisLabels is mandatory.
+
+##### hideXAxisLabels
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | false   |
+
+Whether to visually hide the x axis labels on the chart. The labels will still be displayed to screenreaders.
+
+##### showTicks
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | true    |
+
+Whether to show ticks connecting the xAxis labels to their corresponding grid line.
+
+##### labelFormatter
+
+| type                                                        | default                       |
+| ----------------------------------------------------------- | ----------------------------- |
+| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
+
+This accepts a function that is called to format the labels when the chart draws its X axis.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.
+
+#### yAxisOptions
+
+An object including the following optional proprties that define the appearance of the yAxis.
+
+##### labelFormatter
+
+| type                       | default                       |
+| -------------------------- | ----------------------------- |
+| `(value: number): string;` | `(value) => value.toString()` |
+
+This utilty function is called to format the labels for every y axis value when the chart is laid out.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.
+
+#### lineOptions
+
+An object including the following optional proprties that define the appearance of the line.
+
+##### hasSpline
 
 | type      | default |
 | --------- | ------- |
 | `boolean` | `false` |
+
+Whether to curve the lines between points.
+
+##### width
+
+| type     | default |
+| -------- | ------- |
+| `number` | `2`     |
+
+The width of the lines drawn between points.
+
+#### gridOptions
+
+An object including the following optional proprties that define the grid.
+
+##### showVerticalLines
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+Whether to show lines extending from the xAxis labels through the chart.
+
+##### showHorizontalLines
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+Whether to show lines extending from the yAxis labels through the chart.
+
+##### color
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `"rgb(223, 227, 232)"` |
+
+The color of the grid lines.
+
+#### CrossHairOptions
+
+An object including the following optional proprties that define the crosshair.
+
+##### width
+
+| type     | default |
+| -------- | ------- |
+| `number` | `5`     |
+
+The width of the crosshair.
+
+##### color
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color of the crosshair.
+
+##### opacity
+
+| type     | default |
+| -------- | ------- |
+| `number` | `1`     |
 
 Whether to curve the line between points.
 
-#### isAnimated
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Whether to animate the lines and gradient when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.
+The opacity of the crosshair.

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,40 +1,52 @@
 import React, {useLayoutEffect, useRef, useState} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
+import {colorSky} from '@shopify/polaris-tokens';
 
 import {getDefaultColor, uniqueId} from '../../utilities';
-import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 import {SkipLink} from '../SkipLink';
 import {usePrefersReducedMotion} from '../../hooks';
+import {
+  DEFAULT_GREY_LABEL,
+  CROSSHAIR_WIDTH,
+  DEFAULT_CROSSHAIR_COLOR,
+} from '../../constants';
 
 import {Chart} from './Chart';
-import {Series, RenderTooltipContentData} from './types';
+import {
+  Series,
+  RenderTooltipContentData,
+  LineOptions,
+  XAxisOptions,
+  YAxisOptions,
+  GridOptions,
+  CrossHairOptions,
+} from './types';
 import {TooltipContent} from './components';
 
 export interface LineChartProps {
   series: Series[];
-  xAxisLabels: string[];
-  hideXAxisLabels?: boolean;
-  accessibilityLabel?: string;
-  formatXAxisLabel?: StringLabelFormatter;
-  formatYAxisLabel?: NumberLabelFormatter;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
   skipLinkText?: string;
   emptyStateText?: string;
-  hasSpline?: boolean;
   isAnimated?: boolean;
+  lineOptions?: Partial<LineOptions>;
+  xAxisOptions: Partial<XAxisOptions> & Pick<XAxisOptions, 'xAxisLabels'>;
+  yAxisOptions?: Partial<YAxisOptions>;
+  gridOptions?: Partial<GridOptions>;
+  crossHairOptions?: Partial<CrossHairOptions>;
 }
 
 export function LineChart({
   series,
-  xAxisLabels,
-  formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
-  hideXAxisLabels = false,
   renderTooltipContent,
   skipLinkText,
   emptyStateText,
-  hasSpline = false,
   isAnimated = false,
+  lineOptions,
+  xAxisOptions,
+  yAxisOptions,
+  gridOptions,
+  crossHairOptions,
 }: LineChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -60,6 +72,36 @@ export function LineChart({
     };
   }, [containerRef, updateDimensions]);
 
+  const lineOptionsWithDefaults = {hasSpline: false, width: 2, ...lineOptions};
+
+  const xAxisOptionsWithDefaults = {
+    labelFormatter: (value: string) => value,
+    hideXAxisLabels: false,
+    showTicks: true,
+    labelColor: DEFAULT_GREY_LABEL,
+    ...xAxisOptions,
+  };
+
+  const yAxisOptionsWithDefaults = {
+    labelFormatter: (value: number) => value.toString(),
+    labelColor: DEFAULT_GREY_LABEL,
+    ...yAxisOptions,
+  };
+
+  const gridOptionsWithDefaults = {
+    showVerticalLines: true,
+    showHorizontalLines: true,
+    color: colorSky,
+    ...gridOptions,
+  };
+
+  const crossHairOptionsWithDefaults = {
+    color: DEFAULT_CROSSHAIR_COLOR,
+    opacity: 1,
+    width: CROSSHAIR_WIDTH,
+    ...crossHairOptions,
+  };
+
   function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
     const formattedData = data.map(
       ({name, point: {label, value}, color, lineStyle}) => ({
@@ -67,7 +109,7 @@ export function LineChart({
         color,
         lineStyle,
         point: {
-          value: formatYAxisLabel(value),
+          value: yAxisOptionsWithDefaults.labelFormatter(value),
           label,
         },
       }),
@@ -93,12 +135,12 @@ export function LineChart({
         {chartDimensions == null ? null : (
           <Chart
             series={seriesWithDefaults}
-            xAxisLabels={xAxisLabels}
-            formatXAxisLabel={formatXAxisLabel}
-            formatYAxisLabel={formatYAxisLabel}
+            lineOptions={lineOptionsWithDefaults}
+            xAxisOptions={xAxisOptionsWithDefaults}
+            yAxisOptions={yAxisOptionsWithDefaults}
+            gridOptions={gridOptionsWithDefaults}
+            crossHairOptions={crossHairOptionsWithDefaults}
             dimensions={chartDimensions}
-            hideXAxisLabels={hideXAxisLabels}
-            hasSpline={hasSpline}
             isAnimated={isAnimated && !prefersReducedMotion}
             renderTooltipContent={
               renderTooltipContent != null

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -13,13 +13,16 @@ interface Props {
   series: Required<Series>;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  hasSpline: boolean;
   isAnimated: boolean;
   index: number;
+  lineOptions: {
+    hasSpline: boolean;
+    width: number;
+  };
 }
 
 export const Line = React.memo(function Shape({
-  hasSpline,
+  lineOptions,
   series,
   xScale,
   yScale,
@@ -30,7 +33,7 @@ export const Line = React.memo(function Shape({
     .x((_, index) => xScale(index))
     .y(({rawValue}) => yScale(rawValue));
 
-  if (hasSpline) {
+  if (lineOptions.hasSpline) {
     lineGenerator.curve(curveMonotoneX);
   }
 
@@ -52,7 +55,7 @@ export const Line = React.memo(function Shape({
         animationDuration: `${animationDuration}s`,
       }}
       fill="none"
-      strokeWidth="2px"
+      strokeWidth={`${lineOptions.width}px`}
       paintOrder="stroke"
       stroke={getColorValue(series.color)}
       strokeLinejoin="round"

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -32,9 +32,9 @@ const mockProps = {
   },
   xScale: scaleLinear(),
   yScale: scaleLinear(),
-  hasSpline: false,
   isAnimated: false,
   index: 0,
+  lineOptions: {hasSpline: false, width: 10},
 };
 
 describe('<Line />', () => {
@@ -108,11 +108,32 @@ describe('<Line />', () => {
 
       mount(
         <svg>
-          <Line {...mockProps} hasSpline />
+          <Line
+            {...mockProps}
+            lineOptions={{...mockProps.lineOptions, hasSpline: true}}
+          />
         </svg>,
       );
 
       expect(curveSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('uses the width prop', () => {
+    const actual = mount(
+      <svg>
+        <Line
+          {...mockProps}
+          series={{
+            ...mockProps.series,
+            lineStyle: 'dashed',
+          }}
+        />
+      </svg>,
+    );
+
+    expect(actual).toContainReactComponent('path', {
+      strokeWidth: '10px',
     });
   });
 });

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -10,6 +10,7 @@ import {
   formatYAxisLabel,
   renderTooltipContent,
 } from './utils.stories';
+import {yAxisMinMax} from '../utilities';
 
 export default {
   title: 'LineChart',
@@ -38,8 +39,10 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
 export const Default = Template.bind({});
 Default.args = {
   series,
-  xAxisLabels,
-  formatXAxisLabel,
-  formatYAxisLabel,
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+  },
+  yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -47,27 +47,50 @@ const primarySeries: Required<Series> = {
   ],
 };
 
+const xAxisOptions = {
+  xAxisLabels: ['Jan 1'],
+  labelFormatter: jest.fn((value) => value),
+  hideXAxisLabels: false,
+  showTicks: true,
+  labelColor: 'red',
+};
+
+const lineOptions = {hasSpline: false, width: 2};
+
+const yAxisOptions = {
+  labelFormatter: jest.fn((value) => value),
+  labelColor: 'red',
+};
+
+const gridOptions = {
+  showVerticalLines: true,
+  showHorizontalLines: true,
+  color: 'orange',
+};
+
+const crossHairOptions = {width: 10, color: 'red', opacity: 1};
+
 const mockProps = {
   series: [primarySeries],
-  xAxisLabels: ['Jan 1'],
   dimensions: new DOMRect(),
-  formatXAxisLabel: jest.fn((value) => value),
-  formatYAxisLabel: jest.fn((value) => value),
+  lineOptions,
+  xAxisOptions,
+  yAxisOptions,
+  gridOptions,
+  crossHairOptions,
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
-  hideXAxisLabels: false,
-  hasSpline: false,
   isAnimated: false,
 };
 
 const mockEmptyStateProps = {
   series: [],
-  xAxisLabels: [],
   dimensions: new DOMRect(),
-  formatXAxisLabel: jest.fn((value) => value),
-  formatYAxisLabel: jest.fn((value) => value),
+  lineOptions,
+  xAxisOptions,
+  yAxisOptions,
+  gridOptions,
+  crossHairOptions,
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
-  hideXAxisLabels: false,
-  hasSpline: false,
   isAnimated: false,
 };
 
@@ -119,7 +142,10 @@ describe('<Chart />', () => {
       const chart = mount(
         <Chart
           {...mockProps}
-          formatXAxisLabel={(value) => `Formatted: ${value}`}
+          xAxisOptions={{
+            ...mockProps.xAxisOptions,
+            labelFormatter: (value) => `Formatted: ${value}`,
+          }}
         />,
       );
 
@@ -217,8 +243,8 @@ describe('<Chart />', () => {
 
     expect(chart).toContainReactComponent(VisuallyHiddenRows, {
       series: mockProps.series,
-      xAxisLabels: mockProps.xAxisLabels,
-      formatYAxisLabel: mockProps.formatYAxisLabel,
+      xAxisLabels: mockProps.xAxisOptions.xAxisLabels,
+      formatYAxisLabel: mockProps.yAxisOptions.labelFormatter,
     });
   });
 

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -37,7 +37,10 @@ describe('<LineChart />', () => {
 
   it('renders a <Chart />', () => {
     const lineChart = mount(
-      <LineChart series={[primarySeries]} xAxisLabels={['Jan 1']} />,
+      <LineChart
+        series={[primarySeries]}
+        xAxisOptions={{xAxisLabels: ['Jan 1']}}
+      />,
     );
 
     expect(lineChart).toContainReactComponent(Chart);
@@ -49,7 +52,7 @@ describe('<LineChart />', () => {
       const lineChart = mount(
         <LineChart
           series={[primarySeries]}
-          xAxisLabels={['Jan 1']}
+          xAxisOptions={{xAxisLabels: ['Jan 1']}}
           skipLinkText={mockContent}
         />,
       );
@@ -61,7 +64,10 @@ describe('<LineChart />', () => {
 
     it('does not render a SkipLink if skipLinkText is undefined', () => {
       const lineChart = mount(
-        <LineChart xAxisLabels={['Jan 1']} series={[primarySeries]} />,
+        <LineChart
+          xAxisOptions={{xAxisLabels: ['Jan 1']}}
+          series={[primarySeries]}
+        />,
       );
 
       expect(lineChart).not.toContainReactComponent(SkipLink);

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -1,4 +1,11 @@
-import {Color, DataSeries, Data, LineStyle} from '../../types';
+import {
+  Color,
+  DataSeries,
+  Data,
+  LineStyle,
+  StringLabelFormatter,
+  NumberLabelFormatter,
+} from '../../types';
 
 export interface Series extends DataSeries<Data> {
   showArea?: boolean;
@@ -17,4 +24,34 @@ export interface TooltipData {
 
 export interface RenderTooltipContentData {
   data: TooltipData[];
+}
+
+export interface LineOptions {
+  hasSpline: boolean;
+  width: number;
+}
+
+export interface XAxisOptions {
+  labelFormatter: StringLabelFormatter;
+  xAxisLabels: string[];
+  hideXAxisLabels: boolean;
+  showTicks: boolean;
+  labelColor: string;
+}
+
+export interface YAxisOptions {
+  labelFormatter: NumberLabelFormatter;
+  labelColor: string;
+}
+
+export interface GridOptions {
+  showVerticalLines: boolean;
+  showHorizontalLines: boolean;
+  color: string;
+}
+
+export interface CrossHairOptions {
+  width: number;
+  color: string;
+  opacity: number;
 }

--- a/src/components/LinearXAxis/LinearXAxis.scss
+++ b/src/components/LinearXAxis/LinearXAxis.scss
@@ -1,7 +1,7 @@
 @import '../../styles/common';
 
 .Text {
-  @include axis-text;
+  line-height: 1;
   word-break: break-word;
 }
 

--- a/src/components/LinearXAxis/LinearXAxis.tsx
+++ b/src/components/LinearXAxis/LinearXAxis.tsx
@@ -9,6 +9,7 @@ import {
   DIAGONAL_ANGLE,
   LINE_HEIGHT,
   SPACING_TIGHT,
+  DEFAULT_GREY_LABEL,
 } from '../../constants';
 
 import styles from './LinearXAxis.scss';
@@ -29,6 +30,10 @@ interface Props {
   xAxisDetails: XAxisDetails;
   drawableHeight: number;
   ariaHidden: boolean;
+  showGridLines?: boolean;
+  gridColor?: string;
+  showTicks?: boolean;
+  labelColor?: string;
 }
 
 function getTextAlign({
@@ -57,6 +62,10 @@ function Axis({
   drawableWidth,
   drawableHeight,
   ariaHidden,
+  showGridLines = true,
+  showTicks = true,
+  gridColor = colorSky,
+  labelColor = DEFAULT_GREY_LABEL,
 }: Props) {
   const {
     maxDiagonalLabelLength,
@@ -98,7 +107,7 @@ function Axis({
       <path
         d={`M ${xScaleMin} ${TICK_SIZE} v ${-TICK_SIZE} H ${xScaleMax} v ${TICK_SIZE}`}
         fill="none"
-        stroke={colorSky}
+        stroke={gridColor}
       />
 
       {tickDetails.map(({value, xOffset, firstLabel}, index) => {
@@ -129,13 +138,15 @@ function Axis({
 
         return (
           <g key={index} transform={`translate(${xOffset}, 0)`}>
-            <line y2={TICK_SIZE} stroke={colorSky} />
-            <line
-              y1="0"
-              y2={-drawableHeight}
-              stroke={colorSky}
-              strokeDasharray="3 2"
-            />
+            {showTicks ? <line y2={TICK_SIZE} stroke={gridColor} /> : null}
+            {showGridLines ? (
+              <line
+                y1="0"
+                y2={-drawableHeight}
+                stroke={gridColor}
+                strokeDasharray="3 2"
+              />
+            ) : null}
             <foreignObject
               width={textWidth}
               height={textHeight}
@@ -147,6 +158,7 @@ function Axis({
                 style={{
                   fontSize,
                   textAlign,
+                  color: labelColor,
                 }}
               >
                 {value}

--- a/src/components/YAxis/YAxis.scss
+++ b/src/components/YAxis/YAxis.scss
@@ -1,9 +1,0 @@
-@import '../../styles/common';
-
-.Line {
-  @include axis-line;
-}
-
-.Text {
-  @include axis-label;
-}

--- a/src/components/YAxis/YAxis.tsx
+++ b/src/components/YAxis/YAxis.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import {spacingBase, spacingExtraTight} from '@shopify/polaris-tokens';
+import {
+  spacingBase,
+  spacingExtraTight,
+  colorSky,
+} from '@shopify/polaris-tokens';
 
-import {FONT_SIZE} from '../../constants';
-
-import styles from './YAxis.scss';
+import {FONT_SIZE, DEFAULT_GREY_LABEL} from '../../constants';
 
 interface Props {
   ticks: {
@@ -13,22 +15,34 @@ interface Props {
   }[];
   drawableWidth: number;
   fontSize?: number;
+  showGridLines?: boolean;
+  gridColor?: string;
+  labelColor?: string;
 }
 
-function Axis({ticks, drawableWidth, fontSize}: Props) {
+function Axis({
+  ticks,
+  drawableWidth,
+  fontSize,
+  gridColor = colorSky,
+  showGridLines = true,
+  labelColor = DEFAULT_GREY_LABEL,
+}: Props) {
   return (
     <g>
       {ticks.map(({value, formattedValue, yOffset}) => {
         return (
           <g key={value} transform={`translate(0,${yOffset})`}>
-            <line x2={drawableWidth} className={styles.Line} />
+            {showGridLines ? (
+              <line x2={drawableWidth} stroke={gridColor} />
+            ) : null}
             <text
               aria-hidden
-              className={styles.Text}
               style={{
                 fontSize: `${fontSize ? fontSize : FONT_SIZE}px`,
                 textAnchor: 'end',
                 transform: `translateX(-${spacingBase}) translateY(${spacingExtraTight})`,
+                fill: labelColor,
               }}
             >
               {formattedValue}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,9 @@ export const MIN_BAR_HEIGHT = 5;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
 
+export const DEFAULT_GREY_LABEL = 'rgb(99, 115, 129)';
+export const DEFAULT_CROSSHAIR_COLOR = 'rgb(223, 227, 232)';
+
 export enum Margin {
   Top = SPACING_TIGHT,
   Left = 0,

--- a/src/styles/shared/_axes.scss
+++ b/src/styles/shared/_axes.scss
@@ -19,7 +19,3 @@ $axis-color: rgb(223, 227, 232);
 @mixin axis-line {
   stroke: $axis-color;
 }
-
-@mixin axis-crosshair {
-  fill: $axis-color;
-}


### PR DESCRIPTION
### What problem is this PR solving?
Part of https://github.com/Shopify/core-issues/issues/23750

Makes the line chart API more flexible so we can alter the chart's appearance for light mode, dark mode, etc. This also paves the way for other configurations needed for the orders project, such as more minimal xAxis labels.

Changes the interface for the LineChart to this:
<img width="1543" alt="Screen Shot 2021-04-19 at 11 07 23 AM" src="https://user-images.githubusercontent.com/12213371/115259042-84cc0580-a0ff-11eb-8d56-d4be8f295340.png">

You can see what the options props look like here https://github.com/Shopify/polaris-viz/pull/279/files#diff-85eb8b293ff2d6a38732488e28dc5bebc11feff1ac8996a021c6628ca84d236dR28

No new props become mandatory, and we keep all the same defaults we had before, this just allows more configuration if the user wants it.

### Reviewers’ :tophat: instructions
Make sure the line chart and area chart (since it shares many of the same subcomponents) still look and function as normal. Tweak the line chart's props to see how you can change its appearance, for example pass the following props to LineChartDemo:

```
          themeOptions={{textColor: 'purple'}}
          xAxisOptions={{
            xAxisLabels,
            labelFormatter: formatXAxisLabel,
            showTicks: false,
          }}
          gridOptions={{
            color: 'darkBlue',
            showVerticalLines: false,
            showHorizontalLines: false,
          }}
```

### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~

- [x] Update the Changelog.

- [x] Update relevant documentation.
