### PR TITLE
Add more story coverage

### DIFF
--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -111,7 +111,29 @@ const Template: Story<BarChartProps> = (args: BarChartProps) => {
 };
 
 export const InsightsStyle = Template.bind({});
-InsightsStyle.args = defaultProps;
+InsightsStyle.args = {
+  ...defaultProps,
+  xAxisOptions: {
+    labelFormatter: defaultProps.xAxisOptions.labelFormatter,
+    showTicks: false,
+    labelColor: 'rgb(220, 220, 220)',
+  },
+  gridOptions: {
+    showVerticalLines: false,
+    color: 'rgb(99, 115, 129)',
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+  },
+  yAxisOptions: {
+    backgroundColor: '#333333',
+    labelColor: 'rgb(220, 220, 220)',
+  },
+};
+InsightsStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 
 export const OverflowStyle = Template.bind({});
 OverflowStyle.args = {
@@ -249,4 +271,35 @@ IntegersOnly.args = {
     ...defaultProps.yAxisOptions,
     integersOnly: true,
   },
+};
+
+export const SolidColor = Template.bind({});
+SolidColor.args = {
+  ...defaultProps,
+  barOptions: {
+    ...defaultProps.barOptions,
+    color: 'colorTeal',
+  },
+};
+
+export const NonRoundCorners = Template.bind({});
+NonRoundCorners.args = {
+  ...defaultProps,
+  barOptions: {
+    ...defaultProps.barOptions,
+    hasRoundedCorners: false,
+  },
+};
+
+export const LargeVolume = Template.bind({});
+LargeVolume.args = {
+  ...defaultProps,
+  data: Array(200)
+    .fill(null)
+    .map((x) => {
+      return {
+        rawValue: Math.random() * Math.random() * 100,
+        label: Math.random().toString(),
+      };
+    }),
 };

--- a/src/components/Legend/stories/Legend.stories.tsx
+++ b/src/components/Legend/stories/Legend.stories.tsx
@@ -91,6 +91,14 @@ DottedLineLegend.args = {
   ],
 };
 
+export const DashedLineLegend = Template.bind({});
+DashedLineLegend.args = {
+  series: [
+    {lineStyle: 'dashed', name: 'Sales', color: 'colorRed'},
+    {lineStyle: 'dashed', name: 'Visits', color: 'colorPurple'},
+  ],
+};
+
 export const LineLegend = Template.bind({});
 LineLegend.args = {
   series: [

--- a/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
+++ b/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
@@ -45,6 +45,32 @@ Default.args = {
       name: 'Primary',
       point: {label: 'Sept. 10, 1989', value: 28},
       color: 'colorRed',
+      lineStyle: 'solid',
+    },
+  ],
+};
+
+export const DashedLine = Template.bind({});
+
+DashedLine.args = {
+  data: [
+    {
+      name: 'Primary',
+      point: {label: 'Sept. 10, 1989', value: 28},
+      color: 'colorRed',
+      lineStyle: 'dashed',
+    },
+  ],
+};
+
+export const DottedLine = Template.bind({});
+
+DottedLine.args = {
+  data: [
+    {
+      name: 'Primary',
+      point: {label: 'Sept. 10, 1989', value: 28},
+      color: 'colorRed',
       lineStyle: 'dotted',
     },
   ],

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -9,7 +9,7 @@ import {
   formatXAxisLabel,
   formatYAxisLabel,
   renderTooltipContent,
-  defaultProps,
+  gradient,
 } from './utils.stories';
 
 const tooltipContent = {
@@ -106,7 +106,41 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
 };
 
 export const InsightsStyle = Template.bind({});
-InsightsStyle.args = defaultProps;
+InsightsStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+InsightsStyle.args = {
+  series,
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+    useMinimalLabels: true,
+    showTicks: false,
+    labelColor: 'rgb(220, 220, 220)',
+  },
+  lineOptions: {
+    hasSpline: true,
+    pointStroke: '#333333',
+  },
+  gridOptions: {
+    showVerticalLines: false,
+    color: 'rgb(99, 115, 129)',
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+  },
+  crossHairOptions: {
+    width: 1,
+  },
+  yAxisOptions: {
+    labelFormatter: formatYAxisLabel,
+    backgroundColor: '#333333',
+    labelColor: 'rgb(220, 220, 220)',
+  },
+  renderTooltipContent,
+  isAnimated: true,
+};
 
 export const HideXAxisLabels = Template.bind({});
 HideXAxisLabels.args = {
@@ -161,37 +195,6 @@ curvedLines.args = {
   renderTooltipContent,
 };
 
-export const DarkMode = Template.bind({});
-DarkMode.parameters = {
-  backgrounds: {
-    default: 'dark',
-  },
-};
-DarkMode.args = {
-  series,
-  xAxisOptions: {
-    xAxisLabels,
-    labelFormatter: formatXAxisLabel,
-    useMinimalLabels: true,
-    showTicks: false,
-  },
-  lineOptions: {
-    hasSpline: true,
-    pointStroke: '#333333',
-  },
-  gridOptions: {
-    showVerticalLines: false,
-    color: 'rgb(99, 115, 129)',
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-  },
-  crossHairOptions: {
-    width: 1,
-  },
-  yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: '#333333'},
-  renderTooltipContent,
-};
-
 export const IntegersOnly = Template.bind({});
 IntegersOnly.args = {
   series: [
@@ -213,5 +216,89 @@ IntegersOnly.args = {
     labelFormatter: formatXAxisLabel,
   },
   yAxisOptions: {integersOnly: true},
+  renderTooltipContent,
+};
+
+export const NoArea = Template.bind({});
+NoArea.args = {
+  series: [
+    {
+      name: 'Sales',
+      data: [
+        {rawValue: 100, label: '2020-04-01T12:00:00'},
+        {rawValue: 99, label: '2020-04-02T12:00:00'},
+        {rawValue: 1000, label: '2020-04-03T12:00:00'},
+        {rawValue: 2, label: '2020-04-04T12:00:00'},
+        {rawValue: 22, label: '2020-04-05T12:00:00'},
+        {rawValue: 6, label: '2020-04-06T12:00:00'},
+        {rawValue: 5, label: '2020-04-07T12:00:00'},
+      ],
+      color: gradient,
+    },
+  ],
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+  },
+  renderTooltipContent,
+};
+
+export const SolidColor = Template.bind({});
+SolidColor.args = {
+  series: [
+    {
+      name: 'Sales',
+      data: [
+        {rawValue: 100, label: '2020-04-01T12:00:00'},
+        {rawValue: 99, label: '2020-04-02T12:00:00'},
+        {rawValue: 1000, label: '2020-04-03T12:00:00'},
+        {rawValue: 2, label: '2020-04-04T12:00:00'},
+        {rawValue: 22, label: '2020-04-05T12:00:00'},
+        {rawValue: 6, label: '2020-04-06T12:00:00'},
+        {rawValue: 5, label: '2020-04-07T12:00:00'},
+      ],
+      color: 'colorTeal',
+    },
+  ],
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+  },
+  renderTooltipContent,
+};
+
+export const LargeDataSet = Template.bind({});
+LargeDataSet.args = {
+  series: [
+    {
+      name: 'series 1',
+      data: Array(3000)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: 'Some value',
+          };
+        }),
+    },
+    {
+      name: 'series 2',
+      data: Array(3000)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: 'Some value',
+          };
+        }),
+    },
+  ],
+  xAxisOptions: {
+    xAxisLabels: Array(3000)
+      .fill(null)
+      .map((x) => {
+        return 'Some value';
+      }),
+  },
   renderTooltipContent,
 };

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -9,6 +9,21 @@ import {
 } from '../../../constants';
 import {colorWhite, colorSky} from '@shopify/polaris-tokens';
 
+export const gradient = [
+  {
+    offset: 0,
+    color: '#08CA9B',
+  },
+  {
+    offset: 85,
+    color: 'rgba(92,105,208,0.8)',
+  },
+  {
+    offset: 100,
+    color: 'rgba(92,105,208,0.8)',
+  },
+];
+
 export const series = [
   {
     name: 'Apr 01–Apr 14, 2020',
@@ -28,20 +43,7 @@ export const series = [
       {rawValue: 849, label: '2020-04-13T12:00:00'},
       {rawValue: 129, label: '2020-04-14T12:00:00'},
     ],
-    color: [
-      {
-        offset: 0,
-        color: '#08CA9B',
-      },
-      {
-        offset: 85,
-        color: 'rgba(92,105,208,0.8)',
-      },
-      {
-        offset: 100,
-        color: 'rgba(92,105,208,0.8)',
-      },
-    ],
+    color: gradient,
     lineStyle: 'solid' as 'solid',
     areaColor: 'rgba(92,105,208,0.5)',
   },

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.scss
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.scss
@@ -3,7 +3,6 @@ body {
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 .Container {
-  background: white;
   padding: 20px;
   box-sizing: border-box;
   height: 400px;

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -4,12 +4,10 @@ import {Story, Meta} from '@storybook/react';
 import {
   MultiSeriesBarChart,
   MultiSeriesBarChartProps,
-  TooltipContent,
 } from '../../../components';
 
 import styles from './MultiSeriesBarChart.stories.scss';
 import {DEFAULT_GREY_LABEL} from '../../../constants';
-import {BarMargin} from '../types';
 import {colorSky} from '@shopify/polaris-tokens';
 import {SquareColorPreview} from '../../SquareColorPreview';
 
@@ -201,9 +199,6 @@ const defaultProps = {
   },
 };
 
-export const Default = Template.bind({});
-Default.args = defaultProps;
-
 const purple = '#5052b3';
 const negativePurple = '#39337f';
 const green = '#1bbe9e';
@@ -240,13 +235,33 @@ const gradientSeries = series
   }))
   .filter((_, index) => index < 2);
 
-export const Gradient = Template.bind({});
-Gradient.args = {
+export const InsightsStyle = Template.bind({});
+InsightsStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+InsightsStyle.args = {
   series: gradientSeries,
-  xAxisOptions: {labels},
+  xAxisOptions: {labels, showTicks: false, labelColor: 'rgb(220, 220, 220)'},
   barOptions: {
     hasRoundedCorners: true,
   },
+  yAxisOptions: {
+    backgroundColor: '#333333',
+    labelColor: 'rgb(220, 220, 220)',
+  },
+  gridOptions: {
+    showVerticalLines: false,
+    color: 'rgb(99, 115, 129)',
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+  },
+  crossHairOptions: {
+    width: 1,
+    color: 'rgb(139, 159, 176)',
+  },
+  isAnimated: true,
 };
 
 export const OverflowStyles = Template.bind({});
@@ -255,6 +270,21 @@ OverflowStyles.args = {
   xAxisOptions: {labels},
   barOptions: {
     hasRoundedCorners: true,
+  },
+  yAxisOptions: {backgroundColor: 'white'},
+  gridOptions: {
+    horizontalOverflow: true,
+    horizontalMargin: 30,
+    showVerticalLines: false,
+  },
+};
+
+export const WithoutRoundedCorners = Template.bind({});
+WithoutRoundedCorners.args = {
+  series: gradientSeries,
+  xAxisOptions: {labels},
+  barOptions: {
+    hasRoundedCorners: false,
   },
   yAxisOptions: {backgroundColor: 'white'},
   gridOptions: {
@@ -327,4 +357,39 @@ IntegersOnly.args = {
   ],
   xAxisOptions: {labels},
   yAxisOptions: {integersOnly: true},
+};
+
+export const LargeVolume = Template.bind({});
+LargeVolume.args = {
+  series: [
+    {
+      name: 'Breakfast',
+      color: 'primary',
+      data: Array(200)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Lunch',
+      color: 'secondary',
+      data: Array(200)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+  ],
+  xAxisOptions: {
+    labels: Array(200)
+      .fill(null)
+      .map((x) => 'some label'),
+  },
 };

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -84,15 +84,19 @@ const defaultProps = {
     {x: 9, y: comparisonValue},
     {x: 10, y: comparisonValue},
   ],
-  color: primaryColor,
+  color: 'darkModePositive',
   barFillStyle: 'solid',
   accessibilityLabel:
     'A bar chart showing orders over time for the past 11 weeks. The minimum is 100 orders and the maximum is 1,000 orders, compared to an average of 500 orders during previous 11-week period.',
 };
 
-export const Default = Template.bind({});
-Default.args = defaultProps;
-
+export const DarkMode = Template.bind({});
+DarkMode.args = defaultProps;
+DarkMode.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 export const OffsetAndNulls = Template.bind({});
 OffsetAndNulls.args = {
   ...defaultProps,

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -6,7 +6,7 @@ import {primaryColor, secondaryColor} from '../../../utilities';
 
 const series = [
   {
-    color: primaryColor,
+    color: 'darkModePositive',
     areaStyle: 'gradient',
     hasPoint: true,
     data: [
@@ -24,21 +24,21 @@ const series = [
     ],
   },
   {
-    color: secondaryColor,
+    color: 'darkModePositive',
     areaStyle: 'none',
     lineStyle: 'dashed',
     data: [
-      {x: 0, y: 10},
-      {x: 1, y: 20},
-      {x: 2, y: 30},
-      {x: 3, y: 40},
-      {x: 4, y: 40},
-      {x: 5, y: 400},
-      {x: 6, y: 20},
-      {x: 7, y: 80},
-      {x: 8, y: 90},
-      {x: 9, y: 20},
-      {x: 10, y: 40},
+      {x: 0, y: 200},
+      {x: 1, y: 200},
+      {x: 2, y: 200},
+      {x: 3, y: 200},
+      {x: 4, y: 200},
+      {x: 5, y: 200},
+      {x: 6, y: 200},
+      {x: 7, y: 200},
+      {x: 8, y: 200},
+      {x: 9, y: 200},
+      {x: 10, y: 200},
     ],
   },
 ];
@@ -90,8 +90,13 @@ const defaultProps = {
   accessibilityLabel: 'Customer growth over time',
 };
 
-export const Default = Template.bind({});
-Default.args = defaultProps;
+export const InsightsStyle = Template.bind({});
+InsightsStyle.args = defaultProps;
+InsightsStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 
 export const hasSpline = Template.bind({});
 hasSpline.args = {

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -97,3 +97,37 @@ const Template: Story<StackedAreaChartProps> = (
 };
 export const Default = Template.bind({});
 Default.args = defaultProps;
+
+export const LargeVolume = Template.bind({});
+LargeVolume.args = {
+  ...defaultProps,
+  xAxisLabels: Array(2000)
+    .fill(null)
+    .map((x) => 'label'),
+  series: [
+    {
+      name: 'First-time',
+      data: Array(2000)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+      color: 'primary' as 'primary',
+    },
+    {
+      name: 'Returning',
+      data: Array(2000)
+        .fill(null)
+        .map((x) => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+      color: 'secondary' as 'secondary',
+    },
+  ],
+};


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/415

Adds stories for:
- [x]  different line types in the Legend and Tooltip
- [x]  non-gradient colors
- [x]  dark mode
- [x]  line chart without area
- [x]  stories specifically with and without bar chart rounded corners
- [x]  large volume datasets

### Reviewers’ :tophat: instructions
N/A

### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~
~- [ ] Update the Changelog.~

- [x] Update relevant documentation.
