### PR TITLE
Only nice ticks/yScale when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Changed
+
+- `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>` yScale will allow data to overflow the highest tick if the highest value is less than half way to the next tick
+
 ## [0.11.2] — 2021-05-07
 
 ### Fixed

--- a/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
@@ -12,6 +12,7 @@ jest.mock('d3-scale', () => ({
     scale.range = (range: any) => (range ? scale : range);
     scale.domain = (domain: any) => (domain ? scale : domain);
     scale.nice = () => scale;
+    scale.copy = () => scale;
     return scale;
   }),
 }));
@@ -29,6 +30,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -60,6 +62,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -91,6 +94,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -122,6 +126,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -153,6 +158,7 @@ describe('useYScale', () => {
       scale.range = rangeSpy;
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -178,6 +184,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
 import {Data} from 'types';
 
+import {shouldRoundScaleUp} from '../../../utilities';
 import {MIN_Y_LABEL_SPACE} from '../constants';
 import {DEFAULT_MAX_Y} from '../../../constants';
 import {NumberLabelFormatter} from '../../../types';
@@ -33,8 +34,11 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([min, max])
-      .nice(maxTicks);
+      .domain([min, max]);
+
+    if (shouldRoundScaleUp({yScale, maxValue: max, maxTicks})) {
+      yScale.nice(maxTicks);
+    }
 
     const ticks = yScale.ticks(maxTicks).map((value) => ({
       value,

--- a/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
@@ -13,6 +13,7 @@ jest.mock('d3-scale', () => ({
     scale.range = (range: any) => (range ? scale : range);
     scale.domain = (domain: any) => (domain ? scale : domain);
     scale.nice = () => scale;
+    scale.copy = () => scale;
     return scale;
   }),
 }));
@@ -30,6 +31,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -58,6 +60,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -95,6 +98,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -131,6 +135,7 @@ describe('useYScale', () => {
       scale.range = rangeSpy;
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -157,6 +162,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
 
-import {getTextWidth} from '../../../utilities';
+import {getTextWidth, shouldRoundScaleUp} from '../../../utilities';
 import {yAxisMinMax} from '../utilities';
 import {MIN_Y_LABEL_SPACE} from '../constants';
 import {Series} from '../types';
@@ -28,8 +28,11 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([Math.min(0, minY), Math.max(0, maxY)])
-      .nice(maxTicks);
+      .domain([Math.min(0, minY), Math.max(0, maxY)]);
+
+    if (shouldRoundScaleUp({yScale, maxValue: maxY, maxTicks})) {
+      yScale.nice(maxTicks);
+    }
 
     const ticks = yScale.ticks(maxTicks).map((value) => ({
       value,

--- a/src/components/MultiSeriesBarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/MultiSeriesBarChart/hooks/tests/use-y-scale.test.tsx
@@ -12,6 +12,7 @@ jest.mock('d3-scale', () => ({
     scale.range = (range: any) => (range ? scale : range);
     scale.domain = (domain: any) => (domain ? scale : domain);
     scale.nice = () => scale;
+    scale.copy = () => scale;
     return scale;
   }),
 }));
@@ -76,6 +77,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -92,6 +94,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -108,6 +111,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -136,6 +140,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -164,6 +169,7 @@ describe('useYScale', () => {
       domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
       scale.domain = domainSpy;
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -214,6 +220,7 @@ describe('useYScale', () => {
       scale.range = rangeSpy;
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 
@@ -229,6 +236,7 @@ describe('useYScale', () => {
       scale.range = (range: any) => (range ? scale : range);
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.nice = () => scale;
+      scale.copy = () => scale;
       return scale;
     });
 

--- a/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
 
+import {shouldRoundScaleUp} from '../../../utilities';
 import {Series, StackSeries} from '../types';
 import {MIN_Y_LABEL_SPACE} from '../constants';
 import {getMinMax} from '../utilities';
@@ -27,8 +28,11 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([min, max])
-      .nice(maxTicks);
+      .domain([min, max]);
+
+    if (shouldRoundScaleUp({yScale, maxValue: max, maxTicks})) {
+      yScale.nice(maxTicks);
+    }
 
     const ticks = yScale.ticks(maxTicks).map((value) => ({
       value,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -19,3 +19,4 @@ export {getPathLength} from './get-path-length';
 export {getPointAtLength} from './get-point-at-length';
 export {normalizeData} from './normalize-data';
 export {createCSSGradient} from './create-css-gradient';
+export {shouldRoundScaleUp} from './should-round-scale-up';

--- a/src/utilities/should-round-scale-up.ts
+++ b/src/utilities/should-round-scale-up.ts
@@ -1,0 +1,23 @@
+import {ScaleLinear} from 'd3-scale';
+
+export function shouldRoundScaleUp({
+  yScale,
+  maxTicks,
+  maxValue,
+}: {
+  yScale: ScaleLinear<number, number>;
+  maxTicks: number;
+  maxValue: number;
+}) {
+  const roundedUpTicks = yScale
+    .copy()
+    .nice(maxTicks)
+    .ticks(maxTicks);
+
+  const lastTick = roundedUpTicks[roundedUpTicks.length - 1];
+  const secondLastTick = roundedUpTicks[roundedUpTicks.length - 2];
+  const tickThreshold = (lastTick - secondLastTick) / 2;
+  const shouldRoundScaleUp = maxValue - secondLastTick > tickThreshold;
+
+  return shouldRoundScaleUp;
+}

--- a/src/utilities/tests/should-round-scale-up.test.ts
+++ b/src/utilities/tests/should-round-scale-up.test.ts
@@ -1,0 +1,23 @@
+import {scaleLinear} from 'd3-scale';
+
+import {shouldRoundScaleUp} from '../should-round-scale-up';
+
+describe('shouldRoundScaleUp', () => {
+  it('returns false when the max value is less than half way to the last nice tick', () => {
+    const yScale = scaleLinear()
+      .range([300, 0])
+      .domain([0, 12130]);
+
+    const actual = shouldRoundScaleUp({yScale, maxValue: 12130, maxTicks: 7});
+    expect(actual).toBe(false);
+  });
+
+  it('returns true when the max value is more than half way to the last nice tick', () => {
+    const yScale = scaleLinear()
+      .range([300, 0])
+      .domain([0, 18000]);
+
+    const actual = shouldRoundScaleUp({yScale, maxValue: 18000, maxTicks: 5});
+    expect(actual).toBe(true);
+  });
+});


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/24603
Resolves https://github.com/Shopify/core-issues/issues/24602

Only uses d3's nice method on the ticks, and include the top yAxis label, when they reach a certain threshold. Otherwise the data is drawn above the top bound of the yAxis. The threshold is when the data would be more than half way to the next tick mark.

Note: I have not applied this to the area chart for now, as I thought it could be tackled in https://github.com/Shopify/polaris-viz/issues/314

| Before  | After  | 
|---|---|
| <img width="709" alt="Screen Shot 2021-05-10 at 8 46 37 AM" src="https://user-images.githubusercontent.com/12213371/117663937-30043380-b16f-11eb-8df3-3ea10b3c69a6.png">  |  <img width="705" alt="Screen Shot 2021-05-10 at 8 47 11 AM" src="https://user-images.githubusercontent.com/12213371/117663930-2f6b9d00-b16f-11eb-9e8e-a96eb42b2a5d.png"> |  
| <img width="708" alt="Screen Shot 2021-05-10 at 8 46 49 AM" src="https://user-images.githubusercontent.com/12213371/117663934-30043380-b16f-11eb-85ce-8badd7d697fd.png">  |  <img width="709" alt="Screen Shot 2021-05-10 at 8 47 20 AM" src="https://user-images.githubusercontent.com/12213371/117663929-2ed30680-b16f-11eb-9a6c-f3fa1a1ffea1.png"> | 
|<img width="709" alt="Screen Shot 2021-05-10 at 8 49 20 AM" src="https://user-images.githubusercontent.com/12213371/117663920-2da1d980-b16f-11eb-849e-667ea03998a6.png"> |  <img width="711" alt="Screen Shot 2021-05-10 at 8 48 55 AM" src="https://user-images.githubusercontent.com/12213371/117663926-2e3a7000-b16f-11eb-91ce-d23b9764290f.png"> | 
|<img width="704" alt="Screen Shot 2021-05-10 at 8 46 29 AM" src="https://user-images.githubusercontent.com/12213371/117663939-309cca00-b16f-11eb-9be3-669753f23e97.png">|<img width="705" alt="Screen Shot 2021-05-10 at 8 47 03 AM" src="https://user-images.githubusercontent.com/12213371/117663933-2f6b9d00-b16f-11eb-9fd8-2b47dc2db377.png">|

### Reviewers’ :tophat: instructions

Take a look at either the Playground or Storybook. Modify the values and ensure the output is as is expected.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
