### PR TITLE
Fix labels and round bars for large volume bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixes `<BarChart />` when very large datasets are displayed
+
 ## [0.17.2] - 2021-06-23
 
 ### Changed

--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -24,7 +24,7 @@ interface Props {
   rotateZeroBars: boolean;
 }
 
-export function Bar({
+export const Bar = React.memo(function Bar({
   color,
   x,
   rawValue,
@@ -43,7 +43,9 @@ export function Bar({
   const treatAsNegative = rawValue < 0 || (rawValue === 0 && rotateZeroBars);
   const rotation = treatAsNegative ? 'rotate(180deg)' : 'rotate(0deg)';
   const xPosition = treatAsNegative ? x + width : x;
-  const radius = hasRoundedCorners ? ROUNDED_BAR_RADIUS : 0;
+  const radius = hasRoundedCorners
+    ? Math.min(ROUNDED_BAR_RADIUS, width / 2)
+    : 0;
 
   const yPosition = useMemo(() => {
     if (height == null) return;
@@ -113,4 +115,4 @@ export function Bar({
       className={styles.Bar}
     />
   );
-}
+});

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -201,6 +201,18 @@ export function Chart({
     [barOptions, yScale],
   );
 
+  const handleFocus = useCallback(
+    ({index, cx, cy}: {index: number; cx: number; cy: number}) => {
+      if (index == null) return;
+      setActiveBar(index);
+      setTooltipPosition({
+        x: cx + chartStartPosition + xScale.bandwidth() / 2,
+        y: cy,
+      });
+    },
+    [chartStartPosition, xScale],
+  );
+
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
   const transitions = useTransition(data, {
@@ -408,23 +420,6 @@ export function Chart({
       ) : null}
     </div>
   );
-
-  function handleFocus({
-    index,
-    cx,
-    cy,
-  }: {
-    index: number;
-    cx: number;
-    cy: number;
-  }) {
-    if (index == null) return;
-    setActiveBar(index);
-    setTooltipPosition({
-      x: cx + chartStartPosition + xScale.bandwidth() / 2,
-      y: cy,
-    });
-  }
 
   function handleInteraction(
     event: React.MouseEvent<SVGSVGElement> | React.TouchEvent<SVGSVGElement>,

--- a/src/components/BarChart/hooks/use-x-scale.ts
+++ b/src/components/BarChart/hooks/use-x-scale.ts
@@ -17,15 +17,17 @@ export function useXScale({
   data: Data[];
   formatXAxisLabel: StringLabelFormatter;
 }) {
-  const xScale = scaleBand()
-    .range([0, drawableWidth])
-    .paddingInner(innerMargin)
-    .paddingOuter(outerMargin)
-    .domain(data.map((_, index) => index.toString()));
-
-  const barWidthOffset = xScale.bandwidth() / 2;
+  const xScale = useMemo(() => {
+    return scaleBand()
+      .range([0, drawableWidth])
+      .paddingInner(innerMargin)
+      .paddingOuter(outerMargin)
+      .domain(data.map((_, index) => index.toString()));
+  }, [drawableWidth, innerMargin, outerMargin, data]);
 
   const xAxisLabels = useMemo(() => {
+    const barWidthOffset = xScale.bandwidth() / 2;
+
     const labels = data.map(({label}) => label);
 
     return data.map(({label}, index) => {
@@ -38,7 +40,7 @@ export function useXScale({
         xOffset,
       };
     });
-  }, [data, xScale, barWidthOffset, formatXAxisLabel]);
+  }, [data, xScale, formatXAxisLabel]);
 
   return {xScale, xAxisLabels};
 }

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -294,7 +294,7 @@ NonRoundCorners.args = {
 export const LargeVolume = Template.bind({});
 LargeVolume.args = {
   ...defaultProps,
-  data: Array(200)
+  data: Array(1000)
     .fill(null)
     .map((x) => {
       return {

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -65,7 +65,7 @@ function getMiniminalLabelPosition({
   return xOffset - width / 2;
 }
 
-export function BarChartXAxis({
+export const BarChartXAxis = React.memo(function BarChartXAxis({
   labels,
   xScale,
   fontSize,
@@ -181,4 +181,4 @@ export function BarChartXAxis({
       })}
     </React.Fragment>
   );
-}
+});

--- a/src/components/HorizontalGridLines/HorizontalGridLines.tsx
+++ b/src/components/HorizontalGridLines/HorizontalGridLines.tsx
@@ -9,7 +9,12 @@ interface Props {
   width: number;
 }
 
-export function HorizontalGridLines({ticks, color, transform, width}: Props) {
+export const HorizontalGridLines = React.memo(function HorizontalGridLines({
+  ticks,
+  color,
+  transform,
+  width,
+}: Props) {
   return (
     <React.Fragment>
       {ticks.map(({yOffset}, index) => (
@@ -22,4 +27,4 @@ export function HorizontalGridLines({ticks, color, transform, width}: Props) {
       ))}
     </React.Fragment>
   );
-}
+});

--- a/src/utilities/get-bar-xaxis-details.ts
+++ b/src/utilities/get-bar-xaxis-details.ts
@@ -55,10 +55,12 @@ export function getBarXAxisDetails({
       LABEL_SPACE_MINUS_FIRST_AND_LAST
     : null;
 
+  const spaceBetweenLabels = Math.min(SPACING_EXTRA_TIGHT, step / 2);
+
   // width each label is allowed to take up
   const datumXLabelSpace =
     spaceForMinimalLabels == null
-      ? step - SPACING_EXTRA_TIGHT
+      ? step - spaceBetweenLabels
       : spaceForMinimalLabels;
 
   // calculations are based on the longest label


### PR DESCRIPTION
### What problem is this PR solving?

Fixes the bar chart and multiseries bar chart with high volumes of data. 1,000 bars are shown below. Although we typically won't be using a bar chart for such high volumes of data, it shouldn't be totally broken. On some surfaces it might be possible for a merchant to be able to get into this state even if it isn't recommended. 

| Before 😬  | After 😅  |  
|---|---|
| <img width="1471" alt="Screen Shot 2021-06-23 at 2 47 54 PM" src="https://user-images.githubusercontent.com/12213371/123152065-2b9b8d80-d432-11eb-9fa5-41092193eee8.png">  | <img width="1465" alt="Screen Shot 2021-06-23 at 2 47 05 PM" src="https://user-images.githubusercontent.com/12213371/123152067-2c342400-d432-11eb-8882-ca97deacc94d.png">|

Does the following:
- Ensures the bar radius is never larger than half the width of the bar, which can lead to weird shapes
- no longer removes spacing from `datumXLabelSpace`. It seems unnecessary and was leading to negatives, hence the messed up labels. If we want to include the spacing in most cases, I could make the amount smarter rather than removing it all together.
- some basic performance improvements. We still need to do a thorough examination of performance for the bar chart components but these seemed like obvious wins. I didn't measure in great detail, but they did seem to improve performance for me. 

### Reviewers’ :tophat: instructions
Check the bar chart stories and make sure I didn't break anything unintentionally 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
