### PR TITLE
Add xmlns and specific height/width values to svgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - lowers d3-path dependency to a version matching d3-shape's dependency
 - replaces lodash.isequal with smaller option fast-deep-equal
 - adds a resolution for d3-array so we only have one version of the package in our library
+- Add xmlns and specific height & width values to svgs tags
 
 ## [0.17.2] - 2021-06-23
 

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -9,6 +9,7 @@ import {
   BARS_TRANSITION_CONFIG,
   MASK_HIGHLIGHT_COLOR,
   MASK_SUBDUE_COLOR,
+  XMLNS,
 } from '../../constants';
 import {
   eventPoint,
@@ -249,8 +250,9 @@ export function Chart({
       }}
     >
       <svg
-        width="100%"
-        height="100%"
+        xmlns={XMLNS}
+        width={width}
+        height={height}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBar(null)}

--- a/src/components/ComparisonMetric/components/DownChevron/DownChevron.tsx
+++ b/src/components/ComparisonMetric/components/DownChevron/DownChevron.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {getColorValue} from '../../../../utilities';
+import {XMLNS} from '../../../../constants';
 
 import styles from './DownChevron.scss';
 
@@ -14,6 +15,7 @@ export function DownChevron({accessibilityLabel}: Props) {
     <React.Fragment>
       <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       <svg
+        xmlns={XMLNS}
         aria-hidden="true"
         style={{fill}}
         width="8"

--- a/src/components/ComparisonMetric/components/UpChevron/UpChevron.tsx
+++ b/src/components/ComparisonMetric/components/UpChevron/UpChevron.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {getColorValue} from '../../../../utilities';
+import {XMLNS} from '../../../../constants';
 
 import styles from './UpChevron.scss';
 
@@ -14,6 +15,7 @@ export function UpChevron({accessibilityLabel}: Props) {
     <React.Fragment>
       <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       <svg
+        xmlns={XMLNS}
         aria-hidden="true"
         style={{fill}}
         width="8"

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -20,6 +20,7 @@ import {
   SPACING_TIGHT,
   LineChartMargin as Margin,
   SPACING_BASE_TIGHT,
+  XMLNS,
 } from '../../constants';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
 import {LinearXAxis} from '../LinearXAxis';
@@ -309,9 +310,10 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
+        xmlns={XMLNS}
         role={emptyState ? 'img' : 'table'}
-        width="100%"
-        height="100%"
+        width={dimensions.width}
+        height={dimensions.height}
         onMouseMove={(event) => {
           event.persist();
           handleMouseInteraction(event);

--- a/src/components/LinePreview/LinePreview.tsx
+++ b/src/components/LinePreview/LinePreview.tsx
@@ -4,6 +4,7 @@ import type {SeriesColor} from 'types';
 import {getColorValue, isGradientType, uniqueId} from '../../utilities';
 import type {LineStyle} from '../../types';
 import {LinearGradient} from '../LinearGradient';
+import {XMLNS} from '../../constants';
 
 import {
   DASHED_STROKE_DASHARRAY,
@@ -26,7 +27,7 @@ export function LinePreview({color, lineStyle}: Props) {
 
   return (
     <div>
-      <svg width="15px" height="5px">
+      <svg xmlns={XMLNS} width="15px" height="5px">
         {isGradientType(color) ? (
           <defs>
             <LinearGradient

--- a/src/components/LinearGradient/stories/LinearGradient.stories.tsx
+++ b/src/components/LinearGradient/stories/LinearGradient.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Meta, Story} from '@storybook/react/types-6-0';
 
 import {LinearGradient, LinearGradientProps} from '../LinearGradient';
+import {XMLNS} from '../../../constants';
 
 export default {
   title: 'Subcomponents/LinearGradient',
@@ -49,7 +50,7 @@ export default {
 } as Meta;
 
 const Template: Story<LinearGradientProps> = (args) => (
-  <svg viewBox="0 0 500 500">
+  <svg viewBox="0 0 500 500" xmlns={XMLNS} height={500} width={500}>
     <LinearGradient {...args} />
     <rect x="0" y="0" width="500" height="500" fill="url(#sampleGradient)" />
   </svg>

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useCallback} from 'react';
 
-import {BarChartMargin as Margin} from '../../constants';
+import {BarChartMargin as Margin, XMLNS} from '../../constants';
 import {TooltipContainer} from '../TooltipContainer';
 import {
   eventPoint,
@@ -225,8 +225,9 @@ export function Chart({
       }}
     >
       <svg
-        width="100%"
-        height="100%"
+        xmlns={XMLNS}
+        width={chartDimensions.width}
+        height={chartDimensions.height}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBarGroup(null)}

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -5,7 +5,7 @@ import {line} from 'd3-shape';
 import {useTransition} from '@react-spring/web';
 
 import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
-import {BARS_TRANSITION_CONFIG} from '../../constants';
+import {BARS_TRANSITION_CONFIG, XMLNS} from '../../constants';
 import type {Color, SparkChartData} from '../../types';
 import {
   getColorValue,
@@ -162,6 +162,8 @@ export function Sparkbar({
     config: BARS_TRANSITION_CONFIG,
   });
 
+  const viewboxHeight = height + ANIMATION_MARGIN * 2;
+
   return (
     <div className={styles.Wrapper} ref={setContainerRef}>
       {accessibilityLabel ? (
@@ -169,14 +171,15 @@ export function Sparkbar({
       ) : null}
 
       <svg
+        xmlns={XMLNS}
         aria-hidden
-        viewBox={`0 ${ANIMATION_MARGIN * -1} ${width} ${
-          height + ANIMATION_MARGIN * 2
-        }`}
+        viewBox={`0 -${ANIMATION_MARGIN} ${width} ${viewboxHeight}`}
         style={{
-          transform: `translateY(${ANIMATION_MARGIN * -1}px)`,
+          transform: `translateY(-${ANIMATION_MARGIN}px)`,
         }}
         className={styles.Svg}
+        height={viewboxHeight}
+        width={width}
       >
         {barFillStyle === 'gradient' ? (
           <LinearGradient

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -4,6 +4,7 @@ import {scaleLinear} from 'd3-scale';
 import type {Color, SparkChartData} from 'types';
 
 import {useResizeObserver} from '../../hooks';
+import {XMLNS} from '../../constants';
 
 import styles from './Sparkline.scss';
 import {Series} from './components';
@@ -134,7 +135,7 @@ export function Sparkline({
         <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
       ) : null}
 
-      <svg aria-hidden width={width} height={height}>
+      <svg xmlns={XMLNS} aria-hidden width={width} height={height}>
         {series.map((singleSeries, index) => {
           const {offsetRight = 0, offsetLeft = 0} = singleSeries;
 

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -14,6 +14,7 @@ import {
   FONT_SIZE,
   CROSSHAIR_WIDTH,
   LineChartMargin as Margin,
+  XMLNS,
 } from '../../constants';
 import {TooltipContainer} from '../TooltipContainer';
 import {eventPoint, uniqueId, getColorValue} from '../../utilities';
@@ -173,8 +174,9 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
-        width="100%"
-        height="100%"
+        xmlns={XMLNS}
+        width={dimensions.width}
+        height={dimensions.height}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onTouchEnd={() => setActivePointIndex(null)}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,3 +50,4 @@ export const MAX_TRAIL_DURATION = 500;
 
 export const MASK_HIGHLIGHT_COLOR = '#FFF';
 export const MASK_SUBDUE_COLOR = '#434343';
+export const XMLNS = 'http://www.w3.org/2000/svg';


### PR DESCRIPTION
Fixes Shopify/polaris-viz#444

### What problem is this PR solving?

To get ahead of future potential issues, we're adding `xmlns` attributes to all our SVGs tags. We're also setting specific values for `height` & `width` instead of relying on `100%`.

### Reviewers’ :tophat: instructions

- [ ] Visually spot check all storybook stories. Nothing should be oddly sized.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [ ] Update relevant documentation.
