### PR TITLE
Prevent TooltipContainer from blocking chart elements

### DIFF
--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -24,7 +24,10 @@ import {
 import {Bar} from '../Bar';
 import {YAxis} from '../YAxis';
 import {BarChartXAxis} from '../BarChartXAxis';
-import {TooltipContainer} from '../TooltipContainer';
+import {
+  TooltipContainer,
+  TooltipPosition as TooltipContainerPosition,
+} from '../TooltipContainer';
 import {LinearGradient} from '../LinearGradient';
 import {HorizontalGridLines} from '../HorizontalGridLines';
 import {Dimensions, XAxisOptions, YAxisOptions, BarMargin} from '../../types';
@@ -38,6 +41,12 @@ import type {
 import {useYScale, useXScale, useMinimalLabelIndexes} from './hooks';
 import {SMALL_FONT_SIZE, FONT_SIZE, SMALL_SCREEN, SPACING} from './constants';
 import styles from './Chart.scss';
+
+interface TooltipPosition {
+  x: number;
+  y: number;
+  position: TooltipContainerPosition;
+}
 
 interface Props {
   data: BarChartData[];
@@ -68,10 +77,8 @@ export function Chart({
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const [activeBar, setActiveBar] = useState<number | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
+  const [tooltipPosition, setTooltipPosition] =
+    useState<TooltipPosition | null>(null);
   const {minimalLabelIndexes} = useMinimalLabelIndexes({
     useMinimalLabels: xAxisOptions.useMinimalLabels,
     dataLength: data.length,
@@ -202,6 +209,10 @@ export function Chart({
       setTooltipPosition({
         x: cx + chartStartPosition + xScale.bandwidth() / 2,
         y: cy,
+        position: {
+          horizontal: 'center',
+          vertical: 'above',
+        },
       });
     },
     [chartStartPosition, xScale],
@@ -404,7 +415,8 @@ export function Chart({
           currentY={tooltipPosition.y}
           chartDimensions={chartDimensions}
           margin={Margin}
-          position="center"
+          bandwidth={xScale.bandwidth()}
+          position={tooltipPosition.position}
         >
           {tooltipMarkup}
         </TooltipContainer>
@@ -436,17 +448,15 @@ export function Chart({
       return;
     }
 
-    const xPosition = xScale(currentIndex.toString());
+    const xPosition = xScale(currentIndex.toString()) ?? 0;
     const value = data[currentIndex].rawValue;
-    const tooltipXPositon =
-      xPosition == null
-        ? 0
-        : xPosition + chartStartPosition + xScale.bandwidth() / 2;
+    const tooltipXPositon = xPosition + chartStartPosition;
 
     setActiveBar(currentIndex);
     setTooltipPosition({
       x: tooltipXPositon,
       y: yScale(value),
+      position: {horizontal: 'center', vertical: value < 0 ? 'below' : 'above'},
     });
   }
 }

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -517,6 +517,10 @@ export function Chart({
           chartDimensions={dimensions}
           margin={Margin}
           id={tooltipId.current}
+          position={{
+            horizontal: 'left',
+            vertical: 'inline',
+          }}
         >
           {tooltipMarkup}
         </TooltipContainer>

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -281,7 +281,7 @@ IntegersOnly.args = {
     {
       name: 'Breakfast',
       data: [
-        {label: 'Monday', rawValue: 0.3},
+        {label: 'Monday', rawValue: 2},
         {label: 'Tuesday', rawValue: 0.1},
         {label: 'Wednesday', rawValue: 0.78},
         {label: 'Thursday', rawValue: 0.12},
@@ -297,7 +297,7 @@ IntegersOnly.args = {
         {label: 'Tuesday', rawValue: 0.1},
         {label: 'Wednesday', rawValue: 0.12},
         {label: 'Thursday', rawValue: 0.34},
-        {label: 'Friday', rawValue: 0.54},
+        {label: 'Friday', rawValue: 1.6},
         {label: 'Saturday', rawValue: 0.21},
         {label: 'Sunday', rawValue: 0.1},
       ],
@@ -311,7 +311,7 @@ IntegersOnly.args = {
         {label: 'Thursday', rawValue: 1.2},
         {label: 'Friday', rawValue: 0.5},
         {label: 'Saturday', rawValue: 0.12},
-        {label: 'Sunday', rawValue: 0.6},
+        {label: 'Sunday', rawValue: 2},
       ],
     },
   ],
@@ -350,4 +350,30 @@ LargeVolume.args = {
       .fill(null)
       .map((x) => 'some label'),
   },
+};
+
+export const NegativeOnly = Template.bind({});
+NegativeOnly.args = {
+  series: [
+    {
+      name: 'Breakfast',
+      data: IntegersOnly.args.series[0].data.map(({label, rawValue}) => {
+        return {label, rawValue: rawValue * -1};
+      }),
+    },
+    {
+      name: 'Lunch',
+      data: IntegersOnly.args.series[1].data.map(({label, rawValue}) => {
+        return {label, rawValue: rawValue * -1};
+      }),
+    },
+    {
+      name: 'Dinner',
+      data: IntegersOnly.args.series[2].data.map(({label, rawValue}) => {
+        return {label, rawValue: rawValue * -1};
+      }),
+    },
+  ],
+  xAxisOptions: {labels},
+  yAxisOptions: {integersOnly: true},
 };

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -396,6 +396,10 @@ export function Chart({
           currentY={tooltipPosition.y}
           chartDimensions={dimensions}
           margin={Margin}
+          position={{
+            horizontal: 'left',
+            vertical: 'center',
+          }}
         >
           {tooltipMarkup}
         </TooltipContainer>

--- a/src/components/TooltipContainer/index.ts
+++ b/src/components/TooltipContainer/index.ts
@@ -1,1 +1,2 @@
 export {TooltipContainer} from './TooltipContainer';
+export type {TooltipPosition, TooltipContainerProps} from './TooltipContainer';

--- a/src/components/TooltipContainer/tests/TooltipContainer.test.tsx
+++ b/src/components/TooltipContainer/tests/TooltipContainer.test.tsx
@@ -34,7 +34,7 @@ describe('<TooltipContainer />', () => {
     expect(styles.transform).toBeDefined();
   });
 
-  it('reners its children', () => {
+  it('renders its children', () => {
     const children = <p>tooltip content</p>;
     const tooltipContainer = mount(
       <TooltipContainer {...mockProps}>{children}</TooltipContainer>,

--- a/src/components/TooltipContainer/tests/utils.test.ts
+++ b/src/components/TooltipContainer/tests/utils.test.ts
@@ -1,0 +1,144 @@
+import {
+  getAbovePosition,
+  getBelowPosition,
+  getCenterPosition,
+  getInlinePosition,
+  getLeftPosition,
+  getRightPosition,
+  getVerticalCenterPosition,
+} from '../utils';
+
+const MARGIN = {Top: 0, Left: 0, Right: 0, Bottom: 0};
+const BASE_PROPS = {
+  chartDimensions: {height: 100, width: 100},
+  tooltipDimensions: {height: 20, width: 20},
+  margin: MARGIN,
+  bandwidth: 40,
+} as any;
+
+describe('getInlinePosition()', () => {
+  it('returns altered values', () => {
+    expect(getInlinePosition(0, BASE_PROPS)).toStrictEqual({
+      value: 0,
+      wasOutsideBounds: false,
+    });
+
+    expect(getInlinePosition(90, BASE_PROPS)).toStrictEqual({
+      value: 80,
+      wasOutsideBounds: true,
+    });
+  });
+});
+
+describe('getVerticalCenterPosition()', () => {
+  it('returns altered values', () => {
+    expect(
+      getVerticalCenterPosition(0, {...BASE_PROPS, currentY: 0}),
+    ).toStrictEqual({
+      value: 0,
+      wasOutsideBounds: true,
+    });
+
+    expect(
+      getVerticalCenterPosition(40, {...BASE_PROPS, currentY: 40}),
+    ).toStrictEqual({
+      value: 30,
+      wasOutsideBounds: false,
+    });
+  });
+});
+
+describe('getAbovePosition()', () => {
+  it('returns altered values', () => {
+    expect(getAbovePosition(0, {...BASE_PROPS, currentY: 0})).toStrictEqual({
+      value: 0,
+      wasOutsideBounds: true,
+    });
+
+    expect(getAbovePosition(40, {...BASE_PROPS, currentY: 40})).toStrictEqual({
+      value: 10,
+      wasOutsideBounds: false,
+    });
+  });
+});
+
+describe('getBelowPosition()', () => {
+  it('returns altered values', () => {
+    expect(getBelowPosition(0, BASE_PROPS)).toStrictEqual({
+      value: 20,
+      wasOutsideBounds: false,
+    });
+
+    expect(getBelowPosition(40, BASE_PROPS)).toStrictEqual({
+      value: 60,
+      wasOutsideBounds: false,
+    });
+
+    expect(getBelowPosition(90, BASE_PROPS)).toStrictEqual({
+      value: 80,
+      wasOutsideBounds: true,
+    });
+  });
+});
+
+describe('getLeftPosition()', () => {
+  it('returns altered values', () => {
+    expect(getLeftPosition(0, {...BASE_PROPS, currentX: 0})).toStrictEqual({
+      value: 50,
+      wasOutsideBounds: true,
+    });
+
+    expect(getLeftPosition(40, {...BASE_PROPS, currentX: 40})).toStrictEqual({
+      value: 10,
+      wasOutsideBounds: false,
+    });
+
+    expect(getLeftPosition(90, {...BASE_PROPS, currentX: 90})).toStrictEqual({
+      value: 60,
+      wasOutsideBounds: false,
+    });
+  });
+});
+
+describe('getRightPosition()', () => {
+  it('returns altered values', () => {
+    expect(getRightPosition(0, BASE_PROPS)).toStrictEqual({
+      value: 50,
+      wasOutsideBounds: false,
+    });
+
+    expect(getRightPosition(40, BASE_PROPS)).toStrictEqual({
+      value: 90,
+      wasOutsideBounds: false,
+    });
+
+    expect(getRightPosition(90, BASE_PROPS)).toStrictEqual({
+      value: 60,
+      wasOutsideBounds: true,
+    });
+  });
+});
+
+describe('getCenterPosition()', () => {
+  it('returns altered values', () => {
+    expect(getCenterPosition(-10, BASE_PROPS)).toStrictEqual({
+      value: 0,
+      wasOutsideBounds: false,
+    });
+
+    expect(getCenterPosition(0, BASE_PROPS)).toStrictEqual({
+      value: 10,
+      wasOutsideBounds: false,
+    });
+
+    expect(getCenterPosition(40, BASE_PROPS)).toStrictEqual({
+      value: 50,
+      wasOutsideBounds: false,
+    });
+
+    expect(getCenterPosition(90, BASE_PROPS)).toStrictEqual({
+      value: 60,
+      wasOutsideBounds: true,
+    });
+  });
+});

--- a/src/components/TooltipContainer/utils.ts
+++ b/src/components/TooltipContainer/utils.ts
@@ -1,0 +1,270 @@
+import type {Dimensions, Margin} from '../../types';
+
+import type {TooltipPosition} from './TooltipContainer';
+
+// The space between the cursor and the tooltip
+const TOOLTIP_MARGIN = 10;
+
+interface AlteredPositionProps {
+  currentX: number;
+  currentY: number;
+  position: TooltipPosition;
+  tooltipDimensions: Dimensions;
+  chartDimensions: Dimensions;
+  margin: Margin;
+  bandwidth: number;
+}
+
+interface AlteredPositionReturn {
+  x: number;
+  y: number;
+}
+
+// Keep the tooltip within the bounds of the chart.
+// Based on "position" the tooltip will be placed
+// around the chart item so the item should never
+// be obscured by the tooltip.
+export function getAlteredPosition(
+  props: AlteredPositionProps,
+): AlteredPositionReturn {
+  const {currentX, currentY, position} = props;
+
+  const newPosition = {...position};
+
+  let x = currentX;
+  let y = currentY;
+
+  //
+  // Y POSITIONING
+  //
+
+  if (newPosition.vertical === 'inline') {
+    newPosition.horizontal = 'left';
+
+    const inline = getInlinePosition(y, props);
+    y = inline.value;
+  }
+
+  if (newPosition.vertical === 'center') {
+    const verticalCenter = getVerticalCenterPosition(y, props);
+    y = verticalCenter.value;
+  }
+
+  if (newPosition.vertical === 'above') {
+    const above = getAbovePosition(y, props);
+    y = above.value;
+
+    if (above.wasOutsideBounds) {
+      newPosition.horizontal = 'left';
+    }
+  }
+
+  if (newPosition.vertical === 'below') {
+    const below = getBelowPosition(y, props);
+    y = below.value;
+
+    if (below.wasOutsideBounds) {
+      newPosition.horizontal = 'left';
+    }
+  }
+
+  //
+  // X POSITIONING
+  //
+
+  if (newPosition.horizontal === 'left') {
+    const left = getLeftPosition(x, props);
+    x = left.value;
+  }
+
+  if (newPosition.horizontal === 'right') {
+    const right = getRightPosition(x, props);
+    x = right.value;
+  }
+
+  if (newPosition.horizontal === 'center') {
+    const center = getCenterPosition(x, props);
+    x = center.value;
+  }
+
+  return {x, y};
+}
+
+interface IsOutsideBoundsData {
+  current: number;
+  direction: 'x' | 'y';
+  alteredPosition: AlteredPositionProps;
+}
+
+function isOutsideBounds(data: IsOutsideBoundsData): boolean {
+  const {current, direction, alteredPosition} = data;
+
+  if (direction === 'x') {
+    const isLeft = current < alteredPosition.margin.Left;
+    const isRight =
+      current + alteredPosition.tooltipDimensions.width >
+      alteredPosition.chartDimensions.width - alteredPosition.margin.Right;
+
+    return isLeft || isRight;
+  } else {
+    const isAbove = current < 0;
+    const isBelow =
+      current + alteredPosition.tooltipDimensions.height >
+      alteredPosition.chartDimensions.height - alteredPosition.margin.Bottom;
+
+    return isAbove || isBelow;
+  }
+}
+
+type getFunction = (
+  value: number,
+  props: AlteredPositionProps,
+) => {value: number; wasOutsideBounds: boolean};
+
+export function getInlinePosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let y = value;
+  const wasOutsideBounds = isOutsideBounds({
+    current: y,
+    direction: 'y',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    const bottom = y + props.tooltipDimensions.height;
+    const offset = bottom - props.chartDimensions.height;
+
+    y -= offset + props.margin.Bottom;
+  }
+
+  return {value: y, wasOutsideBounds};
+}
+
+export function getVerticalCenterPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let y = value - props.tooltipDimensions.height / 2;
+  const wasOutsideBounds = isOutsideBounds({
+    current: y,
+    direction: 'y',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    y = props.currentY;
+  }
+
+  return {value: y, wasOutsideBounds};
+}
+
+export function getAbovePosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let y = value - props.tooltipDimensions.height - TOOLTIP_MARGIN;
+  const wasOutsideBounds = isOutsideBounds({
+    current: y,
+    direction: 'y',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    y = props.currentY;
+  }
+
+  return {value: y, wasOutsideBounds};
+}
+
+export function getBelowPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let y = value + TOOLTIP_MARGIN * 2;
+  const wasOutsideBounds = isOutsideBounds({
+    current: y,
+    direction: 'y',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    y -= props.tooltipDimensions.height + TOOLTIP_MARGIN;
+  }
+
+  return {value: y, wasOutsideBounds};
+}
+
+export function getLeftPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let x = value - props.tooltipDimensions.width;
+  const wasOutsideBounds = isOutsideBounds({
+    current: x,
+    direction: 'x',
+    alteredPosition: props,
+  });
+  if (wasOutsideBounds) {
+    x = props.currentX + props.margin.Left + props.bandwidth + TOOLTIP_MARGIN;
+  } else {
+    x -= TOOLTIP_MARGIN;
+  }
+
+  return {value: x, wasOutsideBounds};
+}
+
+export function getRightPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let x = value + props.bandwidth;
+  const wasOutsideBounds = isOutsideBounds({
+    current: x,
+    direction: 'x',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    x -= props.tooltipDimensions.width + props.bandwidth + TOOLTIP_MARGIN;
+  } else {
+    x += TOOLTIP_MARGIN;
+  }
+
+  return {value: x, wasOutsideBounds};
+}
+
+export function getCenterPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  const offset = props.bandwidth - props.tooltipDimensions.width;
+  let x = value + offset / 2;
+
+  if (x < props.margin.Left) {
+    x = props.currentX + props.margin.Left;
+  }
+
+  const wasOutsideBounds = isOutsideBounds({
+    current: x,
+    direction: 'x',
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds) {
+    x =
+      props.chartDimensions.width -
+      props.tooltipDimensions.width -
+      TOOLTIP_MARGIN * 2;
+  }
+
+  return {value: x, wasOutsideBounds};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,3 +171,9 @@ export interface Theme {
   seriesColors: SeriesColors;
   tooltip: TooltipTheme;
 }
+export interface Margin {
+  Top: number;
+  Left: number;
+  Right: number;
+  Bottom: number;
+}


### PR DESCRIPTION
Fixes Shopify/polaris-viz#239

### What problem is this PR solving?

When hovering a bar chart, the default logic is to center the tooltip above the chart. This works great for shorter charts, but breaks when the chart fills vertically.

Example: **Wednesday** has a tooltip that covers the bar

[Old Logic Example](https://screenshot.click/04-49-u85k4-i6iov.mp4)

The new logic we're going for is:

- Push the tooltip X value away from the bar chart.
- Place the tooltip Y value to the top of highest bar value.
- Place the tooltip to the right/left of the set based on where the largest bar currently sits. (Except on the left/right sides of the container. We keep the tooltip in bounds regardless).

[New Logic](https://screenshot.click/04-55-wzyp8-ckxq0.mp4)

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
