### PR TITLE
[Line chart] Allow minimal xaxis label treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Ability to show point at the end of a `<Sparkline />` series
 - `emptyStateText` and empty state handling to `<MultiSeriesBarChart />`
-- `useMinimalLabels` option added to the `<BarChart />` `xAxisOptions` prop
-- Exported `<LinePreview />` and `<SquareColorPreview />` components
+- `<LinePreview />` and `<SquareColorPreview />` components are now exported
+- `useMinimalLabels` option added to the `<BarChart />` and `<LineChart />` `xAxisOptions` prop
 
 ### Changed
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -82,6 +82,7 @@ export function Chart({
     formatXAxisLabel: xAxisOptions.labelFormatter,
     initialTicks,
     xAxisLabels: xAxisOptions.hideXAxisLabels ? [] : xAxisOptions.xAxisLabels,
+    useMinimalLabels: xAxisOptions.useMinimalLabels,
   });
 
   const marginBottom = xAxisOptions.hideXAxisLabels

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -131,6 +131,7 @@ interface LineChartProps {
     xAxisLabels: string[];
     labelFormatter?(value: string, index?: number, data?: string[]): string;
     hideXAxisLabels?: boolean;
+    useMinimalLabels?: boolean;
     showTicks?: boolean;
     labelColor: string;
   };
@@ -292,6 +293,14 @@ Used to indicate to screenreaders that a chart with no data has been rendered, i
 #### xAxisOptions
 
 An object including the following proprties that define the appearance of the xAxis. Only xAxisLabels is mandatory.
+
+##### useMinimalLabels
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+If set to true, a chart that would typically show more than three xAxis labels will instead show a maximum of three labels.
 
 ##### hideXAxisLabels
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -79,6 +79,7 @@ export function LineChart({
     hideXAxisLabels: false,
     showTicks: true,
     labelColor: DEFAULT_GREY_LABEL,
+    useMinimalLabels: false,
     ...xAxisOptions,
   };
 

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -53,6 +53,7 @@ const xAxisOptions = {
   hideXAxisLabels: false,
   showTicks: true,
   labelColor: 'red',
+  useMinimalLabels: false,
 };
 
 const lineOptions = {hasSpline: false, width: 2};

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -37,6 +37,7 @@ export interface XAxisOptions {
   hideXAxisLabels: boolean;
   showTicks: boolean;
   labelColor: string;
+  useMinimalLabels: boolean;
 }
 
 export interface YAxisOptions {

--- a/src/hooks/tests/useLinearXAxisDetails.test.tsx
+++ b/src/hooks/tests/useLinearXAxisDetails.test.tsx
@@ -152,5 +152,34 @@ describe('useLinearXAxisDetails', () => {
       );
       expect(actual).toContainReactText('0/2');
     });
+
+    it('provides three labels if useMinimalLabels is true and the longest series has at least three points', () => {
+      const actual = mount(
+        <TicksTestComponent
+          props={{
+            ...mockProps,
+            useMinimalLabels: true,
+            xAxisLabels: ['Label 1', 'Label 2', 'Label 3', 'Label 4'],
+            series: [
+              {
+                data: [
+                  {rawValue: 10000, label: 'Some label'},
+                  {rawValue: 10, label: 'Some label'},
+                  {rawValue: 10, label: 'Some label'},
+                  {rawValue: 10, label: 'Some label'},
+                  {rawValue: 10, label: 'Some label'},
+                ],
+                name: 'Test series 1',
+                color: 'colorGreen',
+                lineStyle: 'dashed',
+              },
+            ] as any,
+            chartDimensions: {width: 800} as any,
+          }}
+        />,
+      );
+
+      expect(actual).toContainReactText('0/2/4');
+    });
   });
 });


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/core-issues/issues/23742

Adds the option to show minimal xAxis labels on the line chart, which we need for our new designs

| Default   | minimalXLabels: true  | Design  |  
|---|---|---|
|  <img width="1754" alt="Screen Shot 2021-04-23 at 8 56 19 AM" src="https://user-images.githubusercontent.com/12213371/115874218-d7643500-a411-11eb-82a0-ca8a56546483.png"> | <img width="1764" alt="Screen Shot 2021-04-23 at 8 56 05 AM" src="https://user-images.githubusercontent.com/12213371/115874222-d7fccb80-a411-11eb-8d0c-c21ebcf439ac.png">| <img width="1115" alt="Screen Shot 2021-04-23 at 8 51 09 AM" src="https://user-images.githubusercontent.com/12213371/115873661-307f9900-a411-11eb-8712-ae0739b64224.png"> |


### Reviewers’ :tophat: instructions
Make sure the line chart labels look good, with and without the new option, at a variety of widths

### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~

- [x] Update the Changelog.

- [x] Update relevant documentation.
