### PR TITLE
Count comparison data in Sparkbar scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Comparison data is used in the `<Sparkbar />` scale
+
 ## [0.18.0] - 2021-08-10
 
 ### Fixed

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -114,9 +114,14 @@ export function Sparkbar({
     (value) => typeof value === 'number',
   ) as number[];
 
+  const comparisonData = comparison == null ? [] : comparison.map(({y}) => y);
+
   const yScale = scaleLinear()
     .range(calculateRange(data, height))
-    .domain([Math.min(...filteredData, 0), Math.max(...filteredData, 0)]);
+    .domain([
+      Math.min(...filteredData, ...comparisonData, 0),
+      Math.max(...filteredData, ...comparisonData, 0),
+    ]);
 
   const xScale = scaleBand()
     .range([dataOffsetLeft, width - dataOffsetRight])

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -67,7 +67,7 @@ const Template: Story<SparkbarProps> = (args: SparkbarProps) => {
   return <Sparkbar {...args} />;
 };
 
-const comparisonValue = 500;
+const comparisonValue = 2000;
 const defaultProps = {
   isAnimated: true,
   data: [100, 200, 300, 400, 400, 1000, 200, 800, 900, 200, 400],


### PR DESCRIPTION
### What problem is this PR solving?
Fixes a bug where the comparison line was not shown when it fell outside of the range of the primary series data

| Before  | After  |
|---|---|
|  <img width="124" alt="Screen Shot 2021-08-10 at 9 25 20 PM" src="https://user-images.githubusercontent.com/12213371/128955658-c0173ff1-746e-4b14-bb8a-6e17cc51850e.png"> |  <img width="136" alt="Screen Shot 2021-08-10 at 9 24 58 PM" src="https://user-images.githubusercontent.com/12213371/128955659-341e6af3-3173-4ee8-b6a1-0c48a3a17f91.png"> | 

### Reviewers’ :tophat: instructions
I have modified the Sparkbar story so you can see that the issue is fixed.

To see the story, run `dev up && yarn storybook`.

To see it before the fix, do the same on master.

### Before merging

~- [x] Check your changes on a variety of browsers and devices.~

- [ ] Update the Changelog.

~- [ ] Update relevant documentation.~
