### PR TITLE
Don't allow user select on charts

### DIFF
--- a/src/components/BarChart/Chart.scss
+++ b/src/components/BarChart/Chart.scss
@@ -1,3 +1,4 @@
 .ChartContainer {
   position: relative;
+  user-select: none;
 }

--- a/src/components/Legend/Legend.scss
+++ b/src/components/Legend/Legend.scss
@@ -3,6 +3,7 @@
 
 .Container {
   @include legend-container;
+  user-select: none;
 }
 
 .Series {

--- a/src/components/LineChart/Chart.scss
+++ b/src/components/LineChart/Chart.scss
@@ -3,4 +3,5 @@
   overflow: hidden;
   height: 100%;
   width: 100%;
+  user-select: none;
 }

--- a/src/components/MultiSeriesBarChart/Chart.scss
+++ b/src/components/MultiSeriesBarChart/Chart.scss
@@ -1,3 +1,4 @@
 .ChartContainer {
   position: relative;
+  user-select: none;
 }

--- a/src/components/StackedAreaChart/Chart.scss
+++ b/src/components/StackedAreaChart/Chart.scss
@@ -5,6 +5,7 @@
   overflow: hidden;
   height: 100%;
   width: 100%;
+  user-select: none;
 }
 
 .VisuallyHidden {


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/24893

Stops this:

![Image from iOS](https://user-images.githubusercontent.com/12213371/117882776-aa6caa80-b278-11eb-8099-e731737ba85c.png)


### Reviewers’ :tophat: instructions
`dev up && dev server` to see the Playground

Or to see Storybook `dev up && yarn storybook`. Try dragging the charts on desktop and/or on mobile and see that the chart content is not selected.

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
