### PR TITLE
[Multi series bar chart] Fix missing labels bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [UNRELEASED] — 2021-05-12
+## Unreleased
 
 ### Changed
 
 - Replaced `curveMonotoneX` by `curveStepRounded` in `LineChart` and `SparkBar`
+
+### Fixed
+
+- Fixed a bug in <MultiSeriesBarChart /> that was causing the chart to crash when no labels were passed to the chart (in the case of an empty state)
 
 ## [0.12.3] - 2021-05-12
 

--- a/src/utilities/get-bar-xaxis-details.ts
+++ b/src/utilities/get-bar-xaxis-details.ts
@@ -36,6 +36,15 @@ export function getBarXAxisDetails({
       ? xLabels
       : xLabels.filter((_, index) => minimalLabelIndexes.includes(index));
 
+  if (labelsToUse.length === 0) {
+    return {
+      maxXLabelHeight: 0,
+      maxDiagonalLabelLength: 0,
+      needsDiagonalLabels: false,
+      maxWidth: 0,
+    };
+  }
+
   const drawableWidth =
     chartDimensions.width - yAxisLabelWidth - Margin.Right - SPACING;
 

--- a/src/utilities/tests/get-bar-xaxis-details.test.ts
+++ b/src/utilities/tests/get-bar-xaxis-details.test.ts
@@ -86,4 +86,26 @@ describe('getBarXAxisDetails', () => {
       maxWidth: 10.799999999999999,
     });
   });
+
+  it('returns zeros when no xLabels are provided', () => {
+    const actual = getBarXAxisDetails({
+      yAxisLabelWidth: 10,
+      xLabels: [],
+      fontSize: 10,
+      innerMargin: 0,
+      outerMargin: 0,
+      minimalLabelIndexes: null,
+      chartDimensions: {
+        height: 100,
+        width: 100,
+      } as any,
+    });
+
+    expect(actual).toMatchObject({
+      maxXLabelHeight: 0,
+      maxDiagonalLabelLength: 0,
+      needsDiagonalLabels: false,
+      maxWidth: 0,
+    });
+  });
 });


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

Resolves https://github.com/Shopify/core-issues/issues/24896.

In cases where we pass an empty set of labels to the Chart (for a zero state), it would try to divide by zero, and would crash the chart. This checks to see if the labels are empty, and if they are, returns early with non-problematic values.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

- Open the [Product Orders and Returns](https://shop1.myshopify.io/admin/reports/product_orders_and_returns?since=today&until=today) report on web
- Add a new sales channel to your local env by clicking the `+` next to the sales channel. Pick one like `Wholesale app dev` that is unlikely to have data
- Filter by that sales channel; you should see a zero state that looks like this:
  <br/>![image](https://user-images.githubusercontent.com/9555730/118032830-18c37280-b336-11eb-9126-d1d74297f56b.png)<br/>
- You should also see a `trailing garbage` error in your console:
  <br/>![image](https://user-images.githubusercontent.com/9555730/118032896-2973e880-b336-11eb-8f3b-13d8cf7221ad.png)<br/>
- Checkout this branch on polaris-viz, run `yarn build-consumer web`
- Perform the same filter action on web; the zero state should now look like this:
  <br/>![image](https://user-images.githubusercontent.com/9555730/118033134-73f56500-b336-11eb-81c8-cd849a9c1875.png)<br/>
- There should be no console error

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

~- [ ] Update relevant documentation.~ N/A
