### PR TITLE
Added LinePreview and SquareColorPreivew to package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Ability to show point at the end of a `<Sparkline />` series
 - `emptyStateText` and empty state handling to `<MultiSeriesBarChart />`
 - `useMinimalLabels` option added to the `<BarChart />` `xAxisOptions` prop
+- Exported `<LinePreview />` and `<SquareColorPreview />` components
 
 ### Changed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,6 @@ export {
   MultiSeriesBarChartProps,
   TooltipContent,
   TooltipContentProps,
+  LinePreview,
+  SquareColorPreview,
 } from './components';


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->
This PR exports the `LinePreview` and `SquareColorPreview` components. This will allow us make use of them when creating the custom viz tooltips for the orders reports (https://github.com/Shopify/core-issues/issues/23836)

### Reviewers’ :tophat: instructions
0. `dev up` on web 
1. Checkout this branch and run `dev up && yarn build-consumer web`
2. Attempt to import `LinePreview` and `SquareColorPreview` in web and it should work 

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
