### PR TITLE
Fix square preview showing up on legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - renamed `barOptions.margin` to `innerMargin` for `<BarChart/>` and `<MultiSeriesBarChart/>`
 
+### Fixed
+
+- Line chart legend no longer shows square preview
+
 ## [0.10.2] — 2021-05-05
 
 ### Fixed

--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -33,7 +33,7 @@ export function Legend({series}: Props) {
               <LinePreview color={color} lineStyle={lineStyle} />
             ) : null}
 
-            <SquareColorPreview color={color} />
+            {lineStyle == null ? <SquareColorPreview color={color} /> : null}
 
             <p className={styles.SeriesName}>{name}</p>
           </div>


### PR DESCRIPTION
### What problem is this PR solving?
During the gradient work, a check was removed in the legend that determined what kind of preview it should show. This adds the check back!

| Before  | After  | 
|---|---|
| <img width="1872" alt="Screen Shot 2021-05-06 at 7 47 27 AM" src="https://user-images.githubusercontent.com/12213371/117293604-99b6d180-ae3f-11eb-9ba3-9af3103d5da3.png">  | <img width="1870" alt="Screen Shot 2021-05-06 at 7 47 14 AM" src="https://user-images.githubusercontent.com/12213371/117293593-96bbe100-ae3f-11eb-9aa3-02a82d8a1f85.png"> |

### Reviewers’ :tophat: instructions
Check the line chart 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
