### PR TITLE
Add tslib to our dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.17.1] - 2021-06-17
+
+### Changed
+
+- Adds `tslib@^2.1` to our package `dependencies` to avoid different versions of `tslib` resolving and breaking our code.
+
 ## [0.17.0] - 2021-06-16
 
 POTENTIALLY BROKEN -- This release implicitly depends on `tslib>=2.1.0` but other projects may not explicitly be using `tslib>=2.1.0`. For example, this version sporadically breaks in `web` since the version of `tslib` in `web` resolves to `^1`.

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "d3-shape": "^1.3.7",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
-    "use-debounce": "^3.3.0"
+    "use-debounce": "^3.3.0",
+    "tslib": "^2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13270,7 +13270,7 @@ lodash.xorby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -18825,6 +18825,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@~2.0.1:
   version "2.0.3"


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

We actually depend on this package since the code that TypeScript generates will transform some syntax into function calls. For example, Array Spreading syntax gets converted to `__spreadArray` from `tslib`.

When we tried to use version `0.17.0` of this package in the `web` project, we found that the version of `tslib` that gets resolved is actually `1.x` instead of `2.x` which we depend on.

This change requests tslib version `^2.1` since that is when `__spreadArray` was introduced: https://github.com/microsoft/tslib/releases/tag/2.1.0

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

1. `git checkout add-tslib-to-dependencies`
1. `yarn install`
1. `yarn why tslib` and verify you see:

    ```
    => Found "tslib@2.3.0"
    info Has been hoisted to "tslib"
    info This module exists because it's specified in "dependencies".
    info Disk size without dependencies: "72KB"
    info Disk size with unique dependencies: "72KB"
    info Disk size with transitive dependencies: "72KB"
    info Number of shared dependencies: 0
    ```

There isn't really a way to test this in `web` by doing `yarn run build-consumer web` since that doesn't trigger a `yarn install` in the `web` project.

### Before merging

- ~Check your changes on a variety of browsers and devices.~

- [x] Update the Changelog.

- ~Update relevant documentation.~
