### PR TITLE
Add theming to sparkbar

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -38,6 +38,11 @@ export const decorators = [
               padding: '20px',
             },
           },
+          Positive: {
+            bar: {
+              color: 'rgb(0, 164, 124)',
+            },
+          },
         }}
       >
         <Story />

--- a/documentation/code/SparkbarDemo.tsx
+++ b/documentation/code/SparkbarDemo.tsx
@@ -30,7 +30,6 @@ export function SparkbarDemo() {
               {x: 9, y: 500},
               {x: 10, y: 500},
             ]}
-            barFillStyle="solid"
           />
         </div>
       </div>

--- a/src/components/Sparkbar/Sparkbar.md
+++ b/src/components/Sparkbar/Sparkbar.md
@@ -9,6 +9,7 @@ Used in small sizes to give an overview of how a metric has performed over time.
 ```tsx
 
   const props = {
+    theme: 'default',
     data: [
       3, 7, 7, 5, 33, 2, 3, 0, 3, 5, 6, 6, 23, 5, 8, 1, 3, 12,
     ],
@@ -50,12 +51,11 @@ The sparkbar interface looks like this:
 
 ```typescript
 {
+  theme?: string;
   data: (number | null)[];
   comparison?: number;
-  color?: string;
   accessibilityLabel?: string;
   isAnimated?: boolean;
-  barFillStyle?: 'solid' | 'gradient'
   dataOffsetRight?: number;
   dataOffsetLeft?: number;
 }
@@ -81,6 +81,14 @@ The prop to determine the chart's bars. Null bars will not be plotted. Bars with
 
 ### Optional props
 
+#### theme
+
+| type     | default |
+| -------- | ------- |
+| `string` | `default`|
+
+The theme that the chart will inherit its color and container styles from.
+
 #### comparison
 
 | type                      | default     |
@@ -89,13 +97,6 @@ The prop to determine the chart's bars. Null bars will not be plotted. Bars with
 
 The prop to determine the comparison line for the chart.
 
-#### color
-
-| type    | default     |
-| ------- | ----------- |
-| `string` | `"rgb(71, 193, 191)"` |
-
-The sparkbar stroke and fill color. This accepts any CSS color.
 
 #### accessibilityLabel
 
@@ -112,14 +113,6 @@ Visually hidden text for screen readers.
 | `boolean` | `false` |
 
 Determines whether to animate the chart on state changes.
-
-### barFillStyle
-
-| type               | default |
-| ------------------ | ------- |
-| `solid | gradient` | `solid` |
-
-Determines whether what kind of shading to use to fill the bars.
 
 ##### dataOffsetLeft
 

--- a/src/components/Sparkbar/Sparkbar.scss
+++ b/src/components/Sparkbar/Sparkbar.scss
@@ -2,13 +2,8 @@
 
 .Wrapper {
   position: relative;
-  width: 100%;
-  height: 100%;
   overflow: visible;
-}
-
-.Svg {
-  position: absolute;
+  @include chart-container;
 }
 
 .VisuallyHidden {

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -4,10 +4,14 @@ import {scaleBand, scaleLinear} from 'd3-scale';
 import {line} from 'd3-shape';
 import {useTransition} from '@react-spring/web';
 
-import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
-import {BARS_TRANSITION_CONFIG, colorTeal} from '../../constants';
+import {
+  usePrefersReducedMotion,
+  useResizeObserver,
+  useTheme,
+} from '../../hooks';
+import {BARS_TRANSITION_CONFIG, colorWhite} from '../../constants';
 import type {SparkChartData} from '../../types';
-import {rgbToRgba, uniqueId, getAnimationTrail} from '../../utilities';
+import {uniqueId, getAnimationTrail, isGradientType} from '../../utilities';
 import {LinearGradient} from '../LinearGradient';
 
 import {Bar} from './components';
@@ -29,10 +33,9 @@ export interface SparkbarProps {
   dataOffsetRight?: number;
   dataOffsetLeft?: number;
   comparison?: Coordinates[];
-  color?: string;
   accessibilityLabel?: string;
   isAnimated?: boolean;
-  barFillStyle?: 'solid' | 'gradient';
+  theme?: string;
 }
 
 function calculateRange(data: SparkChartData[], height: number) {
@@ -59,12 +62,11 @@ function calculateRange(data: SparkChartData[], height: number) {
 export function Sparkbar({
   data,
   comparison,
-  color = colorTeal,
   accessibilityLabel,
   isAnimated = false,
-  barFillStyle = 'solid',
   dataOffsetRight = 0,
   dataOffsetLeft = 0,
+  theme,
 }: SparkbarProps) {
   const {
     ref: containerRef,
@@ -73,21 +75,18 @@ export function Sparkbar({
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const {prefersReducedMotion} = usePrefersReducedMotion();
+  const selectedTheme = useTheme(theme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
-    if (containerRef == null) return;
+    if (entry == null) return;
 
     setSvgDimensions({
-      height: containerRef.clientHeight,
-      width: containerRef.clientWidth,
+      height: entry.contentRect.height,
+      width: entry.contentRect.width,
     });
   }, 10);
 
   useLayoutEffect(() => {
-    if (entry == null) return;
-
-    if (containerRef == null) return;
-
     updateMeasurements();
 
     const isServer = typeof window === 'undefined';
@@ -131,6 +130,7 @@ export function Sparkbar({
   const barWidth = useMemo(() => xScale.bandwidth(), [xScale]);
 
   const id = useMemo(() => uniqueId('sparkbar'), []);
+  const clipId = useMemo(() => uniqueId('clip'), []);
 
   const getBarHeight = useCallback(
     (rawValue: number) => {
@@ -144,6 +144,17 @@ export function Sparkbar({
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
+  const color = selectedTheme.bar.color;
+
+  const barColor = isGradientType(color)
+    ? color
+    : [
+        {
+          color,
+          offset: 0,
+        },
+      ];
+
   const transitions = useTransition(dataWithIndex, {
     key: ({index}: {index: number}) => index,
     from: {height: 0},
@@ -156,7 +167,15 @@ export function Sparkbar({
   });
 
   return (
-    <div className={styles.Wrapper} ref={setContainerRef}>
+    <div
+      className={styles.Wrapper}
+      ref={setContainerRef}
+      style={{
+        background: selectedTheme.chartContainer.backgroundColor,
+        padding: selectedTheme.chartContainer.padding,
+        borderRadius: selectedTheme.chartContainer.borderRadius,
+      }}
+    >
       {accessibilityLabel ? (
         <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       ) : null}
@@ -169,51 +188,59 @@ export function Sparkbar({
         style={{
           transform: `translateY(${ANIMATION_MARGIN * -1}px)`,
         }}
-        className={styles.Svg}
       >
-        {barFillStyle === 'gradient' ? (
+        <defs>
           <LinearGradient
             id={id}
-            gradient={[
-              {
-                color: rgbToRgba({rgb: color, alpha: 0.5}),
-                offset: 0,
-              },
-              {
-                color: rgbToRgba({rgb: color, alpha: 1}),
-                offset: 100,
-              },
-            ]}
+            gradient={barColor}
+            gradientUnits="userSpaceOnUse"
+            y1="100%"
+            y2="0%"
           />
-        ) : null}
 
-        <g fill={barFillStyle === 'gradient' ? `url(#${id})` : color}>
-          {transitions(({height: barHeight}, item, _transition, index) => {
-            const xPosition = xScale(index.toString());
-            return (
-              <g key={index} opacity={comparison ? '0.9' : '1'}>
-                <Bar
+          <mask id={clipId}>
+            {transitions(({height: barHeight}, item, _transition, index) => {
+              const xPosition = xScale(index.toString());
+              return (
+                <g
+                  fill={colorWhite}
                   key={index}
-                  x={xPosition == null ? 0 : xPosition}
-                  yScale={yScale}
-                  rawValue={item.value}
-                  width={barWidth}
-                  height={barHeight}
+                  opacity={comparison ? '0.9' : '1'}
+                >
+                  <Bar
+                    key={index}
+                    x={xPosition == null ? 0 : xPosition}
+                    yScale={yScale}
+                    rawValue={item.value}
+                    width={barWidth}
+                    height={barHeight}
+                  />
+                </g>
+              );
+            })}
+
+            {comparison == null ? null : (
+              <g>
+                <path
+                  stroke={colorWhite}
+                  strokeWidth={STROKE_WIDTH}
+                  d={lineShape!}
+                  className={styles.ComparisonLine}
                 />
               </g>
-            );
-          })}
+            )}
+          </mask>
+        </defs>
+
+        <g mask={`url(#${clipId})`}>
+          <rect
+            x="0"
+            y="0"
+            width={width}
+            height={height}
+            fill={`url(#${id})`}
+          />
         </g>
-        {comparison == null ? null : (
-          <g>
-            <path
-              stroke={color}
-              strokeWidth={STROKE_WIDTH}
-              d={lineShape!}
-              className={styles.ComparisonLine}
-            />
-          </g>
-        )}
       </svg>
     </div>
   );

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -3,8 +3,6 @@ import {Story, Meta} from '@storybook/react';
 
 import {Sparkbar, SparkbarProps} from '../Sparkbar';
 
-const primaryColor = 'rgb(71, 193, 191)';
-
 export default {
   title: 'Charts/Sparkbar',
   parameters: {
@@ -19,10 +17,14 @@ export default {
   component: Sparkbar,
   decorators: [
     (Story: any) => (
-      <div style={{width: '100px', height: '50px'}}>{Story()}</div>
+      <div style={{width: '200px', height: '100px'}}>{Story()}</div>
     ),
   ],
   argTypes: {
+    theme: {
+      description:
+        'The theme that the chart will inherit its color and container styles from',
+    },
     data: {
       description:
         "The prop to determine the chart's bars. Null bars will not be plotted. Bars with the value of `0` will render a very small bar to indicate the presence of the value. [SparkChartData type definition.]()",
@@ -30,10 +32,6 @@ export default {
     accessibilityLabel: {
       description:
         'Visually hidden text for screen readers.  Make sure to write [informative alt text.](https://medium.com/nightingale/writing-alt-text-for-data-visualization-2a218ef43f81)',
-    },
-    barFillStyle: {
-      description:
-        'Determines whether what kind of shading to use to fill the bars.',
     },
     comparison: {
       description:
@@ -50,7 +48,6 @@ export default {
     isAnimated: {
       description: 'Determines whether to animate the chart on state changes.',
     },
-    color: {description: 'String color value.'},
   },
 } as Meta;
 
@@ -75,27 +72,30 @@ const defaultProps = {
     {x: 9, y: comparisonValue},
     {x: 10, y: comparisonValue},
   ],
-  color: 'rgb(0, 164, 124)',
-  barFillStyle: 'solid',
   accessibilityLabel:
     'A bar chart showing orders over time for the past 11 weeks. The minimum is 100 orders and the maximum is 1,000 orders, compared to an average of 500 orders during previous 11-week period.',
 };
 
-export const DarkMode = Template.bind({});
-DarkMode.args = defaultProps;
-DarkMode.parameters = {
+export const Default = Template.bind({});
+Default.args = defaultProps;
+Default.parameters = {
   backgrounds: {
     default: 'dark',
   },
 };
+
+export const Positive = Template.bind({});
+Positive.args = {...defaultProps, theme: 'Positive'};
+Positive.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
+
 export const OffsetAndNulls = Template.bind({});
 OffsetAndNulls.args = {
   ...defaultProps,
+  dataOffsetLeft: 10,
+  dataOffsetRight: 20,
   data: [100, 200, -300, null, 400, 0, 0, 400, 700, 900, 500],
-};
-
-export const Gradient = Template.bind({});
-Gradient.args = {
-  ...defaultProps,
-  barFillStyle: 'gradient',
 };

--- a/src/components/Sparkbar/tests/Sparkbar.test.tsx
+++ b/src/components/Sparkbar/tests/Sparkbar.test.tsx
@@ -32,23 +32,16 @@ jest.mock('d3-scale', () => ({
 }));
 
 describe('<Sparkbar/>', () => {
-  it('renders a <LinearGradient /> when barFillStyle is gradient', () => {
-    const wrapper = mount(
-      <Sparkbar barFillStyle="gradient" data={sampleData} />,
-    );
+  it('renders a <LinearGradient />', () => {
+    const wrapper = mount(<Sparkbar data={sampleData} />);
 
     expect(wrapper).toContainReactComponent(LinearGradient);
   });
 
-  it('uses a solid colour for fill when barFillStyle is solid', () => {
-    const color = 'blue';
-    const wrapper = mount(
-      <Sparkbar barFillStyle="solid" data={sampleData} color={color} />,
-    );
+  it('renders a mask', () => {
+    const wrapper = mount(<Sparkbar data={sampleData} />);
 
-    expect(wrapper).toContainReactComponent('g', {
-      fill: color,
-    });
+    expect(wrapper).toContainReactComponent('mask');
   });
 
   it('renders an accessibility label', () => {


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/408
Adds theming to the Sparkbar. This is part of a larger project to add theming to all the components in Polaris Viz. You can see [this PR](https://github.com/Shopify/polaris-viz/pull/434) as an example and read the [WIP migration guide here](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit) for more information.

More details throughout the code, but here are some high level details:
- removes the `color` and `barFillStyle` props in favour of inheriting color from the theme and making it flexible enough that a gradient can be provided, so the fill style prop is no longer needed.
- moves the bar shapes and comparison line to within a mask so that a gradient can be used in the same way it is currently used for the bar chart

<img width="248" alt="Screen Shot 2021-07-29 at 3 16 31 PM" src="https://user-images.githubusercontent.com/12213371/127552542-25879ccb-7057-4086-beee-73a7abac1323.png">
<img width="224" alt="Screen Shot 2021-07-29 at 3 16 26 PM" src="https://user-images.githubusercontent.com/12213371/127552545-a96401f0-6590-4607-b7ca-7340ab4e9a1f.png">


### Reviewers’ :tophat: instructions
Make sure the Sparkbar still works as expected and that we can still create the styles we have for our current uses of it

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
