### PR TITLE
Fix perf regression in line chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Performance regression in `<LineChart/>`
+
 ### Added
 
 - Check window is defined before accessing window methods

--- a/src/hooks/useLinearXAxisDetails.ts
+++ b/src/hooks/useLinearXAxisDetails.ts
@@ -90,12 +90,6 @@ export function useLinearXAxisDetails({
     longestSeriesLength: longestSeriesLastIndex,
   });
 
-  const minimalLabelIndexes = [
-    0,
-    Math.floor(longestSeriesLastIndex / 2),
-    longestSeriesLastIndex,
-  ];
-
   const {
     maxXLabelHeight,
     maxDiagonalLabelLength,
@@ -111,6 +105,12 @@ export function useLinearXAxisDetails({
             .filter(function removeNonIntegerTicks(value) {
               return Number.isInteger(value);
             });
+
+    const minimalLabelIndexes = [
+      0,
+      Math.floor(longestSeriesLastIndex / 2),
+      longestSeriesLastIndex,
+    ];
 
     const ticks =
       useMinimalLabels && longestSeriesLastIndex > minimalLabelIndexes.length
@@ -212,7 +212,6 @@ export function useLinearXAxisDetails({
     formatXAxisLabel,
     initialXScale.xScale,
     longestSeriesLastIndex,
-    minimalLabelIndexes,
     useMinimalLabels,
     xAxisLabels,
   ]);


### PR DESCRIPTION
### What problem is this PR solving?

Part of https://github.com/Shopify/core-issues/issues/24498

Fixes a performance issue I introduced. I am a little shocked at home much difference this change makes but my guess is React couldn't tell when `minimalLabelIndexes` changed, so the xAxis label details were being recalculation on every mouseover.

| Before  | After  | 
|---|---|
| ![master](https://user-images.githubusercontent.com/12213371/116829382-bddd8e80-ab71-11eb-9cfb-12dae96d0827.gif)|  ![new](https://user-images.githubusercontent.com/12213371/116828815-2aa35980-ab6f-11eb-9b1d-0f8664c0c619.gif)| 

### Reviewers’ :tophat: instructions

Add a lot of data to the line chart demo or Storybook. You can do so with something like this:

```
Array.from(Array(5000)).map((_, index) => {
  return {rawValue: Math.random() * index, label: ''};
})
```

Or, check out these changes in web and select a long time range, over hour. To do so:
- `dev up && dev server` in web
- `yarn build-consumer web` from Polaris Viz, while on this branch
- See the orders report at `https://shop1.myshopify.io/admin/reports/orders_over_time?since=-30d&until=-1d&over=hour` (use beta override `insights_orders_report`


### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~

- [ ] Update the Changelog.

~- [ ] Update relevant documentation.~
