### PR TITLE
[MultiSeriesBarChart] Adding handling for empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - The timeseries prop has been removed from bar charts, in favour of using that label handling by default (when there is not enough room for all diagonal labels, some will be dropped).
 
+### Added
+
+- `emptyStateText` and empty state handling to `<MultiSeriesBarChart />`
+
 ## [0.8.1] — 2021-04-20
 
 ### Added

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -35,6 +35,7 @@ interface Props {
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
   isAnimated?: boolean;
+  emptyStateText?: string;
 }
 
 export function Chart({
@@ -46,6 +47,7 @@ export function Chart({
   yAxisOptions,
   barOptions,
   isAnimated = false,
+  emptyStateText,
 }: Props) {
   const [activeBarGroup, setActiveBarGroup] = useState<number | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<{
@@ -55,6 +57,8 @@ export function Chart({
 
   const fontSize =
     chartDimensions.width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
+
+  const emptyState = series.length === 0;
 
   const stackedValues = barOptions.isStacked
     ? getStackedValues(series, xAxisOptions.labels)
@@ -197,7 +201,8 @@ export function Chart({
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBarGroup(null)}
         onTouchEnd={() => setActiveBarGroup(null)}
-        role="list"
+        role={emptyState ? 'img' : 'list'}
+        aria-label={emptyState ? emptyStateText : undefined}
       >
         <g
           transform={`translate(${axisMargin},${chartDimensions.height -
@@ -273,7 +278,7 @@ export function Chart({
         </g>
       </svg>
 
-      {tooltipPosition != null && activeBarGroup != null ? (
+      {tooltipPosition != null && activeBarGroup != null && !emptyState ? (
         <TooltipContainer
           activePointIndex={activeBarGroup}
           currentX={tooltipPosition.x}

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -119,6 +119,7 @@ interface MultiSeriesBarChartProps {
   series: Series[];
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
+  emptyStateText?: string;
   barOptions?: {
     isStacked?: boolean;
     hasRoundedCorners?: boolean;
@@ -158,6 +159,8 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
   highlightColor?: Color;
 }
 ```
+
+If `series` may be an empty array, provide <a href="#emptyStateText">`emptyStateText`</a> to communicate the empty state to screenreaders.
 
 #### name
 
@@ -339,3 +342,11 @@ Whether to show lines extending from the yAxis labels through the chart.
 | `string` | `"rgb(223, 227, 232)"` |
 
 The color of the grid lines.
+
+#### emptyStateText
+
+| type     | default     |
+| -------- | ----------- |
+| `string` | `undefined` |
+
+Used to indicate to screenreaders that a chart with no series data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the series prop could be an empty array.

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -26,6 +26,7 @@ export interface MultiSeriesBarChartProps {
   xAxisOptions: Partial<XAxisOptions> & Pick<XAxisOptions, 'labels'>;
   yAxisOptions?: Partial<YAxisOptions>;
   isAnimated?: boolean;
+  emptyStateText?: string;
 }
 
 export function MultiSeriesBarChart({
@@ -37,10 +38,12 @@ export function MultiSeriesBarChart({
   gridOptions,
   xAxisOptions,
   yAxisOptions,
+  emptyStateText,
 }: MultiSeriesBarChartProps) {
   const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const skipLinkAnchorId = useRef(uniqueId('multiSeriesBarChart'));
+  const emptyState = series.length === 0;
 
   const [updateDimensions] = useDebouncedCallback(() => {
     if (containerRef.current != null) {
@@ -105,7 +108,9 @@ export function MultiSeriesBarChart({
     <div style={{height: '100%', width: '100%'}} ref={containerRef}>
       {chartDimensions == null ? null : (
         <React.Fragment>
-          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+          {skipLinkText == null ||
+          skipLinkText.length === 0 ||
+          emptyState ? null : (
             <SkipLink anchorId={skipLinkAnchorId.current}>
               {skipLinkText}
             </SkipLink>
@@ -123,8 +128,11 @@ export function MultiSeriesBarChart({
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
+            emptyStateText={emptyStateText}
           />
-          {skipLinkText == null || skipLinkText.length === 0 ? null : (
+          {skipLinkText == null ||
+          skipLinkText.length === 0 ||
+          emptyState ? null : (
             <SkipLink.Anchor id={skipLinkAnchorId.current} />
           )}
         </React.Fragment>

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -119,6 +119,15 @@ describe('Chart />', () => {
     expect(tooltipContainer).toContainReactText('Mock Tooltip');
   });
 
+  describe('empty state', () => {
+    it('does not render tooltip for empty state', () => {
+      const chart = mount(<Chart {...mockProps} series={[]} />);
+
+      expect(chart).not.toContainReactText('Mock Tooltip');
+      expect(chart).not.toContainReactComponent(TooltipContainer);
+    });
+  });
+
   describe('<BarGroup />', () => {
     it('renders a BarGroup for each data item', () => {
       const chart = mount(<Chart {...mockProps} />);

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
+import {SkipLink} from 'components/SkipLink';
 
 import {MultiSeriesBarChart} from '../MultiSeriesBarChart';
 import {Chart} from '../Chart';
@@ -19,11 +20,26 @@ describe('<MultiSeriesBarChart />', () => {
       },
     ],
     xAxisOptions: {labels: ['Something', 'Another', 'Thing']},
+    skipLinkText: 'Skip Chart Content',
   };
 
   it('renders a <Chart />', () => {
     const multiSeriesBarChart = mount(<MultiSeriesBarChart {...mockProps} />);
 
     expect(multiSeriesBarChart).toContainReactComponent(Chart);
+  });
+
+  it('renders a <SkipLink />', () => {
+    const multiSeriesBarChart = mount(<MultiSeriesBarChart {...mockProps} />);
+
+    expect(multiSeriesBarChart).toContainReactComponent(SkipLink);
+  });
+
+  it('does not render a <SkipLink /> when series is empty', () => {
+    const multiSeriesBarChart = mount(
+      <MultiSeriesBarChart {...mockProps} series={[]} />,
+    );
+
+    expect(multiSeriesBarChart).not.toContainReactComponent(SkipLink);
   });
 });

--- a/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
@@ -13,7 +13,7 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     const calculatedMax = Math.max(...maxStackedValues);
     const min = Math.min(...minStackedValues);
     const max =
-      calculatedMax === 0 && min === 0
+      data.length === 0 || (calculatedMax === 0 && min === 0)
         ? DEFAULT_MAX_Y
         : Math.max(0, calculatedMax);
 
@@ -33,7 +33,7 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
     const calculatedMax = Math.max(...groupedDataPoints);
     const min = Math.min(...groupedDataPoints, 0);
     const max =
-      calculatedMax === 0 && min === 0
+      data.length === 0 || (calculatedMax === 0 && min === 0)
         ? DEFAULT_MAX_Y
         : Math.max(0, calculatedMax);
 


### PR DESCRIPTION
### What problem is this PR solving?

Adds handling for empty state in `MultiSeriesBarChart`, ie when data is an empty array.

| before | after |
| -- | -- |
| <img width="1745" alt="Screen Shot 2021-04-21 at 1 51 58 PM" src="https://user-images.githubusercontent.com/40300265/115598787-c946d500-a2a8-11eb-904c-e5a107b91cfa.png"> | <img width="1752" alt="Screen Shot 2021-04-21 at 1 51 39 PM" src="https://user-images.githubusercontent.com/40300265/115598816-cf3cb600-a2a8-11eb-87b6-42b03ce814a4.png"> |



Also adds `emptyStateText` prop for `MultiSeriesBarChart` for a11y in case of the empty state.

This PR is a part of the changes for https://github.com/Shopify/core-issues/issues/22617

### Reviewers’ :tophat: instructions

1. Pass in an empty array as `series` to `MultiSeriesBarChart`, and make sure it doesn't render the Tooltip or any unnecessary elements.
2. Make sure it plays well with a11y for both tabbing and screenreader support [make sure to add `emptyStateText` when testing].
3. Make sure the aria label for emptyStateText works as expected.
4. These changes should not affect how the `MultiSeriesBarChart` normally works in case of no empty state.
5. Make sure changes work for both grouped and stacked options.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
