### PR TITLE
Add horizontal gridlines component and full width option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `horizontalOverflow` to `gridOptions` for `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>`
+
 ## [0.11.0] — 2021-05-06
 
 ### Added

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -102,6 +102,7 @@ interface BarChartProps {
   gridOptions?: {
     showHorizontalLines?: boolean;
     color?: string;
+    horizontalOverflow?: boolean;
   };
   xAxisOptions?: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
@@ -244,6 +245,14 @@ An object including the following optional proprties that define the grid.
 | `boolean` | `true`  |
 
 Whether to show lines extending from the yAxis labels through the chart.
+
+##### horizontalOverflow
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether the lines should extend through the width of the entire chart.
 
 ##### color
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -97,6 +97,7 @@ export function BarChart({
   const gridOptionsWithDefaults = {
     showHorizontalLines: true,
     color: colorSky,
+    horizontalOverflow: false,
     ...gridOptions,
   };
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -23,6 +23,7 @@ import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
 import {TooltipContainer} from '../TooltipContainer';
 import {LinearGradient} from '../LinearGradient';
+import {HorizontalGridLines} from '../HorizontalGridLines';
 
 import {AnnotationLine} from './components';
 import {
@@ -295,17 +296,30 @@ export function Chart({
           />
         </g>
 
+        {gridOptions.showHorizontalLines ? (
+          <HorizontalGridLines
+            ticks={ticks}
+            color={gridOptions.color}
+            transform={{
+              x: gridOptions.horizontalOverflow ? 0 : axisMargin,
+              y: MARGIN.Top,
+            }}
+            width={
+              gridOptions.horizontalOverflow
+                ? chartDimensions.width
+                : drawableWidth
+            }
+          />
+        ) : null}
+
         <g
           transform={`translate(${axisMargin},${MARGIN.Top})`}
           aria-hidden="true"
         >
           <YAxis
             ticks={ticks}
-            drawableWidth={drawableWidth}
             fontSize={fontSize}
             labelColor={yAxisOptions.labelColor}
-            showGridLines={gridOptions.showHorizontalLines}
-            gridColor={gridOptions.color}
           />
         </g>
 

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -74,6 +74,7 @@ Default.args = {
   xAxisOptions: {labelFormatter: formatXAxisLabel},
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
+  gridOptions: {horizontalOverflow: true},
 };
 
 export const Annotations = Template.bind({});

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
-import {YAxis, TooltipContainer, BarChartXAxis, Bar} from 'components';
 import {vizColors} from 'utilities';
+import {
+  YAxis,
+  TooltipContainer,
+  BarChartXAxis,
+  Bar,
+  HorizontalGridLines,
+} from 'components';
 
 import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
@@ -51,7 +57,11 @@ describe('Chart />', () => {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
     },
-    gridOptions: {showHorizontalLines: true, color: 'red'},
+    gridOptions: {
+      showHorizontalLines: true,
+      color: 'red',
+      horizontalOverflow: false,
+    },
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
     annotationsLookupTable: {
       1: {
@@ -223,6 +233,25 @@ describe('Chart />', () => {
       const chart = mount(<Chart {...mockProps} />);
 
       expect(chart.find('rect', {fill: vizColors.colorGrayDark})).toBeNull();
+    });
+  });
+
+  describe('gridOptions.showHorizontalLines', () => {
+    it('does not render HorizontalGridLines when false', () => {
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          gridOptions={{...mockProps.gridOptions, showHorizontalLines: false}}
+        />,
+      );
+
+      expect(chart).not.toContainReactComponent(HorizontalGridLines);
+    });
+
+    it('renders HorizontalGridLines when true', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(HorizontalGridLines);
     });
   });
 });

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -35,6 +35,7 @@ export interface BarOptions {
 
 export interface GridOptions {
   showHorizontalLines: boolean;
+  horizontalOverflow: boolean;
   color: string;
 }
 

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -125,12 +125,6 @@ export function BarChartXAxis({
 
   return (
     <React.Fragment>
-      <path
-        d={`M ${xScaleMin} ${TICK_SIZE} v ${-TICK_SIZE} H ${xScaleMax} v ${TICK_SIZE}`}
-        fill="none"
-        stroke={gridColor}
-      />
-
       {labels.map(({value, xOffset}, index) => {
         if (
           (needsDiagonalLabels && index % visibleLabelRatio !== 0) ||

--- a/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
+++ b/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
@@ -38,19 +38,6 @@ describe('<BarChartXAxis/>', () => {
     showTicks: true,
   };
 
-  it('renders a path', () => {
-    const axis = mount(
-      <svg>
-        <BarChartXAxis {...mockProps} />,
-      </svg>,
-    );
-
-    expect(axis).toContainReactComponent('path', {
-      fill: 'none',
-      stroke: 'orange',
-    });
-  });
-
   it('renders a line for each label value', () => {
     const axis = mount(
       <svg>

--- a/src/components/HorizontalGridLines/HorizontalGridLines.test.tsx
+++ b/src/components/HorizontalGridLines/HorizontalGridLines.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {HorizontalGridLines} from './HorizontalGridLines';
+
+describe('<HorizontalGridLines />', () => {
+  describe('ticks', () => {
+    it('renders a line for each tick', () => {
+      const actual = mount(
+        <svg>
+          <HorizontalGridLines
+            ticks={[
+              {value: 10, formattedValue: '$10', yOffset: 0},
+              {value: 10, formattedValue: '$8', yOffset: 10},
+            ]}
+            color="red"
+            transform={{x: 10, y: 20}}
+            width={100}
+          />
+          ,
+        </svg>,
+      );
+
+      expect(actual).toContainReactComponentTimes('line', 2);
+    });
+  });
+
+  describe('color, transform, width', () => {
+    it('renders with style attributes', () => {
+      const actual = mount(
+        <svg>
+          <HorizontalGridLines
+            ticks={[{value: 10, formattedValue: '$10', yOffset: 0}]}
+            color="red"
+            transform={{x: 10, y: 20}}
+            width={100}
+          />
+          ,
+        </svg>,
+      );
+
+      expect(actual).toContainReactComponent('line', {
+        x2: 100,
+        transform: `translate(10,20)`,
+        stroke: 'red',
+      });
+    });
+  });
+});

--- a/src/components/HorizontalGridLines/HorizontalGridLines.tsx
+++ b/src/components/HorizontalGridLines/HorizontalGridLines.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import {YAxisTick} from '../../types';
+
+interface Props {
+  ticks: YAxisTick[];
+  color: string;
+  transform: {x: number; y: number};
+  width: number;
+}
+
+export function HorizontalGridLines({ticks, color, transform, width}: Props) {
+  return (
+    <React.Fragment>
+      {ticks.map(({yOffset}, index) => (
+        <line
+          key={index}
+          x2={width}
+          stroke={color}
+          transform={`translate(${transform.x},${transform.y + yOffset})`}
+        />
+      ))}
+    </React.Fragment>
+  );
+}

--- a/src/components/HorizontalGridLines/index.ts
+++ b/src/components/HorizontalGridLines/index.ts
@@ -1,0 +1,1 @@
+export {HorizontalGridLines} from './HorizontalGridLines';

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -9,6 +9,7 @@ import {
   FONT_SIZE,
   SPACING_TIGHT,
   Margin,
+  OVERFLOW_GRID_RIGHT_MARGIN,
 } from '../../constants';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
 import {LinearXAxis} from '../LinearXAxis';
@@ -25,6 +26,7 @@ import {Crosshair} from '../Crosshair';
 import {LinearGradient} from '../LinearGradient';
 import {ActiveTooltip} from '../../types';
 import {TooltipContainer} from '../TooltipContainer';
+import {HorizontalGridLines} from '../HorizontalGridLines';
 
 import {MAX_ANIMATED_SERIES_LENGTH} from './constants';
 import {
@@ -158,8 +160,12 @@ export function Chart({
 
   const reversedSeries = useMemo(() => series.slice().reverse(), [series]);
 
+  const rightMargin = gridOptions.horizontalOverflow
+    ? OVERFLOW_GRID_RIGHT_MARGIN
+    : Margin.Right;
+
   const drawableWidth =
-    axisMargin == null ? null : dimensions.width - Margin.Right - axisMargin;
+    axisMargin == null ? null : dimensions.width - rightMargin - axisMargin;
 
   const longestSeriesIndex = useMemo(
     () =>
@@ -315,13 +321,24 @@ export function Chart({
         <g transform={`translate(${axisMargin},${Margin.Top})`}>
           <YAxis
             ticks={ticks}
-            drawableWidth={drawableWidth}
             fontSize={fontSize}
-            showGridLines={gridOptions.showHorizontalLines}
-            gridColor={gridOptions.color}
             labelColor={yAxisOptions.labelColor}
           />
         </g>
+
+        {gridOptions.showHorizontalLines ? (
+          <HorizontalGridLines
+            ticks={ticks}
+            color={gridOptions.color}
+            transform={{
+              x: gridOptions.horizontalOverflow ? 0 : axisMargin,
+              y: Margin.Top,
+            }}
+            width={
+              gridOptions.horizontalOverflow ? dimensions.width : drawableWidth
+            }
+          />
+        ) : null}
 
         {emptyState ? null : (
           <g transform={`translate(${axisMargin},${Margin.Top})`}>

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -142,6 +142,7 @@ interface LineChartProps {
   gridOptions?: {
     showVerticalLines?: boolean;
     showHorizontalLines?: boolean;
+    horizontalOverflow?: boolean;
     color?: string;
   }
   crossHairOptions?: {
@@ -393,6 +394,14 @@ Whether to show lines extending from the xAxis labels through the chart.
 | `boolean` | `true`  |
 
 Whether to show lines extending from the yAxis labels through the chart.
+
+##### horizontalOverflow
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether the lines should extend through the width of the entire chart.
 
 ##### color
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -100,6 +100,7 @@ export function LineChart({
     showVerticalLines: true,
     showHorizontalLines: true,
     color: colorSky,
+    horizontalOverflow: false,
     ...gridOptions,
   };
 

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -6,6 +6,7 @@ import {
   TooltipContainer,
   VisuallyHiddenRows,
   Point,
+  HorizontalGridLines,
 } from 'components';
 import {line} from 'd3-shape';
 
@@ -69,6 +70,7 @@ const gridOptions = {
   showVerticalLines: true,
   showHorizontalLines: true,
   color: 'orange',
+  horizontalOverflow: false,
 };
 
 const crossHairOptions = {width: 10, color: 'red', opacity: 1};
@@ -390,6 +392,24 @@ describe('<Chart />', () => {
       );
 
       expect(chart).toContainReactComponentTimes(GradientArea, 1);
+    });
+  });
+
+  describe('gridOptions.showHorizontalLines', () => {
+    it('does not render HorizontalGridLines when false', () => {
+      const updatedProps = {
+        ...mockProps,
+        gridOptions: {...mockProps.gridOptions, showHorizontalLines: false},
+      };
+      const chart = mount(<Chart {...updatedProps} />);
+
+      expect(chart).not.toContainReactComponent(HorizontalGridLines);
+    });
+
+    it('renders HorizontalGridLines when true', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(HorizontalGridLines);
     });
   });
 });

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -54,6 +54,7 @@ export interface GridOptions {
   showVerticalLines: boolean;
   showHorizontalLines: boolean;
   color: string;
+  horizontalOverflow: boolean;
 }
 
 export interface CrossHairOptions {

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -4,6 +4,7 @@ import {TooltipContainer} from '../TooltipContainer';
 import {eventPoint, getTextWidth, getBarXAxisDetails} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
+import {HorizontalGridLines} from '../HorizontalGridLines';
 
 import {getStackedValues, formatAriaLabel} from './utilities';
 import {
@@ -234,17 +235,30 @@ export function Chart({
           />
         </g>
 
+        {gridOptions.showHorizontalLines ? (
+          <HorizontalGridLines
+            ticks={ticks}
+            color={gridOptions.color}
+            transform={{
+              x: gridOptions.horizontalOverflow ? 0 : axisMargin,
+              y: MARGIN.Top,
+            }}
+            width={
+              gridOptions.horizontalOverflow
+                ? chartDimensions.width
+                : drawableWidth
+            }
+          />
+        ) : null}
+
         <g
           transform={`translate(${axisMargin},${MARGIN.Top})`}
           aria-hidden="true"
         >
           <YAxis
             ticks={ticks}
-            drawableWidth={drawableWidth}
             fontSize={fontSize}
             labelColor={yAxisOptions.labelColor}
-            showGridLines={gridOptions.showHorizontalLines}
-            gridColor={gridOptions.color}
           />
         </g>
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -125,6 +125,7 @@ interface MultiSeriesBarChartProps {
   };
   gridOptions?: {
     showHorizontalLines?: boolean;
+    horizontalOverflow?: boolean;
     color?: string;
   };
   xAxisOptions: {
@@ -341,13 +342,21 @@ Rounds the top corners of each bar, in the case of positive numbers. Rounds the 
 
 An object including the following optional proprties that define the grid.
 
-##### showVHorizontalLines
+##### showHorizontalLines
 
 | type      | default |
 | --------- | ------- |
 | `boolean` | `true`  |
 
 Whether to show lines extending from the yAxis labels through the chart.
+
+##### horizontalOverflow
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether the lines should extend through the width of the entire chart.
 
 ##### color
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -91,6 +91,7 @@ export function MultiSeriesBarChart({
   const gridOptionsWithDefaults = {
     showHorizontalLines: true,
     color: colorSky,
+    horizontalOverflow: false,
     ...gridOptions,
   };
 

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
-import {YAxis, TooltipContainer, BarChartXAxis} from 'components';
+import {
+  YAxis,
+  TooltipContainer,
+  BarChartXAxis,
+  HorizontalGridLines,
+} from 'components';
 
 import {Chart} from '../Chart';
 import {BarGroup, StackedBarGroup} from '../components';
@@ -79,7 +84,11 @@ describe('Chart />', () => {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
     },
-    gridOptions: {showHorizontalLines: true, color: 'red'},
+    gridOptions: {
+      showHorizontalLines: true,
+      color: 'red',
+      horizontalOverflow: false,
+    },
   };
 
   it('renders an SVG element', () => {
@@ -196,6 +205,24 @@ describe('Chart />', () => {
       expect(chart).toContainReactComponent(StackedBarGroup, {
         activeBarGroup: 0,
       });
+    });
+  });
+
+  describe('gridOptions.showHorizontalLines', () => {
+    it('does not render HorizontalGridLines when false', () => {
+      const updatedProps = {
+        ...mockProps,
+        gridOptions: {...mockProps.gridOptions, showHorizontalLines: false},
+      };
+      const chart = mount(<Chart {...updatedProps} />);
+
+      expect(chart).not.toContainReactComponent(HorizontalGridLines);
+    });
+
+    it('renders HorizontalGridLines when true', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(HorizontalGridLines);
     });
   });
 });

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -51,6 +51,7 @@ export interface BarOptions {
 export interface GridOptions {
   showHorizontalLines: boolean;
   color: string;
+  horizontalOverflow: boolean;
 }
 
 export interface XAxisOptions {

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useMemo, useRef} from 'react';
 import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
+import {colorSky} from '@shopify/polaris-tokens';
 
 import {
   useLinearXAxisDetails,
@@ -20,6 +21,7 @@ import {Crosshair} from '../Crosshair';
 import {Point} from '../Point';
 import {LinearXAxis} from '../LinearXAxis';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
+import {HorizontalGridLines} from '../HorizontalGridLines';
 import {
   StringLabelFormatter,
   NumberLabelFormatter,
@@ -192,12 +194,18 @@ export function Chart({
         </g>
 
         <g transform={`translate(${axisMargin},${Margin.Top})`}>
-          <YAxis
-            ticks={ticks}
-            drawableWidth={drawableWidth}
-            fontSize={fontSize}
-          />
+          <YAxis ticks={ticks} fontSize={fontSize} />
         </g>
+
+        <HorizontalGridLines
+          ticks={ticks}
+          color={colorSky}
+          transform={{
+            x: axisMargin,
+            y: Margin.Top,
+          }}
+          width={drawableWidth}
+        />
 
         <VisuallyHiddenRows
           formatYAxisLabel={formatYAxisLabel}

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {Color} from 'types';
-import {LinearXAxis} from 'components/LinearXAxis';
-import {YAxis} from 'components/YAxis';
 import {
   Point,
   Crosshair,
   TooltipContainer,
   VisuallyHiddenRows,
+  HorizontalGridLines,
+  YAxis,
+  LinearXAxis,
 } from 'components';
 
 import {StackedAreas} from '../components';
@@ -129,7 +130,6 @@ describe('<Chart />', () => {
         {value: 1000, formattedValue: '1000', yOffset: 115},
         {value: 2000, formattedValue: '2000', yOffset: 0},
       ],
-      drawableWidth: 480,
     });
   });
 
@@ -228,5 +228,15 @@ describe('<Chart />', () => {
       xAxisLabels: mockProps.xAxisLabels,
       formatYAxisLabel: mockProps.formatYAxisLabel,
     });
+  });
+
+  it('renders <HorizontalGridLines />', () => {
+    const updatedProps = {
+      ...mockProps,
+      gridOtions: {horizontalOverflow: true},
+    };
+    const chart = mount(<Chart {...updatedProps} />);
+
+    expect(chart).toContainReactComponent(HorizontalGridLines);
   });
 });

--- a/src/components/YAxis/YAxis.tsx
+++ b/src/components/YAxis/YAxis.tsx
@@ -1,41 +1,21 @@
 import React from 'react';
-import {
-  spacingBase,
-  spacingExtraTight,
-  colorSky,
-} from '@shopify/polaris-tokens';
+import {spacingBase, spacingExtraTight} from '@shopify/polaris-tokens';
 
+import {YAxisTick} from '../../types';
 import {FONT_SIZE, DEFAULT_GREY_LABEL} from '../../constants';
 
 interface Props {
-  ticks: {
-    value: number;
-    formattedValue: string;
-    yOffset: number;
-  }[];
-  drawableWidth: number;
+  ticks: YAxisTick[];
   fontSize?: number;
-  showGridLines?: boolean;
-  gridColor?: string;
   labelColor?: string;
 }
 
-function Axis({
-  ticks,
-  drawableWidth,
-  fontSize,
-  gridColor = colorSky,
-  showGridLines = true,
-  labelColor = DEFAULT_GREY_LABEL,
-}: Props) {
+function Axis({ticks, fontSize, labelColor = DEFAULT_GREY_LABEL}: Props) {
   return (
     <g>
       {ticks.map(({value, formattedValue, yOffset}) => {
         return (
           <g key={value} transform={`translate(0,${yOffset})`}>
-            {showGridLines ? (
-              <line x2={drawableWidth} stroke={gridColor} />
-            ) : null}
             <text
               aria-hidden
               style={{

--- a/src/components/YAxis/tests/YAxis.test.tsx
+++ b/src/components/YAxis/tests/YAxis.test.tsx
@@ -10,27 +10,10 @@ const testTicks = [
 ];
 
 describe('<YAxis />', () => {
-  it('draws a horizontal grid line for each tick', () => {
-    const yAxis = mount(
-      <svg>
-        <YAxis ticks={testTicks} drawableWidth={500} />
-      </svg>,
-    );
-
-    const lines = yAxis.findAll('line')!;
-
-    // jsdom does not properly render SVG elements,
-    // so we have to do these assertions manually
-    expect(lines).toHaveLength(3);
-    lines.forEach((line) => {
-      expect(line.prop('x2')).toStrictEqual(500);
-    });
-  });
-
   it('displays a formatted value with each tick', () => {
     const yAxis = mount(
       <svg>
-        <YAxis ticks={testTicks} drawableWidth={500} />
+        <YAxis ticks={testTicks} />
       </svg>,
     );
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export {Point} from './Point';
 export {Bar} from './Bar';
 export {Crosshair} from './Crosshair';
+export {HorizontalGridLines} from './HorizontalGridLines';
 export {Sparkline, SparklineProps} from './Sparkline';
 export {Sparkbar, SparkbarProps} from './Sparkbar';
 export {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const ROUNDED_BAR_RADIUS = 3;
 export const MIN_BAR_HEIGHT = 5;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
+export const OVERFLOW_GRID_RIGHT_MARGIN = 20;
 
 export const DEFAULT_GREY_LABEL = 'rgb(99, 115, 129)';
 export const DEFAULT_CROSSHAIR_COLOR = 'rgb(223, 227, 232)';

--- a/src/hooks/useLinearXAxisDetails.ts
+++ b/src/hooks/useLinearXAxisDetails.ts
@@ -23,6 +23,7 @@ import {
   Data,
   DataSeries,
   SeriesColor,
+  YAxisTick,
 } from '../types';
 
 import {useLinearXScale} from './useLinearXScale';
@@ -34,18 +35,12 @@ function getDatumSpace(width: number, numberOfTicks: number) {
   );
 }
 
-interface Ticks {
-  value: number;
-  formattedValue: string;
-  yOffset: number;
-}
-
 export interface ChartDetails {
   series: DataSeries<Data | NullableData, SeriesColor>[];
   fontSize: number;
   chartDimensions: DOMRect;
   formatXAxisLabel: StringLabelFormatter;
-  initialTicks: Ticks[];
+  initialTicks: YAxisTick[];
   xAxisLabels: string[];
   useMinimalLabels?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,3 +120,9 @@ export interface GradientStop {
   offset: number;
   color: string;
 }
+
+export interface YAxisTick {
+  value: number;
+  formattedValue: string;
+  yOffset: number;
+}


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/24622
Part of https://github.com/Shopify/core-issues/issues/24606
Part of https://github.com/Shopify/core-issues/issues/24604

In order to have our proper "overflow styles", we need to decouple the yAxis and the horizontal grid lines, in order to be able to overflow the grid lines. We also need to remove the extra horizontal line (and its "feet) added within the xAxis component, because they get in the way of configuring the grid, and don't fit with our design.

**This PR does the following:**
- removes the grid lines with the yAxis and creates `<HorizontalGridLines />`. It is rendered conditionally (except in the area chart, since its API is behind 😢)
- adds a new `horizontalOverflow` style for the gridOptions, which determines how wide our grid should be
- adds some additional right margin to the line chart when `horizontalOverflow` is selected. It looked weird without it and it's in the designs.

**This PR does not:**
- Add the right alignment or spacing for the yAxis for these styles, which will be tackled in https://github.com/Shopify/core-issues/issues/24620

### Reviewers’ :tophat: instructions
Make sure, by default, the grid lines look the same as before (with the exception of the removed xAxis feet styles)

<img width="1633" alt="Screen Shot 2021-05-05 at 5 58 21 PM" src="https://user-images.githubusercontent.com/12213371/117214976-8ff38680-adcb-11eb-909d-1b919ef060ae.png">

In Storybook, on the default bar chart, you can see what the overflow styles look like. Note: the yAxis labels are still missing the background color, proper spacing and alignment.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
