### PR TITLE
[Orders Analytics in Context] Added dark mode colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Check window is defined before accessing window methods
+- Added new Dark Mode colors
 
 ## [0.9.2] — 2021-04-29
 

--- a/src/utilities/viz-colors.ts
+++ b/src/utilities/viz-colors.ts
@@ -10,4 +10,6 @@ export const vizColors = {
   pastComparison: 'rgb(145,158,171)',
   positive: 'rgb(0,128,96)',
   negative: 'rgb(215,44,13)',
+  darkModePositive: 'rgb(0, 164, 124)',
+  darkModeNegative: 'rgb(255, 85, 70)',
 };


### PR DESCRIPTION
### What problem is this PR solving?

This PR adds the 2 new colours that OAIC viz use:

![image](https://user-images.githubusercontent.com/4788817/116937697-de1b5500-ac26-11eb-9630-196d9df46306.png)

![image](https://user-images.githubusercontent.com/4788817/116937718-e5426300-ac26-11eb-9e57-21173d2a524d.png)


```
  darkModePositive: 'rgb(0, 164, 124)',
  darkModeNegative: 'rgb(255, 85, 70)',
```

https://www.figma.com/file/jl40kHWZlriADDI3qPX66A/Order-In-Context-Dashboard%2FReports?node-id=918%3A36942

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
