### PR TITLE
upgrade react-spring to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "!*.stories.*"
   ],
   "dependencies": {
+    "@react-spring/web": "^9.1.2",
     "@shopify/css-utilities": "^1.0.0",
     "@shopify/polaris-tokens": "^3.0.0",
     "d3-array": "^2.4.0",
@@ -145,7 +146,6 @@
     "d3-shape": "^1.3.7",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
-    "react-spring": "^8.0.27",
     "use-debounce": "^3.3.0"
   },
   "resolutions": {

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -1,8 +1,10 @@
 import React, {useMemo} from 'react';
-import {animated, OpaqueInterpolation} from 'react-spring';
+import {animated, SpringValue} from '@react-spring/web';
 import {ScaleLinear} from 'd3-scale';
 
 import {ROUNDED_BAR_RADIUS} from '../../constants';
+import {isNumber} from '../../utilities';
+import {PathInterpolator, NumberInterpolator} from '../../types';
 
 import styles from './Bar.scss';
 
@@ -18,7 +20,7 @@ interface Props {
   tabIndex: number;
   role?: string;
   hasRoundedCorners?: boolean;
-  height?: OpaqueInterpolation<any> | number;
+  height?: SpringValue | number;
   rotateZeroBars: boolean;
 }
 
@@ -41,27 +43,24 @@ export function Bar({
   const treatAsNegative = rawValue < 0 || (rawValue === 0 && rotateZeroBars);
   const rotation = treatAsNegative ? 'rotate(180deg)' : 'rotate(0deg)';
   const xPosition = treatAsNegative ? x + width : x;
-  const heightIsNumber = typeof height === 'number';
   const radius = hasRoundedCorners ? ROUNDED_BAR_RADIUS : 0;
 
   const yPosition = useMemo(() => {
     if (height == null) return;
 
-    const getYPosition = (value: number) =>
+    const getYPosition: NumberInterpolator = (value: number) =>
       treatAsNegative ? zeroScale + value : zeroScale - value;
 
-    if (heightIsNumber) {
+    if (isNumber(height)) {
       return getYPosition(height);
     }
-    return height.interpolate(getYPosition);
-  }, [height, heightIsNumber, treatAsNegative, zeroScale]);
-
-  const yPositionIsNumber = typeof yPosition === 'number';
+    return height.to(getYPosition);
+  }, [height, treatAsNegative, zeroScale]);
 
   const handleFocus = () => {
     if (yPosition == null) return;
 
-    const cy = yPositionIsNumber ? yPosition : yPosition.getValue();
+    const cy = isNumber(yPosition) ? yPosition : yPosition.get();
     onFocus({index, cx: x, cy});
   };
 
@@ -71,17 +70,17 @@ export function Bar({
     const getStyle = (y: number) =>
       `translate(${xPosition}px, ${y}px) ${rotation}`;
 
-    if (yPositionIsNumber) return {transform: getStyle(yPosition)};
+    if (isNumber(yPosition)) return {transform: getStyle(yPosition)};
 
     return {
-      transform: yPosition.interpolate(getStyle),
+      transform: yPosition.to(getStyle),
     };
-  }, [yPosition, yPositionIsNumber, xPosition, rotation]);
+  }, [yPosition, xPosition, rotation]);
 
   const path = useMemo(() => {
     if (height == null) return;
 
-    const calculatePath = (heightValue: number) => {
+    const calculatePath: PathInterpolator = (heightValue: number) => {
       const radiusOffset = Math.max(0, radius - heightValue);
 
       return heightValue === 0
@@ -96,11 +95,11 @@ export function Bar({
         Z`;
     };
 
-    if (heightIsNumber) {
+    if (isNumber(height)) {
       return calculatePath(height);
     }
-    return height.interpolate(calculatePath);
-  }, [height, heightIsNumber, radius, width]);
+    return height.to(calculatePath);
+  }, [height, radius, width]);
 
   return (
     <animated.path

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react';
-import {useTransition} from 'react-spring';
+import {useTransition} from '@react-spring/web';
 
 import {usePrefersReducedMotion} from '../../hooks';
 import {
@@ -203,12 +203,13 @@ export function Chart({
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
-  const transitions = useTransition(data, (dataPoint) => dataPoint.label, {
+  const transitions = useTransition(data, {
+    default: {immediate: !shouldAnimate},
+    keys: (dataPoint) => dataPoint.label,
     from: {height: 0},
     leave: {height: 0},
     enter: ({rawValue}) => ({height: getBarHeight(rawValue)}),
     update: ({rawValue}) => ({height: getBarHeight(rawValue)}),
-    immediate: !shouldAnimate,
     trail: shouldAnimate ? getAnimationTrail(data.length) : 0,
     config: BARS_TRANSITION_CONFIG,
   });
@@ -256,7 +257,7 @@ export function Chart({
 
           <mask id={clipId}>
             <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
-              {transitions.map(({item, props: {height}}, index) => {
+              {transitions(({height}, item, _transition, index) => {
                 const xPosition = xScale(index.toString());
                 const ariaLabel = `${xAxisOptions.labelFormatter(
                   data[index].label,
@@ -346,7 +347,7 @@ export function Chart({
             height={height}
             fill={`url(#${gradientId})`}
           />
-          {transitions.map(({item}, index) => {
+          {transitions((_props, item, _transition, index) => {
             const xPosition = xScale(index.toString());
             const xPositionValue = xPosition == null ? 0 : xPosition;
             const translateXValue = xPositionValue + chartStartPosition;
@@ -370,7 +371,7 @@ export function Chart({
         </g>
 
         <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
-          {transitions.map((_, index) => {
+          {transitions((_props, _item, _transition, index) => {
             const xPosition = xScale(index.toString());
             const xPositionValue = xPosition == null ? 0 : xPosition;
             const annotation = annotationsLookupTable[index];

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+import {SpringValue} from '@react-spring/web';
 import {Color} from 'types';
 import {vizColors} from 'utilities';
 import {
@@ -277,11 +278,9 @@ describe('Chart />', () => {
         />,
       );
 
-      expect(chart).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: MIN_BAR_HEIGHT,
-        }),
-      });
+      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
     });
 
     it('does not pass the min bar height to 0 bars if false', () => {
@@ -296,11 +295,9 @@ describe('Chart />', () => {
         />,
       );
 
-      expect(chart).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: 0,
-        }),
-      });
+      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(0);
     });
 
     it('sets rotateZeroBars to false if false', () => {
@@ -338,11 +335,9 @@ describe('Chart />', () => {
         />,
       );
 
-      expect(chart).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: MIN_BAR_HEIGHT,
-        }),
-      });
+      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
     });
   });
 

--- a/src/components/Crosshair/Crosshair.tsx
+++ b/src/components/Crosshair/Crosshair.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {animated} from 'react-spring';
+import {animated, Interpolation} from '@react-spring/web';
 
 import {CROSSHAIR_WIDTH, DEFAULT_CROSSHAIR_COLOR} from '../../constants';
 
 interface Props {
-  x: number;
+  x: number | Interpolation;
   height: number;
   opacity?: number;
   fill?: string;

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -233,13 +233,16 @@ export function Chart({
   const getXPosition = ({isCrosshair} = {isCrosshair: false}) => {
     const offset = isCrosshair ? crossHairOptions.width / 2 : 0;
 
-    return animatedCoordinates != null &&
+    if (
+      animatedCoordinates != null &&
       animatedCoordinates[longestSeriesIndex] != null &&
       animatePoints
-      ? animatedCoordinates[longestSeriesIndex].interpolate(
-          (coord: SVGPoint) => coord.x - offset,
-        )
-      : xScale(activeIndex == null ? 0 : activeIndex) - offset;
+    ) {
+      return animatedCoordinates[longestSeriesIndex].to(
+        (coord) => coord.x - offset,
+      );
+    }
+    return xScale(activeIndex == null ? 0 : activeIndex) - offset;
   };
 
   const handleMouseInteraction = throttle(
@@ -431,9 +434,7 @@ export function Chart({
             const animatedYPostion =
               animatedCoordinates == null || animatedCoordinates[index] == null
                 ? 0
-                : animatedCoordinates[index].interpolate(
-                    (coord: SVGPoint) => coord.y,
-                  );
+                : animatedCoordinates[index].to((coord) => coord.y);
 
             const hidePoint =
               animatedCoordinates == null ||

--- a/src/components/LineChart/hooks/tests/use-line-chart-animations.test.tsx
+++ b/src/components/LineChart/hooks/tests/use-line-chart-animations.test.tsx
@@ -64,7 +64,7 @@ describe('useLineChartAnimations', () => {
 
     mount(<TestComponent />);
 
-    expect(animatedCoordinates![0].getValue()).toMatchObject({x: 0, y: 0});
+    expect(animatedCoordinates![0].get()).toMatchObject({x: 0, y: 0});
   });
 
   it('returns null if isAnimated is false', () => {
@@ -180,7 +180,7 @@ describe('useLineChartAnimations', () => {
 
     mount(<TestComponent />);
 
-    animatedCoordinates![0].getValue();
+    animatedCoordinates![0].get();
 
     expect(getPointAtLength).toHaveBeenCalledWith(expect.any(SVGElement), 0);
   });

--- a/src/components/LineChart/hooks/use-line-chart-animations.tsx
+++ b/src/components/LineChart/hooks/use-line-chart-animations.tsx
@@ -1,6 +1,6 @@
-import {CSSProperties, useCallback, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 import {Line} from 'd3-shape';
-import {useSprings, SpringConfig, OpaqueInterpolation} from 'react-spring';
+import {useSprings} from '@react-spring/web';
 
 import {SPRING_CONFIG} from '../constants';
 import {SeriesWithDefaults} from '../types';
@@ -100,22 +100,14 @@ export function useLineChartAnimations({
   );
 
   // Create a spring with the same config for each series
-  const animatedPercentages = useSprings<
-    {
-      config: SpringConfig;
-      percentage: number;
-    },
-    CSSProperties & {
-      percentage: {interpolate: OpaqueInterpolation<any>};
-    }
-  >(
+  const animatedPercentages = useSprings(
     percentages == null ? 0 : percentages.length,
     percentages == null
       ? []
       : percentages.map((percentage) => ({
           percentage,
           config: SPRING_CONFIG,
-          immediate,
+          default: {immediate},
         })),
   );
 
@@ -125,7 +117,7 @@ export function useLineChartAnimations({
       immediate || totalPaths == null
         ? null
         : animatedPercentages.map(({percentage}, index) => {
-            return percentage.interpolate((percent: number) => {
+            return percentage.to((percent: number) => {
               const totalLength = totalPaths[index].length;
               const path = totalPaths[index].element;
               return getCoordinatesFromPercentage(percent, path, totalLength);

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useMemo} from 'react';
 import {ScaleLinear} from 'd3-scale';
 import {SeriesColor} from 'types';
-import {useTransition} from 'react-spring';
+import {useTransition} from '@react-spring/web';
 
 import {usePrefersReducedMotion} from '../../../../hooks';
 import {Bar} from '../../../Bar';
@@ -69,12 +69,14 @@ export function BarGroup({
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
-  const transitions = useTransition(data, (dataPoint) => dataPoint, {
+  const transitions = useTransition(data, {
+    key: (dataPoint: number, index: number) =>
+      `${index}-${barGroupIndex}${dataPoint}`,
     from: {height: 0},
     leave: {height: 0},
     enter: (rawValue) => ({height: getBarHeight(rawValue)}),
     update: (rawValue) => ({height: getBarHeight(rawValue)}),
-    immediate: !shouldAnimate,
+    default: {immediate: !shouldAnimate},
     trail: shouldAnimate ? getAnimationTrail(data.length) : 0,
     config: BARS_TRANSITION_CONFIG,
   });
@@ -96,7 +98,7 @@ export function BarGroup({
   return (
     <React.Fragment>
       <mask id={maskId}>
-        {transitions.map(({item: value, props: {height}}, index) => {
+        {transitions(({height}, value, _transition, index) => {
           const handleFocus = () => {
             onFocus(barGroupIndex);
           };
@@ -106,7 +108,7 @@ export function BarGroup({
             <g
               role={ariaEnabledBar ? 'listitem' : undefined}
               aria-hidden={!ariaEnabledBar}
-              key={index}
+              key={`${barGroupIndex}${index}`}
             >
               <Bar
                 height={height}
@@ -130,7 +132,7 @@ export function BarGroup({
       <g mask={`url(#${maskId})`}>
         {gradients.map((gradient, index) => {
           return (
-            <g key={index}>
+            <g key={`${maskId}${index}`}>
               <LinearGradient
                 gradient={gradient}
                 id={`${gradientId}${index}`}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
 import {Color} from 'types';
+import {SpringValue} from '@react-spring/web';
 
 import {BAR_SPACING} from '../../../constants';
 import {MIN_BAR_HEIGHT} from '../../../../../constants';
@@ -28,6 +29,7 @@ describe('<BarGroup/>', () => {
     hasRoundedCorners: false,
     isSubdued: false,
     zeroAsMinHeight: false,
+    isAnimated: false,
   };
 
   it('renders a <Bar /> for each data item', () => {
@@ -78,25 +80,21 @@ describe('<BarGroup/>', () => {
         </svg>,
       );
 
-      expect(barGroup).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: MIN_BAR_HEIGHT,
-        }),
-      });
+      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
     });
 
     it('does not pass the min bar height to 0 bars if false', () => {
       const barGroup = mount(
         <svg>
-          <BarGroup {...mockProps} zeroAsMinHeight={false} />,
+          <BarGroup {...mockProps} zeroAsMinHeight={false} data={[0]} />,
         </svg>,
       );
 
-      expect(barGroup).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: 0,
-        }),
-      });
+      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(0);
     });
 
     it('passes the min bar height to non-zero bar if false', () => {
@@ -106,11 +104,9 @@ describe('<BarGroup/>', () => {
         </svg>,
       );
 
-      expect(barGroup).toContainReactComponent(Bar, {
-        height: expect.objectContaining({
-          value: MIN_BAR_HEIGHT,
-        }),
-      });
+      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+
+      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
     });
   });
 

--- a/src/components/Point/Point.tsx
+++ b/src/components/Point/Point.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import tokens from '@shopify/polaris-tokens';
 import {ActiveTooltip} from 'types';
-import {useSpring, animated, OpaqueInterpolation} from 'react-spring';
+import {useSpring, animated, Interpolation} from '@react-spring/web';
 import {classNames} from '@shopify/css-utilities';
 
 import styles from './Point.scss';
 
 interface Props {
   active: boolean;
-  cx: number | OpaqueInterpolation<number>;
-  cy: number;
+  cx: number | Interpolation;
+  cy: number | Interpolation;
   color: string;
   index: number;
   isAnimated: boolean;
@@ -20,6 +20,8 @@ interface Props {
   visuallyHidden?: boolean;
   stroke: string;
 }
+
+const DEFAULT_RADIUS = 5;
 
 export const Point = React.memo(function Point({
   cx,
@@ -37,17 +39,23 @@ export const Point = React.memo(function Point({
 }: Props) {
   const handleFocus = () => {
     if (onFocus != null) {
-      onFocus({index, x: cx, y: cy});
+      return onFocus({
+        index,
+        x: typeof cx === 'number' ? cx : cx.get(),
+        y: typeof cy === 'number' ? cy : cy.get(),
+      });
     }
   };
 
-  const {radius} = useSpring({
-    radius: active ? 5 : 0,
+  const radius = active ? DEFAULT_RADIUS : 0;
+
+  const {animatedRadius} = useSpring({
+    animatedRadius: radius,
     from: {
-      radius: 0,
+      animatedRadius: 0,
     },
     config: {duration: tokens.durationBase},
-    immediate: !isAnimated,
+    default: {immediate: !isAnimated},
   });
 
   return (
@@ -57,7 +65,7 @@ export const Point = React.memo(function Point({
       tabIndex={tabIndex}
       cx={cx}
       cy={cy}
-      r={radius}
+      r={isAnimated ? animatedRadius : radius}
       fill={color}
       stroke={stroke}
       strokeWidth={2}

--- a/src/components/Point/tests/Point.test.tsx
+++ b/src/components/Point/tests/Point.test.tsx
@@ -41,7 +41,7 @@ describe('<Point />', () => {
       });
     });
 
-    it('renders with a radius of 5 when not active', () => {
+    it('renders with a radius of 0 when not active', () => {
       const point = mount(
         <svg>
           <Point {...mockProps} active={false} />

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useState, useLayoutEffect, useMemo} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleBand, scaleLinear} from 'd3-scale';
 import {line} from 'd3-shape';
-import {useTransition} from 'react-spring';
+import {useTransition} from '@react-spring/web';
 
 import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
 import {BARS_TRANSITION_CONFIG} from '../../constants';
@@ -151,12 +151,13 @@ export function Sparkbar({
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
-  const transitions = useTransition(dataWithIndex, ({index}) => index, {
+  const transitions = useTransition(dataWithIndex, {
+    key: ({index}: {index: number}) => index,
     from: {height: 0},
     leave: {height: 0},
     enter: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
     update: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
-    immediate: !shouldAnimate,
+    default: {immediate: !shouldAnimate},
     trail: shouldAnimate ? getAnimationTrail(dataWithIndex.length) : 0,
     config: BARS_TRANSITION_CONFIG,
   });
@@ -193,7 +194,7 @@ export function Sparkbar({
         ) : null}
 
         <g fill={barFillStyle === 'gradient' ? `url(#${id})` : currentColor}>
-          {transitions.map(({item, props: {height: barHeight}}, index) => {
+          {transitions(({height: barHeight}, item, _transition, index) => {
             const xPosition = xScale(index.toString());
             return (
               <g key={index} opacity={comparison ? '0.9' : '1'}>

--- a/src/components/Sparkbar/components/Bar/Bar.tsx
+++ b/src/components/Sparkbar/components/Bar/Bar.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import {ScaleLinear} from 'd3-scale';
-import {animated, OpaqueInterpolation} from 'react-spring';
+import {animated, SpringValue} from '@react-spring/web';
 
 import {SparkChartData} from '../../../../types';
 
@@ -9,7 +9,7 @@ interface Props {
   yScale: ScaleLinear<number, number>;
   rawValue: SparkChartData;
   width: number;
-  height?: OpaqueInterpolation<any> | number;
+  height?: SpringValue<number> | number;
 }
 
 export function Bar({x, rawValue, yScale, width, height}: Props) {
@@ -18,21 +18,17 @@ export function Bar({x, rawValue, yScale, width, height}: Props) {
   const rotation = isNegative ? 'rotate(180deg)' : 'rotate(0deg)';
   const xPosition = isNegative ? x + width : x;
 
-  const heightIsNumber = typeof height === 'number';
-
   const yPosition = useMemo(() => {
     if (height == null) return;
 
     const getYPosition = (value: number) =>
       isNegative ? zeroScale + value : zeroScale - value;
 
-    if (heightIsNumber) {
+    if (typeof height === 'number') {
       return getYPosition(height);
     }
-    return height.interpolate(getYPosition);
-  }, [height, heightIsNumber, isNegative, zeroScale]);
-
-  const yPositionIsNumber = typeof yPosition === 'number';
+    return height.to(getYPosition);
+  }, [height, isNegative, zeroScale]);
 
   const style = useMemo(() => {
     if (yPosition == null) return;
@@ -40,12 +36,12 @@ export function Bar({x, rawValue, yScale, width, height}: Props) {
     const getStyle = (y: number) =>
       `translate(${xPosition}px, ${y}px) ${rotation}`;
 
-    if (yPositionIsNumber) return {transform: getStyle(yPosition)};
+    if (typeof yPosition === 'number') return {transform: getStyle(yPosition)};
 
     return {
-      transform: yPosition.interpolate(getStyle),
+      transform: yPosition.to(getStyle),
     };
-  }, [yPosition, yPositionIsNumber, xPosition, rotation]);
+  }, [yPosition, xPosition, rotation]);
 
   const path = useMemo(() => {
     if (height == null) return;
@@ -82,11 +78,11 @@ export function Bar({x, rawValue, yScale, width, height}: Props) {
       return `${moveToStart}${arc}${moveToEndOfArc}${lineRightTopToBottom}${lineBottomRightToLeft}${lineLeftFromBottomToStart}`;
     };
 
-    if (heightIsNumber) {
+    if (typeof height === 'number') {
       return calculatePath(height);
     }
-    return height.interpolate(calculatePath);
-  }, [height, heightIsNumber, width]);
+    return height.to(calculatePath);
+  }, [height, width]);
 
   if (rawValue == null || width < 0) {
     return null;

--- a/src/components/Sparkbar/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Sparkbar/components/Bar/tests/Bar.test.tsx
@@ -25,7 +25,7 @@ describe('<Bar/>', () => {
     expect(bar).toContainReactComponent('path', {
       // eslint-disable-next-line id-length
       d: 'M 0 50 A 50 50 0 0 1 100 50 M 100 50 L 100 100 L 0 100 L 0 50',
-      style: {transform: 'translate(0px, -100px) rotate(0deg)'},
+      style: {transform: ' translate(0px, -100px) rotate(0deg)'},
     });
   });
 
@@ -45,7 +45,7 @@ describe('<Bar/>', () => {
     expect(bar).toContainReactComponent('path', {
       // eslint-disable-next-line id-length
       d: `M 1 49 A 50 50 0 0 1 99 49 M 100 49 L 0 49`,
-      style: {transform: `translate(0px, -49px) rotate(0deg)`},
+      style: {transform: ` translate(0px, -49px) rotate(0deg)`},
     });
   });
 
@@ -65,7 +65,7 @@ describe('<Bar/>', () => {
     expect(bar).toContainReactComponent('path', {
       // eslint-disable-next-line id-length
       d: ``,
-      style: {transform: `translate(0px, 0px) rotate(0deg)`},
+      style: {transform: ` translate(0px, 0px) rotate(0deg)`},
     });
   });
 });

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo} from 'react';
 import isEqual from 'lodash.isequal';
-import {animated, useSpring} from 'react-spring';
+import {animated, useSpring} from '@react-spring/web';
 import {area, Series} from 'd3-shape';
 import {Color} from 'types';
 import {ScaleLinear} from 'd3-scale';

--- a/src/components/TooltipContainer/TooltipContainer.tsx
+++ b/src/components/TooltipContainer/TooltipContainer.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState, ReactNode} from 'react';
-import {useSpring, animated} from 'react-spring';
+import {useSpring, animated} from '@react-spring/web';
 
 import {clamp} from '../../utilities';
 import {Dimensions} from '../../types';
@@ -85,7 +85,7 @@ export function TooltipContainer({
       const shouldRenderImmediate = firstRender.current;
       firstRender.current = false;
 
-      // react-spring docs do not return the `next` callback
+      // @react-spring/web docs do not return the `next` callback
       // eslint-disable-next-line callback-return
       await next({
         translate: [
@@ -118,7 +118,7 @@ export function TooltipContainer({
         top: 0,
         left: 0,
         opacity: spring.opacity,
-        transform: spring.translate.interpolate(
+        transform: spring.translate.to(
           // eslint-disable-next-line id-length
           (x: number, y: number, z: number) =>
             `translate3d(${x}px, ${y}px, ${z}px)`,

--- a/src/components/TooltipContainer/tests/TooltipContainer.test.tsx
+++ b/src/components/TooltipContainer/tests/TooltipContainer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {animated, OpaqueInterpolation} from 'react-spring';
+import {animated} from '@react-spring/web';
 
 import {TooltipContainer} from '../TooltipContainer';
 
@@ -31,9 +31,7 @@ describe('<TooltipContainer />', () => {
     expect(styles.left).toStrictEqual(0);
     expect(styles.top).toStrictEqual(0);
     // Checking that the styles are being controlled by react spring
-    expect(
-      ((styles.transform as unknown) as OpaqueInterpolation<number>).getValue,
-    ).toBeDefined();
+    expect(styles.transform).toBeDefined();
   });
 
   it('reners its children', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import {InterpolatorFn} from '@react-spring/web';
+
 export interface Data {
   label: string;
   rawValue: number;
@@ -134,3 +136,5 @@ export interface Dimensions {
 }
 
 export type SparkChartData = number | null;
+export type PathInterpolator = InterpolatorFn<ReadonlyArray<number>, string>;
+export type NumberInterpolator = InterpolatorFn<ReadonlyArray<number>, number>;

--- a/src/utilities/get-point-at-length.ts
+++ b/src/utilities/get-point-at-length.ts
@@ -3,7 +3,7 @@ export function getPointAtLength(
   length: number | null,
 ) {
   if (element == null || length == null) {
-    return 0;
+    return {x: 0, y: 0};
   }
   return element.getPointAtLength(length);
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -23,3 +23,4 @@ export {shouldRoundScaleUp} from './should-round-scale-up';
 export {curveStepRounded} from './curve-step-rounded';
 export {makeColorOpaque, makeGradientOpaque} from './make-color-opaque';
 export {shouldRotateZeroBars} from './should-rotate-zero-bars';
+export {isNumber} from './is-number';

--- a/src/utilities/is-number.ts
+++ b/src/utilities/is-number.ts
@@ -1,0 +1,3 @@
+export function isNumber(value: any): value is number {
+  return typeof value === 'number';
+}

--- a/tests/each-test.ts
+++ b/tests/each-test.ts
@@ -1,5 +1,6 @@
 import {destroyAll} from '@shopify/react-testing';
 import '@shopify/react-testing/matchers';
+import {Globals} from '@react-spring/web';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -21,6 +22,10 @@ Object.defineProperty(window, 'ResizeObserver', {
     unobserve: jest.fn(),
     disconnect: jest.fn(),
   })),
+});
+
+Globals.assign({
+  skipAnimation: true,
 });
 
 describe('setup', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,6 +3198,46 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-spring/animated@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.1.2.tgz#e43b122160f8f4cbb0caac8a7f57acd76dd12369"
+  integrity sha512-nKOGk+3aWbNp46V/CB1J2vR3GJI/Vork8N1WTI5mt+32QekrSsBn5/YFt4/iPaDGhLjukFxF0IjLs6hRLqSObw==
+  dependencies:
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
+
+"@react-spring/core@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.1.2.tgz#6d854a12fe9c3caa7942e51e708cb5fb4e2d1124"
+  integrity sha512-rgobYPCcLdDwbHBVqAmvtXhhX92G7MoPltJlzUge843yp1dNr47tkagFdCtw9NMGp6eHu/CE5byh/imlhLLAxw==
+  dependencies:
+    "@react-spring/animated" "~9.1.2"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
+
+"@react-spring/shared@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.1.2.tgz#c36d077d7eb31fd2cbcf8956d9d35037b2998613"
+  integrity sha512-sj/RrhFZAteCWAMk+W0t6Ku/skn/lbskCCs8B7ZnHNLMGPM+Zb3MOk+aVbX3T/D0iq/oTnKWyQYqrXDKiFcZ7g==
+  dependencies:
+    "@react-spring/types" "~9.1.2"
+    rafz "^0.1.14"
+
+"@react-spring/types@~9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.1.2.tgz#3273a182f825b38f44ead2a2f3984344abad1e2b"
+  integrity sha512-NZNImL0ymRFbss1cGKX2qSEeFdFoOgnIJZEW4Uczt+wm04J7g0Zuf23Hf8hM35JtxDr8QO5okp8BBtCM5FzzMg==
+
+"@react-spring/web@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.1.2.tgz#6ec409e8559676834b67aa33f0a2d57643c3c555"
+  integrity sha512-E5W9Hmi2bO6CPorCNV/2iv12ux9LxHJAbpXmrBPKWFRqZixysiHoNQKKPG0DmSvUU1uKkvCvMC4VoB6pj/2kxw==
+  dependencies:
+    "@react-spring/animated" "~9.1.2"
+    "@react-spring/core" "~9.1.2"
+    "@react-spring/shared" "~9.1.2"
+    "@react-spring/types" "~9.1.2"
+
 "@shopify/ast-utilities@^0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@shopify/ast-utilities/-/ast-utilities-0.0.9.tgz#7fe6346aa6959b252517739b7eeae81a02304633"
@@ -15836,7 +15876,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15990,6 +16030,11 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+
+rafz@^0.1.14:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/rafz/-/rafz-0.1.14.tgz#164f01cf7cc6094e08467247ef351ef5c8d278fe"
+  integrity sha512-YiQkedSt1urYtYbvHhTQR3l67M8SZbUvga5eJFM/v4vx/GmDdtXlE2hjJIyRjhhO/PjcdGC+CXCYOUA4onit8w==
 
 ramda@^0.21.0:
   version "0.21.0"
@@ -16291,14 +16336,6 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
-
-react-spring@^8.0.27:
-  version "8.0.27"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
-  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    prop-types "^15.5.8"
 
 react-syntax-highlighter@^13.5.3:
   version "13.5.3"


### PR DESCRIPTION
### What problem is this PR solving?

Solves: https://github.com/Shopify/polaris-viz/issues/232

The new version of react spring offers improved types, new features ( like cancelling animations or globally disabling animations for users that prefer reduced motion ), and fixes memory leaks that were previously caused by mounting/unmounting animated components.

This branch upgrades the package and updates our components to use the new API.

### Reviewers’ :tophat: instructions

We should make sure that this change does not break any existing behaviour.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
