### PR TITLE
[MultSeriesBarChart] Add margin to barOptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `margin` prop to `barOptions` for `<MultiSeriesBarChart/>`
+
 ### Removed
 
 - `highLightColor` from `MultiSeriesBarChart` `barOptions` prop

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -22,7 +22,6 @@ import {
   SMALL_WIDTH,
   SMALL_FONT_SIZE,
   SPACING,
-  INNER_PADDING,
 } from './constants';
 import styles from './Chart.scss';
 
@@ -30,7 +29,7 @@ interface Props {
   series: Required<Series>[];
   chartDimensions: DOMRect;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
-  barOptions: BarOptions;
+  barOptions: Omit<BarOptions, 'margin'> & {margin: number};
   gridOptions: GridOptions;
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
@@ -98,9 +97,15 @@ export function Chart({
         xLabels: formattedXAxisLabels,
         fontSize,
         chartDimensions,
-        padding: INNER_PADDING,
+        padding: barOptions.margin,
       }),
-    [yAxisLabelWidth, formattedXAxisLabels, fontSize, chartDimensions],
+    [
+      yAxisLabelWidth,
+      formattedXAxisLabels,
+      fontSize,
+      chartDimensions,
+      barOptions.margin,
+    ],
   );
 
   const drawableWidth = chartDimensions.width - MARGIN.Right - axisMargin;
@@ -112,6 +117,7 @@ export function Chart({
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
     data: sortedData,
+    barMargin: barOptions.margin,
     labels: formattedXAxisLabels,
   });
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -120,6 +120,7 @@ interface MultiSeriesBarChartProps {
   barOptions?: {
     isStacked?: boolean;
     hasRoundedCorners?: boolean;
+    margin?: 'Small' | 'Medium' | 'Large' | 'None';
   };
   gridOptions?: {
     showHorizontalLines?: boolean;
@@ -302,6 +303,14 @@ This utility function is called for every y axis value when the chart is drawn.
 The color used for axis labels.
 
 #### barOptions
+
+##### margin
+
+| type                                       | default  |
+| ------------------------------------------ | -------- |
+| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
+
+This sets the margin between bar groups. A value of `None` will remove spacing between bar groups.
 
 ##### isStacked
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -15,6 +15,7 @@ import {
   GridOptions,
   XAxisOptions,
   YAxisOptions,
+  BarMargin,
 } from './types';
 
 export interface MultiSeriesBarChartProps {
@@ -69,10 +70,16 @@ export function MultiSeriesBarChart({
     };
   }, [containerRef, updateDimensions]);
 
+  const margin =
+    barOptions != null && barOptions.margin != null
+      ? BarMargin[barOptions.margin]
+      : BarMargin.Medium;
+
   const barOptionsWithDefaults = {
     hasRoundedCorners: false,
     isStacked: false,
     ...barOptions,
+    margin,
   };
 
   const gridOptionsWithDefaults = {

--- a/src/components/MultiSeriesBarChart/constants.ts
+++ b/src/components/MultiSeriesBarChart/constants.ts
@@ -12,4 +12,3 @@ export const SMALL_FONT_SIZE = 10;
 export const DEFAULT_HEIGHT = 250;
 export const BAR_SPACING = 0.5;
 export const DIAGONAL_ANGLE = -40;
-export const INNER_PADDING = 0.3;

--- a/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
@@ -10,6 +10,16 @@ jest.mock('d3-scale', () => ({
   }),
 }));
 
+const mockProps = {
+  drawableWidth: 200,
+  barMargin: 0,
+  data: [
+    [10, 20, 30],
+    [0, 1, 2],
+  ],
+  labels: ['label 1', 'label 2'],
+};
+
 describe('useXScale', () => {
   afterEach(() => {
     (scaleBand as jest.Mock).mockReset();
@@ -28,14 +38,7 @@ describe('useXScale', () => {
     });
 
     function TestComponent() {
-      useXScale({
-        drawableWidth: 200,
-        data: [
-          [10, 20, 30],
-          [0, 1, 2],
-        ],
-        labels: ['label 1', 'label 2'],
-      });
+      useXScale(mockProps);
 
       return null;
     }
@@ -59,14 +62,7 @@ describe('useXScale', () => {
     });
 
     function TestComponent() {
-      useXScale({
-        drawableWidth: 200,
-        data: [
-          [10, 20, 30],
-          [0, 1, 2],
-        ],
-        labels: ['label 1', 'label 2'],
-      });
+      useXScale(mockProps);
       return null;
     }
 
@@ -87,14 +83,7 @@ describe('useXScale', () => {
     });
 
     function TestComponent() {
-      const {xAxisLabels} = useXScale({
-        drawableWidth: 200,
-        data: [
-          [10, 20, 30],
-          [0, 1, 2],
-        ],
-        labels: ['label 1', 'label 2'],
-      });
+      const {xAxisLabels} = useXScale(mockProps);
       return (
         <React.Fragment>
           {xAxisLabels.map(({value, xOffset}, index) => (
@@ -106,5 +95,34 @@ describe('useXScale', () => {
 
     const testComponent = mount(<TestComponent />);
     expect(testComponent).toContainReactText('label 1-50');
+  });
+
+  describe('barMargin', () => {
+    it('adds inner padding using the bar margin', () => {
+      let paddingSpy = jest.fn();
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.domain = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+        paddingSpy = jest.fn(() => scale);
+        scale.paddingInner = paddingSpy;
+        return scale;
+      });
+
+      function TestComponent() {
+        useXScale({
+          ...mockProps,
+          barMargin: 0.5,
+        });
+
+        return null;
+      }
+
+      mount(<TestComponent />);
+
+      expect(paddingSpy).toHaveBeenCalledWith(0.5);
+    });
   });
 });

--- a/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
@@ -1,20 +1,20 @@
 import {useMemo} from 'react';
 import {scaleBand} from 'd3-scale';
 
-import {INNER_PADDING} from '../constants';
-
 export function useXScale({
   drawableWidth,
   data,
   labels,
+  barMargin,
 }: {
   drawableWidth: number;
   data: number[][];
   labels: string[];
+  barMargin: number;
 }) {
   const xScale = scaleBand()
     .range([0, drawableWidth])
-    .paddingInner(INNER_PADDING)
+    .paddingInner(barMargin)
     .domain(data.map((_, index) => index.toString()));
 
   const barWidthOffset = xScale.bandwidth() / 2;

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -29,17 +29,19 @@ describe('<MultiSeriesBarChart />', () => {
     expect(multiSeriesBarChart).toContainReactComponent(Chart);
   });
 
-  it('renders a <SkipLink />', () => {
-    const multiSeriesBarChart = mount(<MultiSeriesBarChart {...mockProps} />);
+  describe('skipLinkText', () => {
+    it('renders a <SkipLink />', () => {
+      const multiSeriesBarChart = mount(<MultiSeriesBarChart {...mockProps} />);
 
-    expect(multiSeriesBarChart).toContainReactComponent(SkipLink);
-  });
+      expect(multiSeriesBarChart).toContainReactComponent(SkipLink);
+    });
 
-  it('does not render a <SkipLink /> when series is empty', () => {
-    const multiSeriesBarChart = mount(
-      <MultiSeriesBarChart {...mockProps} series={[]} />,
-    );
+    it('does not render a <SkipLink /> when series is empty', () => {
+      const multiSeriesBarChart = mount(
+        <MultiSeriesBarChart {...mockProps} series={[]} />,
+      );
 
-    expect(multiSeriesBarChart).not.toContainReactComponent(SkipLink);
+      expect(multiSeriesBarChart).not.toContainReactComponent(SkipLink);
+    });
   });
 });

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -34,7 +34,15 @@ export interface AccessibilitySeries {
   }[];
 }
 
+export enum BarMargin {
+  Small = 0.1,
+  Medium = 0.3,
+  Large = 0.5,
+  None = 0,
+}
+
 export interface BarOptions {
+  margin: keyof typeof BarMargin;
   hasRoundedCorners: boolean;
   isStacked: boolean;
 }


### PR DESCRIPTION
### What problem is this PR solving?

Closes https://github.com/Shopify/core-issues/issues/24207

* adds `margin` prop to `barOptions`
* match the `BarChart` api for configuring small/medium/large margins

I debated if we need any fancier logic dependent on screen size/data size/number of series, but I tried a few different datasets on different screen sizes and I think just this is good.

`margin` could probably be renamed to `innerMargin` or similar once https://github.com/Shopify/core-issues/issues/24490 is implemented.

#### `Large` examples:
![image](https://user-images.githubusercontent.com/30587540/116920350-84b02780-ac20-11eb-8c53-fd3abd5d7056.png)
![image](https://user-images.githubusercontent.com/30587540/116920433-9db8d880-ac20-11eb-9699-5d93ebeb8b20.png)
![image](https://user-images.githubusercontent.com/30587540/116920497-b0cba880-ac20-11eb-9c2a-fdfded6834b5.png)


<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

* in storybook or the playground, add `margin: Small/Medium/Large/None` to `barOptions` for multi series bar chart
* make sure the spacing looks appropriate with different datasets/screen sizes
* if one is not specified, it should be `Medium`

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
