### PR TITLE
Don't show middle label for even bars under a threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Zero value min-height bars are not enabled by default in `<BarChart />` and `<MultiSeriesBarChart />`
+- The `useMinimalLabels` prop for `<BarChart />` will not use a middle label when there are an even number of bars below 12
 
 ### Fixed
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -38,7 +38,7 @@ import {
   YAxisOptions,
   AnnotationLookupTable,
 } from './types';
-import {useYScale, useXScale} from './hooks';
+import {useYScale, useXScale, useMinimalLabelIndexes} from './hooks';
 import {SMALL_FONT_SIZE, FONT_SIZE, SMALL_SCREEN, SPACING} from './constants';
 import styles from './Chart.scss';
 
@@ -78,6 +78,10 @@ export function Chart({
     x: number;
     y: number;
   } | null>(null);
+  const {minimalLabelIndexes} = useMinimalLabelIndexes({
+    useMinimalLabels: xAxisOptions.useMinimalLabels,
+    dataLength: data.length,
+  });
 
   const fontSize =
     chartDimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
@@ -101,11 +105,6 @@ export function Chart({
       ),
     [fontSize, initialTicks],
   );
-
-  const minimalLabelIndexes =
-    xAxisOptions.useMinimalLabels && data.length > 3
-      ? [0, Math.floor(data.length / 2), data.length - 1]
-      : null;
 
   const xAxisDetails = useMemo(
     () =>

--- a/src/components/BarChart/hooks/index.ts
+++ b/src/components/BarChart/hooks/index.ts
@@ -1,2 +1,3 @@
 export {useXScale} from './use-x-scale';
 export {useYScale} from './use-y-scale';
+export {useMinimalLabelIndexes} from './use-minimal-label-indexes';

--- a/src/components/BarChart/hooks/tests/use-minimal-label-indexes.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-minimal-label-indexes.test.tsx
@@ -1,0 +1,48 @@
+import {useMinimalLabelIndexes} from '../use-minimal-label-indexes';
+
+describe('useMinimalLabelIndexes', () => {
+  it('returns null when useMinimalLabels is false', () => {
+    const labels = useMinimalLabelIndexes({
+      dataLength: 10,
+      useMinimalLabels: false,
+    });
+
+    expect(labels).toStrictEqual({minimalLabelIndexes: null});
+  });
+
+  it('returns null when the data length is less than 2', () => {
+    const labels = useMinimalLabelIndexes({
+      dataLength: 2,
+      useMinimalLabels: false,
+    });
+
+    expect(labels).toStrictEqual({minimalLabelIndexes: null});
+  });
+
+  it('returns the first and last indexes when the dataLength is even and less than 10', () => {
+    const labels = useMinimalLabelIndexes({
+      dataLength: 8,
+      useMinimalLabels: true,
+    });
+
+    expect(labels).toStrictEqual({minimalLabelIndexes: [0, 7]});
+  });
+
+  it('includes a middle index when the dataLength is odd and less than 10', () => {
+    const labels = useMinimalLabelIndexes({
+      dataLength: 9,
+      useMinimalLabels: true,
+    });
+
+    expect(labels).toStrictEqual({minimalLabelIndexes: [0, 4, 8]});
+  });
+
+  it('includes a middle index when the dataLength is even and more than 10', () => {
+    const labels = useMinimalLabelIndexes({
+      dataLength: 12,
+      useMinimalLabels: true,
+    });
+
+    expect(labels).toStrictEqual({minimalLabelIndexes: [0, 6, 11]});
+  });
+});

--- a/src/components/BarChart/hooks/use-minimal-label-indexes.ts
+++ b/src/components/BarChart/hooks/use-minimal-label-indexes.ts
@@ -1,0 +1,22 @@
+const MIDDLE_LABEL_EVEN_THRESHOLD = 10;
+
+export function useMinimalLabelIndexes({
+  useMinimalLabels,
+  dataLength,
+}: {
+  useMinimalLabels: boolean;
+  dataLength: number;
+}) {
+  if (!useMinimalLabels || dataLength < 2) {
+    return {minimalLabelIndexes: null};
+  }
+
+  const oddNumberOfBars = dataLength % 2 !== 0;
+
+  const middleLabelIndex =
+    oddNumberOfBars || dataLength > MIDDLE_LABEL_EVEN_THRESHOLD
+      ? [Math.floor(dataLength / 2)]
+      : [];
+
+  return {minimalLabelIndexes: [0, ...middleLabelIndex, dataLength - 1]};
+}

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -224,20 +224,35 @@ LastBarTreatment.args = {
 export const MinimalLabels = Template.bind({});
 MinimalLabels.args = {
   data: [
-    {rawValue: 1324.19, label: '1 day some really long long text'},
-    {rawValue: 1022.79, label: '2020-01-02T12:00:00Z'},
-    {rawValue: 713.29, label: '2020-01-03T12:00:00Z'},
-    {rawValue: 413.29, label: '2020-01-04T12:00:00Z'},
+    {rawValue: 1324.19, label: '1 day'},
+    {rawValue: 1022.79, label: '2 days'},
+    {rawValue: 713.29, label: '3 days'},
+    {rawValue: 413.29, label: '4 days'},
     {
       rawValue: 100.79,
-      label:
-        'Middle day also has very long text / Middle day also has very long text',
+      label: '5 days',
     },
-    {rawValue: 350.6, label: '2020-01-06T12:00:00Z'},
-    {rawValue: 277.69, label: '2020-01-07T12:00:00Z'},
+    {rawValue: 350.6, label: '6 days'},
+    {rawValue: 277.69, label: '7 days'},
     {
-      rawValue: 0,
-      label: 'Last day has especially longgggggggggggg textttttttttt',
+      rawValue: 10,
+      label: '8 days',
+    },
+    {
+      rawValue: 10,
+      label: '9 days',
+    },
+    {
+      rawValue: 10,
+      label: '10 days',
+    },
+    {
+      rawValue: 10,
+      label: '11 days',
+    },
+    {
+      rawValue: 10,
+      label: '12 days',
     },
   ],
   barOptions: {

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -89,46 +89,6 @@ describe('Chart />', () => {
       const barChart = mount(<Chart {...mockProps} />);
       expect(barChart).toContainReactComponent(BarChartXAxis);
     });
-
-    it('is passed three minimalLabelIndexes if useMinimalLabels is true and there are more than three data items', () => {
-      const barChart = mount(
-        <Chart
-          {...mockProps}
-          data={[
-            {rawValue: 10, label: 'data'},
-            {rawValue: 20, label: 'data 2'},
-            {rawValue: 20, label: 'data 3'},
-            {rawValue: 20, label: 'data 4'},
-          ]}
-          xAxisOptions={{
-            labelFormatter: (value: string) => value.toString(),
-            showTicks: true,
-            labelColor: 'red',
-            useMinimalLabels: true,
-          }}
-        />,
-      );
-      expect(barChart).toContainReactComponent(BarChartXAxis, {
-        minimalLabelIndexes: [0, 2, 3],
-      });
-    });
-
-    it('is passed null minimalLabelIndexes if useMinimalLabels is true but there are less than three bars', () => {
-      const barChart = mount(
-        <Chart
-          {...mockProps}
-          xAxisOptions={{
-            labelFormatter: (value: string) => value.toString(),
-            showTicks: true,
-            labelColor: 'red',
-            useMinimalLabels: true,
-          }}
-        />,
-      );
-      expect(barChart).toContainReactComponent(BarChartXAxis, {
-        minimalLabelIndexes: null,
-      });
-    });
   });
 
   it('renders an yAxis', () => {


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/core-issues/issues/25298

Fixes the issue where the bar chart's labels could look awkward, like the image below, when there was a small number of even bars below. The fix, discussed with @alenaiouguina, is to remove the middle label for even numbers of bars under 10.

![image](https://user-images.githubusercontent.com/12213371/119039671-8862de80-b982-11eb-9e25-f586e48d536d.png)

Here's how the change looks:

| Number of bars        | Preview           | 
| ------------- |:-------------:|
| 2 | <img width="1627" alt="2" src="https://user-images.githubusercontent.com/12213371/119031127-b9d6ac80-b978-11eb-8b92-196edf1ed749.png">| 
|3 | <img width="1640" alt="3" src="https://user-images.githubusercontent.com/12213371/119031082-b17e7180-b978-11eb-9a6f-404709076f78.png">| 
|4  | <img width="1637" alt="4" src="https://user-images.githubusercontent.com/12213371/119031085-b17e7180-b978-11eb-829d-41ca8eaaf3ff.png">| 
| 9| <img width="1632" alt="9" src="https://user-images.githubusercontent.com/12213371/119031097-b2af9e80-b978-11eb-8597-07c275f24469.png">| 
|12  | <img width="1631" alt="Screen Shot 2021-05-20 at 3 44 08 PM" src="https://user-images.githubusercontent.com/12213371/119039484-505b9b80-b982-11eb-8a60-6d34e043a7cc.png">| 

### Reviewers’ :tophat: instructions
You can take a look at the story I modified and try removing/adding abrs

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
