### PR TITLE
Add only integers prop y axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - 0 values not showing a min height bar in grouped `<MultiSeriesBarChart />`
 
+### Added
+
+- `integersOnly` prop to `yAxisOptions` for `<LineChart />`, `<BarChart />`, and `<MultiSeriesBarChart />`
+
 ## [0.13.2] - 2021-05-17
 
 ### Changed

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -114,6 +114,7 @@ interface BarChartProps {
   yAxisOptions?: {
     labelFormatter?(value: number): string;
     backgroundColor?: string;
+    integersOnly?: boolean;
   };
   annotations?: {
     dataIndex: number;
@@ -331,6 +332,14 @@ The color used for axis labels.
 | `string` | `transparant` |
 
 The color used behind axis labels.
+
+##### integersOnly
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Only use whole numbers for y axis ticks
 
 #### annotations
 

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -151,6 +151,7 @@ export function BarChart({
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
     backgroundColor: 'transparent',
+    integersOnly: false,
     ...yAxisOptions,
   };
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -88,6 +88,7 @@ export function Chart({
       chartDimensions.height - Margin.Top - Margin.Bottom - LINE_HEIGHT,
     data,
     formatYAxisLabel: yAxisOptions.labelFormatter,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const approxYAxisLabelWidth = useMemo(
@@ -138,6 +139,7 @@ export function Chart({
     drawableHeight,
     data,
     formatYAxisLabel: yAxisOptions.labelFormatter,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const yAxisLabelWidth = useMemo(

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -11,21 +11,26 @@ export function useYScale({
   drawableHeight,
   data,
   formatYAxisLabel,
+  integersOnly,
 }: {
   drawableHeight: number;
   data: Data[];
   formatYAxisLabel: NumberLabelFormatter;
+  integersOnly: boolean;
 }) {
   const {yScale, ticks} = useMemo(() => {
-    const min = Math.min(...data.map(({rawValue}) => rawValue), 0);
+    const minY = Math.min(...data.map(({rawValue}) => rawValue), 0);
 
     const calculatedMax =
       data.length === 0 ? 0 : Math.max(...data.map(({rawValue}) => rawValue));
 
-    const max =
-      calculatedMax === 0 && min === 0
+    const maxY =
+      calculatedMax === 0 && minY === 0
         ? DEFAULT_MAX_Y
         : Math.max(calculatedMax, 0);
+
+    const min = integersOnly ? Math.floor(minY) : minY;
+    const max = integersOnly ? Math.ceil(maxY) : maxY;
 
     const maxTicks = Math.max(
       1,
@@ -40,14 +45,18 @@ export function useYScale({
       yScale.nice(maxTicks);
     }
 
-    const ticks = yScale.ticks(maxTicks).map((value) => ({
+    const filteredTicks = integersOnly
+      ? yScale.ticks(maxTicks).filter((tick) => Number.isInteger(tick))
+      : yScale.ticks(maxTicks);
+
+    const ticks = filteredTicks.map((value) => ({
       value,
       formattedValue: formatYAxisLabel(value),
       yOffset: yScale(value),
     }));
 
     return {yScale, ticks};
-  }, [drawableHeight, data, formatYAxisLabel]);
+  }, [data, integersOnly, drawableHeight, formatYAxisLabel]);
 
   return {yScale, ticks};
 }

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -248,3 +248,18 @@ MinimalLabels.args = {
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };
+
+export const IntegersOnly = Template.bind({});
+IntegersOnly.args = {
+  data: [
+    {rawValue: 0.19, label: '2020-01-01T12:00:00Z'},
+    {rawValue: 1.29, label: '2020-01-02T12:00:00Z'},
+    {rawValue: 1.79, label: '2020-01-03T12:00:00Z'},
+    {rawValue: 0.6, label: '2020-01-04T12:00:00Z'},
+    {rawValue: 1.69, label: '2020-01-05T12:00:00Z'},
+    {rawValue: 0.19, label: '2020-01-06T12:00:00Z'},
+  ],
+  xAxisOptions: {labelFormatter: formatXAxisLabel},
+  yAxisOptions: {integersOnly: true},
+  renderTooltipContent,
+};

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -54,6 +54,7 @@ describe('Chart />', () => {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
       backgroundColor: 'transparent',
+      integersOnly: false,
     },
     gridOptions: {
       showHorizontalLines: true,

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -51,6 +51,7 @@ export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
   backgroundColor: string;
+  integersOnly: boolean;
 }
 
 export interface Annotation {

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -86,6 +86,7 @@ export function Chart({
     drawableHeight: dimensions.height - Margin.Top,
     series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const xAxisDetails = useLinearXAxisDetails({
@@ -114,6 +115,7 @@ export function Chart({
     drawableHeight,
     series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const handleFocus = useCallback(

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -140,6 +140,7 @@ interface LineChartProps {
     labelFormatter?(value: number): string;
     labelColor: string;
     backgroundColor?: string;
+    integersOnly?: boolean;
   }
   gridOptions?: {
     showVerticalLines?: boolean;
@@ -365,6 +366,14 @@ The color used for axis labels.
 | `string` | `transparant` |
 
 The color used behind axis labels.
+
+##### integersOnly
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Only use whole numbers for y axis ticks.
 
 #### lineOptions
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -135,6 +135,7 @@ export function LineChart({
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
     backgroundColor: 'transparent',
+    integersOnly: false,
     ...yAxisOptions,
   };
 

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -12,14 +12,16 @@ export function useYScale({
   series,
   formatYAxisLabel,
   fontSize,
+  integersOnly,
 }: {
   fontSize: number;
   drawableHeight: number;
   series: Series[];
   formatYAxisLabel: NumberLabelFormatter;
+  integersOnly: boolean;
 }) {
   const {yScale, ticks, axisMargin} = useMemo(() => {
-    const [minY, maxY] = yAxisMinMax(series);
+    const [minY, maxY] = yAxisMinMax({series, integersOnly});
 
     const maxTicks = Math.max(
       1,
@@ -28,13 +30,17 @@ export function useYScale({
 
     const yScale = scaleLinear()
       .range([drawableHeight, 0])
-      .domain([Math.min(0, minY), Math.max(0, maxY)]);
+      .domain([minY, maxY]);
 
     if (shouldRoundScaleUp({yScale, maxValue: maxY, maxTicks})) {
       yScale.nice(maxTicks);
     }
 
-    const ticks = yScale.ticks(maxTicks).map((value) => ({
+    const filteredTicks = integersOnly
+      ? yScale.ticks(maxTicks).filter((tick) => Number.isInteger(tick))
+      : yScale.ticks(maxTicks);
+
+    const ticks = filteredTicks.map((value) => ({
       value,
       formattedValue: formatYAxisLabel(value),
       yOffset: yScale(value),
@@ -47,7 +53,7 @@ export function useYScale({
     );
 
     return {yScale, ticks, axisMargin};
-  }, [series, drawableHeight, formatYAxisLabel, fontSize]);
+  }, [series, integersOnly, drawableHeight, formatYAxisLabel, fontSize]);
 
   return {yScale, ticks, axisMargin};
 }

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -141,3 +141,27 @@ DarkMode.args = {
   yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: '#333333'},
   renderTooltipContent,
 };
+
+export const IntegersOnly = Template.bind({});
+IntegersOnly.args = {
+  series: [
+    {
+      name: 'Integers Only',
+      data: [
+        {rawValue: 0.1, label: '2020-04-01T12:00:00'},
+        {rawValue: 0.4, label: '2020-04-02T12:00:00'},
+        {rawValue: 0.6, label: '2020-04-03T12:00:00'},
+        {rawValue: 0.2, label: '2020-04-04T12:00:00'},
+        {rawValue: 0.5, label: '2020-04-05T12:00:00'},
+        {rawValue: 0.9, label: '2020-04-06T12:00:00'},
+        {rawValue: 0.5, label: '2020-04-07T12:00:00'},
+      ],
+    },
+  ],
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+  },
+  yAxisOptions: {integersOnly: true},
+  renderTooltipContent,
+};

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -58,6 +58,7 @@ const yAxisOptions = {
   labelFormatter: jest.fn((value) => value),
   labelColor: 'red',
   backgroundColor: 'transparent',
+  integersOnly: false,
 };
 
 const gridOptions = {
@@ -82,17 +83,6 @@ const mockProps = {
   isAnimated: false,
 };
 
-const mockEmptyStateProps = {
-  series: [],
-  dimensions: {width: 100, height: 100},
-  lineOptions,
-  xAxisOptions,
-  yAxisOptions,
-  gridOptions,
-  crossHairOptions,
-  renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
-  isAnimated: false,
-};
 jest.mock('../../../utilities', () => {
   return {
     ...jest.requireActual('../../../utilities'),
@@ -279,20 +269,20 @@ describe('<Chart />', () => {
 
   describe('empty state', () => {
     it('does not render tooltip for empty state', () => {
-      const chart = mount(<Chart {...mockEmptyStateProps} />);
+      const chart = mount(<Chart {...mockProps} series={[]} />);
 
       expect(chart).not.toContainReactText('Mock Tooltip');
       expect(chart).not.toContainReactComponent(TooltipContainer);
     });
 
     it('does not render crosshair for empty state', () => {
-      const chart = mount(<Chart {...mockEmptyStateProps} />);
+      const chart = mount(<Chart {...mockProps} series={[]} />);
 
       expect(chart).not.toContainReactComponent(Crosshair);
     });
 
     it('does not render Visually Hidden Rows for empty state', () => {
-      const chart = mount(<Chart {...mockEmptyStateProps} />);
+      const chart = mount(<Chart {...mockProps} series={[]} />);
 
       expect(chart).not.toContainReactComponent(VisuallyHiddenRows);
     });

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -50,6 +50,7 @@ export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
   backgroundColor: string;
+  integersOnly: boolean;
 }
 
 export interface GridOptions {

--- a/src/components/LineChart/utilities/y-axis-min-max.ts
+++ b/src/components/LineChart/utilities/y-axis-min-max.ts
@@ -5,7 +5,13 @@ import {
 } from '../../../constants';
 import {Series} from '../types';
 
-export function yAxisMinMax(series: Series[]) {
+export function yAxisMinMax({
+  series,
+  integersOnly,
+}: {
+  series: Series[];
+  integersOnly: boolean;
+}) {
   if (series.length === 0) {
     return [EMPTY_STATE_CHART_MIN, EMPTY_STATE_CHART_MAX];
   }
@@ -21,5 +27,10 @@ export function yAxisMinMax(series: Series[]) {
   });
 
   maxY = maxY === 0 && minY === 0 ? DEFAULT_MAX_Y : maxY;
+
+  if (integersOnly) {
+    return [Math.floor(minY), Math.ceil(maxY)];
+  }
+
   return [minY, maxY];
 }

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -70,6 +70,7 @@ export function Chart({
     data: series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
     stackedValues,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const yAxisLabelWidth = useMemo(
@@ -148,6 +149,7 @@ export function Chart({
     data: series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
     stackedValues,
+    integersOnly: yAxisOptions.integersOnly,
   });
 
   const barColors = series.map(({color}) => color);

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -138,6 +138,7 @@ interface MultiSeriesBarChartProps {
   yAxisOptions: {
     labelFormatter?(value: number): string;
     backgroundColor?: string;
+    integersOnly?: boolean;
   };
 }
 ```
@@ -313,6 +314,14 @@ The color used for axis labels.
 | `string` | `transparant` |
 
 The color used behind axis labels.
+
+##### integersOnly
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Only use whole numbers for y axis ticks.
 
 #### barOptions
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -145,6 +145,7 @@ export function MultiSeriesBarChart({
     labelFormatter: (value: number) => value.toString(),
     labelColor: DEFAULT_GREY_LABEL,
     backgroundColor: 'transparent',
+    integersOnly: false,
     ...yAxisOptions,
   };
 

--- a/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
@@ -12,14 +12,16 @@ export function useYScale({
   data,
   formatYAxisLabel,
   stackedValues,
+  integersOnly,
 }: {
   drawableHeight: number;
   data: Series[];
   formatYAxisLabel: NumberLabelFormatter;
   stackedValues: StackSeries[] | null;
+  integersOnly: boolean;
 }) {
   const {yScale, ticks} = useMemo(() => {
-    const {min, max} = getMinMax(stackedValues, data);
+    const {min, max} = getMinMax({stackedValues, data, integersOnly});
 
     const maxTicks = Math.max(
       1,
@@ -34,14 +36,18 @@ export function useYScale({
       yScale.nice(maxTicks);
     }
 
-    const ticks = yScale.ticks(maxTicks).map((value) => ({
+    const filteredTicks = integersOnly
+      ? yScale.ticks(maxTicks).filter((tick) => Number.isInteger(tick))
+      : yScale.ticks(maxTicks);
+
+    const ticks = filteredTicks.map((value) => ({
       value,
       formattedValue: formatYAxisLabel(value),
       yOffset: yScale(value),
     }));
 
     return {yScale, ticks};
-  }, [data, drawableHeight, formatYAxisLabel, stackedValues]);
+  }, [data, drawableHeight, formatYAxisLabel, integersOnly, stackedValues]);
 
   return {yScale, ticks};
 }

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -174,3 +174,50 @@ StackedGradient.args = {
     isStacked: true,
   },
 };
+
+export const IntegersOnly = Template.bind({});
+IntegersOnly.args = {
+  series: [
+    {
+      name: 'Breakfast',
+      color: 'primary',
+      data: [
+        {label: 'Monday', rawValue: 0.3},
+        {label: 'Tuesday', rawValue: 0.1},
+        {label: 'Wednesday', rawValue: 0.78},
+        {label: 'Thursday', rawValue: 0.12},
+        {label: 'Friday', rawValue: 0.7},
+        {label: 'Saturday', rawValue: 0.3},
+        {label: 'Sunday', rawValue: 0.6},
+      ],
+    },
+    {
+      name: 'Lunch',
+      color: 'secondary',
+      data: [
+        {label: 'Monday', rawValue: 0},
+        {label: 'Tuesday', rawValue: 0.1},
+        {label: 'Wednesday', rawValue: 0.12},
+        {label: 'Thursday', rawValue: 0.34},
+        {label: 'Friday', rawValue: 0.54},
+        {label: 'Saturday', rawValue: 0.21},
+        {label: 'Sunday', rawValue: 0.1},
+      ],
+    },
+    {
+      name: 'Dinner',
+      color: 'tertiary',
+      data: [
+        {label: 'Monday', rawValue: 1.23},
+        {label: 'Tuesday', rawValue: 1.42},
+        {label: 'Wednesday', rawValue: 2},
+        {label: 'Thursday', rawValue: 1.2},
+        {label: 'Friday', rawValue: 0.5},
+        {label: 'Saturday', rawValue: 0.12},
+        {label: 'Sunday', rawValue: 0.6},
+      ],
+    },
+  ],
+  xAxisOptions: {labels},
+  yAxisOptions: {integersOnly: true},
+};

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -77,6 +77,7 @@ describe('Chart />', () => {
       labelFormatter: (value: number) => value.toString(),
       labelColor: 'red',
       backgroundColor: 'transparent',
+      integersOnly: false,
     },
     gridOptions: {
       showHorizontalLines: true,

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -66,4 +66,5 @@ export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
   labelColor: string;
   backgroundColor: string;
+  integersOnly: boolean;
 }

--- a/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-min-max.ts
@@ -1,7 +1,15 @@
 import {DEFAULT_MAX_Y} from '../../../constants';
 import {Series, StackSeries} from '../types';
 
-export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
+export function getMinMax({
+  stackedValues,
+  data,
+  integersOnly,
+}: {
+  stackedValues: StackSeries[] | null;
+  data: Series[];
+  integersOnly: boolean;
+}) {
   if (stackedValues != null) {
     const minStackedValues = stackedValues.map((value) =>
       Math.min(...value.map(([startingValue]) => startingValue)),
@@ -18,8 +26,8 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
         : Math.max(0, calculatedMax);
 
     return {
-      min,
-      max,
+      min: integersOnly ? Math.floor(min) : min,
+      max: integersOnly ? Math.ceil(max) : max,
     };
   } else {
     const groupedDataPoints = data.reduce<number[]>(
@@ -38,8 +46,8 @@ export function getMinMax(stackedValues: StackSeries[] | null, data: Series[]) {
         : Math.max(0, calculatedMax);
 
     return {
-      min,
-      max,
+      min: integersOnly ? Math.floor(min) : min,
+      max: integersOnly ? Math.ceil(max) : max,
     };
   }
 }

--- a/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
+++ b/src/components/MultiSeriesBarChart/utilities/tests/get-min-max.test.tsx
@@ -115,38 +115,89 @@ const mockNegativeSeries: Series[] = [
   },
 ];
 
+const mockProps = {
+  stackedValues: mockStackedData,
+  data: mockData,
+  integersOnly: false,
+};
+
 describe('get-min-max', () => {
   it('returns min and max of non stacked data when stackedValues is null', () => {
-    const {min, max} = getMinMax(null, mockData);
+    const {min, max} = getMinMax({...mockProps, stackedValues: null});
 
     expect(min).toStrictEqual(0);
     expect(max).toStrictEqual(30);
   });
 
   it('returns min and max of stacked values when stackedValues is not null', () => {
-    const {min, max} = getMinMax(mockStackedData, mockData);
+    const {min, max} = getMinMax(mockProps);
 
     expect(min).toStrictEqual(0);
     expect(max).toStrictEqual(33);
   });
 
   it('returns the default max y value for non stacked values of all zeros', () => {
-    const {max} = getMinMax(null, mockZeroData);
+    const {max} = getMinMax({
+      ...mockProps,
+      stackedValues: null,
+      data: mockZeroData,
+    });
     expect(max).toStrictEqual(DEFAULT_MAX_Y);
   });
 
   it('returns the default max y value for stacked values of all zeros', () => {
-    const {max} = getMinMax(mockZeroStackedData, mockZeroData);
+    const {max} = getMinMax({
+      ...mockProps,
+      stackedValues: mockZeroStackedData,
+      data: mockZeroData,
+    });
     expect(max).toStrictEqual(DEFAULT_MAX_Y);
   });
 
   it('returns 0 as the max when all stacked values are negative', () => {
-    const {max} = getMinMax(mockNegativeStackedData, mockNegativeSeries);
+    const {max} = getMinMax({
+      ...mockProps,
+      stackedValues: mockNegativeStackedData,
+      data: mockNegativeSeries,
+    });
     expect(max).toStrictEqual(0);
   });
 
   it('returns 0 as the max when all non-stacked values are negative', () => {
-    const {max} = getMinMax(null, mockNegativeSeries);
+    const {max} = getMinMax({
+      ...mockProps,
+      stackedValues: null,
+      data: mockNegativeSeries,
+    });
     expect(max).toStrictEqual(0);
+  });
+
+  describe('integersOnly', () => {
+    it('returns a rounded down min and rounded up max if true', () => {
+      const minMax = getMinMax({
+        stackedValues: null,
+        data: [
+          {
+            data: [
+              {label: 'label', rawValue: 0.2},
+              {label: 'label', rawValue: 0.8},
+            ],
+            color: 'colorBlack',
+            name: 'LABEL1',
+          },
+          {
+            data: [
+              {label: 'label', rawValue: 0.3},
+              {label: 'label', rawValue: 0.9},
+            ],
+            color: 'colorBlack',
+            name: 'LABEL2',
+          },
+        ],
+        integersOnly: true,
+      });
+
+      expect(minMax).toStrictEqual({min: 0, max: 1});
+    });
   });
 });


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

Continuing off the work done in #188 

Resolves https://github.com/Shopify/core-issues/issues/24890

* Adds a new prop `integersOnly` (open to other names) to `yAxisOptions` in `LineChart`, `BarChart`, and `MultiSeriesBarChart`
* Not yet added for `StackedAreaChart`, that will be added in https://github.com/Shopify/polaris-viz/issues/314

Ticks with decimals only appear for certain datasets, i.e. small ranges from 0 to 1 or 2. Setting `integersOnly` to true should round the domain to the nearest whole numbers and filter out ticks that aren't integers.

I considered making the `shouldRoundScaleUp` util aware of `integersOnly`, but I realized [nice](https://github.com/d3/d3-scale/blob/master/src/nice.js) is also rounding the domain to the nearest integers, so it doesn't really affect it.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

* Check out the new `Integers Only` stories for Line, Bar, and MultiSeriesBar charts
* Confirm there are no ticks with decimals
  ![image](https://user-images.githubusercontent.com/30587540/118295991-7d9fd980-b4aa-11eb-9dd4-866bb9dedbf4.png)
* Set `yAxisOptions.integersOnly` to false for those stories
* Confirm there are ticks with decimals
  ![image](https://user-images.githubusercontent.com/30587540/118296079-8ee8e600-b4aa-11eb-8d61-932aa5a403a7.png)
 

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
