### PR TITLE
Annotation line color tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `<LineChart/>` `lineOptions` now include `pointStroke` which changes the stroke of the active point
 
+### Changed
+
+- The `<BarChart/>` annotation prop now accepts a string as a color and does not apply opacity by default
+
 ## [0.13.0] - 2021-05-13
 
 ### Addded

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -118,7 +118,7 @@ interface BarChartProps {
   annotations?: {
     dataIndex: number;
     width: number;
-    color: string;
+    color: Color | string;
     ariaLabel?: string;
     xOffset?: number;
     tooltipData?: {
@@ -334,9 +334,9 @@ The color used behind axis labels.
 
 #### annotations
 
-| type                                                  |
-| ----------------------------------------------------- |
-| `{dataIndex: number, width: number, color: string}[]` |
+| type                                                           |
+| -------------------------------------------------------------- |
+| `{dataIndex: number, width: number, color: Color \| string}[]` |
 
 An optional array of objects that the chart uses to draw annotations on the bars.
 
@@ -344,7 +344,7 @@ An optional array of objects that the chart uses to draw annotations on the bars
 
 - `width` is used to determine the annotation line `strokeWidth`.
 
-- `color` can be [any valid CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color) such as a named color, hex, rgb, or rgba value.
+- `color` can be a Color token or [any valid CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color) such as a named color, hex, rgb, or rgba value.
 
 ##### Optional annotation props
 

--- a/src/components/BarChart/components/AnnotationLine/AnnotationLine.scss
+++ b/src/components/BarChart/components/AnnotationLine/AnnotationLine.scss
@@ -1,25 +1,14 @@
-@import 'node_modules/@shopify/polaris-tokens/dist/index';
-
-.Line {
-  stroke-opacity: 0.5;
-  &:focus {
-    outline: none;
-    stroke-opacity: 0.75;
-  }
-}
+$animation-duration: 500ms;
 
 .AnimatedLine {
-  animation: fadeIn ease $duration-slow;
-  transition: stroke-opacity ease $duration-fast;
+  animation: fadeIn $animation-duration ease-in;
 }
 
 @keyframes fadeIn {
   0% {
-    opacity: 0;
     stroke-opacity: 0;
   }
   100% {
-    opacity: 0.75;
-    stroke-opacity: 0.5;
+    stroke-opacity: 1;
   }
 }

--- a/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
+++ b/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {classNames} from '@shopify/css-utilities';
 
-import {clamp, getColorValue} from '../../../../utilities';
+import {clamp, getColorValue, isValidColorToken} from '../../../../utilities';
 import {Annotation} from '../../types';
 
 import styles from './AnnotationLine.scss';
@@ -32,10 +31,12 @@ export function AnnotationLine({
     max: xPosition + barWidth - halfAnnotationWidth,
   });
 
+  const lookedUpColor = isValidColorToken(color) ? getColorValue(color) : color;
+
   return (
     <line
-      className={classNames(styles.Line, shouldAnimate && styles.AnimatedLine)}
-      stroke={getColorValue(color)}
+      className={shouldAnimate && styles.AnimatedLine}
+      stroke={lookedUpColor}
       strokeWidth={annotationWidth}
       x1={xValueClamped}
       x2={xValueClamped}

--- a/src/components/BarChart/components/AnnotationLine/tests/AnnotationLine.test.tsx
+++ b/src/components/BarChart/components/AnnotationLine/tests/AnnotationLine.test.tsx
@@ -129,7 +129,33 @@ describe('<AnnotationLine />', () => {
       );
 
       expect(content).toContainReactComponent('line', {
-        className: 'Line AnimatedLine',
+        className: 'AnimatedLine',
+      });
+    });
+  });
+
+  describe('color', () => {
+    it('renders a line with a color string', () => {
+      const content = mount(
+        <svg>
+          <AnnotationLine {...mockProps} color="white" />
+        </svg>,
+      );
+
+      expect(content).toContainReactComponent('line', {
+        stroke: 'white',
+      });
+    });
+
+    it('renders a line with a color token', () => {
+      const content = mount(
+        <svg>
+          <AnnotationLine {...mockProps} color="colorRed" />
+        </svg>,
+      );
+
+      expect(content).toContainReactComponent('line', {
+        stroke: 'rgb(222, 54, 24)',
       });
     });
   });

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -149,6 +149,50 @@ Annotations.args = {
   isAnimated: false,
 };
 
+export const MedianWithColorString = Template.bind({});
+MedianWithColorString.args = {
+  data: [
+    {rawValue: 10, label: '0'},
+    {rawValue: 45, label: '1'},
+    {rawValue: 16, label: '2'},
+    {rawValue: 9, label: '3'},
+    {rawValue: 32, label: '4'},
+    {rawValue: 85, label: '5'},
+    {rawValue: 74, label: '6'},
+    {rawValue: 100, label: '7'},
+    {rawValue: 58, label: '8'},
+    {rawValue: 40, label: '9'},
+    {rawValue: 58, label: '10'},
+    {rawValue: 64, label: '11'},
+    {rawValue: 9, label: '12'},
+    {rawValue: 26, label: '13'},
+    {rawValue: 34, label: '14'},
+    {rawValue: 50, label: '15'},
+    {rawValue: 56, label: '16'},
+    {rawValue: 85, label: '17'},
+    {rawValue: 2, label: '18'},
+    {rawValue: 52, label: '19'},
+  ],
+  annotations: [
+    {
+      dataIndex: 1,
+      xOffset: 0.5,
+      width: 5,
+      color: '#d3d3d3',
+      ariaLabel: 'Median: 1.5',
+      tooltipData: {
+        label: 'Median',
+        value: '1.5 hours',
+      },
+    },
+  ],
+  barOptions: {color: primaryColor, highlightColor: secondaryColor},
+  xAxisOptions: {labelFormatter: formatLabelNoop},
+  yAxisOptions: {labelFormatter: formatLabelNoop},
+  renderTooltipContent: renderTooltipContentWithAnnotation,
+  isAnimated: false,
+};
+
 export const LastBarTreatment = Template.bind({});
 LastBarTreatment.args = {
   data: [

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -56,7 +56,7 @@ export interface YAxisOptions {
 export interface Annotation {
   dataIndex: number;
   width: number;
-  color: Color;
+  color: Color | string;
   tooltipData?: {
     label: string;
     value: string;

--- a/src/utilities/get-color-value.ts
+++ b/src/utilities/get-color-value.ts
@@ -15,7 +15,7 @@ function isVizType(color: Color): color is VizPaletteColor {
   return Object.keys(vizColors).includes(color);
 }
 
-export function isValidColorToken(color: Color) {
+export function isValidColorToken(color: any): color is Color {
   if (isVizType(color) || isTokenType(color)) {
     return true;
   } else {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,7 @@
 export {eventPoint} from './event-point';
 export {getTextWidth} from './get-text-width';
 export {clamp} from './clamp';
-export {getColorValue} from './get-color-value';
+export {getColorValue, isValidColorToken} from './get-color-value';
 export {isGradientType} from './is-gradient-type';
 export {vizColors} from './viz-colors';
 export {colorOptions, primaryColor, secondaryColor} from './color-options';


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/25032

- The focus CSS is removed as it was not being used
- Remove reductions in the opacity except for the animation
- Allow a color string to be used as well as a a color token

### Reviewers’ :tophat: instructions
Have a look at the new story I added for the annotation line with a color string, as well as the one with a token string

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
