### PR TITLE
[BarChart & MultiSeriesBarChart] Add outer padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `outerMargin` prop to `<BarChart/>` and `<MultiSeriesBarChart/>`
+
+### Changed
+
+- renamed `barOptions.margin` to `innerMargin` for `<BarChart/>` and `<MultiSeriesBarChart/>`
+
 ## [0.10.2] — 2021-05-05
 
 ### Fixed

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -93,7 +93,8 @@ interface BarChartProps {
   skipLinkText?: string;
   emptyStateText?: string;
   barOptions?: {
-    margin?: 'Small' | 'Medium' | 'Large' | 'None';
+    innerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
+    outerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
     color?: Color;
     highlightColor?: Color;
     hasRoundedCorners?: boolean;
@@ -190,13 +191,21 @@ Used to indicate to screenreaders that a chart with no data has been rendered, i
 
 An optional object including the following proprties that define the appearance of the bar.
 
-##### margin
+##### innerMargin
 
 | type                                       | default  |
 | ------------------------------------------ | -------- |
 | `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
 
-This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element.
+This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingInner) for more info.
+
+##### outerMargin
+
+| type                                       | default |
+| ------------------------------------------ | ------- |
+| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `None`  |
+
+This sets the margin before and after all bars. A value of `None` will have bars start at the Y axis and end at the edge of the chart. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingOuter) for more info.
 
 ##### color
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -76,16 +76,22 @@ export function BarChart({
     };
   }, [containerRef, updateDimensions]);
 
-  const margin =
-    barOptions != null && barOptions.margin != null
-      ? BarMargin[barOptions.margin]
+  const innerMargin =
+    barOptions != null && barOptions.innerMargin != null
+      ? BarMargin[barOptions.innerMargin]
       : BarMargin.Medium;
+
+  const outerMargin =
+    barOptions != null && barOptions.outerMargin != null
+      ? BarMargin[barOptions.outerMargin]
+      : BarMargin.None;
 
   const barOptionsWithDefaults = {
     color: getDefaultColor(),
     hasRoundedCorners: false,
     ...barOptions,
-    margin,
+    innerMargin,
+    outerMargin,
   };
 
   const gridOptionsWithDefaults = {

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -28,7 +28,7 @@ import {AnnotationLine} from './components';
 import {
   BarChartData,
   RenderTooltipContentData,
-  BarOptions,
+  BarOptions as BarChartBarOptions,
   GridOptions,
   XAxisOptions,
   YAxisOptions,
@@ -44,6 +44,11 @@ import {
 } from './constants';
 import styles from './Chart.scss';
 
+type BarOptions = Omit<BarChartBarOptions, 'innerMargin' | 'outerMargin'> & {
+  innerMargin: number;
+  outerMargin: number;
+};
+
 interface Props {
   data: BarChartData[];
   annotationsLookupTable: AnnotationLookupTable;
@@ -51,7 +56,7 @@ interface Props {
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   emptyStateText?: string;
   isAnimated?: boolean;
-  barOptions: Omit<BarOptions, 'margin'> & {margin: number};
+  barOptions: BarOptions;
   gridOptions: GridOptions;
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
@@ -110,7 +115,8 @@ export function Chart({
         fontSize,
         xLabels: data.map(({label}) => xAxisOptions.labelFormatter(label)),
         chartDimensions,
-        padding: barOptions.margin,
+        innerMargin: barOptions.innerMargin,
+        outerMargin: barOptions.outerMargin,
         minimalLabelIndexes,
       }),
     [
@@ -118,7 +124,8 @@ export function Chart({
       fontSize,
       data,
       chartDimensions,
-      barOptions.margin,
+      barOptions.innerMargin,
+      barOptions.outerMargin,
       minimalLabelIndexes,
       xAxisOptions,
     ],
@@ -152,7 +159,8 @@ export function Chart({
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
     data,
-    barMargin: barOptions.margin,
+    innerMargin: barOptions.innerMargin,
+    outerMargin: barOptions.outerMargin,
     formatXAxisLabel: xAxisOptions.labelFormatter,
   });
 

--- a/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-x-scale.test.tsx
@@ -10,6 +10,18 @@ jest.mock('d3-scale', () => ({
   }),
 }));
 
+const mockProps = {
+  drawableWidth: 200,
+  innerMargin: 0,
+  outerMargin: 0,
+  data: [
+    {rawValue: 0, label: ''},
+    {rawValue: 1000, label: ''},
+    {rawValue: -1000, label: ''},
+  ],
+  formatXAxisLabel: (val: string) => val,
+};
+
 describe('useXScale', () => {
   afterEach(() => {
     (scaleBand as jest.Mock).mockReset();
@@ -24,16 +36,12 @@ describe('useXScale', () => {
       scale.range = rangeSpy;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       return scale;
     });
 
     function TestComponent() {
-      useXScale({
-        drawableWidth: 200,
-        barMargin: 0,
-        data: [{rawValue: 10, label: ''}],
-        formatXAxisLabel: () => '',
-      });
+      useXScale(mockProps);
 
       return null;
     }
@@ -51,22 +59,14 @@ describe('useXScale', () => {
       scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       domainSpy = jest.fn(() => scale);
       scale.domain = domainSpy;
       return scale;
     });
 
     function TestComponent() {
-      useXScale({
-        drawableWidth: 200,
-        barMargin: 0,
-        data: [
-          {rawValue: 0, label: ''},
-          {rawValue: 1000, label: ''},
-          {rawValue: -1000, label: ''},
-        ],
-        formatXAxisLabel: (val: string) => val,
-      });
+      useXScale(mockProps);
       return null;
     }
 
@@ -82,14 +82,14 @@ describe('useXScale', () => {
       scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       scale.domain = () => scale;
       return scale;
     });
 
     function TestComponent() {
       const {xAxisLabels} = useXScale({
-        drawableWidth: 200,
-        barMargin: 0,
+        ...mockProps,
         data: [{rawValue: 0, label: 'Test 1'}],
         formatXAxisLabel: (val: string) => `${val}!`,
       });
@@ -105,5 +105,63 @@ describe('useXScale', () => {
 
     const testComponent = mount(<TestComponent />);
     expect(testComponent).toContainReactText('Test 1!-50');
+  });
+
+  describe('innerMargin', () => {
+    it('calls paddingInner with the innerMargin', () => {
+      let paddingInnerSpy = jest.fn();
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.domain = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+        scale.paddingOuter = () => scale;
+
+        paddingInnerSpy = jest.fn(() => scale);
+        scale.paddingInner = paddingInnerSpy;
+
+        return scale;
+      });
+
+      function TestComponent() {
+        useXScale({...mockProps, innerMargin: 0.5});
+
+        return null;
+      }
+
+      mount(<TestComponent />);
+
+      expect(paddingInnerSpy).toHaveBeenCalledWith(0.5);
+    });
+  });
+
+  describe('outerMargin', () => {
+    it('calls paddingOuter with the outerMargin', () => {
+      let paddingOuterSpy = jest.fn();
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.domain = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+        scale.paddingInner = () => scale;
+
+        paddingOuterSpy = jest.fn(() => scale);
+        scale.paddingOuter = paddingOuterSpy;
+
+        return scale;
+      });
+
+      function TestComponent() {
+        useXScale({...mockProps, outerMargin: 0.5});
+
+        return null;
+      }
+
+      mount(<TestComponent />);
+
+      expect(paddingOuterSpy).toHaveBeenCalledWith(0.5);
+    });
   });
 });

--- a/src/components/BarChart/hooks/use-x-scale.ts
+++ b/src/components/BarChart/hooks/use-x-scale.ts
@@ -6,18 +6,21 @@ import {StringLabelFormatter} from '../../../types';
 
 export function useXScale({
   drawableWidth,
-  barMargin,
+  innerMargin,
+  outerMargin,
   data,
   formatXAxisLabel,
 }: {
   drawableWidth: number;
-  barMargin: number;
+  innerMargin: number;
+  outerMargin: number;
   data: Data[];
   formatXAxisLabel: StringLabelFormatter;
 }) {
   const xScale = scaleBand()
     .range([0, drawableWidth])
-    .paddingInner(barMargin)
+    .paddingInner(innerMargin)
+    .paddingOuter(outerMargin)
     .domain(data.map((_, index) => index.toString()));
 
   const barWidthOffset = xScale.bandwidth() / 2;

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -36,7 +36,8 @@ describe('Chart />', () => {
     chartDimensions: new DOMRect(),
     barOptions: {
       color: 'colorPurple' as Color,
-      margin: 0,
+      innerMargin: 0,
+      outerMargin: 0,
       hasRoundedCorners: false,
     },
     xAxisOptions: {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -27,7 +27,8 @@ export interface RenderTooltipContentData {
 }
 
 export interface BarOptions {
-  margin: keyof typeof BarMargin;
+  innerMargin: keyof typeof BarMargin;
+  outerMargin: keyof typeof BarMargin;
   color: Color | GradientStop[];
   hasRoundedCorners: boolean;
 }

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -9,7 +9,7 @@ import {getStackedValues, formatAriaLabel} from './utilities';
 import {
   Series,
   RenderTooltipContentData,
-  BarOptions,
+  BarOptions as MultiSeriesBarOptions,
   GridOptions,
   XAxisOptions,
   YAxisOptions,
@@ -25,11 +25,16 @@ import {
 } from './constants';
 import styles from './Chart.scss';
 
+type BarOptions = Omit<MultiSeriesBarOptions, 'innerMargin' | 'outerMargin'> & {
+  innerMargin: number;
+  outerMargin: number;
+};
+
 interface Props {
   series: Required<Series>[];
   chartDimensions: DOMRect;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
-  barOptions: Omit<BarOptions, 'margin'> & {margin: number};
+  barOptions: BarOptions;
   gridOptions: GridOptions;
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
@@ -97,14 +102,16 @@ export function Chart({
         xLabels: formattedXAxisLabels,
         fontSize,
         chartDimensions,
-        padding: barOptions.margin,
+        innerMargin: barOptions.innerMargin,
+        outerMargin: barOptions.outerMargin,
       }),
     [
       yAxisLabelWidth,
       formattedXAxisLabels,
       fontSize,
       chartDimensions,
-      barOptions.margin,
+      barOptions.innerMargin,
+      barOptions.outerMargin,
     ],
   );
 
@@ -117,7 +124,8 @@ export function Chart({
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
     data: sortedData,
-    barMargin: barOptions.margin,
+    innerMargin: barOptions.innerMargin,
+    outerMargin: barOptions.outerMargin,
     labels: formattedXAxisLabels,
   });
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -120,7 +120,8 @@ interface MultiSeriesBarChartProps {
   barOptions?: {
     isStacked?: boolean;
     hasRoundedCorners?: boolean;
-    margin?: 'Small' | 'Medium' | 'Large' | 'None';
+    innerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
+    outerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
   };
   gridOptions?: {
     showHorizontalLines?: boolean;
@@ -304,13 +305,21 @@ The color used for axis labels.
 
 #### barOptions
 
-##### margin
+##### innerMargin
 
 | type                                       | default  |
 | ------------------------------------------ | -------- |
 | `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
 
-This sets the margin between bar groups. A value of `None` will remove spacing between bar groups.
+This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingInner) for more info.
+
+##### outerMargin
+
+| type                                       | default |
+| ------------------------------------------ | ------- |
+| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `None`  |
+
+This sets the margin before and after all bars. A value of `None` will have bars start at the Y axis and end at the edge of the chart. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingOuter) for more info.
 
 ##### isStacked
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -70,16 +70,22 @@ export function MultiSeriesBarChart({
     };
   }, [containerRef, updateDimensions]);
 
-  const margin =
-    barOptions != null && barOptions.margin != null
-      ? BarMargin[barOptions.margin]
+  const innerMargin =
+    barOptions != null && barOptions.innerMargin != null
+      ? BarMargin[barOptions.innerMargin]
       : BarMargin.Medium;
+
+  const outerMargin =
+    barOptions != null && barOptions.outerMargin != null
+      ? BarMargin[barOptions.outerMargin]
+      : BarMargin.None;
 
   const barOptionsWithDefaults = {
     hasRoundedCorners: false,
     isStacked: false,
     ...barOptions,
-    margin,
+    innerMargin,
+    outerMargin,
   };
 
   const gridOptionsWithDefaults = {

--- a/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/MultiSeriesBarChart/hooks/tests/use-x-scale.test.tsx
@@ -12,7 +12,8 @@ jest.mock('d3-scale', () => ({
 
 const mockProps = {
   drawableWidth: 200,
-  barMargin: 0,
+  innerMargin: 0,
+  outerMargin: 0,
   data: [
     [10, 20, 30],
     [0, 1, 2],
@@ -34,6 +35,7 @@ describe('useXScale', () => {
       scale.range = rangeSpy;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       return scale;
     });
 
@@ -56,6 +58,7 @@ describe('useXScale', () => {
       scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       domainSpy = jest.fn(() => scale);
       scale.domain = domainSpy;
       return scale;
@@ -78,6 +81,7 @@ describe('useXScale', () => {
       scale.range = () => scale;
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
+      scale.paddingOuter = () => scale;
       scale.domain = () => scale;
       return scale;
     });
@@ -97,24 +101,27 @@ describe('useXScale', () => {
     expect(testComponent).toContainReactText('label 1-50');
   });
 
-  describe('barMargin', () => {
-    it('adds inner padding using the bar margin', () => {
-      let paddingSpy = jest.fn();
+  describe('innerMargin', () => {
+    it('calls the paddingInner method using the innerMargin', () => {
+      let paddingInnerSpy = jest.fn();
 
       (scaleBand as jest.Mock).mockImplementation(() => {
         const scale = (value: any) => value;
         scale.domain = () => scale;
         scale.range = () => scale;
         scale.bandwidth = () => 10;
-        paddingSpy = jest.fn(() => scale);
-        scale.paddingInner = paddingSpy;
+        scale.paddingOuter = () => scale;
+
+        paddingInnerSpy = jest.fn(() => scale);
+        scale.paddingInner = paddingInnerSpy;
+
         return scale;
       });
 
       function TestComponent() {
         useXScale({
           ...mockProps,
-          barMargin: 0.5,
+          innerMargin: 0.5,
         });
 
         return null;
@@ -122,7 +129,39 @@ describe('useXScale', () => {
 
       mount(<TestComponent />);
 
-      expect(paddingSpy).toHaveBeenCalledWith(0.5);
+      expect(paddingInnerSpy).toHaveBeenCalledWith(0.5);
+    });
+  });
+
+  describe('outerMargin', () => {
+    it('calls the paddingOuter method using the outerMargin', () => {
+      let paddingOuterSpy = jest.fn();
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.domain = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+        scale.paddingInner = () => scale;
+
+        paddingOuterSpy = jest.fn(() => scale);
+        scale.paddingOuter = paddingOuterSpy;
+
+        return scale;
+      });
+
+      function TestComponent() {
+        useXScale({
+          ...mockProps,
+          outerMargin: 0.5,
+        });
+
+        return null;
+      }
+
+      mount(<TestComponent />);
+
+      expect(paddingOuterSpy).toHaveBeenCalledWith(0.5);
     });
   });
 });

--- a/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-x-scale.ts
@@ -5,16 +5,19 @@ export function useXScale({
   drawableWidth,
   data,
   labels,
-  barMargin,
+  innerMargin,
+  outerMargin,
 }: {
   drawableWidth: number;
   data: number[][];
   labels: string[];
-  barMargin: number;
+  innerMargin: number;
+  outerMargin: number;
 }) {
   const xScale = scaleBand()
     .range([0, drawableWidth])
-    .paddingInner(barMargin)
+    .paddingInner(innerMargin)
+    .paddingOuter(outerMargin)
     .domain(data.map((_, index) => index.toString()));
 
   const barWidthOffset = xScale.bandwidth() / 2;

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -64,7 +64,8 @@ describe('Chart />', () => {
     chartDimensions: new DOMRect(),
     renderTooltipContent,
     barOptions: {
-      margin: 0,
+      innerMargin: 0,
+      outerMargin: 0,
       hasRoundedCorners: false,
       isStacked: false,
     },

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -42,7 +42,8 @@ export enum BarMargin {
 }
 
 export interface BarOptions {
-  margin: keyof typeof BarMargin;
+  innerMargin: keyof typeof BarMargin;
+  outerMargin: keyof typeof BarMargin;
   hasRoundedCorners: boolean;
   isStacked: boolean;
 }

--- a/src/utilities/tests/get-bar-xaxis-details.test.ts
+++ b/src/utilities/tests/get-bar-xaxis-details.test.ts
@@ -33,6 +33,8 @@ describe('getBarXAxisDetails', () => {
       yAxisLabelWidth: 100,
       xLabels: manyDataPoints.map(({label}) => label),
       fontSize: 10,
+      innerMargin: 0,
+      outerMargin: 0,
       chartDimensions: {
         height: 100,
         width: 100,
@@ -49,9 +51,11 @@ describe('getBarXAxisDetails', () => {
     ];
 
     const actual = getBarXAxisDetails({
-      yAxisLabelWidth: 10,
+      yAxisLabelWidth: 5,
       xLabels: fewDataPoints.map(({label}) => label),
       fontSize: 10,
+      innerMargin: 0,
+      outerMargin: 0,
       chartDimensions: {
         height: 100,
         width: 100,
@@ -66,6 +70,8 @@ describe('getBarXAxisDetails', () => {
       yAxisLabelWidth: 10,
       xLabels: manyDataPoints.map(({label}) => label),
       fontSize: 10,
+      innerMargin: 0,
+      outerMargin: 0,
       minimalLabelIndexes: [0, 4, 9],
       chartDimensions: {
         height: 100,


### PR DESCRIPTION
### What problem is this PR solving?

Closes https://github.com/Shopify/core-issues/issues/24490

* renamed `margin/barMargin` to `paddingInner` to match d3's API
* added [`paddingOuter`](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingOuter) prop to add space before and after bars 
* updated `useXScale` and `getXBarAxisDetails` to account for both inner and outer padding

I found [this resource](https://observablehq.com/@d3/d3-scaleband) helpful to visualize how `paddingInner` and `paddingOuter` are calculated.

### Reviewers’ :tophat: instructions

For BarChart and MultiSeriesBarChart (stacked and regular), try adding `paddingInner` and `paddingOuter` to `barOptions`:
```
barOptions: {
  paddingInner: 'Small' | 'Medium' | 'Large' | 'None',
  paddingOuter: 'Small' | 'Medium' | 'Large' | 'None', 
}
```

* Check that the values look good on different datasets, padding combinations, and screen sizes
* Confirm diagonal label calculation is still working correctly

![image](https://user-images.githubusercontent.com/30587540/117163641-d926e480-ad91-11eb-84a7-aee693d3b84c.png)

![image](https://user-images.githubusercontent.com/30587540/117164059-45094d00-ad92-11eb-9fc3-b7c35a6c7ef1.png)

![image](https://user-images.githubusercontent.com/30587540/117164170-5d796780-ad92-11eb-9a8f-c0a5211a0445.png)


<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
