### PR TITLE
[Bar charts] Make API more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- The line chart and bar chart APIs now allow for custom configuration of chart element appearances. Some top-level props are now nested within more specific object props to configure the appearance of the chart.
+
+### Removed
+
+- The timeseries prop has been removed from bar charts, in favour of using that label handling by default (when there is not enough room for all diagonal labels, some will be dropped).
+
 ## [0.8.1] — 2021-04-20
 
 ### Added
@@ -7,10 +17,6 @@
 - `dotted` lineStyle to `LineChart`
 - `emptyStateText` and empty state handling to `<BarChart />`
 - `isAnimated` prop to `LineChart`, `BarChart` and `MultiSeriesBarChart`
-
-### Changed
-
-- The line chart API now allows for custom configuration of chart element colors and widths. Some top-level props are now nested within more specific object props to configure the appearance of the chart.
 
 ## [0.8.0] — 2021-04-14
 

--- a/documentation/code/BarChartDemo.tsx
+++ b/documentation/code/BarChartDemo.tsx
@@ -72,13 +72,25 @@ export function BarChartDemo() {
   }
 
   return (
-    <div style={OUTER_CONTAINER_STYLE}>
+    <div style={{...OUTER_CONTAINER_STYLE, background: '#1f1f25'}}>
       <div style={innerContainerStyle}>
         <BarChart
           data={data}
-          color="primary"
-          formatXAxisLabel={formatXAxisLabel}
-          formatYAxisLabel={formatYAxisLabel}
+          barOptions={{
+            color: 'quaternary',
+            hasRoundedCorners: true,
+            highlightColor: 'quaternaryProminent',
+          }}
+          xAxisOptions={{
+            labelFormatter: formatXAxisLabel,
+            showTicks: false,
+            labelColor: '#8D8D8E',
+          }}
+          gridOptions={{color: 'rgb(65, 66, 71)'}}
+          yAxisOptions={{
+            labelFormatter: formatYAxisLabel,
+            labelColor: '#8D8D8E',
+          }}
           renderTooltipContent={renderTooltipContent}
           skipLinkText="Skip chart content"
         />

--- a/documentation/code/MultiSeriesBarChartDemo.tsx
+++ b/documentation/code/MultiSeriesBarChartDemo.tsx
@@ -117,10 +117,10 @@ export function MultiSeriesBarChartDemo({isStacked = false}: Props) {
     <div style={OUTER_CONTAINER_STYLE}>
       <div style={innerContainerStyle}>
         <MultiSeriesBarChart
-          formatYAxisLabel={formatYAxisLabel}
-          labels={labels}
+          yAxisOptions={{labelFormatter: formatYAxisLabel}}
+          xAxisOptions={{labels}}
           series={series}
-          isStacked={isStacked}
+          barOptions={{isStacked}}
           renderTooltipContent={renderTooltipContent}
           skipLinkText="Skip chart content"
         />

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -61,9 +61,9 @@ function renderTooltipContent({label, value}: {label: string; value: number}) {
 return (
   <BarChart
     data={data}
-    color="primary"
-    formatXAxisLabel={formatXAxisLabel}
-    formatYAxisLabel={formatYAxisLabel}
+    barOptions={{color: 'primary'}}
+    xAxisOptions={{labelFormatter: formatXAxisLabel}}
+    yAxisOptions={{labelFormatter: formatYAxisLabel}}
     renderTooltipContent={renderTooltipContent}
     skipLinkText="Skip chart content"
   />
@@ -77,10 +77,6 @@ The bar chart interface looks like this:
 ```typescript
 interface BarChartProps {
   data: {rawValue: number; label: string}[];
-  barMargin?: 'Small' | 'Medium' | 'Large' | 'None';
-  color?: Color;
-  formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
-  formatYAxisLabel?(value: number): string;
   renderTooltipContent?({
     label,
     value,
@@ -88,10 +84,26 @@ interface BarChartProps {
     lable: string;
     value: string;
   }): React.ReactNode;
-  highlightColor?: Color;
-  timeSeries?: boolean;
   skipLinkText?: string;
   emptyStateText?: string;
+  barOptions?: {
+    margin?: 'Small' | 'Medium' | 'Large' | 'None';
+    color?: Color;
+    highlightColor?: Color;
+    hasRoundedCorners?: boolean;
+  };
+  gridOptions?: {
+    showHorizontalLines?: boolean;
+    color?: string;
+  };
+  xAxisOptions?: {
+    labelFormatter?(value: string, index?: number, data?: string[]): string;
+    showTicks?: boolean;
+    labelColor?: string;
+  };
+  yAxisOptions?: {
+    labelFormatter?(value: number): string;
+  };
 }
 ```
 
@@ -110,45 +122,13 @@ If `data` may be an empty array, provide <a href="#emptyStateText">`emptyStateTe
 
 ### Optional props
 
-#### accessibilityLabel
+#### isAnimated
 
-| type     | default     |
-| -------- | ----------- |
-| `string` | `undefined` |
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
 
-Visually hidden text for screen readers.
-
-#### barMargin
-
-| type                                       | default  |
-| ------------------------------------------ | -------- |
-| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
-
-This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element.
-
-#### color
-
-| type    | default   |
-| ------- | --------- |
-| `Color` | `primary` |
-
-The bar fill color. This accepts any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md).
-
-#### formatXAxisLabel
-
-| type                                                        | default                       |
-| ----------------------------------------------------------- | ----------------------------- |
-| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
-
-This accepts a function that is called to format the labels when the chart draws its X axis.
-
-#### formatYAxisLabel
-
-| type                      | default                       |
-| ------------------------- | ----------------------------- |
-| `(value: number): string` | `(value) => value.toString()` |
-
-This accepts a function that is called when the Y value (`rawValue`) is formatted for the tooltip and for the Y Axis.
+Whether to animate the bars when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.
 
 #### renderTooltipContent
 
@@ -158,29 +138,13 @@ This accepts a function that is called when the Y value (`rawValue`) is formatte
 
 This accepts a function that is called to render the tooltip content. By default it calls `formatXAxisLabel` and `formatYAxisLabel` to format the the tooltip values and passes them to `<BarChartTooltipContent />`. For more information about tooltip content, read the [tooltip content documentation](/src/components/TooltipContent/TooltipContent.md).
 
-#### highlightColor
+#### skipLinkText
 
-| type    | default   |
-| ------- | --------- |
-| `Color` | `primary` |
+| type     |
+| -------- |
+| `string` |
 
-The bar fill color when you hover over a bar in the chart. This accepts any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md).
-
-#### timeSeries
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-This indicates to the chart if the data provide is time series data. If `true`, the x-axis will display fewer labels as needed according to the data.
-
-#### hasRoundedCorners
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Rounds the top corners of each bar, in the case of positive numbers. Rounds the bottom corners for negatives.
+If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.
 
 #### emptyStateText
 
@@ -189,3 +153,105 @@ Rounds the top corners of each bar, in the case of positive numbers. Rounds the 
 | `string` | `undefined` |
 
 Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the data prop could be an empty array.
+
+#### barOptions
+
+An optional object including the following proprties that define the appearance of the bar.
+
+##### margin
+
+| type                                       | default  |
+| ------------------------------------------ | -------- |
+| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
+
+This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element.
+
+##### color
+
+| type    | default   |
+| ------- | --------- |
+| `Color` | `primary` |
+
+The bar fill color. This accepts any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md).
+
+##### highlightColor
+
+| type    | default   |
+| ------- | --------- |
+| `Color` | `primary` |
+
+The bar fill color when you hover over a bar in the chart. This accepts any [Polaris Viz accepted color](/documentation/Polaris-Viz-colors.md).
+
+##### hasRoundedCorners
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Rounds the top corners of each bar, in the case of positive numbers. Rounds the bottom corners for negatives.
+
+The color used for axis labels.
+
+#### gridOptions
+
+An object including the following optional proprties that define the grid.
+
+##### showHorizontalLines
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+Whether to show lines extending from the yAxis labels through the chart.
+
+##### color
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `"rgb(223, 227, 232)"` |
+
+The color of the grid lines.
+
+#### xAxisOptions
+
+##### labelFormatter
+
+| type                                                        | default                       |
+| ----------------------------------------------------------- | ----------------------------- |
+| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
+
+This accepts a function that is called to format the labels when the chart draws its X axis.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.
+
+##### showTicks
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+Whether to show ticks connecting the xAxis labels to their corresponding grid line.
+
+#### yAxisOptions
+
+##### labelFormatter
+
+| type                      | default                       |
+| ------------------------- | ----------------------------- |
+| `(value: number): string` | `(value) => value.toString()` |
+
+This accepts a function that is called when the Y value (`rawValue`) is formatted for the tooltip and for the Y Axis.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -1,43 +1,45 @@
 import React, {useState, useLayoutEffect, useRef} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
-import {Color, Data} from 'types';
+import {Data} from 'types';
+import {colorSky} from '@shopify/polaris-tokens';
 
+import {DEFAULT_GREY_LABEL} from '../../constants';
 import {SkipLink} from '../SkipLink';
-import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
 import {getDefaultColor, uniqueId} from '../../utilities';
 
 import {TooltipContent} from './components';
 import {Chart} from './Chart';
-import {BarMargin, RenderTooltipContentData} from './types';
+import {
+  RenderTooltipContentData,
+  BarOptions,
+  GridOptions,
+  XAxisOptions,
+  YAxisOptions,
+  BarMargin,
+} from './types';
 
 export interface BarChartProps {
   data: Data[];
-  barMargin?: keyof typeof BarMargin;
-  color?: Color;
-  highlightColor?: Color;
-  formatXAxisLabel?: StringLabelFormatter;
-  formatYAxisLabel?: NumberLabelFormatter;
-  timeSeries?: boolean;
   skipLinkText?: string;
-  renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
-  hasRoundedCorners?: boolean;
   emptyStateText?: string;
   isAnimated?: boolean;
+  renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
+  barOptions?: Partial<BarOptions>;
+  gridOptions?: Partial<GridOptions>;
+  xAxisOptions?: Partial<XAxisOptions>;
+  yAxisOptions?: Partial<YAxisOptions>;
 }
 
 export function BarChart({
   data,
-  color = getDefaultColor(),
-  highlightColor = getDefaultColor(),
-  barMargin = 'Medium',
-  timeSeries = false,
-  hasRoundedCorners = false,
-  formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
-  skipLinkText,
   emptyStateText,
   isAnimated = false,
+  skipLinkText,
+  barOptions,
+  gridOptions,
+  xAxisOptions,
+  yAxisOptions,
 }: BarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -64,12 +66,44 @@ export function BarChart({
     };
   }, [containerRef, updateDimensions]);
 
+  const margin =
+    barOptions != null && barOptions.margin != null
+      ? BarMargin[barOptions.margin]
+      : BarMargin.Medium;
+
+  const barOptionsWithDefaults = {
+    color: getDefaultColor(),
+    highlightColor: getDefaultColor(),
+    hasRoundedCorners: false,
+    ...barOptions,
+    margin,
+  };
+
+  const gridOptionsWithDefaults = {
+    showHorizontalLines: true,
+    color: colorSky,
+    ...gridOptions,
+  };
+
+  const xAxisOptionsWithDefaults = {
+    labelFormatter: (value: string) => value,
+    showTicks: true,
+    labelColor: DEFAULT_GREY_LABEL,
+    ...xAxisOptions,
+  };
+
+  const yAxisOptionsWithDefaults = {
+    labelFormatter: (value: number) => value.toString(),
+    labelColor: DEFAULT_GREY_LABEL,
+    ...yAxisOptions,
+  };
+
   function renderDefaultTooltipContent({
     label,
     value,
   }: RenderTooltipContentData) {
-    const formattedLabel = formatXAxisLabel(label);
-    const formattedValue = formatYAxisLabel(value);
+    const formattedLabel = xAxisOptionsWithDefaults.labelFormatter(label);
+    const formattedValue = yAxisOptionsWithDefaults.labelFormatter(value);
 
     return <TooltipContent label={formattedLabel} value={formattedValue} />;
   }
@@ -89,13 +123,10 @@ export function BarChart({
             isAnimated={isAnimated}
             data={data}
             chartDimensions={chartDimensions}
-            barMargin={BarMargin[barMargin]}
-            color={color}
-            highlightColor={highlightColor}
-            formatXAxisLabel={formatXAxisLabel}
-            formatYAxisLabel={formatYAxisLabel}
-            timeSeries={timeSeries}
-            hasRoundedCorners={hasRoundedCorners}
+            barOptions={barOptionsWithDefaults}
+            gridOptions={gridOptionsWithDefaults}
+            xAxisOptions={xAxisOptionsWithDefaults}
+            yAxisOptions={yAxisOptionsWithDefaults}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -19,28 +19,19 @@ export default {
   title: 'BarChart',
   component: BarChart,
   argTypes: {
-    color: {
-      control: {
-        type: 'select',
-        options: colorOptions,
-        defaultValue: primaryColor,
-      },
-    },
-    highlightColor: {
-      control: {
-        type: 'select',
-        options: colorOptions,
-        defaultValue: secondaryColor,
-      },
-    },
-    // Render the prop documentation but without a control.
-    formatXAxisLabel: {
+    barOptions: {
       control: false,
     },
-    formatYAxisLabel: {
+    xAxisOptions: {
+      control: false,
+    },
+    yAxisOptions: {
       control: false,
     },
     renderTooltipContent: {
+      control: false,
+    },
+    gridOptions: {
       control: false,
     },
   },
@@ -60,9 +51,8 @@ Default.args = {
     {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
     {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
   ],
-  color: primaryColor,
-  highlightColor: secondaryColor,
-  formatXAxisLabel,
-  formatYAxisLabel,
+  barOptions: {color: primaryColor, highlightColor: secondaryColor},
+  xAxisOptions: {labelFormatter: formatXAxisLabel},
+  yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -32,15 +32,23 @@ describe('Chart />', () => {
       {rawValue: 20, label: 'data 2'},
     ],
     chartDimensions: new DOMRect(),
-    histogram: false,
-    color: 'colorPurple' as Color,
-    highlightColor: 'colorPurple' as Color,
-    formatXAxisLabel: (value: string) => value.toString(),
-    formatYAxisLabel: (value: number) => value.toString(),
-    barMargin: 0,
-    timeSeries: false,
+    barOptions: {
+      color: 'colorPurple' as Color,
+      highlightColor: 'colorPurple' as Color,
+      margin: 0,
+      hasRoundedCorners: false,
+    },
+    xAxisOptions: {
+      labelFormatter: (value: string) => value.toString(),
+      showTicks: true,
+      labelColor: 'red',
+    },
+    yAxisOptions: {
+      labelFormatter: (value: number) => value.toString(),
+      labelColor: 'red',
+    },
+    gridOptions: {showHorizontalLines: true, color: 'red'},
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
-    hasRoundedCorners: false,
   };
 
   it('renders an SVG element', () => {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,3 +1,5 @@
+import {Color, StringLabelFormatter, NumberLabelFormatter} from 'types';
+
 export enum BarMargin {
   Small = 0.05,
   Medium = 0.1,
@@ -8,4 +10,27 @@ export enum BarMargin {
 export interface RenderTooltipContentData {
   label: string;
   value: number;
+}
+
+export interface BarOptions {
+  margin: keyof typeof BarMargin;
+  color: Color;
+  highlightColor: Color;
+  hasRoundedCorners: boolean;
+}
+
+export interface GridOptions {
+  showHorizontalLines: boolean;
+  color: string;
+}
+
+export interface XAxisOptions {
+  labelFormatter: StringLabelFormatter;
+  showTicks: boolean;
+  labelColor: string;
+}
+
+export interface YAxisOptions {
+  labelFormatter: NumberLabelFormatter;
+  labelColor: string;
 }

--- a/src/components/BarChartXAxis/BarChartXAxis.scss
+++ b/src/components/BarChartXAxis/BarChartXAxis.scss
@@ -2,12 +2,12 @@
 
 .Text {
   text-align: center;
-  @include axis-text;
+  line-height: 1;
   word-break: break-word;
 }
 
 .DiagonalText {
   text-align: right;
   @include ellipsis-overflow;
-  @include axis-text;
+  line-height: 1;
 }

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {colorSky} from '@shopify/polaris-tokens';
 import {ScaleBand} from 'd3-scale';
 
 import {
@@ -26,14 +25,19 @@ export function BarChartXAxis({
   labels,
   xScale,
   fontSize,
-  showFewerLabels,
   xAxisDetails,
+  textColor,
+  gridColor,
+  showTicks,
 }: {
   xScale: ScaleBand<string>;
   labels: {value: string; xOffset: number}[];
   fontSize: number;
   showFewerLabels: boolean;
   xAxisDetails: XAxisDetails;
+  textColor: string;
+  gridColor: string;
+  showTicks: boolean;
 }) {
   const [xScaleMin, xScaleMax] = xScale.range();
   const {
@@ -72,16 +76,16 @@ export function BarChartXAxis({
       <path
         d={`M ${xScaleMin} ${TICK_SIZE} v ${-TICK_SIZE} H ${xScaleMax} v ${TICK_SIZE}`}
         fill="none"
-        stroke={colorSky}
+        stroke={gridColor}
       />
 
       {labels.map(({value, xOffset}, index) => {
-        if (showFewerLabels && index % visibleLabelRatio !== 0) {
+        if (needsDiagonalLabels && index % visibleLabelRatio !== 0) {
           return null;
         }
         return (
           <g key={index} transform={`translate(${xOffset}, 0)`}>
-            <line y2={TICK_SIZE} stroke={colorSky} />
+            {showTicks ? <line y2={TICK_SIZE} stroke={gridColor} /> : null}
             <foreignObject
               width={textWidth}
               height={textHeight}
@@ -91,6 +95,7 @@ export function BarChartXAxis({
                 className={textContainerClassName}
                 style={{
                   fontSize,
+                  color: textColor,
                 }}
               >
                 {value}

--- a/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
+++ b/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
@@ -34,6 +34,9 @@ describe('<BarChartXAxis/>', () => {
       maxDiagonalLabelLength: 100,
       maxWidth: 100,
     },
+    textColor: 'red',
+    gridColor: 'orange',
+    showTicks: true,
   };
 
   it('renders a path', () => {
@@ -45,7 +48,7 @@ describe('<BarChartXAxis/>', () => {
 
     expect(axis).toContainReactComponent('path', {
       fill: 'none',
-      stroke: 'rgb(223, 227, 232)',
+      stroke: 'orange',
     });
   });
 
@@ -72,7 +75,16 @@ describe('<BarChartXAxis/>', () => {
   it('hides elements if showFewerLabels is true and there is not enough room', () => {
     const axis = mount(
       <svg>
-        <BarChartXAxis {...mockProps} showFewerLabels />,
+        <BarChartXAxis
+          {...mockProps}
+          showFewerLabels
+          xAxisDetails={{
+            ...mockProps.xAxisDetails,
+            needsDiagonalLabels: true,
+            maxWidth: 10,
+          }}
+        />
+        ,
       </svg>,
     );
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -100,10 +100,10 @@ const renderTooltipContent: MultiSeriesBarChartProps['renderTooltipContent'] = (
 
 return (
   <MultiSeriesBarChart
-    formatYAxisLabel={formatYAxisLabel}
-    labels={labels}
+    yAxisOptions={{labelFormatter: formatYAxisLabel}}
+    xAxisOptions={{labels}}
+    barOptions={{isStacked}}
     series={series}
-    isStacked={isStacked}
     renderTooltipContent={renderTooltipContent}
     skipLinkText="Skip chart content"
   />
@@ -112,18 +112,30 @@ return (
 
 ## Usage
 
-The mult-series bar chart interface looks like this:
+The multi-series bar chart interface looks like this:
 
 ```typescript
 interface MultiSeriesBarChartProps {
   series: Series[];
-  labels: string[];
-  timeSeries?: boolean;
-  isStacked?: boolean;
-  formatXAxisLabel?(value: string, index?: number, data?: string[]): string;
-  formatYAxisLabel?(value: number): string;
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
+  barOptions?: {
+    isStacked?: boolean;
+    hasRoundedCorners?: boolean;
+  };
+  gridOptions?: {
+    showHorizontalLines?: boolean;
+    color?: string;
+  };
+  xAxisOptions: {
+    labelFormatter?(value: string, index?: number, data?: string[]): string;
+    showTicks?: boolean;
+    labels: string[];
+    labelColor: string;
+  };
+  yAxisOptions: {
+    labelFormatter?(value: number): string;
+  };
 }
 ```
 
@@ -208,7 +220,7 @@ The distinction between the `RenderTooltipContentData` and series `Data` types i
 
 The prop to determine the chart's drawn area. Each `Series` object corresponds to a group drawn on the chart, and is explained in greater detail [above](#the-series-type).
 
-#### labels
+#### xAxisOptions: labels
 
 | type       |
 | ---------- |
@@ -218,49 +230,21 @@ The labels for the x-axis of the chart. This array should be equal in length to 
 
 ### Optional props
 
-#### accessibilityLabel
-
-| type     | default      |
-| -------- | ------------ |
-| `string` | empty string |
-
-Visually hidden text for screen readers.
-
-Determines the height of the chart.
-
-#### formatXAxisLabel
-
-| type                                                        | default                       |
-| ----------------------------------------------------------- | ----------------------------- |
-| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
-
-This accepts a function that is called to format the labels when the chart draws its X axis.
-
-It's reccomended that you use a legend whenever displaying multiseries data. To display one, use the <a href="../Legend/Legend.md">`<Legend />` component</a>.
-
-#### formatYAxisLabel
-
-| type                       | default                       |
-| -------------------------- | ----------------------------- |
-| `(value: number): string;` | `(value) => value.toString()` |
-
-This utility function is called for every y axis value when the chart is drawn.
-
-#### timeSeries
+#### isAnimated
 
 | type      | default |
 | --------- | ------- |
 | `boolean` | `false` |
 
-This indicates to the chart if the data provide is time series data. If `true`, the x-axis will display fewer labels as needed according to the data.
+Whether to animate the bars when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences. Note: animations are currently only available for the non-stacked bar chart.
 
-#### isStacked
+#### skipLinkText
 
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
+| type     |
+| -------- |
+| `string` |
 
-This changes the grouping of the bars. If `true` the bar groups will stack vertically, otherwise they will render individual bars for each data point in each group. To see an example of stacked vs. grouped orientations, refer to the images above.
+If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.
 
 #### renderTooltipContent
 
@@ -270,10 +254,88 @@ This changes the grouping of the bars. If `true` the bar groups will stack verti
 
 This accepts a function that is called to render the tooltip content. By default it calls `formatYAxisLabel` to format the the tooltip value and passes it to `<TooltipContent />`. For more information about tooltip content, read the [tooltip content documentation](/src/components/TooltipContent/TooltipContent.md).
 
-#### hasRoundedCorners
+#### xAxisOptions
+
+An object including the following proprties that define the appearance of the xAxis. Only labels is mandatory.
+
+##### labelFormatter
+
+| type                                                        | default                       |
+| ----------------------------------------------------------- | ----------------------------- |
+| `(value: string, index?: number, data?: string[]): string;` | `(value) => value.toString()` |
+
+This accepts a function that is called to format the labels when the chart draws its X axis.
+
+It's reccomended that you use a legend whenever displaying multiseries data. To display one, use the <a href="../Legend/Legend.md">`<Legend />` component</a>.
+
+##### showTicks
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | true    |
+
+Whether to show ticks connecting the xAxis labels to their corresponding grid line.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.
+
+#### yAxisOptions
+
+##### labelFormatter
+
+| type                       | default                       |
+| -------------------------- | ----------------------------- |
+| `(value: number): string;` | `(value) => value.toString()` |
+
+This utility function is called for every y axis value when the chart is drawn.
+
+##### labelColor
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `'rgb(223, 227, 232)'` |
+
+The color used for axis labels.
+
+#### barOptions
+
+##### isStacked
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+This changes the grouping of the bars. If `true` the bar groups will stack vertically, otherwise they will render individual bars for each data point in each group. To see an example of stacked vs. grouped orientations, refer to the images above.
+
+##### hasRoundedCorners
 
 | type      | default |
 | --------- | ------- |
 | `boolean` | `false` |
 
 Rounds the top corners of each bar, in the case of positive numbers. Rounds the bottom corners for negatives. Note: this prop only has an impact on grouped bars, not stacked ones.
+
+#### gridOptions
+
+An object including the following optional proprties that define the grid.
+
+##### showVHorizontalLines
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `true`  |
+
+Whether to show lines extending from the yAxis labels through the chart.
+
+##### color
+
+| type     | default                |
+| -------- | ---------------------- |
+| `string` | `"rgb(223, 227, 232)"` |
+
+The color of the grid lines.

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -69,6 +69,23 @@ export default {
   decorators: [
     (Story: any) => <div className={styles.Container}>{Story()}</div>,
   ],
+  argTypes: {
+    barOptions: {
+      control: false,
+    },
+    xAxisOptions: {
+      control: false,
+    },
+    yAxisOptions: {
+      control: false,
+    },
+    renderTooltipContent: {
+      control: false,
+    },
+    gridOptions: {
+      control: false,
+    },
+  },
 } as Meta;
 
 const Template: Story<MultiSeriesBarChartProps> = (
@@ -80,5 +97,5 @@ const Template: Story<MultiSeriesBarChartProps> = (
 export const Default = Template.bind({});
 Default.args = {
   series,
-  labels,
+  xAxisOptions: {labels},
 };

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -61,14 +61,24 @@ describe('Chart />', () => {
         name: 'LABEL2',
       },
     ],
-    isStacked: false,
-    labels: ['stuff 1', 'stuff 2', 'stuff 3'],
     chartDimensions: new DOMRect(),
-    formatXAxisLabel: jest.fn((value: string) => value),
-    formatYAxisLabel: (value: number) => value.toString(),
-    timeSeries: false,
     renderTooltipContent,
-    hasRoundedCorners: false,
+    barOptions: {
+      margin: 0,
+      hasRoundedCorners: false,
+      isStacked: false,
+    },
+    xAxisOptions: {
+      labelFormatter: jest.fn((value: string) => value.toString()),
+      showTicks: true,
+      labels: ['stuff 1', 'stuff 2', 'stuff 3'],
+      labelColor: 'red',
+    },
+    yAxisOptions: {
+      labelFormatter: (value: number) => value.toString(),
+      labelColor: 'red',
+    },
+    gridOptions: {showHorizontalLines: true, color: 'red'},
   };
 
   it('renders an SVG element', () => {
@@ -89,7 +99,7 @@ describe('Chart />', () => {
 
   it('formats the x axis labels', () => {
     mount(<Chart {...mockProps} />);
-    expect(mockProps.formatXAxisLabel).toHaveBeenCalledTimes(3);
+    expect(mockProps.xAxisOptions.labelFormatter).toHaveBeenCalledTimes(3);
   });
 
   it('does not render <TooltipContainer /> if there is no active point', () => {
@@ -170,7 +180,12 @@ describe('Chart />', () => {
     });
 
     it('does not render BarGroup if isStacked is true', () => {
-      const chart = mount(<Chart {...mockProps} isStacked />);
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          barOptions={{...mockProps.barOptions, isStacked: true}}
+        />,
+      );
 
       expect(chart).not.toContainReactComponent(BarGroup);
     });
@@ -178,13 +193,23 @@ describe('Chart />', () => {
 
   describe('<StackedBarGroup />', () => {
     it('renders StackedBarGroup if isStacked is true', () => {
-      const chart = mount(<Chart {...mockProps} isStacked />);
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          barOptions={{...mockProps.barOptions, isStacked: true}}
+        />,
+      );
 
       expect(chart).toContainReactComponent(StackedBarGroup);
     });
 
     it('renders a StackedBarGroup for each stacked data item', () => {
-      const chart = mount(<Chart {...mockProps} isStacked />);
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          barOptions={{...mockProps.barOptions, isStacked: true}}
+        />,
+      );
 
       expect(chart).toContainReactComponentTimes(StackedBarGroup, 2);
     });
@@ -215,7 +240,7 @@ describe('Chart />', () => {
               name: 'LABEL2',
             },
           ]}
-          isStacked
+          barOptions={{...mockProps.barOptions, isStacked: true}}
         />,
       );
 
@@ -225,7 +250,12 @@ describe('Chart />', () => {
     });
 
     it('passes highlightColors with default colors to StackedBarGroup when no highlightColors are provided', () => {
-      const chart = mount(<Chart {...mockProps} isStacked />);
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          barOptions={{...mockProps.barOptions, isStacked: true}}
+        />,
+      );
 
       expect(chart).toContainReactComponent(StackedBarGroup, {
         highlightColors: ['colorBlack', 'colorRed'],
@@ -233,7 +263,12 @@ describe('Chart />', () => {
     });
 
     it('passes active props to the BarGroup that is being hovered', () => {
-      const chart = mount(<Chart {...mockProps} isStacked />);
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          barOptions={{...mockProps.barOptions, isStacked: true}}
+        />,
+      );
 
       const svg = chart.find('svg')!;
       svg.trigger('onMouseMove', fakeSVGEvent);

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -18,7 +18,7 @@ describe('<MultiSeriesBarChart />', () => {
         name: 'LABEL1',
       },
     ],
-    labels: ['Something', 'Another', 'Thing'],
+    xAxisOptions: {labels: ['Something', 'Another', 'Thing']},
   };
 
   it('renders a <Chart />', () => {

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -1,6 +1,12 @@
 import {Series as ShapeSeries} from 'd3-shape';
 
-import {Color, DataSeries, Data} from '../../types';
+import {
+  Color,
+  DataSeries,
+  Data,
+  StringLabelFormatter,
+  NumberLabelFormatter,
+} from '../../types';
 
 export interface Series extends DataSeries<Data> {
   highlightColor?: Color;
@@ -28,4 +34,26 @@ export interface AccessibilitySeries {
     label: string;
     value: string;
   }[];
+}
+
+export interface BarOptions {
+  hasRoundedCorners: boolean;
+  isStacked: boolean;
+}
+
+export interface GridOptions {
+  showHorizontalLines: boolean;
+  color: string;
+}
+
+export interface XAxisOptions {
+  labelFormatter: StringLabelFormatter;
+  showTicks: boolean;
+  labels: string[];
+  labelColor: string;
+}
+
+export interface YAxisOptions {
+  labelFormatter: NumberLabelFormatter;
+  labelColor: string;
 }


### PR DESCRIPTION
### What problem is this PR solving?
Two thirds of https://github.com/Shopify/core-issues/issues/23750: unblocks the customization we need for the Orders project, in terms of dark mode/light mode/general customization of the charts

Counterpart to https://github.com/Shopify/polaris-viz/pull/279

Apologies for a bit of a big PR, but it made the most sense to me to deal with the BarChart and MultiSeriesBarChart all at once, since they have some of the same subcomponents, so it simplified prop changes.

Note: there is a bit of a mismatch with these changes between our uses of Polaris tokens and strings for colors. Later, we will move towards full customizability for colors, and remove the tokens requirement. 

Additionally:
- updates some of out-of-date documentation that looks like it had been missed (for example, removing `accessibilityLabel` and replacing it with `skipLinkText`
- removes the concept of `timeSeries` from the bar charts. This is an [open issue](https://github.com/Shopify/polaris-viz/issues/247) so it didn't make sense to me to carry it over to the new API, since it was simple to get rid of it. All it means is that if we run out of space for xAxis labels even when they have gone diagonal, we will start dropping them to avoid overlap.

### Reviewers’ :tophat: instructions
Try different configurations of the new props to change the appearances of the charts. For example, in BarChartDemo, try the following props:
```jsx
        <BarChart
          data={data}
          barOptions={{color: 'colorOrange'}}
          xAxisOptions={{labelFormatter: formatXAxisLabel, showTicks: true}}
          yAxisOptions={{labelFormatter: formatYAxisLabel}}
          renderTooltipContent={renderTooltipContent}
          skipLinkText="Skip chart content"
          themeOptions={{textColor: 'red'}}
          gridOptions={{color: 'purple', showHorizontalLines: true}}
        />
```


Make sure the Playground and Storybook work as expected and there are no visual changes by default.

### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~

- [x] Update the Changelog.

- [x] Update relevant documentation.
