### PR TITLE
Fix inconsistent spacing in sparkline and sparkbar line dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - yAxis ticks sometimes getting cut off
+- `<SparkLine/>` and `<Sparkbar/>` stroke dasharray treatment is consistent at all sizes
 
 ## [0.12.0] — 2021-05-10
 

--- a/src/components/Sparkbar/Sparkbar.scss
+++ b/src/components/Sparkbar/Sparkbar.scss
@@ -14,3 +14,8 @@
 .VisuallyHidden {
   @include visually-hidden;
 }
+
+.ComparisonLine {
+  fill: none;
+  stroke-dasharray: 3 2;
+}

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useState, useLayoutEffect, useMemo} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleBand, scaleLinear} from 'd3-scale';
-import {area} from 'd3-shape';
+import {line} from 'd3-shape';
 import {useTransition} from 'react-spring';
 
 import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
@@ -122,7 +122,7 @@ export function Sparkbar({
     .range([0, width])
     .domain([0, data.length - 1]);
 
-  const lineGenerator = area<Coordinates>()
+  const lineGenerator = line<Coordinates>()
     .x(({x}) => xScaleLinear(x))
     .y(({y}) => yScale(y));
 
@@ -209,7 +209,7 @@ export function Sparkbar({
               stroke={currentColor}
               strokeWidth={STROKE_WIDTH}
               d={lineShape!}
-              strokeDasharray="2 3"
+              className={styles.ComparisonLine}
             />
           </g>
         )}

--- a/src/components/Sparkbar/tests/Sparkbar.test.tsx
+++ b/src/components/Sparkbar/tests/Sparkbar.test.tsx
@@ -66,16 +66,12 @@ describe('<Sparkbar/>', () => {
       <Sparkbar data={sampleData} comparison={sampleComparison} />,
     );
 
-    expect(wrapper).toContainReactComponent('path', {
-      strokeDasharray: '2 3',
-    });
+    expect(wrapper).toContainReactComponentTimes('path', 5);
   });
 
   it('does not render a comparison line when the prop is not passed', () => {
     const wrapper = mount(<Sparkbar data={sampleData} />);
 
-    expect(wrapper).not.toContainReactComponent('path', {
-      strokeDasharray: '2 3',
-    });
+    expect(wrapper).toContainReactComponentTimes('path', 4);
   });
 });

--- a/src/components/Sparkline/components/Series/Series.scss
+++ b/src/components/Sparkline/components/Series/Series.scss
@@ -1,7 +1,16 @@
 $animation-duration: 500ms;
 
-.Path {
+.AnimatedLine {
   animation: reveal $animation-duration ease-in-out 1;
+}
+
+.Line {
+  fill: none;
+  stroke: 1.5;
+}
+
+.DashedLine {
+  stroke-dasharray: 3 2;
 }
 
 .Area {

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import {ScaleLinear} from 'd3-scale';
-import {area, curveMonotoneX} from 'd3-shape';
+import {area, curveMonotoneX, line} from 'd3-shape';
+import {classNames} from '@shopify/css-utilities';
 
 import {LinearGradient} from '../../../LinearGradient';
 import {getColorValue, uniqueId, rgbToRgba} from '../../../../utilities';
@@ -9,7 +10,6 @@ import {SingleSeries, Coordinates} from '../../Sparkline';
 
 import styles from './Series.scss';
 
-const STROKE_WIDTH = 1.5;
 const POINT_RADIUS = 2;
 
 export function Series({
@@ -36,7 +36,7 @@ export function Series({
     data,
   } = series;
 
-  const lineGenerator = area<Coordinates>()
+  const lineGenerator = line<Coordinates>()
     .x(({x}) => xScale(x))
     .y(({y}) => yScale(y));
 
@@ -72,10 +72,13 @@ export function Series({
     <React.Fragment>
       <path
         stroke={colorValue}
-        strokeWidth={STROKE_WIDTH}
         d={lineShape}
-        strokeDasharray={dashedLine ? '2 4' : ''}
-        className={immediate ? null : styles.Path}
+        fill="none"
+        className={classNames(
+          styles.Line,
+          !immediate && styles.AnimatedLine,
+          dashedLine && styles.DashedLine,
+        )}
       />
       {areaStyle === 'gradient' ? (
         <LinearGradient

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -17,6 +17,13 @@ jest.mock('d3-shape', () => ({
     shape.curve = () => shape;
     return shape;
   }),
+  line: jest.fn(() => {
+    const shape = (value: any) => value;
+    shape.x = () => shape;
+    shape.y = () => shape;
+    shape.curve = () => shape;
+    return shape;
+  }),
 }));
 
 const mockSeries = {
@@ -80,7 +87,7 @@ describe('Series', () => {
     );
 
     expect(actual).toContainReactComponent('path', {
-      strokeDasharray: '',
+      className: 'Line',
     });
   });
 
@@ -91,7 +98,7 @@ describe('Series', () => {
       </svg>,
     );
     expect(actual).toContainReactComponent('path', {
-      strokeDasharray: '2 4',
+      className: 'Line DashedLine',
     });
   });
 


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/core-issues/issues/24778

| Before  | After  |
|---|---|
| <img width="791" alt="Screen Shot 2021-05-10 at 9 31 56 PM" src="https://user-images.githubusercontent.com/12213371/117745130-e7cd2b80-b1d7-11eb-94af-72f3f791b0ce.png">| <img width="784" alt="Screen Shot 2021-05-10 at 9 36 30 PM" src="https://user-images.githubusercontent.com/12213371/117745128-e7cd2b80-b1d7-11eb-9dd9-54c57c0f6b40.png">|  

Fixes inconsistent stroke-dasharray treatment on the sparkline and sparkbar, by using d3's `line` instead of `area`. This means we only draw the path once, rather than drawing back over top of it.


### Reviewers’ :tophat: instructions
One way to easily check the fix is to look at the Sparkline in Storybook (`dev up && yarn storybook`, open http://localhost:6006/?path=/story/sparkline--default). Resize the page and observe that the dashed treatment remains the same.

If you would like to test the changes in web, do the following:
- `dev up && dev server` (or focus your section) in web
- checkout this branch and run `yarn build-consumer web` from Polaris Viz
- refresh the page in web and you should see these changes in web

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
