### PR TITLE
[BarChart and MultiSeriesBarChart] Update min bar height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Replaced `curveMonotoneX` by `curveStepRounded` in `LineChart` and `SparkBar`
+- Updated min bar height to be 1px for 0 values in `<BarChart />` and grouped `<MultiSeriesBarChart />`
 
 ## [0.12.3] - 2021-05-12
 

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -35,7 +35,8 @@ export function Bar({
   height,
   hasRoundedCorners,
 }: Props) {
-  const radius = hasRoundedCorners ? ROUNDED_BAR_RADIUS : 0;
+  const radius =
+    hasRoundedCorners && height >= ROUNDED_BAR_RADIUS ? ROUNDED_BAR_RADIUS : 0;
   const zeroScale = yScale(0);
   const isNegative = rawValue < 0;
   const rotation = isNegative ? 'rotate(180deg)' : 'rotate(0deg)';
@@ -81,9 +82,7 @@ export function Bar({
     if (height == null) return;
 
     const calculatePath = (heightValue: number) =>
-      rawValue === 0
-        ? ''
-        : `M${radius} 0
+      `M${radius} 0
         h${width - radius * 2}
         a${radius} ${radius} 0 01${radius} ${radius}
         v${heightValue - radius}
@@ -96,7 +95,7 @@ export function Bar({
       return calculatePath(height);
     }
     return height.interpolate(calculatePath);
-  }, [height, heightIsNumber, radius, rawValue, width]);
+  }, [height, heightIsNumber, radius, width]);
 
   return (
     <animated.path

--- a/src/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Bar/tests/Bar.test.tsx
@@ -3,7 +3,7 @@ import {mount} from '@shopify/react-testing';
 import {scaleBand} from 'd3-scale';
 
 import {Bar} from '../Bar';
-import {MASK_HIGHLIGHT_COLOR} from '../../../constants';
+import {MASK_HIGHLIGHT_COLOR, ROUNDED_BAR_RADIUS} from '../../../constants';
 
 jest.mock('d3-scale', () => ({
   scaleBand: jest.fn(() => jest.fn((value) => value)),
@@ -62,19 +62,27 @@ describe('<Bar/>', () => {
         Z`,
       });
     });
-  });
-
-  describe('rawValue', () => {
-    it('gives a 0 value an empty path d attribute and 0 height', () => {
+    it('renders sharp corners if true and height is less than the radius', () => {
       const bar = mount(
         <svg>
-          <Bar {...defaultProps} rawValue={0} />,
+          <Bar
+            {...defaultProps}
+            height={ROUNDED_BAR_RADIUS - 1}
+            hasRoundedCorners
+          />
         </svg>,
       );
 
       expect(bar).toContainReactComponent('path', {
         // eslint-disable-next-line id-length
-        d: ``,
+        d: `M0 0
+        h100
+        a0 0 0 010 0
+        v${ROUNDED_BAR_RADIUS - 1}
+        H0
+        V0
+        a0 0 0 010-0
+        Z`,
       });
     });
   });

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -183,7 +183,7 @@ export function Chart({
   const getBarHeight = useCallback(
     (rawValue: number) => {
       const rawHeight = Math.abs(yScale(rawValue) - yScale(0));
-      const needsMinHeight = rawHeight < MIN_BAR_HEIGHT && rawHeight !== 0;
+      const needsMinHeight = rawHeight < MIN_BAR_HEIGHT;
       return needsMinHeight ? MIN_BAR_HEIGHT : rawHeight;
     },
     [yScale],

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -12,7 +12,11 @@ import {
 
 import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
-import {MASK_SUBDUE_COLOR, MASK_HIGHLIGHT_COLOR} from '../../../constants';
+import {
+  MASK_SUBDUE_COLOR,
+  MASK_HIGHLIGHT_COLOR,
+  MIN_BAR_HEIGHT,
+} from '../../../constants';
 
 const fakeSVGEvent = {
   currentTarget: {
@@ -173,6 +177,18 @@ describe('Chart />', () => {
     svg.trigger('onMouseMove', fakeSVGEvent);
 
     expect(chart).toContainReactComponent(Bar, {color: MASK_SUBDUE_COLOR});
+  });
+
+  it('passes the min bar height to the bar if its value is 0', () => {
+    const chart = mount(
+      <Chart {...mockProps} data={[{rawValue: 0, label: 'data'}]} />,
+    );
+
+    expect(chart).toContainReactComponent(Bar, {
+      height: expect.objectContaining({
+        value: MIN_BAR_HEIGHT,
+      }),
+    });
   });
 
   describe('empty state', () => {

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -54,7 +54,7 @@ export function BarGroup({
   const getBarHeight = useCallback(
     (rawValue: number) => {
       const rawHeight = Math.abs(yScale(rawValue) - yScale(0));
-      const needsMinHeight = rawHeight < MIN_BAR_HEIGHT && rawHeight !== 0;
+      const needsMinHeight = rawHeight < MIN_BAR_HEIGHT;
       return needsMinHeight ? MIN_BAR_HEIGHT : rawHeight;
     },
     [yScale],

--- a/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -4,6 +4,7 @@ import {scaleLinear} from 'd3-scale';
 import {Color} from 'types';
 
 import {BAR_SPACING} from '../../../constants';
+import {MIN_BAR_HEIGHT} from '../../../../../constants';
 import {BarGroup} from '../BarGroup';
 import {Bar} from '../../../../../components/Bar';
 import {LinearGradient} from '../../../../../components/LinearGradient';
@@ -66,6 +67,20 @@ describe('<BarGroup/>', () => {
     expect(barGroup).toContainReactComponent(Bar, {x: 35});
     expect(barGroup).toContainReactComponent(Bar, {x: 60});
     expect(barGroup).toContainReactComponent(Bar, {x: 85});
+  });
+
+  it('passes the min bar height to the bar if its value is 0', () => {
+    const barGroup = mount(
+      <svg>
+        <BarGroup {...mockProps} data={[0]} />,
+      </svg>,
+    );
+
+    expect(barGroup).toContainReactComponent(Bar, {
+      height: expect.objectContaining({
+        value: MIN_BAR_HEIGHT,
+      }),
+    });
   });
 
   describe('colors', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const SMALL_LABEL_WIDTH = 50;
 export const LABEL_SPACE_MINUS_FIRST_AND_LAST = 0.6;
 export const DEFAULT_MAX_Y = 10;
 export const ROUNDED_BAR_RADIUS = 3;
-export const MIN_BAR_HEIGHT = 5;
+export const MIN_BAR_HEIGHT = 1;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
 


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/core-issues/issues/24881

Before, for bars with a value of 0, nothing would be shown: 
![image](https://user-images.githubusercontent.com/30587540/118173187-3dcde900-b3fb-11eb-8142-26a20ea604af.png)

Now, a bar with the height of `MIN_BAR_HEIGHT` should be shown. 
![image](https://user-images.githubusercontent.com/30587540/118173018-11b26800-b3fb-11eb-849f-02127cd6c61f.png)

Confirmed with UX that `MIN_BAR_HEIGHT` should be the same as the stroke width of the x-axis, which is 1px.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->
* For `BarChart` and `MultiSeriesBarChart` (grouped, not stacked, that will be tackled in https://github.com/Shopify/polaris-viz/issues/315), change some values to be 0
* Confirm that you see a 1px bar for that data point.

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
