### PR TITLE
introduce themes through PolarisVizProvider

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -2,7 +2,7 @@ import React, {useState, useLayoutEffect, useRef, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {colorSky} from '@shopify/polaris-tokens';
 
-import {Dimensions} from '../../types';
+import {Dimensions, BarOptions, BarMargin} from '../../types';
 import {DEFAULT_GREY_LABEL} from '../../constants';
 import {SkipLink} from '../SkipLink';
 import {getDefaultColor, uniqueId, normalizeData} from '../../utilities';
@@ -13,11 +13,9 @@ import {Chart} from './Chart';
 import {
   BarChartData,
   RenderTooltipContentData,
-  BarOptions,
   GridOptions,
   XAxisOptions,
   YAxisOptions,
-  BarMargin,
   Annotation,
   AnnotationLookupTable,
 } from './types';

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -26,13 +26,12 @@ import {BarChartXAxis} from '../BarChartXAxis';
 import {TooltipContainer} from '../TooltipContainer';
 import {LinearGradient} from '../LinearGradient';
 import {HorizontalGridLines} from '../HorizontalGridLines';
-import {Dimensions} from '../../types';
+import {Dimensions, BarOptions as BarChartBarOptions} from '../../types';
 
 import {AnnotationLine} from './components';
 import {
   BarChartData,
   RenderTooltipContentData,
-  BarOptions as BarChartBarOptions,
   GridOptions,
   XAxisOptions,
   YAxisOptions,

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,9 +1,4 @@
-import {
-  Color,
-  StringLabelFormatter,
-  NumberLabelFormatter,
-  GradientStop,
-} from 'types';
+import {Color, StringLabelFormatter, NumberLabelFormatter} from 'types';
 
 export interface BarChartData {
   barOptions?: {
@@ -13,28 +8,10 @@ export interface BarChartData {
   rawValue: number;
 }
 
-export enum BarMargin {
-  Small = 0.05,
-  Medium = 0.1,
-  Large = 0.3,
-  None = 0,
-}
-
 export interface RenderTooltipContentData {
   label: string;
   value: number;
   annotation?: Annotation;
-}
-
-export interface BarOptions {
-  innerMargin: keyof typeof BarMargin;
-  outerMargin: keyof typeof BarMargin;
-  color: Color | GradientStop[];
-  hasRoundedCorners: boolean;
-  /**
-   * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
-   */
-  zeroAsMinHeight: boolean;
 }
 
 export interface GridOptions {

--- a/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,0 +1,32 @@
+import React, {useMemo} from 'react';
+
+import {Theme} from '../../types';
+import {DefaultTheme as Default} from '../../constants';
+import {PolarisVizContext} from '../../utilities/polaris-viz-context';
+import {createThemes} from '../../utilities';
+
+export interface PolarisVizContextProps {
+  children: React.ReactNode;
+  themes?: Record<string, Theme>;
+}
+
+export function PolarisVizProvider({children, themes}: PolarisVizContextProps) {
+  const customThemes = useMemo(
+    () =>
+      createThemes({
+        Default,
+        ...themes,
+      }),
+    [themes],
+  );
+
+  return (
+    <PolarisVizContext.Provider
+      value={{
+        themes: customThemes,
+      }}
+    >
+      {children}
+    </PolarisVizContext.Provider>
+  );
+}

--- a/src/components/PolarisVizProvider/index.ts
+++ b/src/components/PolarisVizProvider/index.ts
@@ -1,0 +1,1 @@
+export {PolarisVizProvider} from './PolarisVizProvider';

--- a/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
+++ b/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {usePolarisVizContext} from '../../../hooks';
+import {PolarisVizProvider} from '../PolarisVizProvider';
+import {PolarisVizContext} from '../../../utilities/';
+import {DefaultTheme} from '../../../constants';
+
+const MockChild = ({theme = 'Default'}) => {
+  const {themes} = usePolarisVizContext();
+  return <div>{JSON.stringify(themes[theme])}</div>;
+};
+
+describe('<PolarisVizProvider />', () => {
+  it('renders <PolarisVizContext.Provider>', () => {
+    const vizProvider = mount(
+      <PolarisVizProvider>
+        <MockChild />
+      </PolarisVizProvider>,
+    );
+
+    expect(vizProvider).toContainReactComponent(PolarisVizContext.Provider);
+  });
+
+  it('allows children to access the default theme', () => {
+    const vizProvider = mount(
+      <PolarisVizProvider>
+        <MockChild />
+      </PolarisVizProvider>,
+    );
+
+    expect(vizProvider).toContainReactText(JSON.stringify(DefaultTheme));
+  });
+
+  it('passes custom themes to children', () => {
+    const vizProvider = mount(
+      <PolarisVizProvider
+        themes={{
+          Dark: {
+            barOptions: {
+              hasRoundedCorners: false,
+            },
+          },
+        }}
+      >
+        <MockChild theme="Dark" />
+      </PolarisVizProvider>,
+    );
+
+    expect(vizProvider).toContainReactText(
+      JSON.stringify({
+        ...DefaultTheme,
+        barOptions: {
+          ...DefaultTheme.barOptions,
+          hasRoundedCorners: false,
+        },
+      }),
+    );
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,3 +39,4 @@ export {VisuallyHiddenRows} from './VisuallyHiddenRows';
 export {LinePreview} from './LinePreview';
 export {Legend} from './Legend';
 export {LinearGradient} from './LinearGradient';
+export {PolarisVizProvider} from './PolarisVizProvider';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import {Theme} from './types';
+
 export const CROSSHAIR_WIDTH = 5;
 export const SPACING_TIGHT = 8;
 export const SMALL_WIDTH = 300;
@@ -50,3 +52,55 @@ export const MAX_TRAIL_DURATION = 500;
 
 export const MASK_HIGHLIGHT_COLOR = '#FFF';
 export const MASK_SUBDUE_COLOR = '#434343';
+
+const POSITIVE_COLOR = `rgba(46, 237, 145, 0.8)`;
+const PRIMARY_NEUTRAL_COLOR = `rgba(152, 107, 255, 0.8)`;
+const SECONDARY_NEUTRAL_COLOR = `rgba(58, 164, 246, 0.8)`;
+const NEGATIVE_COLOR = `rgba(236, 110, 110, 0.8)`;
+const COMPARISON_COLOR = `rgba(144, 176, 223, 0.6)`;
+
+const VIZ_COMPARISON_GRADIENT = [
+  {offset: 0, color: COMPARISON_COLOR},
+  {offset: 100, color: COMPARISON_COLOR},
+];
+
+export const VIZ_GRADIENT_COLOR = {
+  positive: {
+    comparison: VIZ_COMPARISON_GRADIENT,
+    up: [
+      {offset: 0, color: PRIMARY_NEUTRAL_COLOR},
+      {offset: 60, color: SECONDARY_NEUTRAL_COLOR},
+      {offset: 100, color: POSITIVE_COLOR},
+    ],
+  },
+  negative: {
+    comparison: VIZ_COMPARISON_GRADIENT,
+    up: [
+      {offset: 0, color: SECONDARY_NEUTRAL_COLOR},
+      {offset: 60, color: PRIMARY_NEUTRAL_COLOR},
+      {offset: 100, color: NEGATIVE_COLOR},
+    ],
+    down: [
+      {offset: 0, color: NEGATIVE_COLOR},
+      {offset: 60, color: PRIMARY_NEUTRAL_COLOR},
+      {offset: 100, color: SECONDARY_NEUTRAL_COLOR},
+    ],
+  },
+  neutral: {
+    up: [
+      {offset: 0, color: PRIMARY_NEUTRAL_COLOR},
+      {offset: 100, color: SECONDARY_NEUTRAL_COLOR},
+    ],
+    comparison: VIZ_COMPARISON_GRADIENT,
+  },
+};
+
+export const DefaultTheme: Theme = {
+  barOptions: {
+    color: VIZ_GRADIENT_COLOR.neutral.up,
+    hasRoundedCorners: true,
+    innerMargin: 'Medium',
+    outerMargin: 'Medium',
+    zeroAsMinHeight: false,
+  },
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,4 @@ export {useLinearXAxisDetails, ChartDetails} from './useLinearXAxisDetails';
 export {useLinearXScale} from './useLinearXScale';
 export {usePrevious} from './use-previous';
 export {useResizeObserver} from './useResizeObserver';
+export {usePolarisVizContext} from './usePolarisVizContext';

--- a/src/hooks/usePolarisVizContext.ts
+++ b/src/hooks/usePolarisVizContext.ts
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+
+import {PolarisVizContext} from '../utilities/';
+
+export function usePolarisVizContext() {
+  const context = useContext(PolarisVizContext);
+  return context;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,3 +138,25 @@ export interface Dimensions {
 export type SparkChartData = number | null;
 export type PathInterpolator = InterpolatorFn<ReadonlyArray<number>, string>;
 export type NumberInterpolator = InterpolatorFn<ReadonlyArray<number>, number>;
+
+// === Theme types === //
+export enum BarMargin {
+  Small = 0.05,
+  Medium = 0.1,
+  Large = 0.3,
+  None = 0,
+}
+
+export interface BarOptions {
+  innerMargin: keyof typeof BarMargin;
+  outerMargin: keyof typeof BarMargin;
+  color: Color | GradientStop[];
+  hasRoundedCorners: boolean;
+  /**
+   * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
+   */
+  zeroAsMinHeight: boolean;
+}
+export interface Theme {
+  barOptions: Partial<BarOptions>;
+}

--- a/src/utilities/create-themes.ts
+++ b/src/utilities/create-themes.ts
@@ -1,0 +1,21 @@
+import {Theme} from '../types';
+import {DefaultTheme} from '../constants';
+
+export const createTheme = (theme: Partial<Theme>): Theme => {
+  const themeKeys = Object.keys(DefaultTheme) as [keyof Theme];
+
+  return themeKeys.reduce((accumulator, key: keyof Theme) => {
+    accumulator[key] = {
+      ...DefaultTheme[key],
+      ...theme[key],
+    };
+    return accumulator;
+  }, {} as Theme);
+};
+
+export const createThemes = (themeRecord: Record<string, Theme>) => {
+  return Object.keys(themeRecord).reduce((accumulator, themeName) => {
+    accumulator[themeName] = createTheme(themeRecord[themeName]);
+    return accumulator;
+  }, {} as Record<string, Theme>);
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -24,3 +24,5 @@ export {curveStepRounded} from './curve-step-rounded';
 export {makeColorOpaque, makeGradientOpaque} from './make-color-opaque';
 export {shouldRotateZeroBars} from './should-rotate-zero-bars';
 export {isNumber} from './is-number';
+export {createTheme, createThemes} from './create-themes';
+export {PolarisVizContext} from './polaris-viz-context';

--- a/src/utilities/polaris-viz-context.ts
+++ b/src/utilities/polaris-viz-context.ts
@@ -1,0 +1,12 @@
+import {createContext} from 'react';
+
+import {Theme} from '../types';
+import {DefaultTheme as Default} from '../constants';
+
+export const PolarisVizContext = createContext<{
+  themes: Record<string, Theme>;
+}>({
+  themes: {
+    Default,
+  },
+});

--- a/src/utilities/tests/create-themes.test.ts
+++ b/src/utilities/tests/create-themes.test.ts
@@ -1,0 +1,69 @@
+import {createTheme, createThemes} from '../';
+import {DefaultTheme} from '../../constants';
+
+describe('createTheme', () => {
+  it('generates a theme with default values, from the partial theme provided', () => {
+    const result = createTheme({
+      barOptions: {
+        innerMargin: 'Small',
+      },
+    });
+    expect(result).not.toStrictEqual(DefaultTheme);
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        barOptions: {
+          ...DefaultTheme.barOptions,
+          innerMargin: 'Small',
+        },
+      }),
+    );
+  });
+});
+
+describe('createThemes', () => {
+  it('generates a record of themes with default values, from the partial themes provided', () => {
+    const result = createThemes({
+      Default: {
+        barOptions: {
+          innerMargin: 'Small',
+        },
+      },
+    });
+    expect(result).not.toStrictEqual({Default: DefaultTheme});
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        Default: {
+          barOptions: {
+            ...DefaultTheme.barOptions,
+            innerMargin: 'Small',
+          },
+        },
+      }),
+    );
+  });
+
+  it('generates a record with multiple custom themes', () => {
+    const result = createThemes({
+      Default: DefaultTheme,
+      SomeTheme: {
+        barOptions: {
+          hasRoundedCorners: false,
+        },
+      },
+    });
+
+    expect(result).toStrictEqual(
+      expect.objectContaining({
+        Default: DefaultTheme,
+        SomeTheme: {
+          barOptions: {
+            ...DefaultTheme.barOptions,
+            hasRoundedCorners: false,
+          },
+        },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### What problem is this PR solving?

Introduces `PolarisVizProvider` that will allow us to define themes in a centralized place, so each chart in the library can consume.

This branch does not change any chart yet, just introduces `PolarisVizProvider` and `usePolarisVizContext`

Closes: https://github.com/Shopify/polaris-viz/issues/396

Opens: 
https://github.com/Shopify/polaris-viz/issues/404
https://github.com/Shopify/polaris-viz/issues/405
https://github.com/Shopify/polaris-viz/issues/406
https://github.com/Shopify/polaris-viz/issues/407
https://github.com/Shopify/polaris-viz/issues/408
https://github.com/Shopify/polaris-viz/issues/409
https://github.com/Shopify/polaris-viz/issues/410


### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
