### PR TITLE
Add theming to normalized stacked bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,14 @@
 - Polaris Tokens strings are no longer accepted as colors. Any valid CSS color can now be provided as a color to charts, and in some cases gradients can be specified by supplying an array of gradient stops.
 - `barOptions`, `gridOptions`, `xAxisOptions.showTicks`, `xAxisOptions.labelColor` and `yAxisOptions.labelColor` from `BarChartProps` and `LineChartProps`.
 - `barFillStyle` and `color` props are removed from the `<Sparkbar />` component and are inherited from the chart's theme
+- `colors` prop from  `<NormalizedStackedBarChart />` 
 
 ### Changed
-- `<BarChart />`, `<LineChart />`, `<Sparkline />` and `<Sparkbar />` styles now are defined through themes in `PolarisVizProvider` instead of props. For more details check the [migration guide](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit?usp=sharing)
+- `<BarChart />`, `<LineChart />`, `<Sparkline />`, `<NormalizedStackedBarChart />` and `<Sparkbar />` styles now are defined through themes in `PolarisVizProvider` instead of props. For more details check the [migration guide](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit?usp=sharing)
+- change indicators on the  `<NormalizedStackedBarChart />` can now have their colors configured externally, which applies the color to the metric and percentage change
+
+### Fixed
+- `<NormalizedStackedBarChart />` no longer overflows its container by a few pixels
 
 ## [0.17.2] - 2021-06-23
 

--- a/src/components/ComparisonMetric/ComparisonMetric.tsx
+++ b/src/components/ComparisonMetric/ComparisonMetric.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import type {Legend} from '../../types';
+
 import styles from './ComparisonMetric.scss';
 import {UpChevron, DownChevron} from './components';
 import type {ComparisonMetricShape} from './types';
@@ -8,29 +10,36 @@ export function ComparisonMetric({
   metric,
   trend,
   accessibilityLabel,
-}: ComparisonMetricShape) {
+  theme,
+}: ComparisonMetricShape & {theme: Legend}) {
   switch (trend) {
     case 'neutral':
       return (
         <span className={styles.NeutralIcon}>
           <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
-          <span>-</span>
+          <span style={{color: theme.trendIndicator.neutral}}>-</span>
         </span>
       );
       break;
     case 'positive':
       return (
         <span className={styles.PositiveIcon}>
-          <UpChevron accessibilityLabel={accessibilityLabel} />
-          <span>{metric}</span>
+          <UpChevron
+            accessibilityLabel={accessibilityLabel}
+            fill={theme.trendIndicator.positive}
+          />
+          <span style={{color: theme.trendIndicator.positive}}>{metric}</span>
         </span>
       );
       break;
     case 'negative':
       return (
         <span className={styles.NegativeIcon}>
-          <DownChevron accessibilityLabel={accessibilityLabel} />
-          <span>{metric}</span>
+          <DownChevron
+            accessibilityLabel={accessibilityLabel}
+            fill={theme.trendIndicator.negative}
+          />
+          <span style={{color: theme.trendIndicator.negative}}>{metric}</span>
         </span>
       );
   }

--- a/src/components/ComparisonMetric/components/DownChevron/DownChevron.tsx
+++ b/src/components/ComparisonMetric/components/DownChevron/DownChevron.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 
-import {negativeColor} from '../../../../constants';
-
 import styles from './DownChevron.scss';
 
 interface Props {
   accessibilityLabel: string;
+  fill: string;
 }
 
-export function DownChevron({accessibilityLabel}: Props) {
-  const fill = negativeColor;
+export function DownChevron({accessibilityLabel, fill}: Props) {
   return (
     <React.Fragment>
       <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>

--- a/src/components/ComparisonMetric/components/UpChevron/UpChevron.tsx
+++ b/src/components/ComparisonMetric/components/UpChevron/UpChevron.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 
-import {positiveColor} from '../../../../constants';
-
 import styles from './UpChevron.scss';
 
 interface Props {
   accessibilityLabel: string;
+  fill: string;
 }
 
-export function UpChevron({accessibilityLabel}: Props) {
-  const fill = positiveColor;
+export function UpChevron({accessibilityLabel, fill}: Props) {
   return (
     <React.Fragment>
       <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>

--- a/src/components/ComparisonMetric/tests/ComparisonMetric.test.tsx
+++ b/src/components/ComparisonMetric/tests/ComparisonMetric.test.tsx
@@ -4,6 +4,12 @@ import {mount} from '@shopify/react-testing';
 import {ComparisonMetric} from '../ComparisonMetric';
 import {UpChevron, DownChevron} from '../components';
 
+const theme = {
+  labelColor: 'black',
+  valueColor: 'black',
+  trendIndicator: {positive: 'green', negative: 'red', neutral: 'grey'},
+};
+
 describe('<ComparisonMetric />', () => {
   it('renders a <UpChevron /> if positive', () => {
     const comparisonMetric = mount(
@@ -11,6 +17,7 @@ describe('<ComparisonMetric />', () => {
         metric="5"
         trend="positive"
         accessibilityLabel="label"
+        theme={theme}
       />,
     );
     expect(comparisonMetric).toContainReactComponent(UpChevron);
@@ -22,6 +29,7 @@ describe('<ComparisonMetric />', () => {
         metric="5"
         trend="negative"
         accessibilityLabel="label"
+        theme={theme}
       />,
     );
     expect(comparisonMetric).toContainReactComponent(DownChevron);
@@ -33,6 +41,7 @@ describe('<ComparisonMetric />', () => {
         metric="5"
         trend="neutral"
         accessibilityLabel="label"
+        theme={theme}
       />,
     );
     expect(comparisonMetric).toContainReactComponentTimes('svg', 0);

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.md
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.md
@@ -46,9 +46,9 @@ Used for positive datasets with two to four items. If your dataset has more than
     },
   ]}
   accessibilityLabel="A chart showing the breakdown of ad revenue"
-  colors={['green', 'blue', 'purple', 'grey']}
   orientation="horizontal"
   size="large"
+  theme="Default"
 />
 ```
 
@@ -60,9 +60,9 @@ The normalized stacked bar chart interface looks like this:
 {
   data: Data[];
   accessibilityLabel?: string;
-  colors?: string[];
   orientation?: Orientation;
   size?: Size;
+  theme?: string;
 }
 ```
 
@@ -133,14 +133,6 @@ The prop to determine the chart's drawn area. Each `Data` object corresponds to 
 
 Visually hidden text for screen readers.
 
-#### colors
-
-| type      | default                                                         |
-| --------- | --------------------------------------------------------------- |
-| `Color[]` | `['rgb(80, 36, 143)', 'rgb(0, 111, 187)', 'rgb(71, 193, 191)', 'rgb(196, 205, 213)']` |
-
-An array of colors that determines the fill colors of each bar. The colors are applied sequentially to the chart. This accepts any CSS color.
-
 #### orientation
 
 | type                     | default      |
@@ -156,3 +148,11 @@ Determines the orientation of the chart.
 | `small \| large` | `small` |
 
 Determines the thickness of the chart.
+
+#### theme
+
+| type             | default |
+| ---------------- | ------- |
+| `string` | `Default` |
+
+The theme prop determines the colors of the bars, the background of the chart and the appearance of the legend.

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
@@ -4,6 +4,7 @@
   font-family: $font-stack-base;
   font-size: 14px;
   display: flex;
+  box-sizing: border-box;
 }
 
 .VerticalContainer {

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
@@ -3,12 +3,7 @@ import {sum} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 import {classNames} from '@shopify/css-utilities';
 
-import {
-  colorPurpleDark,
-  colorBlue,
-  colorTeal,
-  colorSkyDark,
-} from '../../constants';
+import {useTheme} from '../../hooks';
 
 import {BarSegment, BarLabel} from './components';
 import type {Size, Data, Orientation} from './types';
@@ -18,15 +13,16 @@ export interface NormalizedStackedBarChartProps {
   data: Data[];
   size?: Size;
   orientation?: Orientation;
-  colors?: string[];
+  theme?: string;
 }
 
 export function NormalizedStackedBarChart({
   data,
   size = 'small',
   orientation = 'horizontal',
-  colors = [colorPurpleDark, colorBlue, colorTeal, colorSkyDark],
+  theme,
 }: NormalizedStackedBarChartProps) {
+  const selectedTheme = useTheme(theme);
   const containsNegatives = data.some(({value}) => value < 0);
   const isDevelopment = process.env.NODE_ENV === 'development';
 
@@ -49,6 +45,7 @@ export function NormalizedStackedBarChart({
   const xScale = scaleLinear().range([0, 100]).domain([0, totalValue]);
 
   const isVertical = orientation === 'vertical';
+  const {colors} = selectedTheme.colorPalette;
 
   return (
     <div
@@ -56,6 +53,11 @@ export function NormalizedStackedBarChart({
         styles.Container,
         isVertical ? styles.VerticalContainer : styles.HorizontalContainer,
       )}
+      style={{
+        background: selectedTheme.chartContainer.backgroundColor,
+        padding: selectedTheme.chartContainer.padding,
+        borderRadius: selectedTheme.chartContainer.borderRadius,
+      }}
     >
       <ul
         className={
@@ -71,6 +73,8 @@ export function NormalizedStackedBarChart({
             value={formattedValue}
             color={colors[index]}
             comparisonMetric={comparisonMetric}
+            legendColors={selectedTheme.legend}
+            orientation={orientation}
           />
         ))}
       </ul>

--- a/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.scss
+++ b/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.scss
@@ -7,7 +7,7 @@
 }
 
 .LabelColor {
-  border: 1px solid transparent;
+  margin: 1px;
   border-radius: 3px;
   height: 10px;
   width: 10px;

--- a/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
@@ -1,30 +1,50 @@
 import React from 'react';
 
+import {createCSSGradient, isGradientType} from '../../../../utilities';
+import type {GradientStop, Legend} from '../../../../types';
 import {
   ComparisonMetric,
   ComparisonMetricShape,
 } from '../../../ComparisonMetric';
+import type {Orientation} from '../../types';
 
 import styles from './BarLabel.scss';
 
 export interface Props {
   label: string;
   value: string;
-  color: string;
+  color: string | GradientStop[];
   comparisonMetric?: ComparisonMetricShape;
+  legendColors: Legend;
+  orientation: Orientation;
 }
 
-export function BarLabel({label, value, color, comparisonMetric}: Props) {
+export function BarLabel({
+  label,
+  value,
+  color,
+  comparisonMetric,
+  legendColors,
+  orientation,
+}: Props) {
+  const {labelColor, valueColor} = legendColors;
+
   const comparisonIndicator = comparisonMetric ? (
-    <ComparisonMetric {...comparisonMetric} />
+    <ComparisonMetric {...comparisonMetric} theme={legendColors} />
   ) : null;
+
+  const angle = orientation === 'horizontal' ? -90 : 180;
+
+  const formattedColor = isGradientType(color)
+    ? createCSSGradient(color, angle)
+    : color;
 
   return (
     <li className={styles.Container}>
-      <div style={{background: color}} className={styles.LabelColor} />
+      <div style={{background: formattedColor}} className={styles.LabelColor} />
       <div className={styles.Label}>
-        <strong>{label}</strong>
-        <div className={styles.Value}>
+        <strong style={{color: labelColor}}>{label}</strong>
+        <div style={{color: valueColor}} className={styles.Value}>
           {value}
           {comparisonIndicator}
         </div>

--- a/src/components/NormalizedStackedBarChart/components/BarLabel/tests/BarLabel.test.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarLabel/tests/BarLabel.test.tsx
@@ -7,7 +7,21 @@ describe('<BarLabel />', () => {
   describe('renders props', () => {
     it('renders BarLabel with props', () => {
       const barLabel = mount(
-        <BarLabel label="Google" value="200" color="rgb(255, 255, 255)" />,
+        <BarLabel
+          label="Google"
+          value="200"
+          color="rgb(255, 255, 255)"
+          legendColors={{
+            labelColor: 'red',
+            valueColor: 'orange',
+            trendIndicator: {
+              positive: 'green',
+              negative: 'red',
+              neutral: 'grey',
+            },
+          }}
+          orientation="horizontal"
+        />,
       );
 
       expect(barLabel).toContainReactText('Google');

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
@@ -1,8 +1,7 @@
 .Segment {
-  border: 1px solid transparent;
-  margin: 0 1px 1px 0;
+  margin: 1px 2px 2px 1px;
   &:last-of-type {
-    margin: 0;
+    margin: 1px;
   }
 }
 

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import {classNames} from '@shopify/css-utilities';
 
+import {createCSSGradient, isGradientType} from '../../../../utilities';
 import type {Orientation, Size} from '../../types';
+import type {GradientStop} from '../../../../types';
 
 import styles from './BarSegment.scss';
 
 interface Props {
   scale: number;
-  color: string;
+  color: string | GradientStop[];
   size: Size;
   orientation: Orientation;
 }
@@ -16,10 +18,16 @@ export function BarSegment({color, scale, size, orientation}: Props) {
   const scaleNeedsRounding = scale > 0 && scale < 1.5;
   const safeScale = scaleNeedsRounding ? 1.5 : scale;
 
+  const angle = orientation === 'horizontal' ? -90 : 180;
+
+  const formattedColor = isGradientType(color)
+    ? createCSSGradient(color, angle)
+    : color;
+
   return (
     <div
       className={classNames(styles.Segment, styles[`${orientation}-${size}`])}
-      style={{flex: `0 0 ${safeScale}%`, background: color}}
+      style={{flexBasis: `${safeScale}%`, background: formattedColor}}
     />
   );
 }

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
@@ -44,9 +44,9 @@ describe('<BarSegment />', () => {
       />,
     );
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flex;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 
-    expect(barSegmentFlex).toBe('0 0 0%');
+    expect(barSegmentFlex).toBe('0%');
   });
 
   it('rounds up a scale above 0 and below 1.5', () => {
@@ -59,9 +59,9 @@ describe('<BarSegment />', () => {
       />,
     );
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flex;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 
-    expect(barSegmentFlex).toBe('0 0 1.5%');
+    expect(barSegmentFlex).toBe('1.5%');
   });
 
   it('does not round up a scale above 1.5', () => {
@@ -74,8 +74,8 @@ describe('<BarSegment />', () => {
       />,
     );
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flex;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 
-    expect(barSegmentFlex).toBe('0 0 1.51%');
+    expect(barSegmentFlex).toBe('1.51%');
   });
 });

--- a/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
+++ b/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
@@ -23,12 +23,12 @@ export default {
       description:
         'Gives the user the ability to define how the bars should look like. [Data type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/NormalizedStackedBarChart/types.ts#L7)',
     },
-    colors: {
-      description:
-        'An array of colors that determines the fill colors of each bar. The colors are applied sequentially to the chart. [Colors type definition.] (https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L29)',
-    },
     orientation: {description: 'Determines the orientation of the chart.'},
     size: {description: 'Determines the width of the chart.'},
+    theme: {
+      description:
+        'The theme prop determines the colors of the bars, the background of the chart and the appearance of the legend.',
+    },
   },
 } as Meta;
 
@@ -76,14 +76,9 @@ const defaultProps = {
       formattedValue: '$20',
     },
   ],
-  colors: [
-    'rgb(80, 36, 143)',
-    'rgb(0, 111, 187)',
-    'rgb(71, 193, 191)',
-    'rgb(196, 205, 213)',
-  ],
   orientation: 'horizontal',
   size: 'large',
+  theme: 'Default',
 };
 
 export const Default = Template.bind({});

--- a/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
+++ b/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {NormalizedStackedBarChart} from 'components';
 
-import {colorPurpleDark} from '../../../constants';
 import {BarSegment, BarLabel} from '../components';
 
 describe('<NormalizedBarChart />', () => {
@@ -141,12 +140,13 @@ describe('<NormalizedBarChart />', () => {
   });
 
   describe('Colors', () => {
-    it('passes down colors', () => {
-      const barChart = mount(
-        <NormalizedStackedBarChart {...mockProps} colors={[colorPurpleDark]} />,
-      );
+    it('inherits colors from the theme', () => {
+      const barChart = mount(<NormalizedStackedBarChart {...mockProps} />);
 
-      expect(barChart.find(BarSegment)!.props.color).toBe('rgb(80, 36, 143)');
+      expect(barChart.find(BarSegment)!.props.color).toStrictEqual([
+        {color: '#936DFF', offset: 0},
+        {color: '#7C44F8', offset: 100},
+      ]);
     });
   });
 

--- a/src/components/SquareColorPreview/SquareColorPreview.tsx
+++ b/src/components/SquareColorPreview/SquareColorPreview.tsx
@@ -10,7 +10,9 @@ export interface SquareColorPreviewProps {
 }
 
 export function SquareColorPreview({color}: SquareColorPreviewProps) {
-  const background = isGradientType(color) ? createCSSGradient(color) : color;
+  const background = isGradientType(color)
+    ? createCSSGradient(color, 305)
+    : color;
 
   return <div className={styles.ColorPreview} style={{background}} />;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -154,6 +154,35 @@ export const DEFAULT_THEME: Theme = {
     color: 'rgb(139, 159, 176)',
     width: 1,
   },
+  colorPalette: {
+    colors: [
+      [
+        {offset: 0, color: '#936DFF'},
+        {offset: 100, color: '#7C44F8'},
+      ],
+      [
+        {offset: 0, color: '#6285FF'},
+        {offset: 100, color: '#3B66FF'},
+      ],
+      [
+        {offset: 0, color: '#34A9BF'},
+        {offset: 100, color: '#0194AF'},
+      ],
+      [
+        {offset: 0, color: '#E564D3'},
+        {offset: 100, color: '#DC42C3'},
+      ],
+    ],
+  },
+  legend: {
+    labelColor: '#DADADD',
+    valueColor: '#fff',
+    trendIndicator: {
+      positive: '#00A47C',
+      negative: '#EC6E6E',
+      neutral: '#8C9196',
+    },
+  },
 };
 
 export const animationDurationBase = 200;

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,16 @@ export interface LineTheme {
   pointStroke: string;
 }
 
+export interface ColorPalette {
+  colors: (string | GradientStop[])[];
+}
+
+export interface Legend {
+  labelColor: string;
+  valueColor: string;
+  trendIndicator: {positive: string; negative: string; neutral: string};
+}
+
 export interface PartialTheme {
   chartContainer?: Partial<ChartContainerTheme>;
   bar?: Partial<BarTheme>;
@@ -138,6 +148,8 @@ export interface PartialTheme {
   xAxis?: Partial<XAxisTheme>;
   yAxis?: Partial<YAxisTheme>;
   crossHair?: Partial<CrossHairTheme>;
+  colorPalette?: Partial<ColorPalette>;
+  legend?: Partial<Legend>;
 }
 
 export interface Theme {
@@ -148,4 +160,6 @@ export interface Theme {
   yAxis: YAxisTheme;
   line: LineTheme;
   crossHair: CrossHairTheme;
+  legend: Legend;
+  colorPalette: ColorPalette;
 }

--- a/src/utilities/create-css-gradient.ts
+++ b/src/utilities/create-css-gradient.ts
@@ -1,9 +1,9 @@
 import type {GradientStop} from 'types';
 
-export const createCSSGradient = (gradient: GradientStop[]) => {
+export const createCSSGradient = (gradient: GradientStop[], angle: number) => {
   const gradientStops = gradient.map(
     ({color, offset}) => `${color} ${offset}%`,
   );
 
-  return `linear-gradient(305deg, ${gradientStops.join(',')})`;
+  return `linear-gradient(${angle}deg, ${gradientStops.join(',')})`;
 };


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/407: Adds theming to the normalized stacked bar chart

<img width="161" alt="Screen Shot 2021-08-16 at 4 08 45 PM" src="https://user-images.githubusercontent.com/12213371/129623445-6467a117-8f31-4563-a1b9-337daecf2bf6.png">
<img width="1587" alt="Screen Shot 2021-08-16 at 4 08 39 PM" src="https://user-images.githubusercontent.com/12213371/129623447-278ef6b8-ce9f-4f95-a83e-b4d9f664cb11.png">

In this case, the default new default colors do vary from our current default implementation. I paired with @mirualves on the details, such as the direction of the gradients, and the color of the legend text.

Additionally, this PR adds support to this chart for gradients, which it did not support before.

### Reviewers’ :tophat: instructions
Make sure the NormalizedStackedBarChart is configurable as expected and that the docs are updated to match

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
