### PR TITLE
Fix negative tick sometimes getting cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- yAxis ticks sometimes getting cut off
+
 ## [0.12.0] — 2021-05-10
 
 ### Fixed
@@ -10,7 +16,7 @@
 
 ## [0.11.3] — 2021-05-10
 
-## Changed
+### Changed
 
 - `<MultiSeriesBarChart/>`, `<BarChart />` and `<LineChart/>` yScale will allow data to overflow the highest tick if the highest value is less than half way to the next tick
 

--- a/documentation/code/LineChartDemo.tsx
+++ b/documentation/code/LineChartDemo.tsx
@@ -30,7 +30,7 @@ export function LineChartDemo() {
         {rawValue: 7200, label: '2020-04-04T12:00:00'},
         {rawValue: 1500, label: '2020-04-05T12:00:00'},
         {rawValue: 6132, label: '2020-04-06T12:00:00'},
-        {rawValue: 3100, label: '2020-04-07T12:00:00'},
+        {rawValue: -3100, label: '2020-04-07T12:00:00'},
         {rawValue: 2200, label: '2020-04-08T12:00:00'},
         {rawValue: 5103, label: '2020-04-09T12:00:00'},
         {rawValue: 2112.5, label: '2020-04-10T12:00:00'},

--- a/src/components/YAxis/YAxis.tsx
+++ b/src/components/YAxis/YAxis.tsx
@@ -44,6 +44,7 @@ function Axis({
               style={{
                 background: backgroundColor,
                 padding: PADDING_SIZE,
+                whiteSpace: 'nowrap',
               }}
             >
               {formattedValue}


### PR DESCRIPTION
### What problem is this PR solving?

Ensures text on the yAxis does not wrap to the next line

| Before        | After           |  
| ------------- |:-------------:| 
| <img width="872" alt="Screen Shot 2021-05-11 at 1 58 44 PM" src="https://user-images.githubusercontent.com/12213371/117863004-47234e00-b261-11eb-96f7-a163851d42c9.png">  | <img width="872" alt="Screen Shot 2021-05-11 at 1 57 24 PM" src="https://user-images.githubusercontent.com/12213371/117863008-47bbe480-b261-11eb-9375-13a292343e0e.png">| 


### Reviewers’ :tophat: instructions
- `dev up && dev server`
- have a look at the line chart in the playground

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
