### PR TITLE
Add overflow styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `horizontalOverflow` to `gridOptions` for `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>`
+- `horizontalOverflow` and `horizontalMargin` to `gridOptions` for `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>`, as well as `backgroundColor` to the `yAxisOptions`
 
 ## [0.11.0] — 2021-05-06
 

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -103,6 +103,7 @@ interface BarChartProps {
     showHorizontalLines?: boolean;
     color?: string;
     horizontalOverflow?: boolean;
+    horizontalMargin?: number;
   };
   xAxisOptions?: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
@@ -112,6 +113,7 @@ interface BarChartProps {
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
+    backgroundColor?: string;
   };
   annotations?: {
     dataIndex: number;
@@ -254,6 +256,14 @@ Whether to show lines extending from the yAxis labels through the chart.
 
 Whether the lines should extend through the width of the entire chart.
 
+##### horizontalMargin
+
+| type     | default |
+| -------- | ------- |
+| `number` | `0`     |
+
+Margin to display on the left and right of the chart.
+
 ##### color
 
 | type     | default                |
@@ -313,6 +323,14 @@ This accepts a function that is called when the Y value (`rawValue`) is formatte
 | `string` | `'rgb(223, 227, 232)'` |
 
 The color used for axis labels.
+
+##### backgroundColor
+
+| type     | default       |
+| -------- | ------------- |
+| `string` | `transparant` |
+
+The color used behind axis labels.
 
 #### annotations
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -98,6 +98,7 @@ export function BarChart({
     showHorizontalLines: true,
     color: colorSky,
     horizontalOverflow: false,
+    horizontalMargin: 0,
     ...gridOptions,
   };
 
@@ -112,6 +113,7 @@ export function BarChart({
   const yAxisOptionsWithDefaults = {
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
+    backgroundColor: 'transparent',
     ...yAxisOptions,
   };
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -155,7 +155,12 @@ export function Chart({
   );
 
   const axisMargin = SPACING + yAxisLabelWidth;
-  const drawableWidth = chartDimensions.width - MARGIN.Right - axisMargin;
+  const chartStartPosition = axisMargin + gridOptions.horizontalMargin;
+  const drawableWidth =
+    chartDimensions.width -
+    MARGIN.Right -
+    axisMargin -
+    gridOptions.horizontalMargin * 2;
 
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
@@ -242,7 +247,7 @@ export function Chart({
           />
 
           <mask id={clipId}>
-            <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
+            <g transform={`translate(${chartStartPosition},${MARGIN.Top})`}>
               {transitions.map(({item, props: {height}}, index) => {
                 const xPosition = xScale(index.toString());
                 const ariaLabel = `${xAxisOptions.labelFormatter(
@@ -279,7 +284,7 @@ export function Chart({
           </mask>
         </defs>
         <g
-          transform={`translate(${axisMargin},${chartDimensions.height -
+          transform={`translate(${chartStartPosition},${chartDimensions.height -
             MARGIN.Bottom -
             xAxisDetails.maxXLabelHeight})`}
           aria-hidden="true"
@@ -301,7 +306,7 @@ export function Chart({
             ticks={ticks}
             color={gridOptions.color}
             transform={{
-              x: gridOptions.horizontalOverflow ? 0 : axisMargin,
+              x: gridOptions.horizontalOverflow ? 0 : chartStartPosition,
               y: MARGIN.Top,
             }}
             width={
@@ -312,14 +317,15 @@ export function Chart({
           />
         ) : null}
 
-        <g
-          transform={`translate(${axisMargin},${MARGIN.Top})`}
-          aria-hidden="true"
-        >
+        <g transform={`translate(0,${MARGIN.Top})`} aria-hidden="true">
           <YAxis
             ticks={ticks}
             fontSize={fontSize}
             labelColor={yAxisOptions.labelColor}
+            textAlign={gridOptions.horizontalOverflow ? 'left' : 'right'}
+            width={yAxisLabelWidth}
+            backgroundColor={yAxisOptions.backgroundColor}
+            outerMargin={gridOptions.horizontalMargin}
           />
         </g>
 
@@ -334,7 +340,7 @@ export function Chart({
           {transitions.map(({item}, index) => {
             const xPosition = xScale(index.toString());
             const xPositionValue = xPosition == null ? 0 : xPosition;
-            const translateXValue = xPositionValue + axisMargin;
+            const translateXValue = xPositionValue + chartStartPosition;
             const barColor =
               item.barOptions != null && item.barOptions.color != null
                 ? item.barOptions.color
@@ -354,7 +360,7 @@ export function Chart({
           ;
         </g>
 
-        <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
+        <g transform={`translate(${chartStartPosition},${MARGIN.Top})`}>
           {transitions.map((_, index) => {
             const xPosition = xScale(index.toString());
             const xPositionValue = xPosition == null ? 0 : xPosition;
@@ -403,7 +409,7 @@ export function Chart({
     if (index == null) return;
     setActiveBar(index);
     setTooltipPosition({
-      x: cx + axisMargin + xScale.bandwidth() / 2,
+      x: cx + chartStartPosition + xScale.bandwidth() / 2,
       y: cy,
     });
   }
@@ -418,7 +424,7 @@ export function Chart({
     }
 
     const {svgX, svgY} = point;
-    const currentPoint = svgX - axisMargin;
+    const currentPoint = svgX - chartStartPosition;
     const currentIndex = Math.floor(currentPoint / xScale.step());
 
     if (
@@ -434,7 +440,9 @@ export function Chart({
     const xPosition = xScale(currentIndex.toString());
     const value = data[currentIndex].rawValue;
     const tooltipXPositon =
-      xPosition == null ? 0 : xPosition + axisMargin + xScale.bandwidth() / 2;
+      xPosition == null
+        ? 0
+        : xPosition + chartStartPosition + xScale.bandwidth() / 2;
 
     setActiveBar(currentIndex);
     setTooltipPosition({

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -74,7 +74,31 @@ Default.args = {
   xAxisOptions: {labelFormatter: formatXAxisLabel},
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
-  gridOptions: {horizontalOverflow: true},
+  gridOptions: {horizontalOverflow: false},
+};
+
+export const OverflowStyle = Template.bind({});
+OverflowStyle.args = {
+  data: [
+    {rawValue: 1324.19, label: '2020-01-01T12:00:00Z'},
+    {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
+    {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
+    {rawValue: 25.6, label: '2020-01-04T12:00:00Z'},
+    {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
+    {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
+  ],
+  barOptions: {
+    color: barGradient,
+    hasRoundedCorners: true,
+  },
+  xAxisOptions: {labelFormatter: formatXAxisLabel, showTicks: false},
+  yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: 'white'},
+  gridOptions: {
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+    showVerticalLines: false,
+  },
+  renderTooltipContent,
 };
 
 export const Annotations = Template.bind({});

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -56,11 +56,13 @@ describe('Chart />', () => {
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
+      backgroundColor: 'transparent',
     },
     gridOptions: {
       showHorizontalLines: true,
       color: 'red',
       horizontalOverflow: false,
+      horizontalMargin: 0,
     },
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
     annotationsLookupTable: {

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -37,6 +37,7 @@ export interface GridOptions {
   showHorizontalLines: boolean;
   horizontalOverflow: boolean;
   color: string;
+  horizontalMargin: number;
 }
 
 export interface XAxisOptions {
@@ -49,6 +50,7 @@ export interface XAxisOptions {
 export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
+  backgroundColor: string;
 }
 
 export interface Annotation {

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -158,7 +158,7 @@ export function BarChartXAxis({
 
         return (
           <g key={index} transform={groupTransform}>
-            {minimalLabelIndexes == null || showTicks ? (
+            {minimalLabelIndexes != null || showTicks ? (
               <line y2={TICK_SIZE} stroke={gridColor} />
             ) : null}
             <foreignObject

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -138,12 +138,14 @@ interface LineChartProps {
   yAxisOptions?: {
     labelFormatter?(value: number): string;
     labelColor: string;
+    backgroundColor?: string;
   }
   gridOptions?: {
     showVerticalLines?: boolean;
     showHorizontalLines?: boolean;
     horizontalOverflow?: boolean;
     color?: string;
+    horizontalMargin?: number;
   }
   crossHairOptions?: {
     width?: number;
@@ -355,6 +357,14 @@ This utilty function is called to format the labels for every y axis value when 
 
 The color used for axis labels.
 
+##### backgroundColor
+
+| type     | default       |
+| -------- | ------------- |
+| `string` | `transparant` |
+
+The color used behind axis labels.
+
 #### lineOptions
 
 An object including the following optional proprties that define the appearance of the line.
@@ -402,6 +412,14 @@ Whether to show lines extending from the yAxis labels through the chart.
 | `boolean` | `false` |
 
 Whether the lines should extend through the width of the entire chart.
+
+##### horizontalMargin
+
+| type     | default |
+| -------- | ------- |
+| `number` | `0`     |
+
+Margin to display on the left and right of the chart.
 
 ##### color
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -93,6 +93,7 @@ export function LineChart({
   const yAxisOptionsWithDefaults = {
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
+    backgroundColor: 'transparent',
     ...yAxisOptions,
   };
 
@@ -101,6 +102,7 @@ export function LineChart({
     showHorizontalLines: true,
     color: colorSky,
     horizontalOverflow: false,
+    horizontalMargin: 0,
     ...gridOptions,
   };
 

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -3,7 +3,7 @@ import {scaleLinear} from 'd3-scale';
 
 import {getTextWidth} from '../../../utilities';
 import {yAxisMinMax} from '../utilities';
-import {MIN_Y_LABEL_SPACE, SPACING} from '../constants';
+import {MIN_Y_LABEL_SPACE} from '../constants';
 import {Series} from '../types';
 import {NumberLabelFormatter} from '../../../types';
 
@@ -37,13 +37,11 @@ export function useYScale({
       yOffset: yScale(value),
     }));
 
-    const maxTickWidth = Math.max(
+    const axisMargin = Math.max(
       ...ticks.map(({formattedValue}) =>
         getTextWidth({fontSize, text: formattedValue}),
       ),
     );
-
-    const axisMargin = maxTickWidth + SPACING;
 
     return {yScale, ticks, axisMargin};
   }, [series, drawableHeight, formatYAxisLabel, fontSize]);

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -45,3 +45,21 @@ Default.args = {
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };
+
+export const OverflowStyle = Template.bind({});
+OverflowStyle.args = {
+  series,
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+    showTicks: false,
+  },
+  yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: 'white'},
+  gridOptions: {
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+    showVerticalLines: false,
+  },
+  lineOptions: {hasSpline: true},
+  renderTooltipContent,
+};

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -64,6 +64,7 @@ const lineOptions = {hasSpline: false, width: 2};
 const yAxisOptions = {
   labelFormatter: jest.fn((value) => value),
   labelColor: 'red',
+  backgroundColor: 'transparent',
 };
 
 const gridOptions = {
@@ -71,6 +72,7 @@ const gridOptions = {
   showHorizontalLines: true,
   color: 'orange',
   horizontalOverflow: false,
+  horizontalMargin: 0,
 };
 
 const crossHairOptions = {width: 10, color: 'red', opacity: 1};

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -48,6 +48,7 @@ export interface XAxisOptions {
 export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
+  backgroundColor: string;
 }
 
 export interface GridOptions {
@@ -55,6 +56,7 @@ export interface GridOptions {
   showHorizontalLines: boolean;
   color: string;
   horizontalOverflow: boolean;
+  horizontalMargin: number;
 }
 
 export interface CrossHairOptions {

--- a/src/components/LinearXAxis/LinearXAxis.tsx
+++ b/src/components/LinearXAxis/LinearXAxis.tsx
@@ -89,8 +89,6 @@ function Axis({
     });
   }, [labels, ticks, xScale]);
 
-  const [xScaleMin, xScaleMax] = xScale.range();
-
   const diagonalLabelOffset = new RightAngleTriangle({
     sideC: maxDiagonalLabelLength,
     sideA: maxXLabelHeight,
@@ -104,12 +102,6 @@ function Axis({
 
   return (
     <React.Fragment>
-      <path
-        d={`M ${xScaleMin} ${TICK_SIZE} v ${-TICK_SIZE} H ${xScaleMax} v ${TICK_SIZE}`}
-        fill="none"
-        stroke={gridColor}
-      />
-
       {tickDetails.map(({value, xOffset, firstLabel}, index) => {
         const textWidth = needsDiagonalLabels
           ? maxDiagonalLabelLength

--- a/src/components/LinearXAxis/tests/LinearXAxis.test.tsx
+++ b/src/components/LinearXAxis/tests/LinearXAxis.test.tsx
@@ -34,19 +34,6 @@ const mockProps = {
 };
 
 describe('<LinearXAxis />', () => {
-  it('renders an axis line with a tick at the start and end of the axis', () => {
-    const axis = mount(
-      <svg>
-        <LinearXAxis {...mockProps} />
-      </svg>,
-    );
-
-    expect(axis).toContainReactComponent('path', {
-      // eslint-disable-next-line id-length
-      d: 'M 0 6 v -6 H 2 v 6',
-    });
-  });
-
   it('renders a small, outer tick for each tick', () => {
     const axis = mount(
       <svg>

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -90,6 +90,12 @@ export function Chart({
   );
 
   const axisMargin = SPACING + yAxisLabelWidth;
+  const chartStartPosition = axisMargin + gridOptions.horizontalMargin;
+  const drawableWidth =
+    chartDimensions.width -
+    MARGIN.Right -
+    axisMargin -
+    gridOptions.horizontalMargin * 2;
 
   const formattedXAxisLabels = useMemo(
     () => xAxisOptions.labels.map(xAxisOptions.labelFormatter),
@@ -115,8 +121,6 @@ export function Chart({
       barOptions.outerMargin,
     ],
   );
-
-  const drawableWidth = chartDimensions.width - MARGIN.Right - axisMargin;
 
   const sortedData = xAxisOptions.labels.map((_, index) => {
     return series.map((type) => type.data[index].rawValue);
@@ -191,13 +195,14 @@ export function Chart({
         : Math.max(...sortedData[index]);
       setActiveBarGroup(index);
 
-      const xOffsetAmount = xPosition + axisMargin + xScaleBandwidth / 2;
+      const xOffsetAmount =
+        xPosition + chartStartPosition + xScaleBandwidth / 2;
       setTooltipPosition({
         x: xOffsetAmount,
         y: yScale(highestValue),
       });
     },
-    [axisMargin, barOptions.isStacked, sortedData, xScale, yScale],
+    [chartStartPosition, barOptions.isStacked, sortedData, xScale, yScale],
   );
 
   return (
@@ -219,7 +224,7 @@ export function Chart({
         aria-label={emptyState ? emptyStateText : undefined}
       >
         <g
-          transform={`translate(${axisMargin},${chartDimensions.height -
+          transform={`translate(${chartStartPosition},${chartDimensions.height -
             MARGIN.Bottom -
             maxXLabelHeight})`}
           aria-hidden="true"
@@ -240,7 +245,7 @@ export function Chart({
             ticks={ticks}
             color={gridOptions.color}
             transform={{
-              x: gridOptions.horizontalOverflow ? 0 : axisMargin,
+              x: gridOptions.horizontalOverflow ? 0 : chartStartPosition,
               y: MARGIN.Top,
             }}
             width={
@@ -251,18 +256,19 @@ export function Chart({
           />
         ) : null}
 
-        <g
-          transform={`translate(${axisMargin},${MARGIN.Top})`}
-          aria-hidden="true"
-        >
+        <g transform={`translate(0,${MARGIN.Top})`} aria-hidden="true">
           <YAxis
             ticks={ticks}
             fontSize={fontSize}
             labelColor={yAxisOptions.labelColor}
+            textAlign={gridOptions.horizontalOverflow ? 'right' : 'left'}
+            width={yAxisLabelWidth}
+            backgroundColor={yAxisOptions.backgroundColor}
+            outerMargin={gridOptions.horizontalMargin}
           />
         </g>
 
-        <g transform={`translate(${axisMargin},${MARGIN.Top})`}>
+        <g transform={`translate(${chartStartPosition},${MARGIN.Top})`}>
           {stackedValues != null
             ? stackedValues.map((stackData, stackIndex) => {
                 return (
@@ -330,7 +336,7 @@ export function Chart({
     }
 
     const {svgX, svgY} = point;
-    const currentPoint = svgX - axisMargin;
+    const currentPoint = svgX - chartStartPosition;
     const currentIndex = Math.floor(currentPoint / xScale.step());
 
     if (
@@ -348,7 +354,9 @@ export function Chart({
       ? sortedData[currentIndex].reduce(sumPositiveData, 0)
       : Math.max(...sortedData[currentIndex]);
     const tooltipXPositon =
-      xPosition == null ? 0 : xPosition + axisMargin + xScale.bandwidth() / 2;
+      xPosition == null
+        ? 0
+        : xPosition + chartStartPosition + xScale.bandwidth() / 2;
 
     setActiveBarGroup(currentIndex);
     setTooltipPosition({

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -127,6 +127,7 @@ interface MultiSeriesBarChartProps {
     showHorizontalLines?: boolean;
     horizontalOverflow?: boolean;
     color?: string;
+    horizontalMargin?: number;
   };
   xAxisOptions: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
@@ -136,6 +137,7 @@ interface MultiSeriesBarChartProps {
   };
   yAxisOptions: {
     labelFormatter?(value: number): string;
+    backgroundColor?: string;
   };
 }
 ```
@@ -304,6 +306,14 @@ This utility function is called for every y axis value when the chart is drawn.
 
 The color used for axis labels.
 
+##### backgroundColor
+
+| type     | default       |
+| -------- | ------------- |
+| `string` | `transparant` |
+
+The color used behind axis labels.
+
 #### barOptions
 
 ##### innerMargin
@@ -357,6 +367,14 @@ Whether to show lines extending from the yAxis labels through the chart.
 | `boolean` | `false` |
 
 Whether the lines should extend through the width of the entire chart.
+
+##### horizontalMargin
+
+| type     | default |
+| -------- | ------- |
+| `number` | `0`     |
+
+Margin to display on the left and right of the chart.
 
 ##### color
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -92,6 +92,7 @@ export function MultiSeriesBarChart({
     showHorizontalLines: true,
     color: colorSky,
     horizontalOverflow: false,
+    horizontalMargin: 0,
     ...gridOptions,
   };
 
@@ -105,6 +106,7 @@ export function MultiSeriesBarChart({
   const yAxisOptionsWithDefaults = {
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
+    backgroundColor: 'transparent',
     ...yAxisOptions,
   };
 

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -142,6 +142,21 @@ Gradient.args = {
   },
 };
 
+export const OverflowStyles = Template.bind({});
+OverflowStyles.args = {
+  series: gradientSeries,
+  xAxisOptions: {labels},
+  barOptions: {
+    hasRoundedCorners: true,
+  },
+  yAxisOptions: {backgroundColor: 'white'},
+  gridOptions: {
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+    showVerticalLines: false,
+  },
+};
+
 export const Stacked = Template.bind({});
 Stacked.args = {
   series: series,

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -83,11 +83,13 @@ describe('Chart />', () => {
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
+      backgroundColor: 'transparent',
     },
     gridOptions: {
       showHorizontalLines: true,
       color: 'red',
       horizontalOverflow: false,
+      horizontalMargin: 0,
     },
   };
 

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -52,6 +52,7 @@ export interface GridOptions {
   showHorizontalLines: boolean;
   color: string;
   horizontalOverflow: boolean;
+  horizontalMargin: number;
 }
 
 export interface XAxisOptions {
@@ -64,4 +65,5 @@ export interface XAxisOptions {
 export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
+  backgroundColor: string;
 }

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -28,7 +28,7 @@ import {
   ActiveTooltip,
 } from '../../types';
 
-import {Margin} from './constants';
+import {Margin, Spacing} from './constants';
 import {useYScale} from './hooks';
 import {StackedAreas} from './components';
 import styles from './Chart.scss';
@@ -129,8 +129,9 @@ export function Chart({
     formatYAxisLabel,
   });
 
-  const drawableWidth =
-    axisMargin == null ? null : dimensions.width - Margin.Right - axisMargin;
+  const dataStartPosition = axisMargin + Spacing.Base;
+
+  const drawableWidth = dimensions.width - Margin.Right - dataStartPosition;
 
   const longestSeriesLength =
     Math.max(...stackedValues.map((stack) => stack.length)) - 1;
@@ -179,7 +180,7 @@ export function Chart({
         role="table"
       >
         <g
-          transform={`translate(${axisMargin},${dimensions.height -
+          transform={`translate(${dataStartPosition},${dimensions.height -
             marginBottom})`}
         >
           <LinearXAxis
@@ -193,15 +194,20 @@ export function Chart({
           />
         </g>
 
-        <g transform={`translate(${axisMargin},${Margin.Top})`}>
-          <YAxis ticks={ticks} fontSize={fontSize} />
+        <g transform={`translate(0,${Margin.Top})`}>
+          <YAxis
+            ticks={ticks}
+            fontSize={fontSize}
+            width={axisMargin}
+            textAlign="right"
+          />
         </g>
 
         <HorizontalGridLines
           ticks={ticks}
           color={colorSky}
           transform={{
-            x: axisMargin,
+            x: dataStartPosition,
             y: Margin.Top,
           }}
           width={drawableWidth}
@@ -216,7 +222,7 @@ export function Chart({
         <StackedAreas
           width={drawableWidth}
           height={drawableHeight}
-          transform={`translate(${axisMargin},${Margin.Top})`}
+          transform={`translate(${dataStartPosition},${Margin.Top})`}
           stackedValues={stackedValues}
           xScale={xScale}
           yScale={yScale}
@@ -226,7 +232,7 @@ export function Chart({
         />
 
         {activePointIndex == null ? null : (
-          <g transform={`translate(${axisMargin},${Margin.Top})`}>
+          <g transform={`translate(${dataStartPosition},${Margin.Top})`}>
             <Crosshair
               x={xScale(activePointIndex) - CROSSHAIR_WIDTH / 2}
               height={drawableHeight}
@@ -235,7 +241,7 @@ export function Chart({
           </g>
         )}
 
-        <g transform={`translate(${axisMargin},${Margin.Top})`}>
+        <g transform={`translate(${dataStartPosition},${Margin.Top})`}>
           {stackedValues.map((value, stackIndex) =>
             value.map(([, startingDataPoint], index) => (
               <Point
@@ -273,7 +279,7 @@ export function Chart({
     if (index == null) return;
     setActivePointIndex(index);
     setTooltipPosition({
-      x: x + axisMargin,
+      x: x + dataStartPosition,
       y,
     });
   }
@@ -291,11 +297,11 @@ export function Chart({
     }
 
     const {svgX, svgY} = point;
-    if (svgX < axisMargin) {
+    if (svgX < dataStartPosition) {
       return;
     }
 
-    const closestIndex = Math.round(xScale.invert(svgX - axisMargin));
+    const closestIndex = Math.round(xScale.invert(svgX - dataStartPosition));
     setActivePointIndex(Math.min(longestSeriesLength, closestIndex));
     setTooltipPosition({
       x: svgX,

--- a/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -3,7 +3,7 @@ import {scaleLinear} from 'd3-scale';
 import {Series} from 'd3-shape';
 
 import {getTextWidth} from '../../../utilities';
-import {MIN_Y_LABEL_SPACE, Spacing} from '../constants';
+import {MIN_Y_LABEL_SPACE} from '../constants';
 import {DEFAULT_MAX_Y} from '../../../constants';
 import {NumberLabelFormatter} from '../../../types';
 
@@ -69,7 +69,7 @@ export function useYScale({
       ),
     );
 
-    const axisMargin = maxTickWidth + Spacing.Base;
+    const axisMargin = maxTickWidth;
 
     return {yScale, ticks, axisMargin};
   }, [stackedValues, drawableHeight, formatYAxisLabel, fontSize]);

--- a/src/components/YAxis/YAxis.tsx
+++ b/src/components/YAxis/YAxis.tsx
@@ -1,36 +1,51 @@
 import React from 'react';
-import {spacingBase, spacingExtraTight} from '@shopify/polaris-tokens';
 
+import {DEFAULT_GREY_LABEL, LINE_HEIGHT, FONT_SIZE} from '../../constants';
 import {YAxisTick} from '../../types';
-import {FONT_SIZE, DEFAULT_GREY_LABEL} from '../../constants';
 
 interface Props {
   ticks: YAxisTick[];
   fontSize?: number;
   labelColor?: string;
+  textAlign: 'left' | 'right';
+  width: number;
+  backgroundColor?: string;
+  outerMargin?: number;
 }
 
-function Axis({ticks, fontSize, labelColor = DEFAULT_GREY_LABEL}: Props) {
+const PADDING_SIZE = 1;
+
+function Axis({
+  ticks,
+  fontSize = FONT_SIZE,
+  width,
+  textAlign,
+  outerMargin = 0,
+  labelColor = DEFAULT_GREY_LABEL,
+  backgroundColor = 'transparent',
+}: Props) {
   return (
-    <g>
+    <React.Fragment>
       {ticks.map(({value, formattedValue, yOffset}) => {
         return (
-          <g key={value} transform={`translate(0,${yOffset})`}>
-            <text
-              aria-hidden
-              style={{
-                fontSize: `${fontSize ? fontSize : FONT_SIZE}px`,
-                textAnchor: 'end',
-                transform: `translateX(-${spacingBase}) translateY(${spacingExtraTight})`,
-                fill: labelColor,
-              }}
-            >
+          <foreignObject
+            key={value}
+            transform={`translate(${outerMargin},${yOffset - LINE_HEIGHT / 2})`}
+            width={width + PADDING_SIZE * 2}
+            height={LINE_HEIGHT}
+            style={{
+              color: labelColor,
+              textAlign,
+              fontSize,
+            }}
+          >
+            <span style={{background: backgroundColor, padding: PADDING_SIZE}}>
               {formattedValue}
-            </text>
-          </g>
+            </span>
+          </foreignObject>
         );
       })}
-    </g>
+    </React.Fragment>
   );
 }
 

--- a/src/components/YAxis/tests/YAxis.test.tsx
+++ b/src/components/YAxis/tests/YAxis.test.tsx
@@ -13,13 +13,11 @@ describe('<YAxis />', () => {
   it('displays a formatted value with each tick', () => {
     const yAxis = mount(
       <svg>
-        <YAxis ticks={testTicks} />
+        <YAxis ticks={testTicks} width={100} textAlign="right" />
       </svg>,
     );
 
-    // jsdom does not properly render SVG elements,
-    // so we have to do these assertions manually
-    const text = yAxis.findAll('text')!;
+    const text = yAxis.findAll('span');
     const values = text.map((node) => node.prop('children'));
     expect(values).toStrictEqual(['0', '1,000', '2,000']);
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,6 @@ export const ROUNDED_BAR_RADIUS = 3;
 export const MIN_BAR_HEIGHT = 5;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
-export const OVERFLOW_GRID_RIGHT_MARGIN = 20;
 
 export const DEFAULT_GREY_LABEL = 'rgb(99, 115, 129)';
 export const DEFAULT_CROSSHAIR_COLOR = 'rgb(223, 227, 232)';


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/24604
Resolves https://github.com/Shopify/core-issues/issues/24620
Resolves https://github.com/Shopify/core-issues/issues/24606

| Line chart  | Bar chart  | Multiseries bar chart  | 
|---|---|---|
| <img width="1570" alt="Screen Shot 2021-05-06 at 3 14 35 PM" src="https://user-images.githubusercontent.com/12213371/117353336-ff29b300-ae7d-11eb-9ac9-e9ebf03264e6.png">  | <img width="1592" alt="Screen Shot 2021-05-06 at 3 14 26 PM" src="https://user-images.githubusercontent.com/12213371/117353341-ffc24980-ae7d-11eb-9791-f17873471463.png">  |  <img width="1561" alt="Screen Shot 2021-05-06 at 3 14 46 PM" src="https://user-images.githubusercontent.com/12213371/117353334-fe911c80-ae7d-11eb-86fb-d43a9abf6ae7.png"> |  

Adds new props to allow the overflow styles:
- horizontalMargin on the gridOptions, which sets the left and right margin between the grid and the chart
- backgroundColor on the yAxisOptions, which adds a background color to the yAxis labels
(Open to renaming!)


### Reviewers’ :tophat: instructions
Have a look at the new Storybooks I added for the overflow styles and make sure I didn't break anything on the existing ones!

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
