### PR TITLE
[BarChart and MultiSeriesBarChart] Increase min bar height and radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- Increased the minimum bar height for 0 values to 2px from 1px in `<BarChart />` and `<MultiSeriesBarChart />`
+- Increased the border radius of rounded bars to 4px from 3px in `<BarChart />` and `<MultiSeriesBarChart />`
+
+### Fixed
+
+- 0 values not showing a min height bar in grouped `<MultiSeriesBarChart />`
+
 ## [0.13.2] - 2021-05-17
 
 ### Changed

--- a/src/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Bar/tests/Bar.test.tsx
@@ -20,6 +20,7 @@ const defaultProps = {
   index: 1,
   onFocus: jest.fn(),
   tabIndex: 0,
+  allValuesNegative: false,
 };
 
 describe('<Bar/>', () => {
@@ -35,14 +36,15 @@ describe('<Bar/>', () => {
         // eslint-disable-next-line id-length
         d: `M0 0
         h100
-        a0 0 0 010 0
+        a0 0 0 0 1 0 0
         v1000
         H0
         V0
-        a0 0 0 010-0
+        a0 0 0 0 1 0 -0
         Z`,
       });
     });
+
     it('rounds the corners if true', () => {
       const bar = mount(
         <svg>
@@ -52,17 +54,18 @@ describe('<Bar/>', () => {
 
       expect(bar).toContainReactComponent('path', {
         // eslint-disable-next-line id-length
-        d: `M3 0
-        h94
-        a3 3 0 013 3
-        v997
+        d: `M4 0
+        h92
+        a4 4 0 0 1 4 4
+        v996
         H0
-        V3
-        a3 3 0 013-3
+        V4
+        a4 4 0 0 1 4 -4
         Z`,
       });
     });
-    it('renders sharp corners if true and height is less than the radius', () => {
+
+    it('rounds the corner if true and height is less than the radius', () => {
       const bar = mount(
         <svg>
           <Bar
@@ -75,13 +78,13 @@ describe('<Bar/>', () => {
 
       expect(bar).toContainReactComponent('path', {
         // eslint-disable-next-line id-length
-        d: `M0 0
-        h100
-        a0 0 0 010 0
-        v${ROUNDED_BAR_RADIUS - 1}
+        d: `M4 0
+        h92
+        a4 4 0 0 1 4 3
+        v0
         H0
-        V0
-        a0 0 0 010-0
+        V3
+        a4 4 0 0 1 4 -3
         Z`,
       });
     });

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -168,6 +168,11 @@ export function Chart({
 
   const barWidth = useMemo(() => xScale.bandwidth(), [xScale]);
 
+  const allValuesNegative = useMemo(
+    () => data.every(({rawValue}) => rawValue <= 0),
+    [data],
+  );
+
   const tooltipMarkup = useMemo(() => {
     if (activeBar == null) {
       return null;
@@ -272,6 +277,7 @@ export function Chart({
                       tabIndex={0}
                       role="img"
                       hasRoundedCorners={barOptions.hasRoundedCorners}
+                      allValuesNegative={allValuesNegative}
                     />
                   </g>
                 );

--- a/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
+++ b/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {classNames} from '@shopify/css-utilities';
 
 import {clamp, getColorValue, isValidColorToken} from '../../../../utilities';
 import {Annotation} from '../../types';
@@ -35,7 +36,7 @@ export function AnnotationLine({
 
   return (
     <line
-      className={shouldAnimate && styles.AnimatedLine}
+      className={classNames(shouldAnimate && styles.AnimatedLine)}
       stroke={lookedUpColor}
       strokeWidth={annotationWidth}
       x1={xValueClamped}

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -63,7 +63,7 @@ Default.args = {
     {rawValue: 1324.19, label: '2020-01-01T12:00:00Z'},
     {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
     {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
-    {rawValue: 25.6, label: '2020-01-04T12:00:00Z'},
+    {rawValue: 0, label: '2020-01-04T12:00:00Z'},
     {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
     {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
   ],
@@ -83,7 +83,7 @@ OverflowStyle.args = {
     {rawValue: 1324.19, label: '2020-01-01T12:00:00Z'},
     {rawValue: 613.29, label: '2020-01-02T12:00:00Z'},
     {rawValue: 422.79, label: '2020-01-03T12:00:00Z'},
-    {rawValue: 25.6, label: '2020-01-04T12:00:00Z'},
+    {rawValue: 0, label: '2020-01-04T12:00:00Z'},
     {rawValue: 277.69, label: '2020-01-05T12:00:00Z'},
     {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
   ],
@@ -126,7 +126,7 @@ Annotations.args = {
     {rawValue: 50, label: '15'},
     {rawValue: 56, label: '16'},
     {rawValue: 85, label: '17'},
-    {rawValue: 2, label: '18'},
+    {rawValue: 0, label: '18'},
     {rawValue: 52, label: '19'},
   ],
   annotations: [
@@ -146,7 +146,7 @@ Annotations.args = {
   xAxisOptions: {labelFormatter: formatLabelNoop},
   yAxisOptions: {labelFormatter: formatLabelNoop},
   renderTooltipContent: renderTooltipContentWithAnnotation,
-  isAnimated: false,
+  isAnimated: true,
 };
 
 export const MedianWithColorString = Template.bind({});
@@ -203,7 +203,7 @@ LastBarTreatment.args = {
     {rawValue: 100.79, label: '2020-01-05T12:00:00Z'},
     {rawValue: 350.6, label: '2020-01-06T12:00:00Z'},
     {rawValue: 277.69, label: '2020-01-07T12:00:00Z'},
-    {rawValue: 50.6, label: '2020-01-08T12:00:00Z'},
+    {rawValue: 0, label: '2020-01-08T12:00:00Z'},
     {
       rawValue: 950.19,
       label: '2020-01-09T12:00:00Z',
@@ -236,7 +236,7 @@ MinimalLabels.args = {
     {rawValue: 350.6, label: '2020-01-06T12:00:00Z'},
     {rawValue: 277.69, label: '2020-01-07T12:00:00Z'},
     {
-      rawValue: 50.6,
+      rawValue: 0,
       label: 'Last day has especially longgggggggggggg textttttttttt',
     },
   ],

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -162,41 +162,79 @@ describe('Chart />', () => {
     });
   });
 
-  it('renders a Bar for each data item', () => {
-    const chart = mount(<Chart {...mockProps} />);
-
-    expect(chart).toContainReactComponentTimes(Bar, 2);
-  });
-
-  it('passes a subdued color to the Bar that is not being hovered on or nearby', () => {
-    const chart = mount(<Chart {...mockProps} />);
-
-    const svg = chart.find('svg')!;
-    expect(chart).toContainReactComponent(Bar, {color: MASK_HIGHLIGHT_COLOR});
-
-    svg.trigger('onMouseMove', fakeSVGEvent);
-
-    expect(chart).toContainReactComponent(Bar, {color: MASK_SUBDUE_COLOR});
-  });
-
-  it('passes the min bar height to the bar if its value is 0', () => {
-    const chart = mount(
-      <Chart {...mockProps} data={[{rawValue: 0, label: 'data'}]} />,
-    );
-
-    expect(chart).toContainReactComponent(Bar, {
-      height: expect.objectContaining({
-        value: MIN_BAR_HEIGHT,
-      }),
-    });
-  });
-
   describe('empty state', () => {
     it('does not render tooltip for empty state', () => {
       const chart = mount(<Chart {...mockProps} data={[]} />);
 
       expect(chart).not.toContainReactText('Mock Tooltip');
       expect(chart).not.toContainReactComponent(TooltipContainer);
+    });
+  });
+
+  describe('<Bar />', () => {
+    it('renders a Bar for each data item', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      expect(chart).toContainReactComponentTimes(Bar, 2);
+    });
+
+    it('passes a subdued color to the Bar that is not being hovered on or nearby', () => {
+      const chart = mount(<Chart {...mockProps} />);
+
+      const svg = chart.find('svg')!;
+      expect(chart).toContainReactComponent(Bar, {color: MASK_HIGHLIGHT_COLOR});
+
+      svg.trigger('onMouseMove', fakeSVGEvent);
+
+      expect(chart).toContainReactComponent(Bar, {color: MASK_SUBDUE_COLOR});
+    });
+
+    it('passes the min bar height to the bar if its value is 0', () => {
+      const chart = mount(
+        <Chart {...mockProps} data={[{rawValue: 0, label: 'data'}]} />,
+      );
+
+      expect(chart).toContainReactComponent(Bar, {
+        height: expect.objectContaining({
+          value: MIN_BAR_HEIGHT,
+        }),
+      });
+    });
+
+    describe('allValuesNegative', () => {
+      it('receives true if all values are 0 or negative', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            data={[
+              {rawValue: 0, label: 'data'},
+              {rawValue: -2, label: 'data'},
+              {rawValue: -1, label: 'data'},
+            ]}
+          />,
+        );
+
+        expect(chart).toContainReactComponent(Bar, {
+          allValuesNegative: true,
+        });
+      });
+
+      it('receives false if not all values are 0 or negative', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            data={[
+              {rawValue: 0, label: 'data'},
+              {rawValue: -2, label: 'data'},
+              {rawValue: 1, label: 'data'},
+            ]}
+          />,
+        );
+
+        expect(chart).toContainReactComponent(Bar, {
+          allValuesNegative: false,
+        });
+      });
     });
   });
 

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -98,6 +98,11 @@ export function Chart({
     [xAxisOptions.labelFormatter, xAxisOptions.labels],
   );
 
+  const allValuesNegative = useMemo(
+    () => series.every(({data}) => data.every(({rawValue}) => rawValue <= 0)),
+    [series],
+  );
+
   const xAxisDetails = useMemo(
     () =>
       getBarXAxisDetails({
@@ -301,6 +306,7 @@ export function Chart({
                     barGroupIndex={index}
                     ariaLabel={ariaLabel}
                     hasRoundedCorners={barOptions.hasRoundedCorners}
+                    allValuesNegative={allValuesNegative}
                   />
                 );
               })}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -32,6 +32,7 @@ interface Props {
   onFocus: (index: number) => void;
   hasRoundedCorners: boolean;
   isAnimated?: boolean;
+  allValuesNegative?: boolean;
 }
 
 export function BarGroup({
@@ -47,6 +48,7 @@ export function BarGroup({
   hasRoundedCorners,
   isSubdued,
   isAnimated = false,
+  allValuesNegative = false,
 }: Props) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const barWidth = width / data.length - BAR_SPACING;
@@ -114,6 +116,7 @@ export function BarGroup({
                 role={ariaEnabledBar ? 'img' : undefined}
                 ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
                 hasRoundedCorners={hasRoundedCorners}
+                allValuesNegative={allValuesNegative}
               />
             </g>
           );

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -27,7 +27,7 @@ const series = [
     color: 'secondary',
     data: [
       {label: 'Monday', rawValue: 4},
-      {label: 'Tuesday', rawValue: 3},
+      {label: 'Tuesday', rawValue: 0},
       {label: 'Wednesday', rawValue: 5},
       {label: 'Thursday', rawValue: 15},
       {label: 'Friday', rawValue: 8},
@@ -40,7 +40,7 @@ const series = [
     color: 'tertiary',
     data: [
       {label: 'Monday', rawValue: 7},
-      {label: 'Tuesday', rawValue: 2},
+      {label: 'Tuesday', rawValue: 0},
       {label: 'Wednesday', rawValue: 6},
       {label: 'Thursday', rawValue: 12},
       {label: 'Friday', rawValue: 10},

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -161,6 +161,66 @@ describe('Chart />', () => {
 
       expect(chart).not.toContainReactComponent(BarGroup);
     });
+
+    describe('allValuesNegative', () => {
+      it('receives true if all values are 0 or negative', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            series={[
+              {
+                ...mockProps.series[0],
+                data: [
+                  {label: '', rawValue: -1},
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: -2},
+                ],
+              },
+              {
+                ...mockProps.series[1],
+                data: [
+                  {label: '', rawValue: -3},
+                  {label: '', rawValue: -4},
+                  {label: '', rawValue: -1},
+                ],
+              },
+            ]}
+          />,
+        );
+        expect(chart).toContainReactComponent(BarGroup, {
+          allValuesNegative: true,
+        });
+      });
+
+      it('receives false if all values are 0 or negative', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            series={[
+              {
+                ...mockProps.series[0],
+                data: [
+                  {label: '', rawValue: 3},
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: 3},
+                ],
+              },
+              {
+                ...mockProps.series[1],
+                data: [
+                  {label: '', rawValue: 4},
+                  {label: '', rawValue: 5},
+                  {label: '', rawValue: -1},
+                ],
+              },
+            ]}
+          />,
+        );
+        expect(chart).toContainReactComponent(BarGroup, {
+          allValuesNegative: false,
+        });
+      });
+    });
   });
 
   describe('<StackedBarGroup />', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,8 +23,8 @@ export const MAX_TEXT_BOX_HEIGHT = LINE_HEIGHT * 3;
 export const SMALL_LABEL_WIDTH = 50;
 export const LABEL_SPACE_MINUS_FIRST_AND_LAST = 0.6;
 export const DEFAULT_MAX_Y = 10;
-export const ROUNDED_BAR_RADIUS = 3;
-export const MIN_BAR_HEIGHT = 1;
+export const ROUNDED_BAR_RADIUS = 4;
+export const MIN_BAR_HEIGHT = 2;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
 


### PR DESCRIPTION
### What problem is this PR solving?

Resolves https://github.com/Shopify/core-issues/issues/25038

* Increased `MIN_BAR_HEIGHT` to 2px from 1px
* Increased `ROUNDED_BAR_RADIUS` to 4px from 3px
* Also fixed a bug in MultiSeriesBarChart where 0 value bars were not showing a min height bar:

| Before            | After               |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30587540/118525231-f1d9b780-b70c-11eb-8a89-9a4cc3292a13.png) | ![image](https://user-images.githubusercontent.com/30587540/118525031-bfc85580-b70c-11eb-94a4-c5fa561ac0a7.png) | 

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

### Reviewers’ :tophat: instructions

* Check out the `BarChart` and `MultiSeriesBarChart` (grouped, not stacked) stories, I changed the values so at least one of the rawValues is 0
* Confirm you can see a min height bar:
  ![image](https://user-images.githubusercontent.com/30587540/118524531-416bb380-b70c-11eb-9f22-9cc55e41cb39.png)
  ![image](https://user-images.githubusercontent.com/30587540/118524578-4c264880-b70c-11eb-88d0-bcb215c6e813.png)
* Repeat with rounded corners, sharp corners, animations, and different `MIN_BAR_HEIGHT` and `ROUNDED_BORDER_RADIUS`

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
