### PR TITLE
Add default width and height for test environments

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -30,6 +30,15 @@ If you prefer [Yarn](https://yarnpkg.com/en/), use the following command instead
 yarn add @shopify/polaris-viz
 ```
 
+#### Peer Dependencies
+
+Polaris Viz has peer dependencies on:
+
+- `react@^16.8.6`
+- `react-dom@^16.8.6`
+- `@juggle/resize-observer@^3.3.1`
+
+You are responsible for providing these packages in your project. By requiring these packages as `peerDependencies` we can be sure there won't be duplicate packages included due to version mismatches, etc.
 
 
 #### Available commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.3] - 2021-05-12
+
+### Fixed
+
+- When `process.env.NODE_ENV === 'test'` a default width and height of 500px is provided so consumers of Polaris Viz don't need to set up any mocks for ResizeObserver (or container widths/heights).
+
 ## [0.12.2] - 2021-05-11
 
 ### Fixed

--- a/src/components/BarChart/tests/BarChart.test.tsx
+++ b/src/components/BarChart/tests/BarChart.test.tsx
@@ -5,17 +5,6 @@ import {BarChart} from '../BarChart';
 import {Chart} from '../Chart';
 import {SkipLink} from '../../SkipLink';
 
-jest.mock('../../../hooks/useResizeObserver.ts', () => ({
-  useResizeObserver: () => {
-    return {
-      setRef: jest.fn(),
-      entry: {
-        contentRect: {width: 100, height: 100},
-      },
-    };
-  },
-}));
-
 describe('BarChart />', () => {
   const mockProps = {data: [{rawValue: 10, label: 'data'}]};
 

--- a/src/components/LineChart/tests/LineChart.test.tsx
+++ b/src/components/LineChart/tests/LineChart.test.tsx
@@ -26,17 +26,6 @@ jest.mock('../../../utilities', () => {
   };
 });
 
-jest.mock('../../../hooks/useResizeObserver.ts', () => ({
-  useResizeObserver: () => {
-    return {
-      setRef: jest.fn(),
-      entry: {
-        contentRect: {width: 500, height: 250},
-      },
-    };
-  },
-}));
-
 describe('<LineChart />', () => {
   beforeAll(() => {
     Object.defineProperty(window, 'matchMedia', {

--- a/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/MultiSeriesBarChart.test.tsx
@@ -6,17 +6,6 @@ import {SkipLink} from 'components/SkipLink';
 import {MultiSeriesBarChart} from '../MultiSeriesBarChart';
 import {Chart} from '../Chart';
 
-jest.mock('../../../hooks/useResizeObserver.ts', () => ({
-  useResizeObserver: () => {
-    return {
-      setRef: jest.fn(),
-      entry: {
-        contentRect: {width: 100, height: 100},
-      },
-    };
-  },
-}));
-
 describe('<MultiSeriesBarChart />', () => {
   const mockProps = {
     series: [

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -75,9 +75,7 @@ export function Sparkbar({
   const {prefersReducedMotion} = usePrefersReducedMotion();
 
   const [updateMeasurements] = useDebouncedCallback(() => {
-    if (containerRef == null) {
-      throw new Error('No SVG rendered');
-    }
+    if (containerRef == null) return;
 
     setSvgDimensions({
       height: containerRef.clientHeight,
@@ -88,9 +86,7 @@ export function Sparkbar({
   useLayoutEffect(() => {
     if (entry == null) return;
 
-    if (containerRef == null) {
-      throw new Error('No SVG rendered');
-    }
+    if (containerRef == null) return;
 
     updateMeasurements();
 

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -47,9 +47,7 @@ export function Sparkline({
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
 
   const [updateMeasurements] = useDebouncedCallback(() => {
-    if (containerRef == null) {
-      throw new Error('No SVG rendered');
-    }
+    if (containerRef == null) return;
 
     setSvgDimensions({
       height: containerRef.clientHeight,
@@ -60,9 +58,7 @@ export function Sparkline({
   useLayoutEffect(() => {
     if (entry == null) return;
 
-    if (containerRef == null) {
-      throw new Error('No SVG rendered');
-    }
+    if (containerRef == null) return;
 
     updateMeasurements();
 

--- a/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
+++ b/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
@@ -37,17 +37,6 @@ const mockData = [
 
 const xAxisLabels = ['1', '2', '3', '4', '5', '6', '7'];
 
-jest.mock('../../../hooks/useResizeObserver.ts', () => ({
-  useResizeObserver: () => {
-    return {
-      setRef: jest.fn(),
-      entry: {
-        contentRect: {width: 500, height: 250},
-      },
-    };
-  },
-}));
-
 describe('<AreaChart />', () => {
   it('renders a <Chart />', () => {
     const areaChart = mount(

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -4,6 +4,12 @@ import {
   ResizeObserverEntry,
 } from '@juggle/resize-observer';
 
+// This default value is used in our tests so that consumers of Polaris Viz don't need to mock or fire a ResizeObserver event
+const defaultEntry =
+  process.env.NODE_ENV === 'test'
+    ? ({contentRect: {width: 500, height: 500}} as ResizeObserverEntry)
+    : null;
+
 function resizeObserver(
   callback: (entries: ResizeObserverEntry[], observer: Polyfill) => void,
 ) {
@@ -20,7 +26,7 @@ export const useResizeObserver = <T extends HTMLElement>(): {
   entry: ResizeObserverEntry | null;
 } => {
   const [ref, setRef] = useState<T | null>(null);
-  const [entry, setEntry] = useState<ResizeObserverEntry | null>(null);
+  const [entry, setEntry] = useState<ResizeObserverEntry | null>(defaultEntry);
 
   useLayoutEffect(() => {
     if (!ref) {


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

As part of [updating `web` to `polaris-vis@0.12.2`](https://github.com/Shopify/web/pull/43426) I encountered [many tests](https://buildkite.com/shopify/web-ci-builder/builds/345009) that now fail because the visualization dimensions have a `0` width and height. A solution is to mock `ResizeObserver` and fire a resize event immediately after rendering the visualization, but this is cumbersome and really only required because of the way we built Polaris Viz. After learning more, we can do better!

This change provides a default width and height of `500px` in `useResizeObserver` so that consumers of Polaris Viz don't have to worry about mocking `ResizeObserver` and firing a `ResizeObserverEntry`.

I tested this change in `web` by directly editing `node_modules` and verifying that all failed tests now pass:

![](https://screenshot.click/21-05-g7uiw-za7rk.png)

I also confirmed that when loading up Polaris Viz in the Web Admin (where the default isn't used), the existing behavior happens:

![](https://screenshot.click/21-05-26swh-o6zye.png)

### Reviewers’ :tophat: instructions

The tests in this change test the new behavior -- all the mocks of `useResizeObserver` were removed since we don't need them anymore.

If you want to test this change in `web`, you can run: `yarn run build-consumer web` to build this package and update `web`. You will need to then run:

```
./node_modules/.bin/sewing-kit clean --vendor-dll --cache
```

**Testing via Web Admin**

1. `dev s --focus Analytics`
1. Navigate to https://shop1.myshopify.io/admin/reports/product_orders_and_returns?since=today&until=today
1. Enable the beta flag via the DevUI: `insights_orders_report` and reload the page 
1. Test that the chart renders, it can't be highlighted, it resizes, etc.

**Testing via Storybook in `web`**

1. `yarn run storybook`
1. Open up http://localhost:6006/?path=/story/sections-orders-components-ordersanalyticsincontext--daily-orders and see the graphs load


### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
