### PR TITLE
Fix sparkbar margins

### DIFF
--- a/documentation/code/SparkbarDemo.tsx
+++ b/documentation/code/SparkbarDemo.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {Sparkbar} from '../../src/components';
 
-import {SparklineDemo} from './SparklineDemo';
 import {OUTER_CONTAINER_STYLE} from './constants';
 
 export function SparkbarDemo() {
@@ -18,7 +17,7 @@ export function SparkbarDemo() {
         <div style={{width: 200, height: 150}}>
           <Sparkbar
             isAnimated
-            data={[100, 200, 300, -400, 400, 1000, 200, 800, 900, 200, 400]}
+            data={[100, 200, 300, 400, 400, 1000, 200, 800, 900, 200, 400]}
             comparison={[
               {x: 0, y: 500},
               {x: 1, y: 500},

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -65,11 +65,8 @@ export default function Playground() {
   return (
     <div>
       <h3>Playground area</h3>
-      <NormalizedStackedBarChart
-        size="large"
-        // orientation="vertical"
-        {...mockProps}
-      />
+
+      <PlaygroundDemos.SparkbarDemo />
       <br />
       <button onClick={toggleDemos}>Toggle Demos</button>
       {showDemos && <Demos />}

--- a/src/components/Sparkbar/Sparkbar.scss
+++ b/src/components/Sparkbar/Sparkbar.scss
@@ -1,5 +1,16 @@
 @import '../../styles/common';
 
+.Wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.Svg {
+  position: absolute;
+}
+
 .VisuallyHidden {
   @include visually-hidden;
 }

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -26,7 +26,8 @@ import styles from './Sparkbar.scss';
 
 const STROKE_WIDTH = 1.5;
 const BAR_PADDING = 0.15;
-const MARGIN = 17;
+const MARGIN = 8;
+const ANIMATION_MARGIN = 17;
 
 interface Coordinates {
   x: number;
@@ -40,6 +41,27 @@ export interface SparkbarProps {
   accessibilityLabel?: string;
   isAnimated?: boolean;
   barFillStyle?: 'solid' | 'gradient';
+}
+
+function calculateRange(data: number[], height: number) {
+  let hasNegatives;
+  let hasPositives;
+  for (const val of data) {
+    if (val < 0) hasNegatives = true;
+    else if (val > 0) hasPositives = true;
+
+    if (hasNegatives && hasPositives) break;
+  }
+
+  let range = [height, MARGIN];
+
+  if (hasNegatives && hasPositives) {
+    range = [height - MARGIN, MARGIN];
+  } else if (hasNegatives) {
+    range = [height - MARGIN, 0];
+  }
+
+  return range;
 }
 
 export function Sparkbar({
@@ -88,7 +110,7 @@ export function Sparkbar({
   const {width, height} = svgDimensions;
 
   const yScale = scaleLinear()
-    .range([height - MARGIN, MARGIN])
+    .range(calculateRange(data, height))
     .domain([Math.min(...data, 0), Math.max(...data, 0)]);
 
   const xScale = scaleBand()
@@ -134,12 +156,20 @@ export function Sparkbar({
   });
 
   return (
-    <div style={{width: '100%', height: '100%'}} ref={containerRef}>
+    <div className={styles.Wrapper} ref={containerRef}>
       {accessibilityLabel ? (
         <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       ) : null}
 
-      <svg aria-hidden width={width} height={height}>
+      <svg
+        aria-hidden
+        viewBox={`0 ${ANIMATION_MARGIN * -1} ${width} ${height +
+          ANIMATION_MARGIN * 2}`}
+        style={{
+          transform: `translateY(${ANIMATION_MARGIN * -1}px)`,
+        }}
+        className={styles.Svg}
+      >
         {barFillStyle === 'gradient' ? (
           <LinearGradient
             id={id}


### PR DESCRIPTION
### What problem is this PR solving?
Fixes the issue of the sparkbar having margins that were too large

![image](https://user-images.githubusercontent.com/61977684/117068589-7bdf5480-acf9-11eb-81c7-7901484131a1.png)


The bottom of the sparkbar lines up with the bottom of the div now

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
