### PR TITLE
[BarChart] Adding handling for empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `dotted` lineStyle to `LineChart`
+- Added `emptyStateText` and empty state handling to `<BarChart />`
 
 ## [0.8.0] — 2021-04-14
 

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -91,6 +91,7 @@ interface BarChartProps {
   highlightColor?: Color;
   timeSeries?: boolean;
   skipLinkText?: string;
+  emptyStateText?: string;
 }
 ```
 
@@ -105,6 +106,7 @@ In order for the user to have visual feedback that a bar has been selected, it i
 | `{rawValue: number, label: string}[]` |
 
 The array of objects that the chart uses to draw the chart.
+If `data` may be an empty array, provide <a href="#emptyStateText">`emptyStateText`</a> to communicate the empty state to screenreaders.
 
 ### Optional props
 
@@ -179,3 +181,11 @@ This indicates to the chart if the data provide is time series data. If `true`, 
 | `boolean` | `false` |
 
 Rounds the top corners of each bar, in the case of positive numbers. Rounds the bottom corners for negatives.
+
+#### emptyStateText
+
+| type     | default     |
+| -------- | ----------- |
+| `string` | `undefined` |
+
+Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the data prop could be an empty array.

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -21,6 +21,7 @@ export interface BarChartProps {
   skipLinkText?: string;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
   hasRoundedCorners?: boolean;
+  emptyStateText?: string;
 }
 
 export function BarChart({
@@ -34,11 +35,14 @@ export function BarChart({
   formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
   skipLinkText,
+  emptyStateText,
 }: BarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const skipLinkAnchorId = useRef(uniqueId('barChart'));
+
+  const emptyState = data.length === 0;
 
   const [updateDimensions] = useDebouncedCallback(() => {
     if (containerRef.current != null) {
@@ -72,7 +76,9 @@ export function BarChart({
     <div style={{width: '100%', height: '100%'}} ref={containerRef}>
       {chartDimensions == null ? null : (
         <React.Fragment>
-          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+          {skipLinkText == null ||
+          skipLinkText.length === 0 ||
+          emptyState ? null : (
             <SkipLink anchorId={skipLinkAnchorId.current}>
               {skipLinkText}
             </SkipLink>
@@ -92,8 +98,11 @@ export function BarChart({
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
+            emptyStateText={emptyStateText}
           />
-          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+          {skipLinkText == null ||
+          skipLinkText.length === 0 ||
+          emptyState ? null : (
             <SkipLink.Anchor id={skipLinkAnchorId.current} />
           )}
         </React.Fragment>

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -31,6 +31,7 @@ interface Props {
   timeSeries: boolean;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   hasRoundedCorners: boolean;
+  emptyStateText?: string;
 }
 
 export function Chart({
@@ -44,6 +45,7 @@ export function Chart({
   timeSeries,
   renderTooltipContent,
   hasRoundedCorners,
+  emptyStateText,
 }: Props) {
   const [activeBar, setActiveBar] = useState<number | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<{
@@ -53,6 +55,8 @@ export function Chart({
 
   const fontSize =
     chartDimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
+
+  const emptyState = data.length === 0;
 
   const {ticks: initialTicks} = useYScale({
     drawableHeight:
@@ -150,7 +154,8 @@ export function Chart({
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBar(null)}
         onTouchEnd={() => setActiveBar(null)}
-        role="list"
+        role={emptyState ? 'img' : 'list'}
+        aria-label={emptyState ? emptyStateText : undefined}
       >
         <g
           transform={`translate(${axisMargin},${chartDimensions.height -
@@ -209,7 +214,7 @@ export function Chart({
         </g>
       </svg>
 
-      {tooltipPosition != null && activeBar != null ? (
+      {tooltipPosition != null && activeBar != null && !emptyState ? (
         <TooltipContainer
           activePointIndex={activeBar}
           currentX={tooltipPosition.x}

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -17,7 +17,10 @@ export function useYScale({
 }) {
   const {yScale, ticks} = useMemo(() => {
     const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
-    const calculatedMax = Math.max(...data.map(({rawValue}) => rawValue));
+
+    const calculatedMax =
+      data.length === 0 ? 0 : Math.max(...data.map(({rawValue}) => rawValue));
+
     const max =
       calculatedMax === 0 && min === 0
         ? DEFAULT_MAX_Y

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -100,4 +100,13 @@ describe('Chart />', () => {
 
     expect(chart).toContainReactComponent(Bar, {isSelected: true});
   });
+
+  describe('empty state', () => {
+    it('does not render tooltip for empty state', () => {
+      const chart = mount(<Chart {...mockProps} data={[]} />);
+
+      expect(chart).not.toContainReactText('Mock Tooltip');
+      expect(chart).not.toContainReactComponent(TooltipContainer);
+    });
+  });
 });


### PR DESCRIPTION
### What problem is this PR solving?

Adds handling for empty state in `BarChart`, ie when data is an empty array.

| before | after |
| -- | -- |
| ![Screen Shot 2021-04-19 at 11 39 26 AM](https://user-images.githubusercontent.com/40300265/115264075-fe65f280-a103-11eb-920c-8d54f9ec8fa0.png) | ![Screen Shot 2021-04-19 at 11 37 01 AM](https://user-images.githubusercontent.com/40300265/115263822-bb0b8400-a103-11eb-9f83-222518279a50.png) |


Also adds `emptyStateText` prop for `BarChart` for a11y in case of the empty state.

This PR is a part of the changes for https://github.com/Shopify/core-issues/issues/22617

### Reviewers’ :tophat: instructions

1. Pass in an empty array as `data` to `BarChart`, and make sure it doesn't render the Tooltip or any unnecessary elements.
2. Make sure it plays well with a11y for both tabbing and screenreader support [make sure to add `emptyStateText` when testing].
3. Make sure the aria label for emptyStateText works as expected.
4. These changes should not affect how the `BarChart` normally works in case of no empty state.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
