### PR TITLE
Use resize observer on components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - yAxis ticks sometimes getting cut off
 - `<SparkLine/>` and `<Sparkbar/>` stroke dasharray treatment is consistent at all sizes
+- Components now resize when their container resizes, not just when the page resizes
 
 ## [0.12.0] — 2021-05-10
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -25,6 +25,7 @@ import {BarChartXAxis} from '../BarChartXAxis';
 import {TooltipContainer} from '../TooltipContainer';
 import {LinearGradient} from '../LinearGradient';
 import {HorizontalGridLines} from '../HorizontalGridLines';
+import {Dimensions} from '../../types';
 
 import {AnnotationLine} from './components';
 import {
@@ -48,7 +49,7 @@ type BarOptions = Omit<BarChartBarOptions, 'innerMargin' | 'outerMargin'> & {
 interface Props {
   data: BarChartData[];
   annotationsLookupTable: AnnotationLookupTable;
-  chartDimensions: DOMRect;
+  chartDimensions: Dimensions;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   emptyStateText?: string;
   isAnimated?: boolean;

--- a/src/components/BarChart/tests/BarChart.test.tsx
+++ b/src/components/BarChart/tests/BarChart.test.tsx
@@ -5,6 +5,17 @@ import {BarChart} from '../BarChart';
 import {Chart} from '../Chart';
 import {SkipLink} from '../../SkipLink';
 
+jest.mock('../../../hooks/useResizeObserver.ts', () => ({
+  useResizeObserver: () => {
+    return {
+      setRef: jest.fn(),
+      entry: {
+        contentRect: {width: 100, height: 100},
+      },
+    };
+  },
+}));
+
 describe('BarChart />', () => {
   const mockProps = {data: [{rawValue: 10, label: 'data'}]};
 

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -14,13 +14,6 @@ import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
 import {MASK_SUBDUE_COLOR, MASK_HIGHLIGHT_COLOR} from '../../../constants';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 const fakeSVGEvent = {
   currentTarget: {
     getScreenCTM: () => ({
@@ -40,7 +33,7 @@ describe('Chart />', () => {
       {rawValue: 10, label: 'data'},
       {rawValue: 20, label: 'data 2'},
     ],
-    chartDimensions: new DOMRect(),
+    chartDimensions: {width: 500, height: 250},
     barOptions: {
       color: 'colorPurple' as Color,
       innerMargin: 0,

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../utilities';
 import {Crosshair} from '../Crosshair';
 import {LinearGradient} from '../LinearGradient';
-import {ActiveTooltip} from '../../types';
+import {ActiveTooltip, Dimensions} from '../../types';
 import {TooltipContainer} from '../TooltipContainer';
 import {HorizontalGridLines} from '../HorizontalGridLines';
 
@@ -45,7 +45,7 @@ import styles from './Chart.scss';
 
 interface Props {
   series: SeriesWithDefaults[];
-  dimensions: DOMRect;
+  dimensions: Dimensions;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   emptyStateText?: string;
   isAnimated: boolean;

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -16,13 +16,6 @@ import {Series} from '../types';
 import {Line, GradientArea} from '../components';
 import {YAxis} from '../../YAxis';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 const fakeSVGEvent = {
   persist: jest.fn(),
   currentTarget: {
@@ -79,7 +72,7 @@ const crossHairOptions = {width: 10, color: 'red', opacity: 1};
 
 const mockProps = {
   series: [primarySeries],
-  dimensions: new DOMRect(),
+  dimensions: {width: 500, height: 250},
   lineOptions,
   xAxisOptions,
   yAxisOptions,
@@ -91,7 +84,7 @@ const mockProps = {
 
 const mockEmptyStateProps = {
   series: [],
-  dimensions: new DOMRect(),
+  dimensions: {width: 100, height: 100},
   lineOptions,
   xAxisOptions,
   yAxisOptions,

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -6,13 +6,6 @@ import {SkipLink} from '../../SkipLink';
 import {Chart} from '../Chart';
 import {Series} from '../types';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 const primarySeries: Series = {
   name: 'Primary',
   color: 'primary',
@@ -32,6 +25,17 @@ jest.mock('../../../utilities', () => {
     getPointAtLength: () => ({x: 0, y: 0}),
   };
 });
+
+jest.mock('../../../hooks/useResizeObserver.ts', () => ({
+  useResizeObserver: () => {
+    return {
+      setRef: jest.fn(),
+      entry: {
+        contentRect: {width: 500, height: 250},
+      },
+    };
+  },
+}));
 
 describe('<LineChart />', () => {
   beforeAll(() => {

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -6,6 +6,7 @@ import {eventPoint, getTextWidth, getBarXAxisDetails} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
 import {HorizontalGridLines} from '../HorizontalGridLines';
+import {Dimensions} from '../../types';
 
 import {getStackedValues, formatAriaLabel} from './utilities';
 import {
@@ -28,7 +29,7 @@ type BarOptions = Omit<MultiSeriesBarOptions, 'innerMargin' | 'outerMargin'> & {
 
 interface Props {
   series: Required<Series>[];
-  chartDimensions: DOMRect;
+  chartDimensions: Dimensions;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   barOptions: BarOptions;
   gridOptions: GridOptions;

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -1,11 +1,13 @@
-import React, {useState, useLayoutEffect, useRef} from 'react';
+import React, {useState, useLayoutEffect, useRef, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {colorSky} from '@shopify/polaris-tokens';
 
+import {Dimensions} from '../../types';
 import {DEFAULT_GREY_LABEL} from '../../constants';
 import {SkipLink} from '../SkipLink';
 import {TooltipContent} from '../TooltipContent';
 import {getDefaultColor, uniqueId} from '../../utilities';
+import {useResizeObserver} from '../../hooks';
 
 import {Chart} from './Chart';
 import {
@@ -41,34 +43,50 @@ export function MultiSeriesBarChart({
   yAxisOptions,
   emptyStateText,
 }: MultiSeriesBarChartProps) {
-  const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
+    null,
+  );
   const skipLinkAnchorId = useRef(uniqueId('multiSeriesBarChart'));
+  const {setRef, entry} = useResizeObserver();
+
   const emptyState = series.length === 0;
 
-  const [updateDimensions] = useDebouncedCallback(() => {
-    if (containerRef.current != null) {
-      setChartDimensions(containerRef.current.getBoundingClientRect());
+  const updateDimensions = useCallback(() => {
+    if (entry != null) {
+      const {width, height} = entry.contentRect;
+      setChartDimensions((prevDimensions) => {
+        if (
+          prevDimensions != null &&
+          width === prevDimensions.width &&
+          height === prevDimensions.height
+        ) {
+          return prevDimensions;
+        } else {
+          return {width, height};
+        }
+      });
     }
+  }, [entry]);
+
+  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
+    updateDimensions();
   }, 100);
 
   useLayoutEffect(() => {
-    if (containerRef.current != null) {
-      setChartDimensions(containerRef.current.getBoundingClientRect());
-    }
+    updateDimensions();
 
     const isServer = typeof window === 'undefined';
 
     if (!isServer) {
-      window.addEventListener('resize', updateDimensions);
+      window.addEventListener('resize', debouncedUpdateDimensions);
     }
 
     return () => {
       if (!isServer) {
-        window.removeEventListener('resize', updateDimensions);
+        window.removeEventListener('resize', debouncedUpdateDimensions);
       }
     };
-  }, [containerRef, updateDimensions]);
+  }, [entry, debouncedUpdateDimensions, updateDimensions]);
 
   const innerMargin =
     barOptions != null && barOptions.innerMargin != null
@@ -126,7 +144,7 @@ export function MultiSeriesBarChart({
   }));
 
   return (
-    <div style={{height: '100%', width: '100%'}} ref={containerRef}>
+    <div style={{height: '100%', width: '100%'}} ref={setRef}>
       {chartDimensions == null ? null : (
         <React.Fragment>
           {skipLinkText == null ||

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -11,13 +11,6 @@ import {
 import {Chart} from '../Chart';
 import {BarGroup, StackedBarGroup} from '../components';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 const fakeSVGEvent = {
   currentTarget: {
     getScreenCTM: () => ({
@@ -66,7 +59,7 @@ describe('Chart />', () => {
         name: 'LABEL2',
       },
     ],
-    chartDimensions: new DOMRect(),
+    chartDimensions: {width: 500, height: 250},
     renderTooltipContent,
     barOptions: {
       innerMargin: 0,

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -6,6 +6,17 @@ import {SkipLink} from 'components/SkipLink';
 import {MultiSeriesBarChart} from '../MultiSeriesBarChart';
 import {Chart} from '../Chart';
 
+jest.mock('../../../hooks/useResizeObserver.ts', () => ({
+  useResizeObserver: () => {
+    return {
+      setRef: jest.fn(),
+      entry: {
+        contentRect: {width: 100, height: 100},
+      },
+    };
+  },
+}));
+
 describe('<MultiSeriesBarChart />', () => {
   const mockProps = {
     series: [

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -27,6 +27,7 @@ import {
   StringLabelFormatter,
   NumberLabelFormatter,
   ActiveTooltip,
+  Dimensions,
 } from '../../types';
 
 import {Spacing} from './constants';
@@ -41,7 +42,7 @@ interface Props {
   formatXAxisLabel: StringLabelFormatter;
   formatYAxisLabel: NumberLabelFormatter;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
-  dimensions: DOMRect;
+  dimensions: Dimensions;
   opacity: number;
   isAnimated: boolean;
 }

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -1,10 +1,15 @@
-import React, {useLayoutEffect, useRef, useState} from 'react';
+import React, {useLayoutEffect, useRef, useState, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
 import {SkipLink} from '../SkipLink';
-import {StringLabelFormatter, NumberLabelFormatter} from '../../types';
+import {
+  StringLabelFormatter,
+  NumberLabelFormatter,
+  Dimensions,
+} from '../../types';
 import {TooltipContent} from '../TooltipContent';
 import {getDefaultColor, uniqueId} from '../../utilities';
+import {useResizeObserver} from '../../hooks';
 
 import {Chart} from './Chart';
 import {Series, RenderTooltipContentData} from './types';
@@ -30,34 +35,49 @@ export function StackedAreaChart({
   isAnimated = false,
   skipLinkText,
 }: StackedAreaChartProps) {
-  const [chartDimensions, setChartDimensions] = useState<DOMRect | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
+    null,
+  );
 
   const skipLinkAnchorId = useRef(uniqueId('stackedAreaChart'));
 
-  const [updateDimensions] = useDebouncedCallback(() => {
-    if (containerRef.current != null) {
-      setChartDimensions(containerRef.current.getBoundingClientRect());
+  const {setRef, entry} = useResizeObserver();
+
+  const updateDimensions = useCallback(() => {
+    if (entry != null) {
+      const {width, height} = entry.contentRect;
+      setChartDimensions((prevDimensions) => {
+        if (
+          prevDimensions != null &&
+          width === prevDimensions.width &&
+          height === prevDimensions.height
+        ) {
+          return prevDimensions;
+        } else {
+          return {width, height};
+        }
+      });
     }
+  }, [entry]);
+
+  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
+    updateDimensions();
   }, 100);
 
   useLayoutEffect(() => {
-    if (containerRef.current != null) {
-      setChartDimensions(containerRef.current.getBoundingClientRect());
-    }
-
+    updateDimensions();
     const isServer = typeof window === 'undefined';
 
     if (!isServer) {
-      window.addEventListener('resize', updateDimensions);
+      window.addEventListener('resize', debouncedUpdateDimensions);
     }
 
     return () => {
       if (!isServer) {
-        window.removeEventListener('resize', updateDimensions);
+        window.removeEventListener('resize', debouncedUpdateDimensions);
       }
     };
-  }, [containerRef, updateDimensions]);
+  }, [entry, debouncedUpdateDimensions, updateDimensions]);
 
   if (series.length === 0) {
     return null;
@@ -86,7 +106,7 @@ export function StackedAreaChart({
       {skipLinkText == null || skipLinkText.length === 0 ? null : (
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
-      <div style={{height: '100%', width: '100%'}} ref={containerRef}>
+      <div style={{height: '100%', width: '100%'}} ref={setRef}>
         {chartDimensions == null ? null : (
           <Chart
             xAxisLabels={xAxisLabels}

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -14,13 +14,6 @@ import {
 import {StackedAreas} from '../components';
 import {Chart} from '../Chart';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 describe('<Chart />', () => {
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {
@@ -81,7 +74,7 @@ describe('<Chart />', () => {
       },
     ],
     xAxisLabels: ['Day 1', 'Day 2'],
-    dimensions: new DOMRect(),
+    dimensions: {width: 500, height: 250},
     opacity: 1,
     isAnimated: true,
     formatXAxisLabel: (val: string) => val,

--- a/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
+++ b/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
@@ -6,13 +6,6 @@ import {StackedAreaChart} from '../StackedAreaChart';
 import {Chart} from '../Chart';
 import {SkipLink} from '../../SkipLink';
 
-(global as any).DOMRect = class DOMRect {
-  width = 500;
-  height = 250;
-  top = 100;
-  left = 100;
-};
-
 const mockData = [
   {
     name: 'Asia',
@@ -44,15 +37,18 @@ const mockData = [
 
 const xAxisLabels = ['1', '2', '3', '4', '5', '6', '7'];
 
-describe('<AreaChart />', () => {
-  beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      value: jest.fn(() => {
-        return {matches: false};
-      }),
-    });
-  });
+jest.mock('../../../hooks/useResizeObserver.ts', () => ({
+  useResizeObserver: () => {
+    return {
+      setRef: jest.fn(),
+      entry: {
+        contentRect: {width: 500, height: 250},
+      },
+    };
+  },
+}));
 
+describe('<AreaChart />', () => {
   it('renders a <Chart />', () => {
     const areaChart = mount(
       <StackedAreaChart series={mockData} xAxisLabels={xAxisLabels} />,

--- a/src/components/TooltipContainer/TooltipContainer.tsx
+++ b/src/components/TooltipContainer/TooltipContainer.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useRef, useState, ReactNode} from 'react';
 import {useSpring, animated} from 'react-spring';
 
 import {clamp} from '../../utilities';
+import {Dimensions} from '../../types';
 
 import styles from './TooltipContainer.scss';
 
@@ -11,7 +12,7 @@ interface Props {
   activePointIndex: number;
   currentX: number;
   currentY: number;
-  chartDimensions: DOMRect;
+  chartDimensions: Dimensions;
   position?: 'center' | 'auto';
   id?: string;
 }
@@ -30,7 +31,7 @@ export function TooltipContainer({
   id = '',
 }: Props) {
   const tooltipRef = useRef<HTMLDivElement | null>(null);
-  const [tooltipDimensions, setTooltipDimensions] = useState<DOMRect | null>(
+  const [tooltipDimensions, setTooltipDimensions] = useState<Dimensions | null>(
     null,
   );
   const firstRender = useRef(true);

--- a/src/hooks/useLinearXAxisDetails.ts
+++ b/src/hooks/useLinearXAxisDetails.ts
@@ -24,6 +24,7 @@ import {
   DataSeries,
   SeriesColor,
   YAxisTick,
+  Dimensions,
 } from '../types';
 
 import {useLinearXScale} from './useLinearXScale';
@@ -38,7 +39,7 @@ function getDatumSpace(width: number, numberOfTicks: number) {
 export interface ChartDetails {
   series: DataSeries<Data | NullableData, SeriesColor>[];
   fontSize: number;
-  chartDimensions: DOMRect;
+  chartDimensions: Dimensions;
   formatXAxisLabel: StringLabelFormatter;
   initialTicks: YAxisTick[];
   xAxisLabels: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,3 +126,8 @@ export interface YAxisTick {
   formattedValue: string;
   yOffset: number;
 }
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}

--- a/src/utilities/get-bar-xaxis-details.ts
+++ b/src/utilities/get-bar-xaxis-details.ts
@@ -6,6 +6,7 @@ import {
   LABEL_SPACE_MINUS_FIRST_AND_LAST,
   SPACING_EXTRA_TIGHT,
 } from '../constants';
+import {Dimensions} from '../types';
 
 import {getTextContainerHeight} from './get-text-container-height';
 import {getLongestLabelDetails} from './get-longest-label-details';
@@ -15,7 +16,7 @@ interface LayoutDetails {
   yAxisLabelWidth: number;
   fontSize: number;
   xLabels: string[];
-  chartDimensions: DOMRect;
+  chartDimensions: Dimensions;
   innerMargin: number;
   outerMargin: number;
   minimalLabelIndexes?: number[] | null;


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/24506

Uses the ResizeObserver that was added for the Sparkline and Sparkbar to the other components. This means that if the container changes, without a resize, the components still update. Also added a comparison check in the state update to avoid unnecessary rerenders.

### Reviewers’ :tophat: instructions
I find it easier to tophat this change in the Playground rather than Storybook, but you can use either.

Check that:
- resizing the page still causes components to update their size
- using the inspector, modify the chart's container's size. See the component update without resizing the page.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
