### PR TITLE
Fix bar chart types

### DIFF
--- a/documentation/code/BarChartDemo.tsx
+++ b/documentation/code/BarChartDemo.tsx
@@ -79,7 +79,6 @@ export function BarChartDemo() {
           barOptions={{
             color: 'quaternary',
             hasRoundedCorners: true,
-            highlightColor: 'quaternaryProminent',
           }}
           xAxisOptions={{
             labelFormatter: formatXAxisLabel,

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,15 +1,16 @@
 import {
-  Data,
   Color,
   StringLabelFormatter,
   NumberLabelFormatter,
   GradientStop,
 } from 'types';
 
-export interface BarChartData extends Data {
+export interface BarChartData {
   barOptions?: {
     color: Color;
   };
+  label: string;
+  rawValue: number;
 }
 
 export enum BarMargin {


### PR DESCRIPTION
### What problem is this PR solving?
Fyi @pbojinov I noticed the changes to the BarChart types were making it so that the rawValue and label types on the data object were no longer passing typecheck. Going to merge this to unblock web, but we should take a closer look at what went wrong with extending the data type, and whether we can have better typechecking on Storybook. The types failed on BarChartDemo but not Storybook :/ 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
