### PR TITLE
Check for window.matchMedia before calling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.13.1] - 2021-05-13
+
+### Fixed
+
+- Check for `window.matchMedia` before calling it.
+
 ## [0.13.0] - 2021-05-13
 
 ### Addded

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -5,7 +5,13 @@ import {colorSky} from '@shopify/polaris-tokens';
 import {Dimensions} from '../../types';
 import {DEFAULT_GREY_LABEL} from '../../constants';
 import {SkipLink} from '../SkipLink';
-import {getDefaultColor, uniqueId, normalizeData} from '../../utilities';
+import {
+  getDefaultColor,
+  uniqueId,
+  normalizeData,
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from '../../utilities';
 import {useResizeObserver} from '../../hooks';
 
 import {TooltipContent} from './components';
@@ -93,17 +99,13 @@ export function BarChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-      window
-        .matchMedia('print')
-        .addEventListener('change', handlePrintMediaQueryChange);
+      addPrintMediaChangeEventListener(handlePrintMediaQueryChange);
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-        window
-          .matchMedia('print')
-          .removeEventListener('change', handlePrintMediaQueryChange);
+        removePrintMediaChangeEventListener(handlePrintMediaQueryChange);
       }
     };
   }, [

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -3,7 +3,12 @@ import {useDebouncedCallback} from 'use-debounce';
 import {colorSky} from '@shopify/polaris-tokens';
 
 import {Dimensions} from '../../types';
-import {getDefaultColor, uniqueId} from '../../utilities';
+import {
+  getDefaultColor,
+  uniqueId,
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from '../../utilities';
 import {SkipLink} from '../SkipLink';
 import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
 import {
@@ -95,17 +100,13 @@ export function LineChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-      window
-        .matchMedia('print')
-        .addEventListener('change', handlePrintMediaQueryChange);
+      addPrintMediaChangeEventListener(handlePrintMediaQueryChange);
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-        window
-          .matchMedia('print')
-          .removeEventListener('change', handlePrintMediaQueryChange);
+        removePrintMediaChangeEventListener(handlePrintMediaQueryChange);
       }
     };
   }, [

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -6,7 +6,12 @@ import {Dimensions} from '../../types';
 import {DEFAULT_GREY_LABEL} from '../../constants';
 import {SkipLink} from '../SkipLink';
 import {TooltipContent} from '../TooltipContent';
-import {getDefaultColor, uniqueId} from '../../utilities';
+import {
+  getDefaultColor,
+  uniqueId,
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from '../../utilities';
 import {useResizeObserver} from '../../hooks';
 
 import {Chart} from './Chart';
@@ -88,17 +93,13 @@ export function MultiSeriesBarChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-      window
-        .matchMedia('print')
-        .addEventListener('change', handlePrintMediaQueryChange);
+      addPrintMediaChangeEventListener(handlePrintMediaQueryChange);
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-        window
-          .matchMedia('print')
-          .removeEventListener('change', handlePrintMediaQueryChange);
+        removePrintMediaChangeEventListener(handlePrintMediaQueryChange);
       }
     };
   }, [

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -4,6 +4,10 @@ import {scaleLinear} from 'd3-scale';
 import {Color, SparkChartData} from 'types';
 
 import {useResizeObserver} from '../../hooks';
+import {
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from '../../utilities';
 
 import styles from './Sparkline.scss';
 import {Series} from './components';
@@ -80,17 +84,13 @@ export function Sparkline({
 
     if (!isServer) {
       window.addEventListener('resize', () => updateMeasurements());
-      window
-        .matchMedia('print')
-        .addEventListener('change', handlePrintMediaQueryChange);
+      addPrintMediaChangeEventListener(handlePrintMediaQueryChange);
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', () => updateMeasurements());
-        window
-          .matchMedia('print')
-          .removeEventListener('change', handlePrintMediaQueryChange);
+        removePrintMediaChangeEventListener(handlePrintMediaQueryChange);
       }
     };
   }, [entry, containerRef, updateMeasurements, handlePrintMediaQueryChange]);

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -8,7 +8,12 @@ import {
   Dimensions,
 } from '../../types';
 import {TooltipContent} from '../TooltipContent';
-import {getDefaultColor, uniqueId} from '../../utilities';
+import {
+  getDefaultColor,
+  uniqueId,
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from '../../utilities';
 import {useResizeObserver} from '../../hooks';
 
 import {Chart} from './Chart';
@@ -79,17 +84,13 @@ export function StackedAreaChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-      window
-        .matchMedia('print')
-        .addEventListener('change', handlePrintMediaQueryChange);
+      addPrintMediaChangeEventListener(handlePrintMediaQueryChange);
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-        window
-          .matchMedia('print')
-          .removeEventListener('change', handlePrintMediaQueryChange);
+        removePrintMediaChangeEventListener(handlePrintMediaQueryChange);
       }
     };
   }, [

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,8 +1,8 @@
 export function usePrefersReducedMotion() {
   const prefersReducedMotion =
-    typeof window === 'undefined'
-      ? false
-      : window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false;
 
   return {prefersReducedMotion};
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -21,3 +21,7 @@ export {normalizeData} from './normalize-data';
 export {createCSSGradient} from './create-css-gradient';
 export {shouldRoundScaleUp} from './should-round-scale-up';
 export {curveStepRounded} from './curve-step-rounded';
+export {
+  addPrintMediaChangeEventListener,
+  removePrintMediaChangeEventListener,
+} from './print-media';

--- a/src/utilities/print-media.ts
+++ b/src/utilities/print-media.ts
@@ -1,0 +1,23 @@
+export type ChangeEventListener = (event: MediaQueryListEvent) => void;
+
+export function addPrintMediaChangeEventListener(
+  callback: ChangeEventListener,
+): void {
+  if (window.matchMedia) {
+    const match = window.matchMedia('print');
+    if (match) {
+      match.addEventListener('change', callback);
+    }
+  }
+}
+
+export function removePrintMediaChangeEventListener(
+  callback: ChangeEventListener,
+): void {
+  if (window.matchMedia) {
+    const match = window.matchMedia('print');
+    if (match) {
+      match.removeEventListener('change', callback);
+    }
+  }
+}

--- a/tests/each-test.ts
+++ b/tests/each-test.ts
@@ -1,20 +1,6 @@
 import {destroyAll} from '@shopify/react-testing';
 import '@shopify/react-testing/matchers';
 
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
-
 Object.defineProperty(window, 'ResizeObserver', {
   value: jest.fn(() => ({
     observe: jest.fn(),


### PR DESCRIPTION
I initially thought that `web` didn't provide a `window.matchMedia` implementation but the reality was much more confusing. We [do provide an implementation](https://github.com/Shopify/web/blob/fe5cfc22ac172272d89d80e8b6f4941ce7f01357/tests/setup.ts#L57-L59) but it's missing `addEventListener`/`removeEventListener` which is part of the [spec](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList) for a long time.

I don't think it's worth being "defensive" around our usable of `matchMedia` at this time, since we only support browser targets that implement `matchMedia` and it should be the consuming app's responsibility to provide a test environment that mostly matches the browser.