### PR TITLE
Align comparison line and bars in Sparkbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `SparkChartData` now accepts `value` and `color` properties, instead of `number | null`, to allow individual bars to override the `seriesColors`.
 
 ### Fixed
+- in `<Sparkbar />`, align comparison bar and bars.
 - `<NormalizedStackedBarChart />` no longer overflows its container by a few pixels
 - [Updates `serialize-javascript` package](https://github.com/Shopify/polaris-viz/pull/477). No consumer-facing changes are expected.
 

--- a/src/components/Sparkbar/Sparkbar.scss
+++ b/src/components/Sparkbar/Sparkbar.scss
@@ -12,5 +12,5 @@
 
 .ComparisonLine {
   fill: none;
-  stroke-dasharray: 3 2;
+  stroke-linecap: round;
 }

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -135,6 +135,16 @@ export function Sparkbar({
   const lineShape = comparison ? lineGenerator(comparison) : null;
 
   const barWidth = useMemo(() => xScale.bandwidth(), [xScale]);
+  const barGap = useMemo(
+    () => xScale.step() * xScale.paddingInner() + STROKE_WIDTH,
+    [xScale],
+  );
+
+  const strokeDashoffset =
+    dataOffsetLeft == null
+      ? -(STROKE_WIDTH / 2)
+      : -(STROKE_WIDTH / 2) - dataOffsetLeft;
+  const strokeDasharray = `${barWidth - STROKE_WIDTH} ${barGap}`;
 
   const id = useMemo(() => uniqueId('sparkbar'), []);
 
@@ -269,6 +279,8 @@ export function Sparkbar({
             d={lineShape!}
             className={styles.ComparisonLine}
             opacity="0.9"
+            strokeDashoffset={strokeDashoffset}
+            strokeDasharray={strokeDasharray}
           />
         )}
       </svg>

--- a/src/components/Sparkbar/tests/Sparkbar.test.tsx
+++ b/src/components/Sparkbar/tests/Sparkbar.test.tsx
@@ -21,6 +21,7 @@ jest.mock('d3-scale', () => ({
       paddingInner ? scale : paddingInner;
     scale.domain = (domain: any) => (domain ? scale : domain);
     scale.bandwidth = (width: any) => (width ? scale : width);
+    scale.step = (step: any) => (step ? scale : step);
     return scale;
   }),
   scaleLinear: jest.fn(() => {
@@ -78,6 +79,52 @@ describe('<Sparkbar/>', () => {
     expect(wrapper).toContainReactComponentTimes('path', 4);
   });
 
+  it('has the comparison line align with the bars', () => {
+    (scaleBand as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.range = (range: any) => (range ? scale : range);
+      scale.paddingInner = (paddingInner: any) => (paddingInner ? scale : 0.5);
+      scale.domain = (domain: any) => (domain ? scale : domain);
+      scale.bandwidth = (width: any) => (width ? scale : 20);
+      scale.step = (step: any) => (step ? scale : 20);
+      return scale;
+    });
+
+    const wrapper = mount(
+      <Sparkbar data={sampleData} comparison={sampleComparison} />,
+    );
+
+    expect(wrapper).toContainReactComponent('path', {
+      strokeDasharray: '18.5 11.5',
+      strokeDashoffset: -0.75,
+    });
+  });
+
+  it('has the comparison line align with the bars when using dataOffsetLeft', () => {
+    (scaleBand as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      scale.range = (range: any) => (range ? scale : range);
+      scale.paddingInner = (paddingInner: any) => (paddingInner ? scale : 0.5);
+      scale.domain = (domain: any) => (domain ? scale : domain);
+      scale.bandwidth = (width: any) => (width ? scale : 20);
+      scale.step = (step: any) => (step ? scale : 20);
+      return scale;
+    });
+
+    const wrapper = mount(
+      <Sparkbar
+        data={sampleData}
+        comparison={sampleComparison}
+        dataOffsetLeft={25}
+      />,
+    );
+
+    expect(wrapper).toContainReactComponent('path', {
+      strokeDasharray: '18.5 11.5',
+      strokeDashoffset: -25.75,
+    });
+  });
+
   it('reduces the chart width according to the offset and margin', () => {
     let rangeSpy = jest.fn();
     (scaleBand as jest.Mock).mockImplementation(() => {
@@ -88,6 +135,7 @@ describe('<Sparkbar/>', () => {
         paddingInner ? scale : paddingInner;
       scale.domain = (domain: any) => (domain ? scale : domain);
       scale.bandwidth = (width: any) => (width ? scale : width);
+      scale.step = (step: any) => (step ? scale : step);
       return scale;
     });
 


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

Part of https://github.com/Shopify/core-issues/issues/25892

~There are two goals here.~ (Updated PR to only do part 1)
1. To have the  strokes of the comparison line dashed line to overlap the bars perfect and also for  the gaps in the  dashed line to overlap the  gaps between  the bars perfectly.
2. ~Change the colours of the comparison bar for the negative and positive~
<details><summary><em>(open for screenshot)</em></summary>

[![alt](https://screenshot.click/21-55-zmieu-l7em8.png)](https://screenshot.click/21-55-zmieu-l7em8.png)
</details>

**_How this PR does that:_**

~**Colour:**~
- ~Adds colour names ending with comparison and also adding a prop to the component to allow these colours (or any other) to be added for comparison. When prop not present, the comparison line will be the same color as the the bar color, but with a different opacity.~

**Stroke:**
- Finds width of bar
- Finds width of gap
- Using [stroke-linecap](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap) as a resource, using widths of bar and gap, finds [stroke-dasharray](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray) 

**_Questions_** @carysmills  @krystalcampioni 
1. Main question is whether this should be the default behaviour of a comparison line on the Sparkbar component, or whether it should optional by using a prop as a setting. **Going with default 👍🏻** 



### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->


1. checkout branch
2. `yarn dev`
3. Using the code below, take a look at how it is showing up.

<details><summary><em>(open for screenshot)</em></summary>

```
import React, {useState} from 'react';

import '@shopify/polyfills/base';
import {OUTER_CONTAINER_STYLE} from '../documentation/code/constants';

import {Sparkbar} from '../src/components/Sparkbar';

import * as PlaygroundDemos from '../documentation/code';

const Demos = () => {
  return (
    <>
      {Object.entries(PlaygroundDemos).map(([title, Component]) => {
        return (
          <span key={title}>
            <h3>{title}</h3>
            <Component />
          </span>
        );
      })}
    </>
  );
};

export default function Playground() {
  const [showDemos, setShowDemos] = useState(false);
  const toggleDemos = () => setShowDemos((showingDemos) => !showingDemos);

  return (
    <div>
      <h3>Playground area</h3>
      <div style={OUTER_CONTAINER_STYLE}>
        <div
          style={{
            display: 'grid',
            placeItems: 'center',
          }}
        >
          <div style={{width: 400, height: 450, border: '1px dotted #ddd'}}>
            <Sparkbar
              data={[10, 9, 8, 8, 8, 8, 8, 6, 9]}
              dataOffsetRight={40}
              color={'darkModeNegative'}
              comparison={[
                {x: 0, y: 5},
                {x: 1, y: 5},
                {x: 2, y: 5},
                {x: 3, y: 5},
                {x: 4, y: 5},
                {x: 5, y: 5},
                {x: 6, y: 5},
                {x: 7, y: 5},
                {x: 8, y: 5},
                {x: 9, y: 5},
                {x: 10, y: 5},
              ]}
              barFillStyle="solid"
            />
          </div>
        </div>
      </div>
      <br />
      <button onClick={toggleDemos}>Toggle Demos</button>
      {showDemos && <Demos />}
    </div>
  );
}

```
</details>

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
