### PR TITLE
Add theming to Sparkline

### DIFF
--- a/documentation/code/SparklineDemo.tsx
+++ b/documentation/code/SparklineDemo.tsx
@@ -19,7 +19,6 @@ export function SparklineDemo() {
             series={[
               {
                 color: 'rgb(0,161,159)',
-                areaStyle: 'gradient',
                 data: [
                   {x: 0, y: 100},
                   {x: 1, y: 200},
@@ -36,7 +35,6 @@ export function SparklineDemo() {
               },
               {
                 color: 'rgb(145,158,171)',
-                areaStyle: 'none',
                 lineStyle: 'dashed',
                 data: [
                   {x: 0, y: 10},

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -38,7 +38,6 @@ const props = {
         {y: 2, x: 22},
         {y: 2, x: 23},
       ],
-      areaStyle: 'gradient',
       hasPoint: true,
       color: 'red',
       offsetRight: 12,
@@ -91,7 +90,7 @@ The sparkline interface looks like this:
 
 ```typescript
 {
-  series: {color: string, areaStyle: AreaStyle, lineStyle: LineStyle, hasPoint: boolean, data: Coordinates[]}[];
+  series: {color: string | GradientStop[], area: string | GradientStop[] | null, lineStyle: LineStyle, hasPoint: boolean, data: Coordinates[]}[];
   accessibilityLabel?: string;
   isAnimated?: boolean;
 }
@@ -111,7 +110,7 @@ This component determines its width and height based off its parent element. The
 
 | type                                                                                                                                                  |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `{data: Coordinates[], color?: string, areaStyle?: AreaStyle, lineStyle?: LineStyle, hasPoint?: boolean, offsetLeft?: number; offsetRight?: number}[]` |
+| `{data: Coordinates[], color?: string, area?: string \| GradientStop[] \| null, lineStyle?: LineStyle, hasPoint?: boolean, offsetLeft?: number; offsetRight?: number}[]` |
 
 The sparkline can show one data series or a set of comparison data series.
 
@@ -135,7 +134,7 @@ The sparkline stroke and fill color. This accepts any CSS color.
 
 | type                      | default |
 | ------------------------- | ------- |
-| `none | solid | gradient` | `none`  |
+| `none \| solid \| gradient` | `none`  |
 
 Determines whether to fill in the area beneath the line and what kind of shading to use.
 
@@ -143,7 +142,7 @@ Determines whether to fill in the area beneath the line and what kind of shading
 
 | type             | default |
 | ---------------- | ------- |
-| `solid | dashed` | `solid` |
+| `solid \| dashed` | `solid` |
 
 Determines the style of line used for the series.
 

--- a/src/components/Sparkline/Sparkline.scss
+++ b/src/components/Sparkline/Sparkline.scss
@@ -1,3 +1,5 @@
+@import '../../styles/common';
+
 .VisuallyHidden {
   // Importants are required to ensure component is available to screenreaders as expected
   // stylelint-disable declaration-no-important
@@ -10,4 +12,8 @@
   padding: 0 !important;
   border: 0 !important;
   // stylelint-enable declaration-no-important
+}
+
+.Container {
+  @include chart-container;
 }

--- a/src/components/Sparkline/Sparkline.test.tsx
+++ b/src/components/Sparkline/Sparkline.test.tsx
@@ -22,7 +22,6 @@ describe('<Sparkline />', () => {
   const mockSeries = [
     {
       color: 'red',
-      areaStyle: 'gradient' as any,
       data: [
         {x: 0, y: 100},
         {x: 1, y: 200},
@@ -39,7 +38,6 @@ describe('<Sparkline />', () => {
     },
     {
       color: 'purple',
-      areaStyle: 'none' as any,
       lineStyle: 'dashed' as any,
       data: [
         {x: 0, y: 10},

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -1,9 +1,9 @@
 import React, {useState, useLayoutEffect, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
-import type {SparkChartData} from 'types';
+import type {GradientStop, SparkChartData} from 'types';
 
-import {useResizeObserver} from '../../hooks';
+import {useResizeObserver, useTheme} from '../../hooks';
 
 import styles from './Sparkline.scss';
 import {Series} from './components';
@@ -15,13 +15,12 @@ export interface Coordinates {
   y: SparkChartData;
 }
 
-type AreaStyle = 'none' | 'solid' | 'gradient';
 type LineStyle = 'solid' | 'dashed';
 
 export interface SingleSeries {
   data: Coordinates[];
-  color?: string;
-  areaStyle?: AreaStyle;
+  color?: string | GradientStop[];
+  area?: string | GradientStop[];
   lineStyle?: LineStyle;
   hasPoint?: boolean;
   offsetRight?: number;
@@ -33,6 +32,7 @@ export interface SparklineProps {
   accessibilityLabel?: string;
   isAnimated?: boolean;
   hasSpline?: boolean;
+  theme?: string;
 }
 
 export function Sparkline({
@@ -40,6 +40,7 @@ export function Sparkline({
   accessibilityLabel,
   isAnimated = false,
   hasSpline = false,
+  theme,
 }: SparklineProps) {
   const {
     ref: containerRef,
@@ -47,26 +48,27 @@ export function Sparkline({
     entry,
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
+  const selectedTheme = useTheme(theme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
-    if (containerRef == null) return;
+    if (entry == null) return;
 
     setSvgDimensions({
-      height: containerRef.clientHeight,
-      width: containerRef.clientWidth,
+      height: entry.contentRect.height,
+      width: entry.contentRect.width,
     });
   }, 10);
 
   const handlePrintMediaQueryChange = useCallback(
     (event: MediaQueryListEvent) => {
-      if (event.matches && containerRef != null) {
+      if (event.matches && entry != null) {
         setSvgDimensions({
-          height: containerRef.clientHeight,
-          width: containerRef.clientWidth,
+          height: entry.contentRect.width,
+          width: entry.contentRect.height,
         });
       }
     },
-    [containerRef],
+    [entry],
   );
 
   useLayoutEffect(() => {
@@ -129,7 +131,15 @@ export function Sparkline({
     .domain([Math.min(...yValues), Math.max(...yValues)]);
 
   return (
-    <div style={{width: '100%', height: '100%'}} ref={setContainerRef}>
+    <div
+      ref={setContainerRef}
+      className={styles.Container}
+      style={{
+        background: selectedTheme.chartContainer.backgroundColor,
+        padding: selectedTheme.chartContainer.padding,
+        borderRadius: selectedTheme.chartContainer.borderRadius,
+      }}
+    >
       {accessibilityLabel ? (
         <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       ) : null}
@@ -151,6 +161,7 @@ export function Sparkline({
                 isAnimated={isAnimated}
                 height={height}
                 hasSpline={hasSpline}
+                theme={selectedTheme}
               />
             </g>
           );

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -1,17 +1,35 @@
 import React, {useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
-import {area, line} from 'd3-shape';
+import {area as areaShape, line} from 'd3-shape';
 import {classNames} from '@shopify/css-utilities';
 
-import {colorTeal} from '../../../../constants';
+import type {GradientStop, Theme} from '../../../../types';
 import {LinearGradient} from '../../../LinearGradient';
-import {curveStepRounded, uniqueId, rgbToRgba} from '../../../../utilities';
+import {
+  curveStepRounded,
+  uniqueId,
+  isGradientType,
+} from '../../../../utilities';
 import {usePrefersReducedMotion} from '../../../../hooks';
 import type {SingleSeries, Coordinates} from '../../Sparkline';
 
 import styles from './Series.scss';
 
 const POINT_RADIUS = 2;
+
+function getGradientFill(area: string | GradientStop[] | null) {
+  if (area == null) {
+    return null;
+  }
+  return isGradientType(area)
+    ? area
+    : [
+        {
+          color: area,
+          offset: 0,
+        },
+      ];
+}
 
 export function Series({
   xScale,
@@ -20,6 +38,7 @@ export function Series({
   isAnimated,
   height,
   hasSpline,
+  theme,
 }: {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
@@ -27,13 +46,14 @@ export function Series({
   isAnimated: boolean;
   height: number;
   hasSpline: boolean;
+  theme: Theme;
 }) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const {
-    areaStyle = 'none',
-    lineStyle = 'solid',
-    color = colorTeal,
-    hasPoint = false,
+    area = theme.line.area,
+    lineStyle = theme.line.style,
+    color = theme.line.color,
+    hasPoint = theme.line.hasPoint,
     data,
   } = series;
 
@@ -42,7 +62,7 @@ export function Series({
     .y(({y}) => (y == null ? yScale(0) : yScale(y)))
     .defined(({y}) => y != null);
 
-  const areaGenerator = area<Coordinates>()
+  const areaGenerator = areaShape<Coordinates>()
     .x(({x}) => xScale(x))
     .y0(height)
     .y1(({y}) => (y == null ? yScale(0) : yScale(y)))
@@ -64,21 +84,49 @@ export function Series({
         }
       : null;
 
-  const areaShape = areaGenerator(data);
+  const areaPath = areaGenerator(data);
 
   const id = useMemo(() => uniqueId('sparkline'), []);
   const immediate = !isAnimated || prefersReducedMotion;
 
   const dashedLine = lineStyle === 'dashed';
 
-  if (lineShape == null || areaShape == null) {
+  const lineGradientColor = isGradientType(color)
+    ? color
+    : [
+        {
+          color,
+          offset: 0,
+        },
+      ];
+
+  if (lineShape == null || areaPath == null) {
     return null;
   }
 
+  const areaGradientColor = getGradientFill(area);
+
   return (
     <React.Fragment>
+      <defs>
+        <LinearGradient
+          id={`line-${id}`}
+          gradient={lineGradientColor}
+          gradientUnits="userSpaceOnUse"
+          y1="100%"
+          y2="0%"
+        />
+
+        {area == null ? null : (
+          <LinearGradient
+            id={`area-${id}`}
+            gradient={areaGradientColor as GradientStop[]}
+          />
+        )}
+      </defs>
+
       <path
-        stroke={color}
+        stroke={`url(#line-${id})`}
         d={lineShape}
         fill="none"
         className={classNames(
@@ -87,25 +135,11 @@ export function Series({
           dashedLine && styles.DashedLine,
         )}
       />
-      {areaStyle === 'gradient' ? (
-        <LinearGradient
-          id={id}
-          gradient={[
-            {
-              color: rgbToRgba({rgb: color, alpha: 0}),
-              offset: 0,
-            },
-            {
-              color: rgbToRgba({rgb: color, alpha: 0.8}),
-              offset: 100,
-            },
-          ]}
-        />
-      ) : null}
-      {areaStyle === 'none' ? null : (
+
+      {area === null ? null : (
         <path
-          fill={areaStyle === 'gradient' ? `url(#${id})` : color}
-          d={areaShape}
+          fill={`url(#area-${id})`}
+          d={areaPath}
           className={immediate ? undefined : styles.Area}
         />
       )}
@@ -115,7 +149,7 @@ export function Series({
           cx={lastLinePointCoordinates.x}
           cy={lastLinePointCoordinates.y}
           r={POINT_RADIUS}
-          fill={color}
+          fill={`url(#line-${id})`}
           className={styles.Point}
         />
       ) : null}

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
 import {area} from 'd3-shape';
+import type {Theme} from 'types';
 
 import {LinearGradient} from '../../../../LinearGradient';
 import {Series} from '../Series';
@@ -29,7 +30,6 @@ jest.mock('d3-shape', () => ({
 
 const mockSeries = {
   color: 'red',
-  areaStyle: 'none' as any,
   data: [
     {x: 0, y: 100},
     {x: 1, y: 200},
@@ -55,6 +55,9 @@ const mockProps = {
   isAnimated: false,
   height: 250,
   hasSpline: false,
+  theme: {
+    line: {area: null, style: 'solid', color: 'red', hasPoint: true},
+  } as Theme,
 };
 
 jest.mock('utilities/unique-id', () => ({
@@ -98,37 +101,21 @@ describe('Series', () => {
   it('renders an additional path if an area style is set', () => {
     const actual = mount(
       <svg>
-        <Series {...mockProps} series={{...mockSeries, areaStyle: 'solid'}} />
+        <Series {...mockProps} series={{...mockSeries, area: 'red'}} />
       </svg>,
     );
 
     expect(actual).toContainReactComponentTimes('path', 2);
   });
 
-  it('uses a URL as the fill if the area style is set to gradient', () => {
+  it('renders an additional LinearGradient if the area style is not null', () => {
     const actual = mount(
       <svg>
-        <Series
-          {...mockProps}
-          series={{...mockSeries, areaStyle: 'gradient'}}
-        />
+        <Series {...mockProps} series={{...mockSeries, area: 'red'}} />
       </svg>,
     );
 
-    expect(actual).toContainReactComponent('path', {fill: 'url(#sparkline-1)'});
-  });
-
-  it('renders a LinearGradient if the area style is set to gradient', () => {
-    const actual = mount(
-      <svg>
-        <Series
-          {...mockProps}
-          series={{...mockSeries, areaStyle: 'gradient'}}
-        />
-      </svg>,
-    );
-
-    expect(actual).toContainReactComponent(LinearGradient);
+    expect(actual).toContainReactComponentTimes(LinearGradient, 2);
   });
 
   it('calls the d3 curve method when hasSpline is true', () => {
@@ -159,8 +146,6 @@ describe('Series', () => {
         <Series
           {...mockProps}
           series={{
-            color: 'red',
-            areaStyle: 'none' as any,
             hasPoint: true,
             data: [
               {x: 0, y: 100},
@@ -187,7 +172,6 @@ describe('Series', () => {
     expect(actual).toContainReactComponent('circle', {
       cx: xScale(lastDataPoint.x),
       cy: yScale(lastDataPoint.y),
-      fill: mockSeries.color,
     });
   });
 });

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -5,7 +5,6 @@ import {Sparkline, SparklineProps} from '../..';
 
 const series = [
   {
-    color: 'rgb(0, 164, 124)',
     areaStyle: 'gradient',
     hasPoint: true,
     data: [
@@ -23,9 +22,9 @@ const series = [
     ],
   },
   {
-    color: 'rgb(0, 164, 124)',
     areaStyle: 'none',
     lineStyle: 'dashed',
+    hasPoint: false,
     data: [
       {x: 0, y: 200},
       {x: 1, y: 200},
@@ -109,7 +108,7 @@ OffsetAndNulls.args = {
   series: [
     {
       color: 'rgb(255, 85, 70)',
-      areaStyle: 'gradient',
+      area: 'rgba(255, 85, 70, 0.1)',
       hasPoint: true,
       offsetRight: 12,
       offsetLeft: 50,
@@ -129,8 +128,8 @@ OffsetAndNulls.args = {
     },
     {
       color: 'rgb(255, 85, 70)',
-      areaStyle: 'none',
       lineStyle: 'dashed',
+      hasPoint: false,
       data: [
         {x: 0, y: 20},
         {x: 1, y: 20},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -117,6 +117,13 @@ export const DEFAULT_THEME: Theme = {
     padding: '0px',
     backgroundColor: '#1f1f25',
   },
+  line: {
+    color: VIZ_GRADIENT_COLOR.neutral.up,
+    area: null,
+    spline: true,
+    style: 'solid',
+    hasPoint: true,
+  },
   bar: {
     color: VIZ_GRADIENT_COLOR.neutral.up,
     hasRoundedCorners: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,9 +112,18 @@ export interface ChartContainerTheme {
   backgroundColor: string;
 }
 
+export interface LineTheme {
+  color: string | GradientStop[];
+  area: string | GradientStop[] | null;
+  spline: boolean;
+  style: 'solid' | 'dashed';
+  hasPoint: boolean;
+}
+
 export interface PartialTheme {
   chartContainer?: Partial<ChartContainerTheme>;
   bar?: Partial<BarTheme>;
+  line?: Partial<LineTheme>;
   grid?: Partial<GridTheme>;
   xAxis?: Partial<XAxisTheme>;
   yAxis?: Partial<YAxisTheme>;
@@ -125,4 +134,5 @@ export interface Theme {
   grid: GridTheme;
   xAxis: XAxisTheme;
   yAxis: YAxisTheme;
+  line: LineTheme;
 }


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/409

Adds theming to the Sparkline. More details commented throughout the code. 

The overall approach is to make most styles available and inherited through the theme, but allow them to be overwritten by config directly on each series, which is the approach for the grouped bar chart that I discussed with @krystalcampioni.

Some examples:
<img width="227" alt="Screen Shot 2021-07-28 at 11 15 22 AM" src="https://user-images.githubusercontent.com/12213371/127351819-3d9227eb-1b12-4555-b03c-aa2fc8b93138.png">
<img width="245" alt="Screen Shot 2021-07-28 at 11 15 13 AM" src="https://user-images.githubusercontent.com/12213371/127351822-e90376a8-68d1-4cce-9142-4f3baa66a0ae.png">
<img width="254" alt="Screen Shot 2021-07-28 at 11 15 07 AM" src="https://user-images.githubusercontent.com/12213371/127351826-20f0ccd0-8ade-435e-953e-803f6e9bb124.png">
<img width="231" alt="Screen Shot 2021-07-28 at 11 14 58 AM" src="https://user-images.githubusercontent.com/12213371/127351827-27c1dec7-bece-4c08-869e-1d350f5a0d7a.png">

### Reviewers’ :tophat: instructions
Make sure the Sparkline still works as expected and that it is possible to create 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
