### PR TITLE
Theming - BarChart

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,22 @@
 import React from 'react';
-
+import {PolarisVizProvider} from '../src/components';
 export const parameters = {
+  backgrounds: {
+    default: 'twitter',
+    values: [
+      {
+        name: 'light',
+        value: '#FFF',
+      },
+      {
+        name: 'dark',
+        value: '#1f1f25',
+      },
+    ],
+  },
   options: {
     storySort: {
-      order: ['Charts', 'Subcomponents'],
+      order: ['Providers', 'Charts', 'Subcomponents'],
     },
   },
 };
@@ -18,7 +31,17 @@ export const decorators = [
         overflow: 'hidden',
       }}
     >
-      <Story />
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            chartContainer: {
+              padding: '20px',
+            },
+          },
+        }}
+      >
+        <Story />
+      </PolarisVizProvider>
     </div>
   ),
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Fixed
 
 - Fixes `<BarChart />` when very large datasets are displayed
+### Added
+- `PolarisVizProvider` to support theming charts
+- `theme` to `BarChartProps`
+### Removed 
+- `barOptions`, `gridOptions`, `xAxisOptions.showTicks`, `xAxisOptions.labelColor` and `yAxisOptions.labelColor` from `BarChartProps`.
+
+### Changed
+- BarChart styles now are defined through themes in `PolarisVizProvider` instead of props. For more details check the [migration guide](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit?usp=sharing)
 
 ## [0.17.2] - 2021-06-23
 

--- a/documentation/code/BarChartDemo.tsx
+++ b/documentation/code/BarChartDemo.tsx
@@ -2,14 +2,7 @@ import React from 'react';
 
 import {BarChart, BarChartTooltipContent} from '../../src/components';
 
-import {OUTER_CONTAINER_STYLE} from './constants';
-
-export function BarChartDemo() {
-  const innerContainerStyle = {
-    width: '100%',
-    height: '300px',
-  };
-
+export function BarChartDemo({theme = 'Default'}) {
   document.body.style.fontFamily =
     "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";
 
@@ -70,28 +63,17 @@ export function BarChartDemo() {
   }
 
   return (
-    <div style={{...OUTER_CONTAINER_STYLE, background: '#1f1f25'}}>
-      <div style={innerContainerStyle}>
-        <BarChart
-          data={data}
-          barOptions={{
-            color: 'quaternary',
-            hasRoundedCorners: true,
-          }}
-          xAxisOptions={{
-            labelFormatter: formatXAxisLabel,
-            showTicks: false,
-            labelColor: '#8D8D8E',
-          }}
-          gridOptions={{color: 'rgb(65, 66, 71)'}}
-          yAxisOptions={{
-            labelFormatter: formatYAxisLabel,
-            labelColor: '#8D8D8E',
-          }}
-          renderTooltipContent={renderTooltipContent}
-          skipLinkText="Skip chart content"
-        />
-      </div>
-    </div>
+    <BarChart
+      theme={theme}
+      data={data}
+      xAxisOptions={{
+        labelFormatter: formatXAxisLabel,
+      }}
+      yAxisOptions={{
+        labelFormatter: formatYAxisLabel,
+      }}
+      renderTooltipContent={renderTooltipContent}
+      skipLinkText="Skip chart content"
+    />
   );
 }

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -11,7 +11,13 @@ const Demos = () => {
         return (
           <span key={title}>
             <h3>{title}</h3>
-            <Component />
+            <div
+              style={{
+                height: title == 'BarChartDemo' ? '300px' : '100%',
+              }}
+            >
+              <Component />
+            </div>
           </span>
         );
       })}

--- a/src/components/BarChart/BarChart.scss
+++ b/src/components/BarChart/BarChart.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.ChartContainer {
+  @include chart-container;
+}

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -1,21 +1,18 @@
 import React, {useState, useLayoutEffect, useRef, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
-import {colorSky} from '@shopify/polaris-tokens';
 
-import {Dimensions, BarOptions, BarMargin} from '../../types';
-import {DEFAULT_GREY_LABEL} from '../../constants';
+import {Dimensions, BarMargin} from '../../types';
 import {SkipLink} from '../SkipLink';
-import {getDefaultColor, uniqueId, normalizeData} from '../../utilities';
-import {useResizeObserver} from '../../hooks';
+import {uniqueId, normalizeData} from '../../utilities';
+import {useResizeObserver, useTheme} from '../../hooks';
+import type {XAxisOptions, YAxisOptions} from '../../types';
 
+import styles from './BarChart.scss';
 import {TooltipContent} from './components';
 import {Chart} from './Chart';
 import type {
   BarChartData,
   RenderTooltipContentData,
-  GridOptions,
-  XAxisOptions,
-  YAxisOptions,
   Annotation,
   AnnotationLookupTable,
 } from './types';
@@ -27,10 +24,9 @@ export interface BarChartProps {
   emptyStateText?: string;
   isAnimated?: boolean;
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
-  barOptions?: Partial<BarOptions>;
-  gridOptions?: Partial<GridOptions>;
-  xAxisOptions?: Partial<XAxisOptions>;
-  yAxisOptions?: Partial<YAxisOptions>;
+  xAxisOptions?: XAxisOptions;
+  yAxisOptions?: YAxisOptions;
+  theme?: string;
 }
 
 export function BarChart({
@@ -40,11 +36,18 @@ export function BarChart({
   emptyStateText,
   isAnimated = false,
   skipLinkText,
-  barOptions,
-  gridOptions,
-  xAxisOptions,
-  yAxisOptions,
+  xAxisOptions = {
+    labelFormatter: (value: string) => value,
+    useMinimalLabels: false,
+  },
+  yAxisOptions = {
+    integersOnly: false,
+    labelFormatter: (value: number) => value.toString(),
+  },
+  theme = 'Default',
 }: BarChartProps) {
+  const selectedTheme = useTheme(theme);
+
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
   );
@@ -83,6 +86,26 @@ export function BarChart({
     },
     [ref],
   );
+
+  const xAxisOptionsWithDefaults = {
+    labelFormatter:
+      xAxisOptions.labelFormatter == null
+        ? (value: string) => value
+        : xAxisOptions.labelFormatter,
+    useMinimalLabels:
+      xAxisOptions.useMinimalLabels == null
+        ? false
+        : xAxisOptions.useMinimalLabels,
+  };
+
+  const yAxisOptionsWithDefaults = {
+    labelFormatter:
+      yAxisOptions.labelFormatter == null
+        ? (value: number) => value.toString()
+        : yAxisOptions.labelFormatter,
+    integersOnly:
+      yAxisOptions.integersOnly == null ? false : yAxisOptions.integersOnly,
+  };
 
   useLayoutEffect(() => {
     updateDimensions();
@@ -126,47 +149,10 @@ export function BarChart({
     handlePrintMediaQueryChange,
   ]);
 
-  const innerMargin =
-    barOptions != null && barOptions.innerMargin != null
-      ? BarMargin[barOptions.innerMargin]
-      : BarMargin.Medium;
-
-  const outerMargin =
-    barOptions != null && barOptions.outerMargin != null
-      ? BarMargin[barOptions.outerMargin]
-      : BarMargin.None;
-
-  const barOptionsWithDefaults = {
-    color: getDefaultColor(),
-    hasRoundedCorners: false,
-    zeroAsMinHeight: false,
-    ...barOptions,
-    innerMargin,
-    outerMargin,
-  };
-
-  const gridOptionsWithDefaults = {
-    showHorizontalLines: true,
-    color: colorSky,
-    horizontalOverflow: false,
-    horizontalMargin: 0,
-    ...gridOptions,
-  };
-
-  const xAxisOptionsWithDefaults = {
-    labelFormatter: (value: string) => value,
-    showTicks: true,
-    labelColor: DEFAULT_GREY_LABEL,
-    useMinimalLabels: false,
-    ...xAxisOptions,
-  };
-
-  const yAxisOptionsWithDefaults = {
-    labelFormatter: (value: number) => value.toString(),
-    labelColor: DEFAULT_GREY_LABEL,
-    backgroundColor: 'transparent',
-    integersOnly: false,
-    ...yAxisOptions,
+  const barThemeWithMargins = {
+    ...selectedTheme.bar,
+    innerMargin: BarMargin[selectedTheme.bar.innerMargin],
+    outerMargin: BarMargin[selectedTheme.bar.outerMargin],
   };
 
   function renderDefaultTooltipContent({
@@ -191,7 +177,15 @@ export function BarChart({
   }
 
   return (
-    <div style={{width: '100%', height: '100%'}} ref={setRef}>
+    <div
+      className={styles.ChartContainer}
+      style={{
+        background: selectedTheme.chartContainer.backgroundColor,
+        padding: selectedTheme.chartContainer.padding,
+        borderRadius: selectedTheme.chartContainer.borderRadius,
+      }}
+      ref={setRef}
+    >
       {chartDimensions == null ? null : (
         <React.Fragment>
           {skipLinkText == null ||
@@ -206,15 +200,17 @@ export function BarChart({
             data={data}
             annotationsLookupTable={annotationsLookupTable}
             chartDimensions={chartDimensions}
-            barOptions={barOptionsWithDefaults}
-            gridOptions={gridOptionsWithDefaults}
-            xAxisOptions={xAxisOptionsWithDefaults}
-            yAxisOptions={yAxisOptionsWithDefaults}
+            barTheme={barThemeWithMargins}
+            gridTheme={selectedTheme.grid}
+            xAxisTheme={selectedTheme.xAxis}
+            yAxisTheme={selectedTheme.yAxis}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
+            xAxisOptions={xAxisOptionsWithDefaults}
+            yAxisOptions={yAxisOptionsWithDefaults}
             emptyStateText={emptyStateText}
           />
           {skipLinkText == null ||

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Story, Meta} from '@storybook/react';
 
-import {BarChart, BarChartProps} from '../../../components';
+import {BarChart, BarChartProps, PolarisVizProvider} from '../../../components';
 
 import {formatXAxisLabel, defaultProps} from './utils.stories';
 
@@ -38,6 +38,9 @@ export default {
   },
   argTypes: {
     annotations: {
+      control: {
+        type: 'select',
+      },
       description:
         'An array of annotations to show on the chart. [Annotation type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L61)',
       options: ['No annotation', 'Annotation on second bar'],
@@ -72,20 +75,11 @@ export default {
       },
     },
     data: {
-      description:
-        'Data represented as bars. Required. [BarChartData type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L8-L14)',
-    },
-    barOptions: {
-      description:
-        'Control the appearance of bars and the spacing between them. [BarOptions type definition](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L29).',
+      description: 'Data represented as bars. Required.',
     },
     emptyStateText: {
       description:
         'Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the data prop could be an empty array.',
-    },
-    gridOptions: {
-      description:
-        'An object including the following optional proprties that define the grid. [GridOptions type defintion.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L40)',
     },
     isAnimated: {
       description:
@@ -96,12 +90,10 @@ export default {
         'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
     },
     xAxisOptions: {
-      description:
-        'An object used to configure the appearance of the xAxis and its labels. [XAxisOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L47)',
+      description: 'An object used to configure the xAxis and its labels.',
     },
     yAxisOptions: {
-      description:
-        'An object used to configure the appearance of the yAxis and its labels. [YAxisOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L54)',
+      description: 'An object used to configure the yAxis and its labels.',
     },
   },
 } as Meta;
@@ -110,45 +102,19 @@ const Template: Story<BarChartProps> = (args: BarChartProps) => {
   return <BarChart {...args} />;
 };
 
-export const InsightsStyle = Template.bind({});
-InsightsStyle.args = {
+export const Default = Template.bind({});
+Default.args = {
   ...defaultProps,
   xAxisOptions: {
     labelFormatter: defaultProps.xAxisOptions.labelFormatter,
-    showTicks: false,
-    labelColor: 'rgb(220, 220, 220)',
-  },
-  gridOptions: {
-    showVerticalLines: false,
-    color: 'rgb(99, 115, 129)',
-    horizontalOverflow: true,
-    horizontalMargin: 20,
   },
   yAxisOptions: {
-    backgroundColor: '#333333',
-    labelColor: 'rgb(220, 220, 220)',
+    labelFormatter: defaultProps.yAxisOptions.labelFormatter,
   },
 };
-InsightsStyle.parameters = {
+Default.parameters = {
   backgrounds: {
     default: 'dark',
-  },
-};
-
-export const OverflowStyle = Template.bind({});
-OverflowStyle.args = {
-  ...defaultProps,
-  yAxisOptions: {...defaultProps.yAxisOptions, backgroundColor: 'white'},
-  xAxisOptions: {
-    ...defaultProps.xAxisOptions,
-    showTicks: false,
-    useMinimalLabels: true,
-  },
-  gridOptions: {
-    ...defaultProps.gridOptions,
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-    showVerticalLines: false,
   },
 };
 
@@ -191,7 +157,11 @@ Annotations.args = {
     },
   ],
 };
-
+Annotations.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 export const LastBarTreatment = Template.bind({});
 LastBarTreatment.args = {
   ...defaultProps,
@@ -203,15 +173,18 @@ LastBarTreatment.args = {
     {rawValue: 100.79, label: '2020-01-05T12:00:00Z'},
     {rawValue: 350.6, label: '2020-01-06T12:00:00Z'},
     {rawValue: 277.69, label: '2020-01-07T12:00:00Z'},
-    {rawValue: 0, label: '2020-01-08T12:00:00Z'},
+    {rawValue: 10, label: '2020-01-08T12:00:00Z'},
     {
       rawValue: 950.19,
       label: '2020-01-09T12:00:00Z',
-      barOptions: {
-        color: 'colorPurple',
-      },
+      barColor: 'yellow',
     },
   ],
+};
+LastBarTreatment.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
 };
 
 export const MinimalLabels = Template.bind({});
@@ -255,6 +228,11 @@ MinimalLabels.args = {
     useMinimalLabels: true,
   },
 };
+MinimalLabels.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 
 export const IntegersOnly = Template.bind({});
 IntegersOnly.args = {
@@ -272,22 +250,9 @@ IntegersOnly.args = {
     integersOnly: true,
   },
 };
-
-export const SolidColor = Template.bind({});
-SolidColor.args = {
-  ...defaultProps,
-  barOptions: {
-    ...defaultProps.barOptions,
-    color: 'colorTeal',
-  },
-};
-
-export const NonRoundCorners = Template.bind({});
-NonRoundCorners.args = {
-  ...defaultProps,
-  barOptions: {
-    ...defaultProps.barOptions,
-    hasRoundedCorners: false,
+IntegersOnly.parameters = {
+  backgrounds: {
+    default: 'dark',
   },
 };
 
@@ -303,3 +268,81 @@ LargeVolume.args = {
       };
     }),
 };
+LargeVolume.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
+const SolidColorsTemplate: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          bar: {
+            color: 'yellow',
+          },
+        },
+      }}
+    >
+      <BarChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const SolidColors = SolidColorsTemplate.bind({});
+SolidColors.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+SolidColors.args = defaultProps;
+
+const NonRoundCornersTemplate: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          bar: {
+            hasRoundedCorners: false,
+          },
+        },
+      }}
+    >
+      <BarChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const NonRoundCorners = NonRoundCornersTemplate.bind({});
+NonRoundCorners.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+NonRoundCorners.args = defaultProps;
+
+const NoOverflowStyleTemplate: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          grid: {
+            horizontalOverflow: false,
+            horizontalMargin: 0,
+          },
+        },
+      }}
+    >
+      <BarChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const NoOverflowStyle = NoOverflowStyleTemplate.bind({});
+NoOverflowStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+NoOverflowStyle.args = defaultProps;

--- a/src/components/BarChart/stories/utils.stories.tsx
+++ b/src/components/BarChart/stories/utils.stories.tsx
@@ -1,19 +1,8 @@
 import React from 'react';
-import tokens, {colorSky} from '@shopify/polaris-tokens';
 
 import {BarChartTooltipContent} from '../../../components';
-import {vizColors} from '../../../utilities';
 
-import {Color} from '../../../types';
-import {Annotation, BarMargin} from '../types';
-import {DEFAULT_GREY_LABEL} from '../../../constants';
-
-const polarisTokensColors = Object.keys(tokens).filter((key) =>
-  key.startsWith('color'),
-);
-
-export const colorOptions: string[] =
-  Object.keys(vizColors).concat(polarisTokensColors);
+import {Annotation} from '../types';
 
 export function formatYAxisLabel(value: number) {
   return new Intl.NumberFormat('en-CA', {
@@ -57,37 +46,15 @@ export const defaultProps = {
     {rawValue: 1, label: '2020-01-05T12:00:00Z'},
     {rawValue: 421.19, label: '2020-01-06T12:00:00Z'},
   ],
-  barOptions: {
-    innerMargin: 'Medium',
-    outerMargin: 'Medium',
-    color: barGradient,
-    hasRoundedCorners: true,
-    zeroAsMinHeight: false,
-  },
   xAxisOptions: {
     labelFormatter: formatXAxisLabel,
-    showTicks: false,
-    labelColor: DEFAULT_GREY_LABEL,
-    useMinimalLabels: false,
   },
   yAxisOptions: {
     labelFormatter: formatYAxisLabel,
-    labelColor: DEFAULT_GREY_LABEL,
-    backgroundColor: 'transparent',
-    integersOnly: false,
   },
   renderTooltipContent,
-  gridOptions: {
-    horizontalOverflow: false,
-    showHorizontalLines: true,
-    horizontalMargin: 0,
-    color: colorSky,
-  },
   isAnimated: true,
 };
-
-export const primaryColor = colorOptions[0] as Color;
-export const secondaryColor = colorOptions[1] as Color;
 
 export const getDataPoint = (limit = 1000, allowNegative = false) => {
   if (allowNegative)

--- a/src/components/BarChart/tests/BarChart.test.tsx
+++ b/src/components/BarChart/tests/BarChart.test.tsx
@@ -5,9 +5,11 @@ import {BarChart} from '../BarChart';
 import {Chart} from '../Chart';
 import {SkipLink} from '../../SkipLink';
 
-describe('BarChart />', () => {
-  const mockProps = {data: [{rawValue: 10, label: 'data'}]};
+const mockProps = {
+  data: [{rawValue: 10, label: 'data'}],
+};
 
+describe('BarChart />', () => {
   it('renders a <Chart />', () => {
     const barChart = mount(<BarChart {...mockProps} />);
 
@@ -16,8 +18,6 @@ describe('BarChart />', () => {
 });
 
 describe('skipLinkText', () => {
-  const mockProps = {data: [{rawValue: 10, label: 'data'}]};
-
   it('renders an anchor tag that allows skipping the chart content', () => {
     const barChart = mount(
       <BarChart {...mockProps} skipLinkText="Skip chart content" />,

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {mount} from '@shopify/react-testing';
 import type {SpringValue} from '@react-spring/web';
 import type {Color} from 'types';
 import {vizColors} from 'utilities';
@@ -11,6 +10,7 @@ import {
   HorizontalGridLines,
 } from 'components';
 
+import {mountWithProvider} from '../../../test-utilities';
 import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
 import {
@@ -39,32 +39,6 @@ describe('Chart />', () => {
       {rawValue: 20, label: 'data 2'},
     ],
     chartDimensions: {width: 500, height: 250},
-    barOptions: {
-      color: 'colorPurple' as Color,
-      innerMargin: 0,
-      outerMargin: 0,
-      hasRoundedCorners: false,
-      zeroAsMinHeight: false,
-    },
-    xAxisOptions: {
-      labelFormatter: (value: string) => value.toString(),
-      showTicks: true,
-      labelColor: 'red',
-      useMinimalLabels: false,
-    },
-    yAxisOptions: {
-      labelFormatter: (value: number) => value.toString(),
-      labelColor: 'red',
-      backgroundColor: 'transparent',
-      integersOnly: false,
-    },
-    gridOptions: {
-      showHorizontalLines: true,
-      color: 'red',
-      horizontalOverflow: false,
-      horizontalMargin: 0,
-    },
-    renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
     annotationsLookupTable: {
       1: {
         dataIndex: 1,
@@ -78,33 +52,67 @@ describe('Chart />', () => {
         },
       },
     },
+    renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
+    emptyStateText: 'Empty',
+    isAnimated: false,
+    barTheme: {
+      color: 'red',
+      innerMargin: 0,
+      outerMargin: 0,
+      hasRoundedCorners: false,
+      zeroAsMinHeight: false,
+    },
+    gridTheme: {
+      showHorizontalLines: true,
+      color: 'red',
+      horizontalOverflow: false,
+      horizontalMargin: 0,
+    },
+    xAxisOptions: {
+      labelFormatter: (value: string) => value.toString(),
+      useMinimalLabels: false,
+    },
+    xAxisTheme: {
+      showTicks: true,
+      labelColor: 'red',
+      useMinimalLabels: false,
+    },
+    yAxisOptions: {
+      labelFormatter: (value: number) => value.toString(),
+      integersOnly: false,
+    },
+    yAxisTheme: {
+      labelColor: 'red',
+      backgroundColor: 'blue',
+      integersOnly: false,
+    },
   };
 
   it('renders an SVG element', () => {
-    const barChart = mount(<Chart {...mockProps} />);
+    const barChart = mountWithProvider(<Chart {...mockProps} />);
     expect(barChart).toContainReactComponent('svg');
   });
 
   describe('<BarChartXAxis />', () => {
     it('renders', () => {
-      const barChart = mount(<Chart {...mockProps} />);
+      const barChart = mountWithProvider(<Chart {...mockProps} />);
       expect(barChart).toContainReactComponent(BarChartXAxis);
     });
   });
 
   it('renders an yAxis', () => {
-    const barChart = mount(<Chart {...mockProps} />);
+    const barChart = mountWithProvider(<Chart {...mockProps} />);
     expect(barChart).toContainReactComponent(YAxis);
   });
 
   it('does not render a <TooltipContainer /> if there is no active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mountWithProvider(<Chart {...mockProps} />);
 
     expect(chart).not.toContainReactComponent(TooltipContainer);
   });
 
   it('renders a <TooltipContainer /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mountWithProvider(<Chart {...mockProps} />);
     const svg = chart.find('svg')!;
 
     svg.trigger('onMouseMove', fakeSVGEvent);
@@ -113,7 +121,7 @@ describe('Chart />', () => {
   });
 
   it('renders the tooltip content in a <TooltipContainer /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mountWithProvider(<Chart {...mockProps} />);
     const svg = chart.find('svg')!;
 
     svg.trigger('onMouseMove', fakeSVGEvent);
@@ -127,7 +135,7 @@ describe('Chart />', () => {
 
   describe('empty state', () => {
     it('does not render tooltip for empty state', () => {
-      const chart = mount(<Chart {...mockProps} data={[]} />);
+      const chart = mountWithProvider(<Chart {...mockProps} data={[]} />);
 
       expect(chart).not.toContainReactText('Mock Tooltip');
       expect(chart).not.toContainReactComponent(TooltipContainer);
@@ -136,13 +144,13 @@ describe('Chart />', () => {
 
   describe('<Bar />', () => {
     it('renders a Bar for each data item', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mountWithProvider(<Chart {...mockProps} />);
 
       expect(chart).toContainReactComponentTimes(Bar, 2);
     });
 
     it('passes a subdued color to the Bar that is not being hovered on or nearby', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mountWithProvider(<Chart {...mockProps} />);
 
       const svg = chart.find('svg')!;
       expect(chart).toContainReactComponent(Bar, {color: MASK_HIGHLIGHT_COLOR});
@@ -154,11 +162,11 @@ describe('Chart />', () => {
 
     describe('rotateZeroBars', () => {
       it('receives true if all values are 0 or negative', () => {
-        const chart = mount(
+        const chart = mountWithProvider(
           <Chart
             {...mockProps}
-            barOptions={{
-              ...mockProps.barOptions,
+            barTheme={{
+              ...mockProps.barTheme,
               zeroAsMinHeight: true,
             }}
             data={[
@@ -175,11 +183,11 @@ describe('Chart />', () => {
       });
 
       it('receives false if not all values are 0 or negative', () => {
-        const chart = mount(
+        const chart = mountWithProvider(
           <Chart
             {...mockProps}
-            barOptions={{
-              ...mockProps.barOptions,
+            barTheme={{
+              ...mockProps.barTheme,
               zeroAsMinHeight: true,
             }}
             data={[
@@ -196,11 +204,11 @@ describe('Chart />', () => {
       });
 
       it('receives false if all values are 0', () => {
-        const chart = mount(
+        const chart = mountWithProvider(
           <Chart
             {...mockProps}
-            barOptions={{
-              ...mockProps.barOptions,
+            barTheme={{
+              ...mockProps.barTheme,
               zeroAsMinHeight: true,
             }}
             data={[
@@ -224,20 +232,20 @@ describe('Chart />', () => {
         ...mockProps,
         annotationsLookupTable: {},
       };
-      const chart = mount(<Chart {...updatedProps} />);
+      const chart = mountWithProvider(<Chart {...updatedProps} />);
 
       expect(chart).not.toContainReactComponent(AnnotationLine);
     });
 
     it('renders when annotatated data exists', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mountWithProvider(<Chart {...mockProps} />);
 
       expect(chart).toContainReactComponent(AnnotationLine);
     });
   });
 
-  describe('data.barOptions.color', () => {
-    it('renders when the barOptions.color exists', () => {
+  describe('data.barColor', () => {
+    it('renders when the barColor exists', () => {
       const updatedProps = {
         ...mockProps,
         data: [
@@ -245,33 +253,29 @@ describe('Chart />', () => {
           {
             rawValue: 20,
             label: 'data 2',
-            barOptions: {
-              color: 'colorGrayDark' as Color,
-            },
+            barColor: 'purple',
           },
         ],
       };
-      const chart = mount(<Chart {...updatedProps} />);
+      const chart = mountWithProvider(<Chart {...updatedProps} />);
 
-      expect(
-        chart.find('rect', {fill: vizColors.colorGrayDark}),
-      ).not.toBeNull();
+      expect(chart.find('rect', {fill: 'purple'})).not.toBeNull();
     });
 
-    it('does not render when the barOptions.color does not exist', () => {
-      const chart = mount(<Chart {...mockProps} />);
+    it('does not render when the barTheme.color does not exist', () => {
+      const chart = mountWithProvider(<Chart {...mockProps} />);
 
       expect(chart.find('rect', {fill: vizColors.colorGrayDark})).toBeNull();
     });
   });
 
-  describe('barOptions.zeroAsMinHeight', () => {
+  describe('barTheme.zeroAsMinHeight', () => {
     it('passes the min bar height to 0 bars if true', () => {
-      const chart = mount(
+      const chart = mountWithProvider(
         <Chart
           {...mockProps}
-          barOptions={{
-            ...mockProps.barOptions,
+          barTheme={{
+            ...mockProps.barTheme,
             zeroAsMinHeight: true,
           }}
           data={[{rawValue: 0, label: 'data'}]}
@@ -284,11 +288,11 @@ describe('Chart />', () => {
     });
 
     it('does not pass the min bar height to 0 bars if false', () => {
-      const chart = mount(
+      const chart = mountWithProvider(
         <Chart
           {...mockProps}
-          barOptions={{
-            ...mockProps.barOptions,
+          barTheme={{
+            ...mockProps.barTheme,
             zeroAsMinHeight: false,
           }}
           data={[{rawValue: 0, label: 'data'}]}
@@ -301,11 +305,11 @@ describe('Chart />', () => {
     });
 
     it('sets rotateZeroBars to false if false', () => {
-      const chart = mount(
+      const chart = mountWithProvider(
         <Chart
           {...mockProps}
-          barOptions={{
-            ...mockProps.barOptions,
+          barTheme={{
+            ...mockProps.barTheme,
             zeroAsMinHeight: false,
           }}
           data={[
@@ -321,11 +325,11 @@ describe('Chart />', () => {
     });
 
     it('passes the min bar height to non-zero bar if false', () => {
-      const chart = mount(
+      const chart = mountWithProvider(
         <Chart
           {...mockProps}
-          barOptions={{
-            ...mockProps.barOptions,
+          barTheme={{
+            ...mockProps.barTheme,
             zeroAsMinHeight: false,
           }}
           data={[
@@ -341,12 +345,12 @@ describe('Chart />', () => {
     });
   });
 
-  describe('gridOptions.showHorizontalLines', () => {
+  describe('gridTheme.showHorizontalLines', () => {
     it('does not render HorizontalGridLines when false', () => {
-      const chart = mount(
+      const chart = mountWithProvider(
         <Chart
           {...mockProps}
-          gridOptions={{...mockProps.gridOptions, showHorizontalLines: false}}
+          gridTheme={{...mockProps.gridTheme, showHorizontalLines: false}}
         />,
       );
 
@@ -354,7 +358,7 @@ describe('Chart />', () => {
     });
 
     it('renders HorizontalGridLines when true', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mountWithProvider(<Chart {...mockProps} />);
 
       expect(chart).toContainReactComponent(HorizontalGridLines);
     });

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,9 +1,7 @@
-import type {Color, StringLabelFormatter, NumberLabelFormatter} from 'types';
+import type {Color} from 'types';
 
 export interface BarChartData {
-  barOptions?: {
-    color: Color;
-  };
+  barColor?: Color | string;
   label: string;
   rawValue: number;
 }
@@ -13,28 +11,6 @@ export interface RenderTooltipContentData {
   value: number;
   annotation?: Annotation;
 }
-
-export interface GridOptions {
-  showHorizontalLines: boolean;
-  horizontalOverflow: boolean;
-  color: string;
-  horizontalMargin: number;
-}
-
-export interface XAxisOptions {
-  labelFormatter: StringLabelFormatter;
-  showTicks: boolean;
-  labelColor: string;
-  useMinimalLabels: boolean;
-}
-
-export interface YAxisOptions {
-  labelFormatter: NumberLabelFormatter;
-  labelColor: string;
-  backgroundColor: string;
-  integersOnly: boolean;
-}
-
 export interface Annotation {
   dataIndex: number;
   width: number;

--- a/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,28 +1,30 @@
 import React, {useMemo} from 'react';
 
-import type {Theme} from '../../types';
-import {DefaultTheme as Default} from '../../constants';
+import type {PartialTheme} from '../../types';
+import {DEFAULT_THEME as Default} from '../../constants';
 import {PolarisVizContext} from '../../utilities/polaris-viz-context';
 import {createThemes} from '../../utilities';
 
-export interface PolarisVizContextProps {
+export interface PolarisVizProviderProps {
   children: React.ReactNode;
-  themes?: {[key: string]: Theme};
+  themes?: {[key: string]: PartialTheme};
 }
 
-export function PolarisVizProvider({children, themes}: PolarisVizContextProps) {
-  const customThemes = useMemo(
-    () => ({
+export function PolarisVizProvider({
+  children,
+  themes,
+}: PolarisVizProviderProps) {
+  const value = useMemo(() => {
+    return {
       themes: createThemes({
         Default,
         ...themes,
       }),
-    }),
-    [themes],
-  );
+    };
+  }, [themes]);
 
   return (
-    <PolarisVizContext.Provider value={customThemes}>
+    <PolarisVizContext.Provider value={value}>
       {children}
     </PolarisVizContext.Provider>
   );

--- a/src/components/PolarisVizProvider/index.ts
+++ b/src/components/PolarisVizProvider/index.ts
@@ -1,1 +1,2 @@
 export {PolarisVizProvider} from './PolarisVizProvider';
+export type {PolarisVizProviderProps} from './PolarisVizProvider';

--- a/src/components/PolarisVizProvider/stories/PolarisVizProvider.stories.tsx
+++ b/src/components/PolarisVizProvider/stories/PolarisVizProvider.stories.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import {Story, Meta} from '@storybook/react';
+
+import {PolarisVizProvider} from '../../../components';
+import type {PolarisVizProviderProps} from '../../../components/PolarisVizProvider';
+import {DEFAULT_THEME} from '../../../constants';
+import {BarChartDemo} from '../../../../documentation/code';
+
+export default {
+  title: 'Providers/PolarisVizProvider',
+  component: PolarisVizProvider,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The \`PolarisVizProvider\` is an optional component that you can use to:
+\n - Overwite the default styles of all charts in your application
+\n - Define multiple themes that can be used by each instance of your charts
+
+By including the \`PolarisVizProvider\` as a top level component in your application, each child chart will have access to the themes you define in the  \`themes\` prop.
+
+This is what the **Default Polaris Viz theme** looks like in a BarChart 👇
+        `,
+      },
+    },
+  },
+  argTypes: {
+    themes: {
+      defaultValue: {Default: DEFAULT_THEME},
+      description:
+        'A collection of themes. If nothing is provided it uses the Default Polaris Viz theme. You can define multiple themes here, and choose which one should be used in your chart instance.',
+      table: {
+        type: {
+          summary: 'Record<string, PartialTheme>',
+        },
+        defaultValue: {
+          summary: '-',
+        },
+      },
+      control: {
+        type: 'object',
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<PolarisVizProviderProps> = (
+  args: PolarisVizProviderProps,
+) => {
+  return (
+    <PolarisVizProvider {...args}>
+      <BarChartDemo />
+    </PolarisVizProvider>
+  );
+};
+
+const MultipleThemesTemplate: Story<PolarisVizProviderProps> = (
+  args: PolarisVizProviderProps,
+) => {
+  return (
+    <PolarisVizProvider {...args}>
+      <div style={{height: '180px', marginBottom: '10px'}}>
+        <BarChartDemo theme="AngryRed" />
+      </div>
+      <div style={{height: '180px'}}>
+        <BarChartDemo theme="HappyGreen" />
+      </div>
+    </PolarisVizProvider>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {};
+Default.parameters = {
+  docs: {
+    source: {
+      code: `
+<PolarisVizProvider>
+  <BarChart />
+</PolarisVizProvider>`,
+    },
+  },
+  viewMode: 'docs',
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
+export const OverwrittenDefault = Template.bind({});
+OverwrittenDefault.args = {
+  themes: {
+    Default: {
+      chartContainer: {
+        padding: '10px',
+        borderRadius: '5px',
+        backgroundColor: 'white',
+      },
+      bar: {
+        hasRoundedCorners: false,
+        innerMargin: 'Large',
+        outerMargin: 'Large',
+        color: 'purple',
+      },
+      grid: {
+        showVerticalLines: true,
+        showHorizontalLines: true,
+        color: '#ebebeb',
+        horizontalOverflow: false,
+        horizontalMargin: 0,
+      },
+      xAxis: {
+        showTicks: true,
+        labelColor: 'gray',
+        useMinimalLabels: false,
+      },
+      yAxis: {
+        labelColor: 'gray',
+        backgroundColor: 'white',
+        integersOnly: false,
+      },
+    },
+  },
+};
+OverwrittenDefault.parameters = {
+  viewMode: 'docs',
+  docs: {
+    description: {
+      story: `
+If you want all charts to have custom styles to be applied to all charts by default, just overwrite the \`Default\` key in the themes object.
+
+In this example that has an **overwritten Default Theme**, all \`BarCharts\` that are children of this \`PolarisVizProvider\` will have purple bars and white background by default, even if no \`theme\` prop is passed to each \`BarChart\`  👇
+      `,
+    },
+  },
+};
+
+export const MultipleThemes = MultipleThemesTemplate.bind({});
+MultipleThemes.args = {
+  themes: {
+    HappyGreen: {
+      chartContainer: {
+        padding: '20px',
+        borderRadius: '5px',
+      },
+      bar: {
+        hasRoundedCorners: false,
+        innerMargin: 'Large',
+        outerMargin: 'Large',
+        color: '#00ff64',
+      },
+      grid: {
+        showVerticalLines: true,
+        showHorizontalLines: true,
+        color: '#000000',
+        horizontalOverflow: false,
+        horizontalMargin: 0,
+      },
+      xAxis: {
+        showTicks: true,
+        labelColor: '#FFF',
+      },
+      yAxis: {
+        labelColor: '#FFF',
+      },
+    },
+    AngryRed: {
+      chartContainer: {
+        padding: '20px',
+        borderRadius: '5px',
+      },
+      bar: {
+        hasRoundedCorners: false,
+        innerMargin: 'Large',
+        outerMargin: 'Large',
+        color: '#ff0025',
+      },
+      grid: {
+        showVerticalLines: true,
+        showHorizontalLines: true,
+        color: '#000000',
+        horizontalOverflow: false,
+        horizontalMargin: 0,
+      },
+      xAxis: {
+        showTicks: true,
+        labelColor: '#FFF',
+        useMinimalLabels: false,
+      },
+      yAxis: {
+        labelColor: '#FFF',
+        integersOnly: false,
+      },
+    },
+  },
+};
+MultipleThemes.parameters = {
+  viewMode: 'docs',
+  backgrounds: {
+    default: 'light',
+  },
+  docs: {
+    description: {
+      story: `
+You can also define multiple extra themes in the \`themes\` object.
+Each top level key in this object will be used as a theme name, that
+later on you can pass to individual charts.
+
+In this example, the first chart uses a theme named \`AngryRed\` and the second \`HappyGreen\` 👇
+        `,
+    },
+  },
+};

--- a/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
+++ b/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
@@ -4,7 +4,7 @@ import {mount} from '@shopify/react-testing';
 import {usePolarisVizContext} from '../../../hooks';
 import {PolarisVizProvider} from '../PolarisVizProvider';
 import {PolarisVizContext} from '../../../utilities/';
-import {DefaultTheme} from '../../../constants';
+import {DEFAULT_THEME} from '../../../constants';
 
 const MockChild = ({theme = 'Default'}) => {
   const {themes} = usePolarisVizContext();
@@ -29,7 +29,7 @@ describe('<PolarisVizProvider />', () => {
       </PolarisVizProvider>,
     );
 
-    expect(vizProvider).toContainReactText(JSON.stringify(DefaultTheme));
+    expect(vizProvider).toContainReactText(JSON.stringify(DEFAULT_THEME));
   });
 
   it('passes custom themes to children', () => {
@@ -37,7 +37,7 @@ describe('<PolarisVizProvider />', () => {
       <PolarisVizProvider
         themes={{
           Dark: {
-            barOptions: {
+            bar: {
               hasRoundedCorners: false,
             },
           },
@@ -49,9 +49,9 @@ describe('<PolarisVizProvider />', () => {
 
     expect(vizProvider).toContainReactText(
       JSON.stringify({
-        ...DefaultTheme,
-        barOptions: {
-          ...DefaultTheme.barOptions,
+        ...DEFAULT_THEME,
+        bar: {
+          ...DEFAULT_THEME.bar,
           hasRoundedCorners: false,
         },
       }),

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -30,3 +30,4 @@ export {LinePreview} from './LinePreview';
 export {Legend} from './Legend';
 export {LinearGradient} from './LinearGradient';
 export {PolarisVizProvider} from './PolarisVizProvider';
+export type {PolarisVizProviderProps} from './PolarisVizProvider';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,12 +95,32 @@ export const VIZ_GRADIENT_COLOR = {
   },
 };
 
-export const DefaultTheme: Theme = {
-  barOptions: {
+export const DEFAULT_THEME: Theme = {
+  chartContainer: {
+    borderRadius: '0px',
+    padding: '0px',
+    backgroundColor: '#1f1f25',
+  },
+  bar: {
     color: VIZ_GRADIENT_COLOR.neutral.up,
     hasRoundedCorners: true,
     innerMargin: 'Medium',
     outerMargin: 'Medium',
     zeroAsMinHeight: false,
+  },
+  grid: {
+    showVerticalLines: false,
+    showHorizontalLines: true,
+    color: 'rgb(99, 115, 129)',
+    horizontalOverflow: true,
+    horizontalMargin: 20,
+  },
+  xAxis: {
+    showTicks: false,
+    labelColor: 'rgb(220, 220, 220)',
+  },
+  yAxis: {
+    backgroundColor: '#1f1f25',
+    labelColor: 'rgb(220, 220, 220)',
   },
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,5 @@ export type {ChartDetails} from './useLinearXAxisDetails';
 export {useLinearXScale} from './useLinearXScale';
 export {usePrevious} from './use-previous';
 export {useResizeObserver} from './useResizeObserver';
+export {useTheme} from './useTheme';
 export {usePolarisVizContext} from './usePolarisVizContext';

--- a/src/hooks/tests/usePolarisVizContext.test.tsx
+++ b/src/hooks/tests/usePolarisVizContext.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {mountWithProvider} from '../../test-utilities';
+import {DEFAULT_THEME} from '../../constants';
+import {usePolarisVizContext} from '../usePolarisVizContext';
+
+describe('usePolarisVizContext', () => {
+  function TestComponent() {
+    const {themes} = usePolarisVizContext();
+    return <div>{JSON.stringify(themes)}</div>;
+  }
+
+  it('exposes the default theme if used without a parent PolarisVizProvider', () => {
+    const mockComponent = mount(<TestComponent />);
+
+    expect(mockComponent.text()).toBe(
+      JSON.stringify({
+        Default: DEFAULT_THEME,
+      }),
+    );
+  });
+
+  it('exposes the default values overwritten by PolarisVizProvider', () => {
+    const mockComponent = mountWithProvider(<TestComponent />, {
+      themes: {
+        Default: {
+          chartContainer: {
+            backgroundColor: 'purple',
+          },
+        },
+      },
+    });
+
+    expect(mockComponent.text()).toBe(
+      JSON.stringify({
+        Default: {
+          ...DEFAULT_THEME,
+          chartContainer: {
+            ...DEFAULT_THEME.chartContainer,
+            backgroundColor: 'purple',
+          },
+        },
+      }),
+    );
+  });
+
+  it('exposes custom themes created in PolarisVizProvider', () => {
+    const mockComponent = mountWithProvider(<TestComponent />, {
+      themes: {
+        SomeOtherTheme: {
+          chartContainer: {
+            backgroundColor: 'purple',
+          },
+        },
+      },
+    });
+
+    expect(mockComponent.text()).toBe(
+      JSON.stringify({
+        Default: DEFAULT_THEME,
+        SomeOtherTheme: {
+          ...DEFAULT_THEME,
+          chartContainer: {
+            ...DEFAULT_THEME.chartContainer,
+            backgroundColor: 'purple',
+          },
+        },
+      }),
+    );
+  });
+});

--- a/src/hooks/tests/useTheme.test.tsx
+++ b/src/hooks/tests/useTheme.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {mountWithProvider} from '../../test-utilities';
+import {DEFAULT_THEME} from '../../constants';
+import {useTheme} from '../useTheme';
+
+describe('useTheme', () => {
+  it('returns the default theme if no theme name is provided', () => {
+    function TestComponent() {
+      const theme = useTheme();
+      return <div>{JSON.stringify(theme)}</div>;
+    }
+
+    const mockComponent = mount(<TestComponent />);
+    expect(mockComponent.text()).toBe(JSON.stringify(DEFAULT_THEME));
+  });
+
+  it('returns the theme defined in PolarisVizContext with the provided theme name', () => {
+    function TestComponent() {
+      const theme = useTheme('SomeTheme');
+      return <div>{JSON.stringify(theme)}</div>;
+    }
+
+    const mockComponent = mountWithProvider(<TestComponent />, {
+      themes: {
+        SomeTheme: {
+          chartContainer: {
+            backgroundColor: 'Purple',
+          },
+        },
+      },
+    });
+    expect(mockComponent.text()).toBe(
+      JSON.stringify({
+        ...DEFAULT_THEME,
+        chartContainer: {
+          ...DEFAULT_THEME.chartContainer,
+          backgroundColor: 'Purple',
+        },
+      }),
+    );
+  });
+
+  it('throws an error if a theme with the given name cannot be found', () => {
+    function TestComponent() {
+      const theme = useTheme('SomeOtherTheme');
+      return <div>{JSON.stringify(theme)}</div>;
+    }
+
+    expect(() => {
+      mount(<TestComponent />);
+    }).toThrow(
+      `SomeOtherTheme theme not found. Did you forget to define it in the PolarisVizProvider?`,
+    );
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,16 @@
+import {useContext} from 'react';
+
+import type {Theme} from '../types';
+import {PolarisVizContext} from '../utilities/';
+
+export function useTheme(themeName = 'Default'): Theme {
+  const {themes} = useContext(PolarisVizContext);
+
+  if (Object.prototype.hasOwnProperty.call(themes, themeName)) {
+    return themes[themeName];
+  } else {
+    throw new Error(
+      `${themeName} theme not found. Did you forget to define it in the PolarisVizProvider?`,
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   TooltipContent,
   LinePreview,
   SquareColorPreview,
+  PolarisVizProvider,
 } from './components';
 
 export type {
@@ -25,6 +26,11 @@ export type {
   StackedAreaChartProps,
   MultiSeriesBarChartProps,
   TooltipContentProps,
+  PolarisVizProviderProps,
 } from './components';
+
+export {DEFAULT_THEME as PolarisVizTheme} from './constants';
+
+export {createTheme} from './utilities/create-themes';
 
 export type {Color, GradientStop} from './types';

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -4,3 +4,4 @@
 @import './shared/axes';
 @import './shared/variables';
 @import './shared/accessibility';
+@import './shared/chart-container';

--- a/src/styles/shared/_chart-container.scss
+++ b/src/styles/shared/_chart-container.scss
@@ -1,0 +1,5 @@
+@mixin chart-container {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}

--- a/src/test-utilities/index.ts
+++ b/src/test-utilities/index.ts
@@ -1,0 +1,1 @@
+export {mountWithProvider} from './mount-with-provider';

--- a/src/test-utilities/mount-with-provider.tsx
+++ b/src/test-utilities/mount-with-provider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import type {PartialTheme} from 'types';
+
+import {PolarisVizProvider} from '../components/';
+
+export const mountWithProvider = (
+  child: React.ReactElement<any, any>,
+  providerValues?: {
+    themes: {[key: string]: PartialTheme};
+  },
+) => {
+  const {themes} = providerValues || {themes: {}};
+
+  return mount(
+    <PolarisVizProvider themes={themes}>
+      <React.Fragment>{child}</React.Fragment>
+    </PolarisVizProvider>,
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,15 @@ export type SparkChartData = number | null;
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;
 export type NumberInterpolator = InterpolatorFn<readonly number[], number>;
 
+export interface XAxisOptions {
+  labelFormatter?: StringLabelFormatter;
+  useMinimalLabels?: boolean;
+}
+export interface YAxisOptions {
+  labelFormatter?: NumberLabelFormatter;
+  integersOnly?: boolean;
+}
+
 // === Theme types === //
 export enum BarMargin {
   Small = 0.05,
@@ -148,16 +157,51 @@ export enum BarMargin {
   None = 0,
 }
 
-export interface BarOptions {
+export interface GridTheme {
+  showHorizontalLines: boolean;
+  showVerticalLines?: boolean;
+  horizontalOverflow: boolean;
+  color: string;
+  horizontalMargin: number;
+}
+
+export interface BarTheme {
   innerMargin: keyof typeof BarMargin;
   outerMargin: keyof typeof BarMargin;
-  color: Color | GradientStop[];
+  color: string | GradientStop[];
   hasRoundedCorners: boolean;
   /**
    * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
    */
   zeroAsMinHeight: boolean;
 }
+
+export interface XAxisTheme {
+  showTicks: boolean;
+  labelColor: string;
+}
+
+export interface YAxisTheme {
+  labelColor: string;
+  backgroundColor: string;
+}
+export interface ChartContainerTheme {
+  borderRadius: string;
+  padding: string;
+  backgroundColor: string;
+}
+
+export interface PartialTheme {
+  chartContainer?: Partial<ChartContainerTheme>;
+  bar?: Partial<BarTheme>;
+  grid?: Partial<GridTheme>;
+  xAxis?: Partial<XAxisTheme>;
+  yAxis?: Partial<YAxisTheme>;
+}
 export interface Theme {
-  barOptions: Partial<BarOptions>;
+  chartContainer: ChartContainerTheme;
+  bar: BarTheme;
+  grid: GridTheme;
+  xAxis: XAxisTheme;
+  yAxis: YAxisTheme;
 }

--- a/src/utilities/create-themes.ts
+++ b/src/utilities/create-themes.ts
@@ -1,19 +1,29 @@
-import type {Theme} from '../types';
-import {DefaultTheme} from '../constants';
+import type {Theme, PartialTheme} from '../types';
+import {DEFAULT_THEME} from '../constants';
 
-export const createTheme = (theme: Partial<Theme>): Theme => {
-  const themeKeys = Object.keys(DefaultTheme) as [keyof Theme];
+export const createTheme = (
+  theme: PartialTheme,
+  baseTheme = DEFAULT_THEME,
+): Theme => {
+  const themeKeys = Object.keys(baseTheme);
 
-  return themeKeys.reduce((accumulator, key: keyof Theme) => {
-    accumulator[key] = {
-      ...DefaultTheme[key],
-      ...theme[key],
-    };
+  return themeKeys.reduce((accumulator: any, key: keyof Theme) => {
+    const defaultValue = DEFAULT_THEME[key];
+    const value = theme[key];
+
+    if (typeof defaultValue === 'string' || typeof value === 'string') {
+      accumulator[key] = value;
+    } else {
+      accumulator[key] = {
+        ...DEFAULT_THEME[key],
+        ...theme[key],
+      };
+    }
     return accumulator;
-  }, {} as Theme);
+  }, {});
 };
 
-export const createThemes = (themeRecord: {[key: string]: Theme}) => {
+export const createThemes = (themeRecord: {[key: string]: PartialTheme}) => {
   return Object.keys(themeRecord).reduce((accumulator, themeName) => {
     accumulator[themeName] = createTheme(themeRecord[themeName]);
     return accumulator;

--- a/src/utilities/polaris-viz-context.ts
+++ b/src/utilities/polaris-viz-context.ts
@@ -1,7 +1,7 @@
 import {createContext} from 'react';
 
 import type {Theme} from '../types';
-import {DefaultTheme as Default} from '../constants';
+import {DEFAULT_THEME as Default} from '../constants';
 
 export const PolarisVizContext = createContext<{
   themes: {[key: string]: Theme};

--- a/src/utilities/tests/create-themes.test.ts
+++ b/src/utilities/tests/create-themes.test.ts
@@ -1,19 +1,19 @@
 import {createTheme, createThemes} from '../';
-import {DefaultTheme} from '../../constants';
+import {DEFAULT_THEME} from '../../constants';
 
 describe('createTheme', () => {
   it('generates a theme with default values, from the partial theme provided', () => {
     const result = createTheme({
-      barOptions: {
+      bar: {
         innerMargin: 'Small',
       },
     });
-    expect(result).not.toStrictEqual(DefaultTheme);
+    expect(result).not.toStrictEqual(DEFAULT_THEME);
 
     expect(result).toStrictEqual(
       expect.objectContaining({
-        barOptions: {
-          ...DefaultTheme.barOptions,
+        bar: {
+          ...DEFAULT_THEME.bar,
           innerMargin: 'Small',
         },
       }),
@@ -25,18 +25,19 @@ describe('createThemes', () => {
   it('generates a record of themes with default values, from the partial themes provided', () => {
     const result = createThemes({
       Default: {
-        barOptions: {
+        bar: {
           innerMargin: 'Small',
         },
       },
     });
-    expect(result).not.toStrictEqual({Default: DefaultTheme});
+    expect(result).not.toStrictEqual({Default: DEFAULT_THEME});
 
     expect(result).toStrictEqual(
       expect.objectContaining({
         Default: {
-          barOptions: {
-            ...DefaultTheme.barOptions,
+          ...DEFAULT_THEME,
+          bar: {
+            ...DEFAULT_THEME.bar,
             innerMargin: 'Small',
           },
         },
@@ -46,9 +47,9 @@ describe('createThemes', () => {
 
   it('generates a record with multiple custom themes', () => {
     const result = createThemes({
-      Default: DefaultTheme,
+      Default: DEFAULT_THEME,
       SomeTheme: {
-        barOptions: {
+        bar: {
           hasRoundedCorners: false,
         },
       },
@@ -56,10 +57,11 @@ describe('createThemes', () => {
 
     expect(result).toStrictEqual(
       expect.objectContaining({
-        Default: DefaultTheme,
+        Default: DEFAULT_THEME,
         SomeTheme: {
-          barOptions: {
-            ...DefaultTheme.barOptions,
+          ...DEFAULT_THEME,
+          bar: {
+            ...DEFAULT_THEME.bar,
             hasRoundedCorners: false,
           },
         },


### PR DESCRIPTION
### What problem is this PR solving?

Solves: https://github.com/Shopify/polaris-viz/issues/404

- Splits `barOptions`, `gridOptions`, `xAxisOptions`, `yAxisOptions`  into separate structures containing logic and theme related information, e.g.:
```
interface YAxisOptions {
  labelFormatter: NumberLabelFormatter;
  integersOnly: boolean;
}

interface YAxisTheme {
  labelColor: string;
  backgroundColor: string;
}
```

- Consumes themes  from `useTheme` instead of directly as props


### Reviewers’ :tophat: instructions

- We should make sure that these changes don't break any existing functionality on the bar chart


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
