### PR TITLE
Theming linechart

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -38,6 +38,13 @@ export const decorators = [
               padding: '20px',
             },
           },
+          NoSpline: {
+            line: {hasSpline: false},
+          },
+          NoxAxisLabels: {
+            xAxis: {hide: true},
+          },
+          NoOverflow: {grid: {horizontalOverflow: false}},
           Positive: {
             bar: {
               color: 'rgb(0, 164, 124)',

--- a/documentation/code/LineChartDemo.tsx
+++ b/documentation/code/LineChartDemo.tsx
@@ -122,7 +122,6 @@ export function LineChartDemo() {
           xAxisOptions={{
             xAxisLabels,
             labelFormatter: formatXAxisLabel,
-            showTicks: true,
           }}
           yAxisOptions={{labelFormatter: formatYAxisLabel}}
           renderTooltipContent={renderTooltipContent}

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -65,6 +65,7 @@ describe('Chart />', () => {
       color: 'red',
       horizontalOverflow: false,
       horizontalMargin: 0,
+      showVerticalLines: true,
     },
     xAxisOptions: {
       labelFormatter: (value: string) => value.toString(),
@@ -74,6 +75,7 @@ describe('Chart />', () => {
       showTicks: true,
       labelColor: 'red',
       useMinimalLabels: false,
+      hide: false,
     },
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -26,7 +26,15 @@ import {YAxis} from '../YAxis';
 import {Point} from '../Point';
 import {Crosshair} from '../Crosshair';
 import {LinearGradient} from '../LinearGradient';
-import type {ActiveTooltip, Dimensions} from '../../types';
+import type {
+  ActiveTooltip,
+  CrossHairTheme,
+  Dimensions,
+  GridTheme,
+  LineTheme,
+  XAxisTheme,
+  YAxisTheme,
+} from '../../types';
 import {TooltipContainer} from '../TooltipContainer';
 import {HorizontalGridLines} from '../HorizontalGridLines';
 
@@ -34,11 +42,8 @@ import {MAX_ANIMATED_SERIES_LENGTH} from './constants';
 import type {
   RenderTooltipContentData,
   TooltipData,
-  LineOptions,
   XAxisOptions,
   YAxisOptions,
-  GridOptions,
-  CrossHairOptions,
   SeriesWithDefaults,
 } from './types';
 import {useYScale, useLineChartAnimations} from './hooks';
@@ -51,11 +56,11 @@ interface Props {
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   emptyStateText?: string;
   isAnimated: boolean;
-  lineOptions: LineOptions;
-  xAxisOptions: XAxisOptions;
-  yAxisOptions: YAxisOptions;
-  gridOptions: GridOptions;
-  crossHairOptions: CrossHairOptions;
+  lineOptions: LineTheme;
+  xAxisOptions: XAxisOptions & XAxisTheme;
+  yAxisOptions: YAxisOptions & YAxisTheme;
+  gridOptions: GridTheme;
+  crossHairOptions: CrossHairTheme;
 }
 
 export function Chart({
@@ -96,11 +101,11 @@ export function Chart({
     width: dimensions.width - gridOptions.horizontalMargin * 2,
     formatXAxisLabel: xAxisOptions.labelFormatter,
     initialTicks,
-    xAxisLabels: xAxisOptions.hideXAxisLabels ? [] : xAxisOptions.xAxisLabels,
+    xAxisLabels: xAxisOptions.hide ? [] : xAxisOptions.xAxisLabels,
     useMinimalLabels: xAxisOptions.useMinimalLabels,
   });
 
-  const marginBottom = xAxisOptions.hideXAxisLabels
+  const marginBottom = xAxisOptions.hide
     ? SPACING_TIGHT
     : Number(Margin.Bottom) + xAxisDetails.maxXLabelHeight;
 
@@ -331,7 +336,7 @@ export function Chart({
           <LinearXAxis
             xAxisDetails={xAxisDetails}
             xScale={xScale}
-            labels={xAxisOptions.hideXAxisLabels ? null : formattedLabels}
+            labels={xAxisOptions.hide ? null : formattedLabels}
             drawableWidth={drawableWidth}
             fontSize={fontSize}
             drawableHeight={drawableHeight}
@@ -374,7 +379,7 @@ export function Chart({
             <Crosshair
               x={getXPosition({isCrosshair: true})}
               height={drawableHeight}
-              opacity={tooltipDetails == null ? 0 : crossHairOptions.opacity}
+              opacity={tooltipDetails == null ? 0 : 1}
               fill={crossHairOptions.color}
               width={crossHairOptions.width}
             />

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -127,31 +127,13 @@ const props = {
     xAxisLabels: xAxisLabels,
     labelFormatter: formatXAxisLabel,
     useMinimalLabels: true,
-    showTicks: false,
-    labelColor: 'rgb(220, 220, 220)',
   },
   yAxisOptions: {
     labelFormatter: formatYAxisLabel,
-    backgroundColor: 'rgb(31, 31, 37)',
-    labelColor: 'rgb(220, 220, 220)',
     integersOnly: true,
   },
-  gridOptions: {
-    showVerticalLines: false,
-    color: 'rgb(65, 66, 71)',
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-  },
-  lineOptions: {
-    hasSpline: true,
-    width: 3,
-    pointStroke: 'rgb(31, 31, 37)',
-  },
-  crossHairOptions: {
-    width: 1,
-    color: 'rgb(139, 159, 176)',
-  },
   skipLinkText = 'Skip chart content',
+  theme: "Default"
 };
 
 return <LineChart {...props} />;
@@ -165,37 +147,15 @@ The line chart interface looks like this:
 interface LineChartProps {
   series: Series[];
   isAnimated?: boolean;
-  lineOptions?: {
-    hasSpline?: boolean;
-    width?: number;
-    pointStroke?: string;
-  };
   xAxisOptions: {
     xAxisLabels: string[];
     labelFormatter?(value: string, index?: number, data?: string[]): string;
-    hideXAxisLabels?: boolean;
     useMinimalLabels?: boolean;
-    showTicks?: boolean;
-    labelColor: string;
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
-    labelColor: string;
-    backgroundColor?: string;
     integersOnly?: boolean;
-  }
-  gridOptions?: {
-    showVerticalLines?: boolean;
-    showHorizontalLines?: boolean;
-    horizontalOverflow?: boolean;
-    color?: string;
-    horizontalMargin?: number;
-  }
-  crossHairOptions?: {
-    width?: number;
-    color?: string;
-    opacity?: number;
-  }
+  };
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
   emptyStateText?: string;
@@ -220,6 +180,8 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
   areaColor?: string;
 }
 ```
+
+Note: the configuration of color, line style and area color on the series type overrides the defaults set by the theme provider.
 
 #### name
 
@@ -349,14 +311,6 @@ An object including the following proprties that define the appearance of the xA
 
 If set to true, a chart that would typically show more than three xAxis labels will instead show a maximum of three labels.
 
-##### hideXAxisLabels
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | false   |
-
-Whether to visually hide the x axis labels on the chart. The labels will still be displayed to screenreaders.
-
 ##### showTicks
 
 | type      | default |
@@ -373,14 +327,6 @@ Whether to show ticks connecting the xAxis labels to their corresponding grid li
 
 This accepts a function that is called to format the labels when the chart draws its X axis.
 
-##### labelColor
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `'rgb(223, 227, 232)'` |
-
-The color used for axis labels.
-
 #### yAxisOptions
 
 An object including the following optional proprties that define the appearance of the yAxis.
@@ -393,22 +339,6 @@ An object including the following optional proprties that define the appearance 
 
 This utilty function is called to format the labels for every y axis value when the chart is laid out.
 
-##### labelColor
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `'rgb(223, 227, 232)'` |
-
-The color used for axis labels.
-
-##### backgroundColor
-
-| type     | default       |
-| -------- | ------------- |
-| `string` | `transparant` |
-
-The color used behind axis labels.
-
 ##### integersOnly
 
 | type      | default |
@@ -417,104 +347,10 @@ The color used behind axis labels.
 
 Only use whole numbers for y axis ticks.
 
-#### lineOptions
-
-An object including the following optional proprties that define the appearance of the line.
-
-##### hasSpline
+### theme
 
 | type      | default |
 | --------- | ------- |
-| `boolean` | `false` |
+| `string` | `default` |
 
-Whether to curve the lines between points.
-
-##### width
-
-| type     | default |
-| -------- | ------- |
-| `number` | `2`     |
-
-The width of the lines drawn between points.
-
-##### pointStroke
-
-| type     | default |
-| -------- | ------- |
-| `string` | `#fff`  |
-
-The color around the circle depicting the active point.
-
-#### gridOptions
-
-An object including the following optional proprties that define the grid.
-
-##### showVerticalLines
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `true`  |
-
-Whether to show lines extending from the xAxis labels through the chart.
-
-##### showHorizontalLines
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `true`  |
-
-Whether to show lines extending from the yAxis labels through the chart.
-
-##### horizontalOverflow
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Whether the lines should extend through the width of the entire chart.
-
-##### horizontalMargin
-
-| type     | default |
-| -------- | ------- |
-| `number` | `0`     |
-
-Margin to display on the left and right of the chart.
-
-##### color
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `"rgb(223, 227, 232)"` |
-
-The color of the grid lines.
-
-#### CrossHairOptions
-
-An object including the following optional proprties that define the crosshair.
-
-##### width
-
-| type     | default |
-| -------- | ------- |
-| `number` | `5`     |
-
-The width of the crosshair.
-
-##### color
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `'rgb(223, 227, 232)'` |
-
-The color of the crosshair.
-
-##### opacity
-
-| type     | default |
-| -------- | ------- |
-| `number` | `1`     |
-
-Whether to curve the line between points.
-
-The opacity of the crosshair.
+The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider. Individual line styles can be overwritten as part of the series prop.

--- a/src/components/LineChart/LineChart.scss
+++ b/src/components/LineChart/LineChart.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.Container {
+  @include chart-container;
+}

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -2,41 +2,34 @@ import React, {useLayoutEffect, useRef, useState, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
 import type {Dimensions} from '../../types';
-import {getDefaultColor, uniqueId} from '../../utilities';
+import {uniqueId} from '../../utilities';
 import {SkipLink} from '../SkipLink';
-import {usePrefersReducedMotion, useResizeObserver} from '../../hooks';
 import {
-  DEFAULT_GREY_LABEL,
-  CROSSHAIR_WIDTH,
-  DEFAULT_CROSSHAIR_COLOR,
-  colorSky,
-  colorWhite,
-} from '../../constants';
+  usePrefersReducedMotion,
+  useResizeObserver,
+  useTheme,
+} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {
   Series,
   RenderTooltipContentData,
-  LineOptions,
   XAxisOptions,
   YAxisOptions,
-  GridOptions,
-  CrossHairOptions,
   SeriesWithDefaults,
 } from './types';
 import {TooltipContent} from './components';
+import styles from './LineChart.scss';
 
 export interface LineChartProps {
   series: Series[];
-  renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
+  xAxisOptions: Partial<XAxisOptions> & Pick<XAxisOptions, 'xAxisLabels'>;
+  yAxisOptions?: Partial<YAxisOptions>;
   skipLinkText?: string;
   emptyStateText?: string;
   isAnimated?: boolean;
-  lineOptions?: Partial<LineOptions>;
-  xAxisOptions: Partial<XAxisOptions> & Pick<XAxisOptions, 'xAxisLabels'>;
-  yAxisOptions?: Partial<YAxisOptions>;
-  gridOptions?: Partial<GridOptions>;
-  crossHairOptions?: Partial<CrossHairOptions>;
+  renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
+  theme?: string;
 }
 
 export function LineChart({
@@ -45,12 +38,12 @@ export function LineChart({
   skipLinkText,
   emptyStateText,
   isAnimated = false,
-  lineOptions,
   xAxisOptions,
   yAxisOptions,
-  gridOptions,
-  crossHairOptions,
+  theme,
 }: LineChartProps) {
+  const selectedTheme = useTheme(theme);
+
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
   );
@@ -130,44 +123,25 @@ export function LineChart({
     handlePrintMediaQueryChange,
   ]);
 
-  const lineOptionsWithDefaults = {
-    hasSpline: false,
-    width: 2,
-    pointStroke: colorWhite,
-    ...lineOptions,
-  };
-
   const xAxisOptionsWithDefaults = {
-    labelFormatter: (value: string) => value,
-    hideXAxisLabels: false,
-    showTicks: true,
-    labelColor: DEFAULT_GREY_LABEL,
-    useMinimalLabels: false,
-    ...xAxisOptions,
+    labelFormatter:
+      xAxisOptions.labelFormatter == null
+        ? (value: string) => value
+        : xAxisOptions.labelFormatter,
+    xAxisLabels: xAxisOptions.xAxisLabels,
+    useMinimalLabels: xAxisOptions.useMinimalLabels ?? false,
+    ...selectedTheme.xAxis,
   };
 
   const yAxisOptionsWithDefaults = {
-    labelFormatter: (value: number) => value.toString(),
-    labelColor: DEFAULT_GREY_LABEL,
-    backgroundColor: 'transparent',
-    integersOnly: false,
-    ...yAxisOptions,
-  };
-
-  const gridOptionsWithDefaults = {
-    showVerticalLines: true,
-    showHorizontalLines: true,
-    color: colorSky,
-    horizontalOverflow: false,
-    horizontalMargin: 0,
-    ...gridOptions,
-  };
-
-  const crossHairOptionsWithDefaults = {
-    color: DEFAULT_CROSSHAIR_COLOR,
-    opacity: 1,
-    width: CROSSHAIR_WIDTH,
-    ...crossHairOptions,
+    labelFormatter:
+      yAxisOptions?.labelFormatter == null
+        ? (value: number) => value.toString()
+        : yAxisOptions.labelFormatter,
+    labelColor: selectedTheme.yAxis.labelColor,
+    backgroundColor: selectedTheme.yAxis.backgroundColor,
+    integersOnly:
+      yAxisOptions?.integersOnly == null ? false : yAxisOptions.integersOnly,
   };
 
   function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
@@ -185,12 +159,11 @@ export function LineChart({
     return <TooltipContent data={formattedData} />;
   }
 
-  const seriesWithDefaults = series.map<SeriesWithDefaults>((series, index) => {
-    const defaultColor = getDefaultColor(index);
-
+  const seriesWithDefaults = series.map<SeriesWithDefaults>((series) => {
     return {
-      color: defaultColor,
-      lineStyle: 'solid',
+      color: selectedTheme.line.color,
+      lineStyle: selectedTheme.line.style,
+      areaColor: selectedTheme.line.area,
       ...series,
     };
   });
@@ -202,15 +175,23 @@ export function LineChart({
       series.length === 0 ? null : (
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
-      <div style={{width: '100%', height: '100%'}} ref={setRef}>
+      <div
+        ref={setRef}
+        className={styles.Container}
+        style={{
+          background: selectedTheme.chartContainer.backgroundColor,
+          padding: selectedTheme.chartContainer.padding,
+          borderRadius: selectedTheme.chartContainer.borderRadius,
+        }}
+      >
         {chartDimensions == null ? null : (
           <Chart
             series={seriesWithDefaults}
-            lineOptions={lineOptionsWithDefaults}
+            lineOptions={selectedTheme.line}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
-            gridOptions={gridOptionsWithDefaults}
-            crossHairOptions={crossHairOptionsWithDefaults}
+            gridOptions={selectedTheme.grid}
+            crossHairOptions={selectedTheme.crossHair}
             dimensions={chartDimensions}
             isAnimated={isAnimated && !prefersReducedMotion}
             renderTooltipContent={

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type {Line as D3Line} from 'd3-shape';
 
+import type {LineTheme} from '../../../../types';
 import type {SeriesWithDefaults} from '../../types';
 import {ANIMATION_DELAY, FAST_DURATION, SLOW_DURATION} from '../../constants';
 
@@ -13,10 +14,7 @@ interface Props {
   index: number;
   lineGenerator: D3Line<{rawValue: number}>;
   color: string;
-  lineOptions: {
-    hasSpline: boolean;
-    width: number;
-  };
+  lineOptions: LineTheme;
 }
 
 export const Line = React.memo(function Shape({

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -30,7 +30,16 @@ const mockProps = {
   index: 0,
   isAnimated: false,
   lineGenerator: (() => '') as any,
-  lineOptions: {hasSpline: false, width: 10},
+  lineOptions: {
+    color: 'red',
+    area: null,
+    sparkArea: null,
+    style: 'dotted' as 'dotted',
+    hasSpline: false,
+    hasPoint: false,
+    width: 10,
+    pointStroke: 'red',
+  },
   color,
 };
 

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -50,33 +50,24 @@ export default {
     },
   },
   argTypes: {
+    theme: {
+      description: 'The theme that the chart will inherit its styles from',
+    },
     series: {
       description:
-        'The `Series` type gives the user the flexibility to define exactly what each series/line should look like, as well as providing the data to be plotted. [Series type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L10)',
+        'The `Series` type gives the user the flexibility to define exactly what each series/line should look like, as well as providing the data to be plotted.',
     },
     xAxisOptions: {
       description:
-        'Configures the appearance of the xAxis and provides the labels that should be used. [XAxisOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L40)',
-    },
-    crossHairOptions: {
-      description:
-        'An object including the following optional proprties that define the crosshair. [CrossHairOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L64)',
+        'Configures the xAxis and provides the labels that should be used.',
     },
     emptyStateText: {
       description:
         'Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the series data. It is strongly recommended that this is included if the series prop could be an empty array.',
     },
-    gridOptions: {
-      description:
-        'An object including the following optional proprties that define the grid. [GridOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L56)',
-    },
     isAnimated: {
       description:
         'Whether to animate the lines and gradient when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.',
-    },
-    lineOptions: {
-      description:
-        'An object including the following optional proprties that define the appearance of the line. [LineOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L34)',
     },
     renderTooltipContent: {
       options: Object.keys(tooltipContent),
@@ -97,7 +88,7 @@ export default {
     },
     yAxisOptions: {
       description:
-        'An object of optional proprties that define the appearance of the yAxis. [YAxisOptions type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L49)',
+        'An object of optional proprties that define the appearance of the yAxis.',
     },
   },
 } as Meta;
@@ -114,90 +105,60 @@ InsightsStyle.parameters = {
 };
 InsightsStyle.args = {
   series,
+  theme: 'Default',
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
-    useMinimalLabels: true,
-    showTicks: false,
-    labelColor: 'rgb(220, 220, 220)',
-  },
-  lineOptions: {
-    hasSpline: true,
-    pointStroke: '#333333',
-  },
-  gridOptions: {
-    showVerticalLines: false,
-    color: 'rgb(99, 115, 129)',
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-  },
-  crossHairOptions: {
-    width: 1,
   },
   yAxisOptions: {
     labelFormatter: formatYAxisLabel,
-    backgroundColor: '#333333',
-    labelColor: 'rgb(220, 220, 220)',
   },
   renderTooltipContent,
   isAnimated: true,
 };
 
 export const HideXAxisLabels = Template.bind({});
+HideXAxisLabels.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 HideXAxisLabels.args = {
+  theme: 'NoxAxisLabels',
   series,
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
-    hideXAxisLabels: true,
   },
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };
 
-export const OverflowStyle = Template.bind({});
-OverflowStyle.args = {
-  series,
-  xAxisOptions: {
-    xAxisLabels,
-    labelFormatter: formatXAxisLabel,
-    showTicks: false,
+export const NoOverflowStyle = Template.bind({});
+NoOverflowStyle.parameters = {
+  backgrounds: {
+    default: 'dark',
   },
-  yAxisOptions: {labelFormatter: formatYAxisLabel, backgroundColor: 'white'},
-  gridOptions: {
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-    showVerticalLines: false,
-  },
-  lineOptions: {hasSpline: true},
-  renderTooltipContent,
 };
-
-export const curvedLines = Template.bind({});
-curvedLines.args = {
+NoOverflowStyle.args = {
+  theme: 'NoOverflow',
   series,
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
-    showTicks: false,
-    hideXAxisLabels: true,
   },
-  yAxisOptions: {
-    labelFormatter: formatYAxisLabel,
-    backgroundColor: 'white',
-  },
-  gridOptions: {
-    horizontalOverflow: true,
-    horizontalMargin: 20,
-    showVerticalLines: false,
-  },
-  isAnimated: true,
-  lineOptions: {hasSpline: true},
+  yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,
 };
 
 export const IntegersOnly = Template.bind({});
+IntegersOnly.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 IntegersOnly.args = {
+  theme: 'Default',
   series: [
     {
       name: 'Integers Only',
@@ -221,7 +182,13 @@ IntegersOnly.args = {
 };
 
 export const NoArea = Template.bind({});
+NoArea.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 NoArea.args = {
+  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -235,6 +202,7 @@ NoArea.args = {
         {rawValue: 5, label: '2020-04-07T12:00:00'},
       ],
       color: gradient,
+      area: null,
     },
   ],
   xAxisOptions: {
@@ -245,7 +213,13 @@ NoArea.args = {
 };
 
 export const SolidColor = Template.bind({});
+SolidColor.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 SolidColor.args = {
+  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -269,7 +243,13 @@ SolidColor.args = {
 };
 
 export const LargeDataSet = Template.bind({});
+LargeDataSet.parameters = {
+  backgrounds: {
+    default: 'dark',
+  },
+};
 LargeDataSet.args = {
+  theme: 'Default',
   series: [
     {
       name: 'series 1',

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -50,9 +50,19 @@ const xAxisOptions = {
   showTicks: true,
   labelColor: 'red',
   useMinimalLabels: false,
+  hide: false,
 };
 
-const lineOptions = {hasSpline: false, width: 2, pointStroke: '#fff'};
+const lineOptions = {
+  color: 'red',
+  area: null,
+  sparkArea: null,
+  hasSpline: false,
+  style: 'dotted' as 'dotted',
+  hasPoint: false,
+  width: 2,
+  pointStroke: '#fff',
+};
 
 const yAxisOptions = {
   labelFormatter: jest.fn((value) => value),

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -8,13 +8,13 @@ import type {
 } from '../../types';
 
 export interface Series extends DataSeries<Data, SeriesColor> {
-  areaColor?: string;
+  areaColor?: string | null;
   lineStyle?: LineStyle;
 }
 
 export type SeriesWithDefaults = Required<DataSeries<Data, SeriesColor>> & {
   lineStyle: LineStyle;
-  areaColor?: string;
+  areaColor?: string | null;
 };
 
 export interface TooltipData {
@@ -31,38 +31,13 @@ export interface RenderTooltipContentData {
   data: TooltipData[];
 }
 
-export interface LineOptions {
-  hasSpline: boolean;
-  width: number;
-  pointStroke: string;
-}
-
 export interface XAxisOptions {
   labelFormatter: StringLabelFormatter;
   xAxisLabels: string[];
-  hideXAxisLabels: boolean;
-  showTicks: boolean;
-  labelColor: string;
   useMinimalLabels: boolean;
 }
 
 export interface YAxisOptions {
   labelFormatter: NumberLabelFormatter;
-  labelColor: string;
-  backgroundColor: string;
   integersOnly: boolean;
-}
-
-export interface GridOptions {
-  showVerticalLines: boolean;
-  showHorizontalLines: boolean;
-  color: string;
-  horizontalOverflow: boolean;
-  horizontalMargin: number;
-}
-
-export interface CrossHairOptions {
-  width: number;
-  color: string;
-  opacity: number;
 }

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -142,7 +142,7 @@ Determines whether to fill in the area beneath the line and what kind of shading
 
 | type             | default |
 | ---------------- | ------- |
-| `solid \| dashed` | `solid` |
+| `solid \| dashed\| dotted` | `solid` |
 
 Determines the style of line used for the series.
 
@@ -190,10 +190,10 @@ Visually hidden text for screen readers.
 
 Determines whether to animate the chart on state changes.
 
-#### hasSpline
+### theme
 
 | type      | default |
 | --------- | ------- |
-| `boolean` | `false` |
+| `string` | `default` |
 
-Whether to curve the line between points.
+The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider. Individual line styles can be overwritten as part of the series prop.

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useLayoutEffect, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
-import type {GradientStop, SparkChartData} from 'types';
+import type {GradientStop, LineStyle, SparkChartData} from 'types';
 
 import {useResizeObserver, useTheme} from '../../hooks';
 
@@ -14,8 +14,6 @@ export interface Coordinates {
   x: number;
   y: SparkChartData;
 }
-
-type LineStyle = 'solid' | 'dashed';
 
 export interface SingleSeries {
   data: Coordinates[];
@@ -31,7 +29,6 @@ export interface SparklineProps {
   series: SingleSeries[];
   accessibilityLabel?: string;
   isAnimated?: boolean;
-  hasSpline?: boolean;
   theme?: string;
 }
 
@@ -39,7 +36,6 @@ export function Sparkline({
   series,
   accessibilityLabel,
   isAnimated = false,
-  hasSpline = false,
   theme,
 }: SparklineProps) {
   const {
@@ -160,7 +156,6 @@ export function Sparkline({
                 series={singleSeries}
                 isAnimated={isAnimated}
                 height={height}
-                hasSpline={hasSpline}
                 theme={selectedTheme}
               />
             </g>

--- a/src/components/Sparkline/components/Series/Series.scss
+++ b/src/components/Sparkline/components/Series/Series.scss
@@ -9,10 +9,6 @@ $animation-duration: 500ms;
   stroke: 1.5;
 }
 
-.DashedLine {
-  stroke-dasharray: 3 2;
-}
-
 .Area {
   opacity: 0;
   animation: fadeIn $animation-duration ease-in-out 1 forwards;

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -17,6 +17,12 @@ import styles from './Series.scss';
 
 const POINT_RADIUS = 2;
 
+const StrokeDasharray = {
+  dotted: '0.1 4',
+  dashed: '2 4',
+  solid: 'unset',
+};
+
 function getGradientFill(area: string | GradientStop[] | null) {
   if (area == null) {
     return null;
@@ -37,7 +43,6 @@ export function Series({
   series,
   isAnimated,
   height,
-  hasSpline,
   theme,
 }: {
   xScale: ScaleLinear<number, number>;
@@ -45,12 +50,11 @@ export function Series({
   series: SingleSeries;
   isAnimated: boolean;
   height: number;
-  hasSpline: boolean;
   theme: Theme;
 }) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const {
-    area = theme.line.area,
+    area = theme.line.sparkArea,
     lineStyle = theme.line.style,
     color = theme.line.color,
     hasPoint = theme.line.hasPoint,
@@ -68,7 +72,7 @@ export function Series({
     .y1(({y}) => (y == null ? yScale(0) : yScale(y)))
     .defined(({y}) => y != null);
 
-  if (hasSpline) {
+  if (theme.line.hasSpline) {
     lineGenerator.curve(curveStepRounded);
     areaGenerator.curve(curveStepRounded);
   }
@@ -88,8 +92,6 @@ export function Series({
 
   const id = useMemo(() => uniqueId('sparkline'), []);
   const immediate = !isAnimated || prefersReducedMotion;
-
-  const dashedLine = lineStyle === 'dashed';
 
   const lineGradientColor = isGradientType(color)
     ? color
@@ -129,11 +131,10 @@ export function Series({
         stroke={`url(#line-${id})`}
         d={lineShape}
         fill="none"
-        className={classNames(
-          styles.Line,
-          !immediate && styles.AnimatedLine,
-          dashedLine && styles.DashedLine,
-        )}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+        className={classNames(styles.Line, !immediate && styles.AnimatedLine)}
+        style={{strokeDasharray: StrokeDasharray[lineStyle]}}
       />
 
       {area === null ? null : (

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -56,7 +56,7 @@ const mockProps = {
   height: 250,
   hasSpline: false,
   theme: {
-    line: {area: null, style: 'solid', color: 'red', hasPoint: true},
+    line: {sparkArea: null, style: 'solid', color: 'red', hasPoint: true},
   } as Theme,
 };
 
@@ -83,7 +83,7 @@ describe('Series', () => {
     );
 
     expect(actual).toContainReactComponent('path', {
-      className: 'Line',
+      style: {strokeDasharray: 'unset'},
     });
   });
 
@@ -94,7 +94,7 @@ describe('Series', () => {
       </svg>,
     );
     expect(actual).toContainReactComponent('path', {
-      className: 'Line DashedLine',
+      style: {strokeDasharray: '2 4'},
     });
   });
 
@@ -133,7 +133,13 @@ describe('Series', () => {
 
     mount(
       <svg>
-        <Series {...mockProps} hasSpline />
+        <Series
+          {...mockProps}
+          theme={{
+            ...mockProps.theme,
+            line: {...mockProps.theme.line, hasSpline: true},
+          }}
+        />
       </svg>,
     );
 

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -59,6 +59,10 @@ export default {
     ),
   ],
   argTypes: {
+    theme: {
+      description:
+        'The theme that the chart will inherit its color, container and line styles from',
+    },
     series: {
       description:
         'The sparkline can show one data series or a set of comparison data series. Each series is configured by the series item in the array. [Series type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/Sparkline/Sparkline.tsx#L21)',
@@ -67,7 +71,6 @@ export default {
       description:
         'Visually hidden text for screen readers. Make sure to write [informative alt text.](https://medium.com/nightingale/writing-alt-text-for-data-visualization-2a218ef43f81)',
     },
-    hasSpline: {description: 'Whether to curve the line between points.'},
     isAnimated: {
       description: 'Determines whether to animate the chart on state changes.',
     },
@@ -96,10 +99,10 @@ InsightsStyle.parameters = {
   },
 };
 
-export const hasSpline = Template.bind({});
-hasSpline.args = {
+export const withoutSpline = Template.bind({});
+withoutSpline.args = {
   ...defaultProps,
-  hasSpline: true,
+  theme: 'NoSpline',
 };
 
 export const OffsetAndNulls = Template.bind({});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,9 +120,12 @@ export const DEFAULT_THEME: Theme = {
   line: {
     color: VIZ_GRADIENT_COLOR.neutral.up,
     area: null,
-    spline: true,
+    sparkArea: null,
+    hasSpline: true,
     style: 'solid',
     hasPoint: true,
+    width: 2,
+    pointStroke: 'white',
   },
   bar: {
     color: VIZ_GRADIENT_COLOR.neutral.up,
@@ -141,10 +144,15 @@ export const DEFAULT_THEME: Theme = {
   xAxis: {
     showTicks: false,
     labelColor: 'rgb(220, 220, 220)',
+    hide: false,
   },
   yAxis: {
     backgroundColor: '#1f1f25',
     labelColor: 'rgb(220, 220, 220)',
+  },
+  crossHair: {
+    color: 'rgb(139, 159, 176)',
+    width: 1,
   },
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ export enum BarMargin {
 
 export interface GridTheme {
   showHorizontalLines: boolean;
-  showVerticalLines?: boolean;
+  showVerticalLines: boolean;
   horizontalOverflow: boolean;
   color: string;
   horizontalMargin: number;
@@ -100,12 +100,19 @@ export interface BarTheme {
 export interface XAxisTheme {
   showTicks: boolean;
   labelColor: string;
+  hide: boolean;
+}
+
+export interface CrossHairTheme {
+  color: string;
+  width: number;
 }
 
 export interface YAxisTheme {
   labelColor: string;
   backgroundColor: string;
 }
+
 export interface ChartContainerTheme {
   borderRadius: string;
   padding: string;
@@ -114,10 +121,13 @@ export interface ChartContainerTheme {
 
 export interface LineTheme {
   color: string | GradientStop[];
-  area: string | GradientStop[] | null;
-  spline: boolean;
-  style: 'solid' | 'dashed';
+  area: string | null;
+  sparkArea: string | GradientStop[] | null;
+  hasSpline: boolean;
+  style: LineStyle;
   hasPoint: boolean;
+  width: number;
+  pointStroke: string;
 }
 
 export interface PartialTheme {
@@ -127,7 +137,9 @@ export interface PartialTheme {
   grid?: Partial<GridTheme>;
   xAxis?: Partial<XAxisTheme>;
   yAxis?: Partial<YAxisTheme>;
+  crossHair?: Partial<CrossHairTheme>;
 }
+
 export interface Theme {
   chartContainer: ChartContainerTheme;
   bar: BarTheme;
@@ -135,4 +147,5 @@ export interface Theme {
   xAxis: XAxisTheme;
   yAxis: YAxisTheme;
   line: LineTheme;
+  crossHair: CrossHairTheme;
 }


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/405
Adds theming to the line chart

Some notes about changes/decisions I made and a few questions (have also left some comments where relevant in the code):
- I added the dotted line style option to the sparkline so we can share the type. Any objections?
- I made hasSpline part of the theme config. Does that seem like the right place, or should it be configured as a prop still? Just wondering if there are some charts where the type of data doesn't lend itself to splines. This would still be possible with an additional theme, though.
- I added `sparkArea` as well as `area` because they work differently for the Sparkline and Line Chart. The Sparkline accepts a string, null or gradient stop. The line chart just accepts a color and we determine the gradient internally. Changing that on this PR felt out of scope, but let me know if you disagree.
- hiding the xAxis is something that is only possible for the line chart currently. Right now, I have added it to the xAxis theme object. Perhaps it belongs on the line chart props instead, since it isn't applicable to the other charts. Thoughts?
- Since the crosshair color option accepts rgba values, I have removed the opacity key/value that was previously accessible via props

### Reviewers’ :tophat: instructions
Make sure all configuration is still possible for the line chart and sparkline as before

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
