### PR TITLE
Force print preview to show background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ### Fixed
 
 - Fixes `<BarChart />` when very large datasets are displayed
+- Fixes background color not showing when printing `<NormalizedStackedBarChart />`.
 
 ### Changed
-- removes @shopify/css-utilities in favour of adding our own utility 
+- removes @shopify/css-utilities in favour of adding our own utility
 - lowers d3-path dependency to a version matching d3-shape's dependency
 - replaces lodash.isequal with smaller option fast-deep-equal
 - adds a resolution for d3-array so we only have one version of the package in our library

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
@@ -4,6 +4,7 @@
   font-family: $font-stack-base;
   font-size: 14px;
   display: flex;
+  color-adjust: exact;
 }
 
 .VerticalContainer {


### PR DESCRIPTION
Fixes Shopify/polaris-viz#366

### What problem is this PR solving?

When printing the `NormalizedStackedBarChart` page, because we use divs & css to render the bar instead of SVG, the background colors are ignored by default.

### Reviewers’ :tophat: instructions

[![alt](https://screenshot.click/03-18-454gl-1cbf2.png)](https://screenshot.click/03-18-454gl-1cbf2.png)

- [ ] <kbd>CMD+P</kbd> to print the page

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
