### PR TITLE
[BarChart and MultiSeriesBarChart] Fix min height bars not showing for all 0 datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Min height bars not being shown when all bars are negative in `<BarChart />` and `<MultiSeriesBarChart />`
+
 ## [0.14.1] - 2021-05-18
 
 ### Fixed

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -19,7 +19,7 @@ interface Props {
   role?: string;
   hasRoundedCorners?: boolean;
   height?: OpaqueInterpolation<any> | number;
-  allValuesNegative: boolean;
+  rotateZeroBars: boolean;
 }
 
 export function Bar({
@@ -35,12 +35,12 @@ export function Bar({
   role,
   height,
   hasRoundedCorners,
-  allValuesNegative,
+  rotateZeroBars,
 }: Props) {
   const zeroScale = yScale(0);
-  const isNegative = rawValue < 0 || (rawValue === 0 && allValuesNegative);
-  const rotation = isNegative ? 'rotate(180deg)' : 'rotate(0deg)';
-  const xPosition = isNegative ? x + width : x;
+  const treatAsNegative = rawValue < 0 || (rawValue === 0 && rotateZeroBars);
+  const rotation = treatAsNegative ? 'rotate(180deg)' : 'rotate(0deg)';
+  const xPosition = treatAsNegative ? x + width : x;
   const heightIsNumber = typeof height === 'number';
   const radius = hasRoundedCorners ? ROUNDED_BAR_RADIUS : 0;
 
@@ -48,13 +48,13 @@ export function Bar({
     if (height == null) return;
 
     const getYPosition = (value: number) =>
-      isNegative ? zeroScale + value : zeroScale - value;
+      treatAsNegative ? zeroScale + value : zeroScale - value;
 
     if (heightIsNumber) {
       return getYPosition(height);
     }
     return height.interpolate(getYPosition);
-  }, [height, heightIsNumber, isNegative, zeroScale]);
+  }, [height, heightIsNumber, treatAsNegative, zeroScale]);
 
   const yPositionIsNumber = typeof yPosition === 'number';
 

--- a/src/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Bar/tests/Bar.test.tsx
@@ -20,7 +20,7 @@ const defaultProps = {
   index: 1,
   onFocus: jest.fn(),
   tabIndex: 0,
-  allValuesNegative: false,
+  rotateZeroBars: false,
 };
 
 describe('<Bar/>', () => {

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -18,6 +18,7 @@ import {
   uniqueId,
   getColorValue,
   isGradientType,
+  shouldRotateZeroBars,
 } from '../../utilities';
 import {Bar} from '../Bar';
 import {YAxis} from '../YAxis';
@@ -171,10 +172,7 @@ export function Chart({
 
   const barWidth = useMemo(() => xScale.bandwidth(), [xScale]);
 
-  const allValuesNegative = useMemo(
-    () => data.every(({rawValue}) => rawValue <= 0),
-    [data],
-  );
+  const rotateZeroBars = useMemo(() => shouldRotateZeroBars(data), [data]);
 
   const tooltipMarkup = useMemo(() => {
     if (activeBar == null) {
@@ -280,7 +278,7 @@ export function Chart({
                       tabIndex={0}
                       role="img"
                       hasRoundedCorners={barOptions.hasRoundedCorners}
-                      allValuesNegative={allValuesNegative}
+                      rotateZeroBars={rotateZeroBars}
                     />
                   </g>
                 );

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -202,7 +202,7 @@ describe('Chart />', () => {
       });
     });
 
-    describe('allValuesNegative', () => {
+    describe('rotateZeroBars', () => {
       it('receives true if all values are 0 or negative', () => {
         const chart = mount(
           <Chart
@@ -216,7 +216,7 @@ describe('Chart />', () => {
         );
 
         expect(chart).toContainReactComponent(Bar, {
-          allValuesNegative: true,
+          rotateZeroBars: true,
         });
       });
 
@@ -233,7 +233,24 @@ describe('Chart />', () => {
         );
 
         expect(chart).toContainReactComponent(Bar, {
-          allValuesNegative: false,
+          rotateZeroBars: false,
+        });
+      });
+
+      it('receives false if all values are 0', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            data={[
+              {rawValue: 0, label: 'data'},
+              {rawValue: 0, label: 'data'},
+              {rawValue: 0, label: 'data'},
+            ]}
+          />,
+        );
+
+        expect(chart).toContainReactComponent(Bar, {
+          rotateZeroBars: false,
         });
       });
     });

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -2,7 +2,12 @@ import React, {useState, useMemo, useCallback} from 'react';
 
 import {BarChartMargin as Margin} from '../../constants';
 import {TooltipContainer} from '../TooltipContainer';
-import {eventPoint, getTextWidth, getBarXAxisDetails} from '../../utilities';
+import {
+  eventPoint,
+  getTextWidth,
+  getBarXAxisDetails,
+  shouldRotateZeroBars,
+} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
 import {HorizontalGridLines} from '../HorizontalGridLines';
@@ -99,8 +104,8 @@ export function Chart({
     [xAxisOptions.labelFormatter, xAxisOptions.labels],
   );
 
-  const allValuesNegative = useMemo(
-    () => series.every(({data}) => data.every(({rawValue}) => rawValue <= 0)),
+  const rotateZeroBars = useMemo(
+    () => series.every(({data}) => shouldRotateZeroBars(data)),
     [series],
   );
 
@@ -309,7 +314,7 @@ export function Chart({
                     barGroupIndex={index}
                     ariaLabel={ariaLabel}
                     hasRoundedCorners={barOptions.hasRoundedCorners}
-                    allValuesNegative={allValuesNegative}
+                    rotateZeroBars={rotateZeroBars}
                   />
                 );
               })}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -32,7 +32,7 @@ interface Props {
   onFocus: (index: number) => void;
   hasRoundedCorners: boolean;
   isAnimated?: boolean;
-  allValuesNegative?: boolean;
+  rotateZeroBars?: boolean;
 }
 
 export function BarGroup({
@@ -48,7 +48,7 @@ export function BarGroup({
   hasRoundedCorners,
   isSubdued,
   isAnimated = false,
-  allValuesNegative = false,
+  rotateZeroBars = false,
 }: Props) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const barWidth = width / data.length - BAR_SPACING;
@@ -116,7 +116,7 @@ export function BarGroup({
                 role={ariaEnabledBar ? 'img' : undefined}
                 ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
                 hasRoundedCorners={hasRoundedCorners}
-                allValuesNegative={allValuesNegative}
+                rotateZeroBars={rotateZeroBars}
               />
             </g>
           );

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -163,7 +163,7 @@ describe('Chart />', () => {
       expect(chart).not.toContainReactComponent(BarGroup);
     });
 
-    describe('allValuesNegative', () => {
+    describe('rotateZeroBars', () => {
       it('receives true if all values are 0 or negative', () => {
         const chart = mount(
           <Chart
@@ -189,11 +189,11 @@ describe('Chart />', () => {
           />,
         );
         expect(chart).toContainReactComponent(BarGroup, {
-          allValuesNegative: true,
+          rotateZeroBars: true,
         });
       });
 
-      it('receives false if all values are 0 or negative', () => {
+      it('receives false if not all values are 0 or negative', () => {
         const chart = mount(
           <Chart
             {...mockProps}
@@ -203,22 +203,51 @@ describe('Chart />', () => {
                 data: [
                   {label: '', rawValue: 3},
                   {label: '', rawValue: 0},
-                  {label: '', rawValue: 3},
+                  {label: '', rawValue: -3},
                 ],
               },
               {
                 ...mockProps.series[1],
                 data: [
-                  {label: '', rawValue: 4},
+                  {label: '', rawValue: -4},
                   {label: '', rawValue: 5},
-                  {label: '', rawValue: -1},
+                  {label: '', rawValue: -4},
                 ],
               },
             ]}
           />,
         );
         expect(chart).toContainReactComponent(BarGroup, {
-          allValuesNegative: false,
+          rotateZeroBars: false,
+        });
+      });
+
+      it('receives false if all values are 0', () => {
+        const chart = mount(
+          <Chart
+            {...mockProps}
+            series={[
+              {
+                ...mockProps.series[0],
+                data: [
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: 0},
+                ],
+              },
+              {
+                ...mockProps.series[1],
+                data: [
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: 0},
+                  {label: '', rawValue: 0},
+                ],
+              },
+            ]}
+          />,
+        );
+        expect(chart).toContainReactComponent(BarGroup, {
+          rotateZeroBars: false,
         });
       });
     });

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -22,3 +22,4 @@ export {createCSSGradient} from './create-css-gradient';
 export {shouldRoundScaleUp} from './should-round-scale-up';
 export {curveStepRounded} from './curve-step-rounded';
 export {makeColorOpaque, makeGradientOpaque} from './make-color-opaque';
+export {shouldRotateZeroBars} from './should-rotate-zero-bars';

--- a/src/utilities/should-rotate-zero-bars.ts
+++ b/src/utilities/should-rotate-zero-bars.ts
@@ -1,0 +1,19 @@
+import {Data} from '../types';
+
+export function shouldRotateZeroBars(data: Data[]) {
+  let allValuesZero = true;
+
+  const allValuesLessThanOne = data.every(({rawValue}) => {
+    if (rawValue !== 0) {
+      allValuesZero = false;
+    }
+
+    if (rawValue > 0) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return allValuesLessThanOne && !allValuesZero;
+}

--- a/src/utilities/tests/should-rotate-zero-bars.test.ts
+++ b/src/utilities/tests/should-rotate-zero-bars.test.ts
@@ -1,0 +1,67 @@
+import {shouldRotateZeroBars} from '../should-rotate-zero-bars';
+
+describe('shouldRotateZeroBars', () => {
+  describe('returns true if', () => {
+    it('receives all negative values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: -5},
+        {label: '', rawValue: -3},
+        {label: '', rawValue: -1},
+      ]);
+
+      expect(rotateZeroBars).toBe(true);
+    });
+
+    it('receives negative and 0 values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: -5},
+        {label: '', rawValue: -3},
+        {label: '', rawValue: 0},
+      ]);
+
+      expect(rotateZeroBars).toBe(true);
+    });
+  });
+
+  describe('returns false if', () => {
+    it('receives all positive values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: 5},
+        {label: '', rawValue: 3},
+        {label: '', rawValue: 2},
+      ]);
+
+      expect(rotateZeroBars).toBe(false);
+    });
+
+    it('receives all 0 values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: 0},
+        {label: '', rawValue: 0},
+        {label: '', rawValue: 0},
+      ]);
+
+      expect(rotateZeroBars).toBe(false);
+    });
+
+    it('receives 0 and positive values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: 0},
+        {label: '', rawValue: 3},
+        {label: '', rawValue: 3},
+      ]);
+
+      expect(rotateZeroBars).toBe(false);
+    });
+
+    it('receives 0, negative, and positive values', () => {
+      const rotateZeroBars = shouldRotateZeroBars([
+        {label: '', rawValue: 0},
+        {label: '', rawValue: -3},
+        {label: '', rawValue: 3},
+      ]);
+
+      expect(rotateZeroBars).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### What problem is this PR solving?

Fix https://github.com/Shopify/core-issues/issues/25261

This case where all values are 0 was missed in https://github.com/Shopify/polaris-viz/pull/382 😅 

### Reviewers’ :tophat: instructions

For both BarChart and MultiSeriesBarChart check:
* All 0 values (min height bars pointing up)
   ```
   [{ label: 1, value: 0 }, { label: 2, value: 0 }, { label: 2, value: 0}]
   ```
   ![image](https://user-images.githubusercontent.com/30587540/118884555-9f42fb80-b8c4-11eb-8303-51f14d26e160.png)

* A mix of 0 and positive values (min height bar pointing up)
   ```
   [{ label: 1, value: 5 }, { label: 2, value: 0 }, { label: 2, value: 2 }]
   ```
   ![image](https://user-images.githubusercontent.com/30587540/118885029-3a3bd580-b8c5-11eb-8307-662e20681fc9.png)

* A mix of 0 and negative values (min height bar pointing down)
   ```
   [{ label: 1, value: -5 }, { label: 2, value: 0 }, { label: 2, value: -2 }]
   ```
   ![image](https://user-images.githubusercontent.com/30587540/118885118-59d2fe00-b8c5-11eb-9c84-53c8e871b914.png)

* A mix of 0, positive, and negative values (min height bar pointing up)
  ```
   [{ label: 1, value: -5 }, { label: 2, value: 0 }, { label: 2, value: 2 }]
   ```
   ![image](https://user-images.githubusercontent.com/30587540/118884632-bbdf3380-b8c4-11eb-86c0-7a162cf63fa8.png)


Make sure a min height bar are visible for 0 values in all scenarioes

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
