### PR TITLE
Fix missing border radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixes border radius not being applied to animated bars
+
 ## [0.13.0] - 2021-05-13
 
 ### Addded

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -35,14 +35,16 @@ export function Bar({
   height,
   hasRoundedCorners,
 }: Props) {
-  const radius =
-    hasRoundedCorners && height >= ROUNDED_BAR_RADIUS ? ROUNDED_BAR_RADIUS : 0;
   const zeroScale = yScale(0);
   const isNegative = rawValue < 0;
   const rotation = isNegative ? 'rotate(180deg)' : 'rotate(0deg)';
   const xPosition = isNegative ? x + width : x;
 
   const heightIsNumber = typeof height === 'number';
+  const heightAmount = heightIsNumber ? height : height.value;
+  const shouldRoundCorners =
+    hasRoundedCorners && heightAmount >= ROUNDED_BAR_RADIUS;
+  const radius = shouldRoundCorners ? ROUNDED_BAR_RADIUS : 0;
 
   const yPosition = useMemo(() => {
     if (height == null) return;


### PR DESCRIPTION
### What problem is this PR solving?

I noticed that our min-height changes on the bar chart mean that we're missing border radius when animation is applied. This fixes that by looking at the value for the height.

| Before  | After  |  
|---|---|
| <img width="556" alt="Screen Shot 2021-05-13 at 9 15 08 PM" src="https://user-images.githubusercontent.com/12213371/118206380-61f7ed00-b430-11eb-96ce-b10867be00ee.png">  | <img width="573" alt="Screen Shot 2021-05-13 at 9 14 52 PM" src="https://user-images.githubusercontent.com/12213371/118206381-62908380-b430-11eb-93ad-20ae8a2d55bf.png">| 

### Reviewers’ :tophat: instructions
Check the border radius is applied when the bar chart is animated (the default story should do the trick) 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
