### PR TITLE
Allow point stroke configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fixes border radius not being applied to animated bars
 
+### Added
+
+- `<LineChart/>` `lineOptions` now include `pointStroke` which changes the stroke of the active point
+
 ## [0.13.0] - 2021-05-13
 
 ### Addded

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -398,6 +398,17 @@ export function Chart({
 
             return (
               <React.Fragment key={`${name}-${index}`}>
+                {areaColor != null ? (
+                  <GradientArea
+                    series={singleSeries}
+                    yScale={yScale}
+                    xScale={xScale}
+                    isAnimated={isAnimated}
+                    index={index}
+                    hasSpline={lineOptions.hasSpline}
+                  />
+                ) : null}
+
                 {isGradientType(color) ? (
                   <defs>
                     <LinearGradient
@@ -420,6 +431,7 @@ export function Chart({
                 {animatePoints ? (
                   <Point
                     color={lineColor}
+                    stroke={lineOptions.pointStroke}
                     cx={getXPosition()}
                     cy={animatedYPostion}
                     active={tooltipDetails != null}
@@ -435,6 +447,7 @@ export function Chart({
                   return (
                     <Point
                       key={`${name}-${index}-${dataIndex}`}
+                      stroke={lineOptions.pointStroke}
                       color={lineColor}
                       cx={xScale(dataIndex)}
                       cy={yScale(rawValue)}
@@ -449,17 +462,6 @@ export function Chart({
                     />
                   );
                 })}
-
-                {areaColor != null ? (
-                  <GradientArea
-                    series={singleSeries}
-                    yScale={yScale}
-                    xScale={xScale}
-                    isAnimated={isAnimated}
-                    index={index}
-                    hasSpline={lineOptions.hasSpline}
-                  />
-                ) : null}
               </React.Fragment>
             );
           })}

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -126,6 +126,7 @@ interface LineChartProps {
   lineOptions?: {
     hasSpline?: boolean;
     width?: number;
+    pointStroke?: string;
   };
   xAxisOptions: {
     xAxisLabels: string[];
@@ -384,6 +385,14 @@ Whether to curve the lines between points.
 | `number` | `2`     |
 
 The width of the lines drawn between points.
+
+##### pointStroke
+
+| type     | default |
+| -------- | ------- |
+| `string` | `#fff`  |
+
+The color around the circle depicting the active point.
 
 #### gridOptions
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,6 +1,6 @@
 import React, {useLayoutEffect, useRef, useState, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
-import {colorSky} from '@shopify/polaris-tokens';
+import {colorSky, colorWhite} from '@shopify/polaris-tokens';
 
 import {Dimensions} from '../../types';
 import {getDefaultColor, uniqueId} from '../../utilities';
@@ -115,7 +115,12 @@ export function LineChart({
     handlePrintMediaQueryChange,
   ]);
 
-  const lineOptionsWithDefaults = {hasSpline: false, width: 2, ...lineOptions};
+  const lineOptionsWithDefaults = {
+    hasSpline: false,
+    width: 2,
+    pointStroke: colorWhite,
+    ...lineOptions,
+  };
 
   const xAxisOptionsWithDefaults = {
     labelFormatter: (value: string) => value,

--- a/src/components/LineChart/stories/LineChart.stories.scss
+++ b/src/components/LineChart/stories/LineChart.stories.scss
@@ -3,7 +3,6 @@ body {
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 .Container {
-  background: white;
   padding: 20px;
   box-sizing: border-box;
   height: 400px;

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -109,3 +109,35 @@ curvedLines.args = {
   lineOptions: {hasSpline: true},
   renderTooltipContent,
 };
+
+export const DarkMode = Template.bind({});
+DarkMode.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+DarkMode.args = {
+  series,
+  isAnimated: true,
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+    useMinimalLabels: true,
+    showTicks: false,
+  },
+  lineOptions: {
+    hasSpline: true,
+    pointStroke: '#333333',
+  },
+  gridOptions: {
+    showVerticalLines: false,
+    color: 'rgb(99, 115, 129)',
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+  },
+  crossHairOptions: {
+    width: 1,
+  },
+  yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: '#333333'},
+  renderTooltipContent,
+};

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -52,7 +52,7 @@ const xAxisOptions = {
   useMinimalLabels: false,
 };
 
-const lineOptions = {hasSpline: false, width: 2};
+const lineOptions = {hasSpline: false, width: 2, pointStroke: '#fff'};
 
 const yAxisOptions = {
   labelFormatter: jest.fn((value) => value),
@@ -211,7 +211,7 @@ describe('<Chart />', () => {
     mount(
       <Chart
         {...mockProps}
-        lineOptions={{hasSpline: true, width: 2}}
+        lineOptions={{...mockProps.lineOptions, hasSpline: true}}
         series={[primarySeries, {...primarySeries, name: 'A second series'}]}
       />,
     );

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -34,6 +34,7 @@ export interface RenderTooltipContentData {
 export interface LineOptions {
   hasSpline: boolean;
   width: number;
+  pointStroke: string;
 }
 
 export interface XAxisOptions {

--- a/src/components/Point/Point.tsx
+++ b/src/components/Point/Point.tsx
@@ -18,6 +18,7 @@ interface Props {
   ariaLabelledby?: string;
   ariaHidden?: boolean;
   visuallyHidden?: boolean;
+  stroke: string;
 }
 
 export const Point = React.memo(function Point({
@@ -32,6 +33,7 @@ export const Point = React.memo(function Point({
   isAnimated,
   ariaHidden = false,
   visuallyHidden = false,
+  stroke,
 }: Props) {
   const handleFocus = () => {
     if (onFocus != null) {
@@ -57,8 +59,8 @@ export const Point = React.memo(function Point({
       cy={cy}
       r={radius}
       fill={color}
-      stroke={tokens.colorWhite}
-      strokeWidth={1.5}
+      stroke={stroke}
+      strokeWidth={2}
       onFocus={handleFocus}
       className={classNames(
         styles.Point,

--- a/src/components/Point/tests/Point.test.tsx
+++ b/src/components/Point/tests/Point.test.tsx
@@ -10,6 +10,7 @@ const mockProps = {
   color: '#00ff00',
   index: 0,
   isAnimated: false,
+  stroke: 'white',
 };
 
 describe('<Point />', () => {
@@ -140,6 +141,20 @@ describe('<Point />', () => {
 
       expect(point).toContainReactComponent('circle', {
         fill: '#00ff00',
+      });
+    });
+  });
+
+  describe('stroke', () => {
+    it('renders a circle with the given color', () => {
+      const point = mount(
+        <svg>
+          <Point {...mockProps} />
+        </svg>,
+      );
+
+      expect(point).toContainReactComponent('circle', {
+        stroke: 'white',
       });
     });
   });

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useRef} from 'react';
 import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
-import {colorSky} from '@shopify/polaris-tokens';
+import {colorSky, colorWhite} from '@shopify/polaris-tokens';
 
 import {
   useLinearXAxisDetails,
@@ -247,6 +247,7 @@ export function Chart({
           {stackedValues.map((value, stackIndex) =>
             value.map(([, startingDataPoint], index) => (
               <Point
+                stroke={colorWhite}
                 key={index}
                 color={getColorValue(colors[stackIndex])}
                 cx={xScale(index)}


### PR DESCRIPTION
### What problem is this PR solving?
Polaris Viz part of https://github.com/Shopify/core-issues/issues/24883

Does the following:
- Allows the consumer to control the color of the Point's stroke
- Increases the stroke to 2px, as we have in our designs (this is a small enough change that I don't think it needs to be configurable at the moment)
- Moves the area color behind the lines and points, so that it layers behind rather than on top of them
- Adds a story for the changes

<img width="1598" alt="Screen Shot 2021-05-14 at 9 13 16 AM" src="https://user-images.githubusercontent.com/12213371/118275707-c64c9800-b494-11eb-96e9-97991366f4ee.png">


### Reviewers’ :tophat: instructions
Take a look at the line chart "Dark Mode" story
You will need to toggle on dark mode here (maybe there's a way to automatically do this for a story, but I couldn't figure it out!):
<img width="223" alt="Screen Shot 2021-05-14 at 9 14 00 AM" src="https://user-images.githubusercontent.com/12213371/118275762-d82e3b00-b494-11eb-931f-6f5738e37901.png">


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
