### PR TITLE
Fix overlap on xAxis when minimal labels used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `horizontalOverflow` to `gridOptions` for `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>`
 
+### Fixed
+
+- Bar chart xAxis label overlap when useMinimalLabels is set
+
 ## [0.11.0] — 2021-05-06
 
 ### Added

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -148,3 +148,31 @@ LastBarTreatment.args = {
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };
+
+export const MinimalLabels = Template.bind({});
+MinimalLabels.args = {
+  data: [
+    {rawValue: 1324.19, label: '1 day some really long long text'},
+    {rawValue: 1022.79, label: '2020-01-02T12:00:00Z'},
+    {rawValue: 713.29, label: '2020-01-03T12:00:00Z'},
+    {rawValue: 413.29, label: '2020-01-04T12:00:00Z'},
+    {
+      rawValue: 100.79,
+      label:
+        'Middle day also has very long text / Middle day also has very long text',
+    },
+    {rawValue: 350.6, label: '2020-01-06T12:00:00Z'},
+    {rawValue: 277.69, label: '2020-01-07T12:00:00Z'},
+    {
+      rawValue: 50.6,
+      label: 'Last day has especially longgggggggggggg textttttttttt',
+    },
+  ],
+  barOptions: {
+    color: barGradient,
+    hasRoundedCorners: true,
+  },
+  xAxisOptions: {useMinimalLabels: true},
+  yAxisOptions: {labelFormatter: formatYAxisLabel},
+  renderTooltipContent,
+};

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -84,8 +84,6 @@ export function BarChartXAxis({
   showTicks: boolean;
   minimalLabelIndexes?: number[] | null;
 }) {
-  const [xScaleMin, xScaleMax] = xScale.range();
-
   const {
     maxXLabelHeight,
     maxDiagonalLabelLength,
@@ -116,12 +114,9 @@ export function BarChartXAxis({
     ? Math.max(diagonalLabelSpacePerBar, 1)
     : DEFAULT_LABEL_RATIO;
 
-  const width =
-    minimalLabelIndexes == null
-      ? maxWidth
-      : (xScaleMax - xScaleMin) / minimalLabelIndexes.length;
-
-  const angleAwareWidth = needsDiagonalLabels ? maxDiagonalLabelLength : width;
+  const angleAwareWidth = needsDiagonalLabels
+    ? maxDiagonalLabelLength
+    : maxWidth;
 
   return (
     <React.Fragment>
@@ -140,7 +135,7 @@ export function BarChartXAxis({
           isLastLabel,
           isFirstLabel,
           xOffset,
-          width,
+          width: maxWidth,
           bandWidth: xScale.bandwidth(),
         });
 

--- a/src/utilities/get-bar-xaxis-details.ts
+++ b/src/utilities/get-bar-xaxis-details.ts
@@ -3,6 +3,7 @@ import {
   MAX_TEXT_BOX_HEIGHT,
   MIN_HORIZONTAL_LABEL_SPACE,
   SPACING,
+  LABEL_SPACE_MINUS_FIRST_AND_LAST,
   SPACING_EXTRA_TIGHT,
 } from '../constants';
 
@@ -42,7 +43,8 @@ export function getBarXAxisDetails({
   const step = drawableWidth / (xLabels.length + outerMargin * 2 - innerMargin);
 
   const spaceForMinimalLabels = minimalLabelIndexes
-    ? drawableWidth / minimalLabelIndexes.length
+    ? (drawableWidth / minimalLabelIndexes.length) *
+      LABEL_SPACE_MINUS_FIRST_AND_LAST
     : null;
 
   // width each label is allowed to take up

--- a/src/utilities/tests/get-bar-xaxis-details.test.ts
+++ b/src/utilities/tests/get-bar-xaxis-details.test.ts
@@ -83,7 +83,7 @@ describe('getBarXAxisDetails', () => {
       maxXLabelHeight: 10.656565315951458,
       maxDiagonalLabelLength: 16.57867257451994,
       needsDiagonalLabels: true,
-      maxWidth: 18,
+      maxWidth: 10.799999999999999,
     });
   });
 });


### PR DESCRIPTION
### What problem is this PR solving?

| Before        | After           | 
| ------------- |:-------------:| 
|<img width="1076" alt="Screen Shot 2021-05-05 at 7 18 20 PM" src="https://user-images.githubusercontent.com/12213371/117221142-ae12b400-add6-11eb-95ae-2c321704b981.png"> | <img width="1074" alt="Screen Shot 2021-05-05 at 7 02 48 PM" src="https://user-images.githubusercontent.com/12213371/117221160-b834b280-add6-11eb-941b-2616935c0361.png"> |

### Reviewers’ :tophat: instructions
You can take a look on Storybook at this demo http://localhost:6006/?path=/story/barchart--minimal-labels

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
