### PR TITLE
Add `SeriesColor` type to package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Export `Color` and `GradientStop` types
+
 ## [0.10.0] — 2021-05-04
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,5 @@ export {
   LinePreview,
   SquareColorPreview,
 } from './components';
+
+export {Color, GradientStop} from './types';


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->
This PR exports the `SeriesColor` type so that we can reference it in web. Based off [this slack discussion](https://shopify.slack.com/archives/C01MJ1XEJ0Y/p1620149438402700).

### Reviewers’ :tophat: instructions
0. `dev up` on web 
1. Checkout this branch and run `dev up && yarn build-consumer web`
2. Attempt to import `SeriesColor` in web and it should work 

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.
- [x] Update the Changelog.
- [ ] Update relevant documentation.
