### PR TITLE
Add theme to StackedAreaChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,19 @@
 - Fixes `<BarChart />` when very large datasets are displayed
 
 ### Added
-- `PolarisVizProvider` to support theming charts
-- `theme` to `BarChartProps`
-### Removed 
 
-### Added
 - `PolarisVizProvider` to support theming charts
 - The`theme` to prop to `<BarChart />`, `<LineChart />`, `<Sparkline />` and `<Sparkbar />`
 - `<Sparkline />` now supports the dotted line style
 - `<Sparkline />` and `<Sparkbar />` support gradient fills
+- `theme` to `BarChartProps` & `StackedAreaChartProps`
 
-### Removed 
+### Removed
+
 - Polaris Tokens strings are no longer accepted as colors. Any valid CSS color can now be provided as a color to charts, and in some cases gradients can be specified by supplying an array of gradient stops.
 - `barOptions`, `gridOptions`, `xAxisOptions.showTicks`, `xAxisOptions.labelColor` and `yAxisOptions.labelColor` from `BarChartProps` and `LineChartProps`.
 - `barFillStyle` and `color` props are removed from the `<Sparkbar />` component and are inherited from the chart's theme
-- `colors` prop from  `<NormalizedStackedBarChart />` 
+- `colors` prop from  `<NormalizedStackedBarChart />`
 
 ### Changed
 - `<BarChart />`, `<LineChart />`, `<Sparkline />`, `<NormalizedStackedBarChart />` and `<Sparkbar />` styles now are defined through themes in `PolarisVizProvider` instead of props. For more details check the [migration guide](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit?usp=sharing)

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -76,7 +76,7 @@ interface BarChartProps {
     rawValue: number;
     label: string;
     barOptions?: {
-      color: string | GradientStop[];
+      color: Color;
     };
   }[];
   renderTooltipContent?({
@@ -91,7 +91,7 @@ interface BarChartProps {
   barOptions?: {
     innerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
     outerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
-    color?: string | GradientStop[];
+    color?: Color;
     hasRoundedCorners?: boolean;
     zeroAsMinHeight?: boolean;
   };
@@ -209,7 +209,7 @@ This sets the margin before and after all bars. A value of `None` will have bars
 
 | type    | default   |
 | ------- | --------- |
-| `string | GradientStop[]` | |
+| `Color` | |
 
 The bar fill color. This accepts any CSS color.
 

--- a/src/components/Crosshair/Crosshair.tsx
+++ b/src/components/Crosshair/Crosshair.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import {animated, Interpolation} from '@react-spring/web';
 
-import {CROSSHAIR_WIDTH, DEFAULT_CROSSHAIR_COLOR} from '../../constants';
+import {DEFAULT_CROSSHAIR_COLOR} from '../../constants';
 
 interface Props {
   x: number | Interpolation;
   height: number;
+  width: number;
   opacity?: number;
   fill?: string;
-  width?: number;
 }
 
 export function Crosshair({
   x,
   height,
   opacity = 1,
-  width = CROSSHAIR_WIDTH,
+  width,
   fill = DEFAULT_CROSSHAIR_COLOR,
 }: Props) {
   return (

--- a/src/components/Crosshair/tests/Crosshair.test.tsx
+++ b/src/components/Crosshair/tests/Crosshair.test.tsx
@@ -7,7 +7,7 @@ describe('<Crosshair />', () => {
   it('renders a rect centered on the given x', () => {
     const crosshair = mount(
       <svg>
-        <Crosshair x={50} height={500} />
+        <Crosshair width={1} x={50} height={500} />
       </svg>,
     );
 
@@ -17,7 +17,7 @@ describe('<Crosshair />', () => {
   it('renders a rect with the given height', () => {
     const crosshair = mount(
       <svg>
-        <Crosshair x={50} height={500} />
+        <Crosshair width={1} x={50} height={500} />
       </svg>,
     );
 
@@ -27,7 +27,7 @@ describe('<Crosshair />', () => {
   it('gives the rect full opacity by default', () => {
     const crosshair = mount(
       <svg>
-        <Crosshair x={50} height={500} />
+        <Crosshair width={1} x={50} height={500} />
       </svg>,
     );
 
@@ -39,7 +39,7 @@ describe('<Crosshair />', () => {
   it('applies opacity from props to the rect', () => {
     const crosshair = mount(
       <svg>
-        <Crosshair x={50} height={500} opacity={0.8} />
+        <Crosshair width={1} x={50} height={500} opacity={0.8} />
       </svg>,
     );
 
@@ -51,7 +51,7 @@ describe('<Crosshair />', () => {
   it('applies color from props to the rect', () => {
     const crosshair = mount(
       <svg>
-        <Crosshair x={50} height={500} fill="red" />
+        <Crosshair width={1} x={50} height={500} fill="red" />
       </svg>,
     );
 

--- a/src/components/Legend/Legend.md
+++ b/src/components/Legend/Legend.md
@@ -33,7 +33,7 @@ The props interface for `<Legend />` accepts a series type, which is the same ty
 ```typescript
 interface Series {
   name: string;
-  color: string | GradientStop[];
+  color: Color;
   lineStyle?: LineStyle;
   data?: Data[];
 }

--- a/src/components/LineChart/Chart.scss
+++ b/src/components/LineChart/Chart.scss
@@ -1,7 +1,13 @@
+@import '../../styles/common';
+
 .Container {
+  @include chart-container;
   position: relative;
-  overflow: hidden;
+  user-select: none;
+}
+
+.Chart {
   height: 100%;
   width: 100%;
-  user-select: none;
+  overflow: visible;
 }

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -313,9 +313,8 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
+        className={styles.Chart}
         role={emptyState ? 'img' : 'table'}
-        width="100%"
-        height="100%"
         onMouseMove={(event) => {
           event.persist();
           handleMouseInteraction(event);

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -4,7 +4,6 @@ import {TooltipContent} from '../components/TooltipContent/TooltipContent';
 import {LineChartProps} from '../LineChart';
 import {
   DEFAULT_CROSSHAIR_COLOR,
-  CROSSHAIR_WIDTH,
   DEFAULT_GREY_LABEL,
   colorWhite,
   colorSky,
@@ -127,7 +126,6 @@ export const defaultProps = {
   isAnimated: true,
   renderTooltipContent,
   crossHairOptions: {
-    width: CROSSHAIR_WIDTH,
     color: DEFAULT_CROSSHAIR_COLOR,
     opacity: 1,
   },

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -157,7 +157,7 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
     label: string;
     rawValue: number;
   }[];
-  color?: string | GradientStop[];
+  color?: Color;
 }
 ```
 
@@ -183,7 +183,7 @@ The array of objects that the chart uses to draw the groups.
 
 | type    | default     |
 | ------- | ----------- |
-| `string | GradientStop[]` | `rgb(0,161,159)` |
+| `Color` | `rgb(0,161,159)` |
 
 This accepts any CSS color or gradient stop array, and corresponds to the color of the bar for that series.
 

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -90,7 +90,7 @@ The sparkline interface looks like this:
 
 ```typescript
 {
-  series: {color: string | GradientStop[], area: string | GradientStop[] | null, lineStyle: LineStyle, hasPoint: boolean, data: Coordinates[]}[];
+  series: {color: Color, area: Color | null, lineStyle: LineStyle, hasPoint: boolean, data: Coordinates[]}[];
   accessibilityLabel?: string;
   isAnimated?: boolean;
 }

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useLayoutEffect, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
-import type {GradientStop, LineStyle, SparkChartData} from 'types';
+import type {Color, LineStyle, SparkChartData} from 'types';
 
 import {useResizeObserver, useTheme} from '../../hooks';
 
@@ -17,8 +17,8 @@ export interface Coordinates {
 
 export interface SingleSeries {
   data: Coordinates[];
-  color?: string | GradientStop[];
-  area?: string | GradientStop[];
+  color?: Color;
+  area?: Color;
   lineStyle?: LineStyle;
   hasPoint?: boolean;
   offsetRight?: number;

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -3,7 +3,7 @@ import type {ScaleLinear} from 'd3-scale';
 import {area as areaShape, line} from 'd3-shape';
 import {classNames} from '@shopify/css-utilities';
 
-import type {GradientStop, Theme} from '../../../../types';
+import type {Color, GradientStop, Theme} from '../../../../types';
 import {LinearGradient} from '../../../LinearGradient';
 import {
   curveStepRounded,
@@ -23,7 +23,7 @@ const StrokeDasharray = {
   solid: 'unset',
 };
 
-function getGradientFill(area: string | GradientStop[] | null) {
+function getGradientFill(area: Color | null) {
   if (area == null) {
     return null;
   }

--- a/src/components/StackedAreaChart/Chart.scss
+++ b/src/components/StackedAreaChart/Chart.scss
@@ -1,13 +1,13 @@
 @import '../../styles/common';
 
 .Container {
+  @include chart-container;
   position: relative;
-  overflow: hidden;
-  height: 100%;
-  width: 100%;
   user-select: none;
 }
 
-.VisuallyHidden {
-  @include visually-hidden;
+.Chart {
+  height: 100%;
+  width: 100%;
+  overflow: visible;
 }

--- a/src/components/StackedAreaChart/StackedAreaChart.md
+++ b/src/components/StackedAreaChart/StackedAreaChart.md
@@ -166,6 +166,14 @@ The distinction between the `RenderTooltipContentData` and series `Data` types i
 
 The prop to determine the chart's drawn area. Each `Series` object corresponds to an area drawn on the chart, and is explained in greater detail [above](#series).
 
+#### theme
+
+| type      | default |
+| --------- | ------- |
+| `string` | `Default` |
+
+The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider.
+
 ### Optional Props
 
 #### formatXAxisLabel

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -8,11 +8,12 @@ import type {
   Dimensions,
 } from '../../types';
 import {TooltipContent} from '../TooltipContent';
-import {getDefaultColor, uniqueId} from '../../utilities';
-import {useResizeObserver} from '../../hooks';
+import {uniqueId} from '../../utilities';
+import {useResizeObserver, useTheme} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {Series, RenderTooltipContentData} from './types';
+import styles from './Chart.scss';
 
 export interface StackedAreaChartProps {
   formatXAxisLabel?: StringLabelFormatter;
@@ -23,6 +24,7 @@ export interface StackedAreaChartProps {
   opacity?: number;
   isAnimated?: boolean;
   skipLinkText?: string;
+  theme?: string;
 }
 
 export function StackedAreaChart({
@@ -34,7 +36,10 @@ export function StackedAreaChart({
   opacity = 1,
   isAnimated = false,
   skipLinkText,
+  theme,
 }: StackedAreaChartProps) {
+  const selectedTheme = useTheme(theme);
+
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
   );
@@ -119,7 +124,7 @@ export function StackedAreaChart({
     title,
     data,
   }: RenderTooltipContentData) {
-    const formattedData = data.map(({label, value, color}) => ({
+    const formattedData = data.map(({color, label, value}) => ({
       color,
       label,
       value: formatYAxisLabel(value),
@@ -128,21 +133,23 @@ export function StackedAreaChart({
     return <TooltipContent title={title} data={formattedData} />;
   }
 
-  const seriesWithDefaults = series.map((series, index) => ({
-    color: getDefaultColor(index),
-    ...series,
-  }));
-
   return (
     <React.Fragment>
       {skipLinkText == null || skipLinkText.length === 0 ? null : (
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
-      <div style={{height: '100%', width: '100%'}} ref={setRef}>
+      <div
+        className={styles.Container}
+        style={{
+          background: selectedTheme.chartContainer.backgroundColor,
+          padding: selectedTheme.chartContainer.padding,
+        }}
+        ref={setRef}
+      >
         {chartDimensions == null ? null : (
           <Chart
             xAxisLabels={xAxisLabels}
-            series={seriesWithDefaults}
+            series={series}
             formatXAxisLabel={formatXAxisLabel}
             formatYAxisLabel={formatYAxisLabel}
             dimensions={chartDimensions}
@@ -153,6 +160,7 @@ export function StackedAreaChart({
             }
             opacity={opacity}
             isAnimated={isAnimated}
+            theme={theme}
           />
         )}
       </div>

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -3,8 +3,10 @@ import isEqual from 'lodash.isequal';
 import {animated, useSpring} from '@react-spring/web';
 import {area, Series} from 'd3-shape';
 import type {ScaleLinear} from 'd3-scale';
+import type {Color, GradientStop} from 'types';
 
-import {uniqueId} from '../../../../utilities';
+import {LinearGradient} from '../../../LinearGradient';
+import {isGradientType, uniqueId} from '../../../../utilities';
 import {usePrevious} from '../../../../hooks';
 
 type StackedSeries = Series<
@@ -18,7 +20,7 @@ interface Props {
   width: number;
   height: number;
   transform: string;
-  colors: string[];
+  colors: Color[];
   stackedValues: StackedSeries[];
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
@@ -74,15 +76,33 @@ export function Areas({
             return null;
           }
 
+          const currentColor = colors[index];
+          const isGradient = isGradientType(currentColor);
+
+          const gradient = isGradient
+            ? currentColor
+            : [{offset: 0, color: currentColor}];
+
           return (
-            <path
-              key={index}
-              d={shape}
-              fill={colors[index]}
-              stroke={colors[index]}
-              strokeWidth="0.1"
-              opacity={opacity}
-            />
+            <React.Fragment key={index}>
+              <defs>
+                <LinearGradient
+                  id={`area-${id}-${index}`}
+                  gradient={gradient as GradientStop[]}
+                  gradientUnits="userSpaceOnUse"
+                  y1="100%"
+                  y2="0%"
+                />
+              </defs>
+              <path
+                key={index}
+                d={shape}
+                fill={`url(#area-${id}-${index})`}
+                stroke={`url(#area-${id}-${index})`}
+                strokeWidth="0.1"
+                opacity={opacity}
+              />
+            </React.Fragment>
           );
         })}
       </g>

--- a/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -91,8 +91,8 @@ describe('<StackedAreas />', () => {
     expect(stackedArea).toContainReactComponent('path', {
       // eslint-disable-next-line id-length
       d: 'M250,250L250,250L250,250L250,250Z',
-      fill: 'red',
-      stroke: 'red',
+      fill: 'url(#area-stackedAreas-1-0)',
+      stroke: 'url(#area-stackedAreas-1-0)',
       strokeWidth: '0.1',
       opacity: 1,
     });

--- a/src/components/StackedAreaChart/hooks/index.ts
+++ b/src/components/StackedAreaChart/hooks/index.ts
@@ -1,2 +1,3 @@
 export {useXScale} from './use-x-scale';
 export {useYScale} from './use-y-scale';
+export {useThemeSeriesColors} from './use-theme-series-colors';

--- a/src/components/StackedAreaChart/hooks/tests/use-theme-series-colors.test.tsx
+++ b/src/components/StackedAreaChart/hooks/tests/use-theme-series-colors.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import type {Theme} from '../../../../types';
+import {
+  useThemeSeriesColors,
+  getSeriesColors,
+} from '../use-theme-series-colors';
+
+const SELECTED_THEME = {
+  seriesColors: {
+    upToFour: ['#9479F7', '#578FE1', '#CF68C1', '#5B97AD'],
+    fromFiveToSeven: [
+      '#5B97AD',
+      '#578FE1',
+      '#9479F7',
+      '#C29FED',
+      '#CF68C1',
+      '#D7905B',
+      '#F4CE74',
+    ],
+    all: [
+      '#41778B',
+      '#8DAEEF',
+      '#7847F4',
+      '#AA77DE',
+      '#A74E9B',
+      '#E4A175',
+      '#BE9D44',
+      '#87C9E3',
+      '#4D7FC9',
+      '#C3B6FB',
+      '#9643D7',
+      '#CF68C1',
+      '#AD7349',
+      '#F4CE74',
+    ],
+  },
+} as Theme;
+
+describe('useThemeSeriesColors', () => {
+  const spy = jest.fn((_) => {});
+
+  beforeEach(() => {
+    spy.mockReset();
+  });
+
+  it('builds a simple array with no overrides', () => {
+    function MockComponent() {
+      const colors = useThemeSeriesColors(
+        [
+          {
+            name: 'First-time',
+            data: [{label: 'January', rawValue: 4237}],
+          },
+          {
+            name: 'Returning',
+            data: [{label: 'January', rawValue: 5663}],
+          },
+        ],
+        SELECTED_THEME as Theme,
+      );
+      spy(colors);
+      return null;
+    }
+
+    mount(<MockComponent />);
+
+    expect(spy).toHaveBeenCalledWith(['#9479F7', '#578FE1']);
+  });
+
+  it('builds a simple array with overrides', () => {
+    function MockComponent() {
+      const colors = useThemeSeriesColors(
+        [
+          {
+            name: 'First-time',
+            data: [{label: 'January', rawValue: 4237}],
+          },
+          {
+            name: 'Returning',
+            data: [{label: 'January', rawValue: 5663}],
+            color: '#ff1111',
+          },
+        ],
+        SELECTED_THEME,
+      );
+      spy(colors);
+      return null;
+    }
+
+    mount(<MockComponent />);
+
+    expect(spy).toHaveBeenCalledWith(['#9479F7', '#ff1111']);
+  });
+
+  it('builds big array with no overrides', () => {
+    const series = Array(10)
+      .fill(null)
+      .map((index) => {
+        return {
+          name: index,
+          data: [{label: 'January', rawValue: 4237}],
+        };
+      });
+
+    function MockComponent() {
+      const colors = useThemeSeriesColors(series, SELECTED_THEME);
+      spy(colors);
+      return null;
+    }
+
+    mount(<MockComponent />);
+
+    expect(spy).toHaveBeenCalledWith([
+      '#41778B',
+      '#8DAEEF',
+      '#7847F4',
+      '#AA77DE',
+      '#A74E9B',
+      '#E4A175',
+      '#BE9D44',
+      '#87C9E3',
+      '#4D7FC9',
+      '#C3B6FB',
+    ]);
+  });
+
+  it('builds big array with overrides', () => {
+    const series = Array(10)
+      .fill(null)
+      .map((_, index) => {
+        return {
+          name: `${index}`,
+          data: [{label: 'January', rawValue: 4237}],
+          color: index === 5 ? '#ff1111' : undefined,
+        };
+      });
+
+    function MockComponent() {
+      const colors = useThemeSeriesColors(series, SELECTED_THEME);
+      spy(colors);
+      return null;
+    }
+
+    mount(<MockComponent />);
+
+    expect(spy).toHaveBeenCalledWith([
+      '#41778B',
+      '#8DAEEF',
+      '#7847F4',
+      '#AA77DE',
+      '#A74E9B',
+      '#ff1111',
+      '#E4A175',
+      '#BE9D44',
+      '#87C9E3',
+      '#4D7FC9',
+    ]);
+  });
+
+  describe('getSeriesColors', () => {
+    it('returns upToFour', () => {
+      expect(getSeriesColors(0, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.upToFour,
+      );
+      expect(getSeriesColors(2, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.upToFour,
+      );
+      expect(getSeriesColors(4, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.upToFour,
+      );
+    });
+
+    it('returns fromFiveToSeven', () => {
+      expect(getSeriesColors(5, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.fromFiveToSeven,
+      );
+      expect(getSeriesColors(6, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.fromFiveToSeven,
+      );
+      expect(getSeriesColors(7, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.fromFiveToSeven,
+      );
+    });
+
+    it('returns all', () => {
+      expect(getSeriesColors(8, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.all,
+      );
+      expect(getSeriesColors(10, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.all,
+      );
+      expect(getSeriesColors(20, SELECTED_THEME)).toStrictEqual(
+        SELECTED_THEME.seriesColors.all,
+      );
+    });
+  });
+});

--- a/src/components/StackedAreaChart/hooks/use-theme-series-colors.ts
+++ b/src/components/StackedAreaChart/hooks/use-theme-series-colors.ts
@@ -1,0 +1,48 @@
+import {useMemo} from 'react';
+
+import type {Theme, Color} from '../../../types';
+import type {Series} from '../types';
+
+// Build an array of colors for each item in the series. Colors provided directly
+// to series.color are used in place of the theme color.
+export function useThemeSeriesColors(
+  series: Series[],
+  selectedTheme: Theme,
+): Color[] {
+  return useMemo(() => {
+    const seriesColors = getSeriesColors(series.length, selectedTheme);
+
+    let lastUsedColorIndex = -1;
+
+    return series.map(({color}) => {
+      // If the series doesn't have a color property
+      // explicitly set on itself, we're going to grab
+      // the next available color in the array.
+      if (!color) {
+        lastUsedColorIndex += 1;
+
+        // Once we've hit the last item in the array,
+        // reset the count and grab the first color.
+        if (lastUsedColorIndex === seriesColors.length) {
+          lastUsedColorIndex = 0;
+        }
+
+        return seriesColors[lastUsedColorIndex];
+      }
+
+      return color;
+    });
+  }, [series, selectedTheme]);
+}
+
+export function getSeriesColors(count: number, selectedTheme: Theme): Color[] {
+  if (count <= 4) {
+    return selectedTheme.seriesColors.upToFour;
+  }
+
+  if (count >= 5 && count <= 7) {
+    return selectedTheme.seriesColors.fromFiveToSeven;
+  }
+
+  return selectedTheme.seriesColors.all;
+}

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -4,7 +4,11 @@ import {Story, Meta} from '@storybook/react';
 import {StackedAreaChart, StackedAreaChartProps} from '../StackedAreaChart';
 
 import {data, labels, formatYAxisLabel} from './utils.stories';
-import {colorPurpleDark, colorTeal} from '../../../constants';
+import {
+  colorPurpleDark,
+  colorTeal,
+  VIZ_GRADIENT_COLOR,
+} from '../../../constants';
 
 const tooltipContent = {
   empty: undefined,
@@ -20,7 +24,7 @@ const tooltipContent = {
         fontSize: 12,
       }}
     >
-      {data.map((x) => (
+      {data.map(() => (
         <div>{`${x.label}: ${x.value}`}</div>
       ))}
     </div>
@@ -80,6 +84,9 @@ export default {
       description:
         'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
     },
+    theme: {
+      description: 'The theme that the chart will inherit its styles from',
+    },
   },
 } as Meta;
 
@@ -89,6 +96,8 @@ const defaultProps = {
   xAxisLabels: labels,
   formatYAxisLabel: formatYAxisLabel,
   isAnimated: true,
+  theme: 'Default',
+  opacity: 1,
 };
 
 const Template: Story<StackedAreaChartProps> = (
@@ -99,18 +108,51 @@ const Template: Story<StackedAreaChartProps> = (
 export const Default = Template.bind({});
 Default.args = defaultProps;
 
+export const Gradients = Template.bind({});
+Gradients.args = {
+  ...defaultProps,
+  xAxisLabels: Array(5)
+    .fill(null)
+    .map(() => 'label'),
+  series: [
+    {
+      name: 'One',
+      data: Array(5)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+      color: VIZ_GRADIENT_COLOR.negative.down,
+    },
+    {
+      name: 'Two',
+      data: Array(5)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+  ],
+};
+
 export const LargeVolume = Template.bind({});
 LargeVolume.args = {
   ...defaultProps,
   xAxisLabels: Array(2000)
     .fill(null)
-    .map((x) => 'label'),
+    .map(() => 'label'),
   series: [
     {
       name: 'First-time',
       data: Array(2000)
         .fill(null)
-        .map((x) => {
+        .map(() => {
           return {
             rawValue: Math.random() * Math.random() * 100,
             label: Math.random().toString(),
@@ -122,13 +164,112 @@ LargeVolume.args = {
       name: 'Returning',
       data: Array(2000)
         .fill(null)
-        .map((x) => {
+        .map(() => {
           return {
             rawValue: Math.random() * Math.random() * 100,
             label: Math.random().toString(),
           };
         }),
       color: colorPurpleDark,
+    },
+  ],
+};
+
+export const MediumVolume = Template.bind({});
+MediumVolume.args = {
+  ...defaultProps,
+  xAxisLabels: Array(10)
+    .fill(null)
+    .map(() => 'label'),
+  series: [
+    {
+      name: 'One',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Two',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Three',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Four (Custom Color)',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+      color: '#ff1111',
+    },
+    {
+      name: 'Five',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Six',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Seven',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
+    },
+    {
+      name: 'Eight',
+      data: Array(10)
+        .fill(null)
+        .map(() => {
+          return {
+            rawValue: Math.random() * Math.random() * 100,
+            label: Math.random().toString(),
+          };
+        }),
     },
   ],
 };

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -71,6 +71,8 @@ describe('<Chart />', () => {
     formatXAxisLabel: (val: string) => val,
     formatYAxisLabel: (val: number) => val.toString(),
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
+    colors: ['purple', 'teal'],
+    theme: 'Default',
   };
 
   it('renders an SVG', () => {

--- a/src/components/StackedAreaChart/types.ts
+++ b/src/components/StackedAreaChart/types.ts
@@ -1,11 +1,11 @@
-import type {DataSeries, NullableData} from '../../types';
+import type {Color, DataSeries, NullableData} from '../../types';
 
 export interface Series extends DataSeries<NullableData, string> {}
 
 export interface RenderTooltipContentData {
   title: string;
   data: {
-    color: string;
+    color: Color;
     label: string;
     value: number;
   }[];

--- a/src/components/TooltipContent/TooltipContent.md
+++ b/src/components/TooltipContent/TooltipContent.md
@@ -97,7 +97,7 @@ The props interface for `<TooltipContent />` looks like this:
 interface TooltipContentProps {
   title?: string;
   data: {
-    color: string | GradientStop[];
+    color: Color;
     label: string;
     value: string;
   }[];
@@ -114,7 +114,7 @@ interface TooltipContentProps {
 
 | type                                            |
 | ----------------------------------------------- |
-| `{color:string | GradientStop[]; label: string; value: number}[]` |
+| `{color:Color; label: string; value: number}[]` |
 
 Each member of the `data` array corresponds to a row in the `<TooltipContent />` object. The value for `color` corresponds to the fill color for the square preview, and accepts any CSS color or GradientStop[].
 
@@ -148,7 +148,7 @@ interface LineChartTooltipContentProps {
       label: string;
       value: string;
     };
-    color?: string | GradientStop[];
+    color?: Color;
     lineStyle?: LineStyle;
   }[];
 }
@@ -180,7 +180,7 @@ The values to display for the given data point.
 
 | type    | default       |
 | ------- | ------------- |
-| `string | GradientStop[]` | None |
+| `Color` | None |
 
 Accepts any CSS color or GradientStop[].
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,6 @@
 import type {Theme} from './types';
 import variables from './styles/shared/_variables.scss';
 
-export const CROSSHAIR_WIDTH = 5;
 export const SMALL_WIDTH = 300;
 export const MIN_LABEL_SPACE = 100;
 export const TICK_SIZE = 6;
@@ -112,6 +111,34 @@ export const VIZ_GRADIENT_COLOR = {
 };
 
 export const DEFAULT_THEME: Theme = {
+  seriesColors: {
+    upToFour: ['#9479F7', '#578FE1', '#CF68C1', '#5B97AD'],
+    fromFiveToSeven: [
+      '#5B97AD',
+      '#578FE1',
+      '#9479F7',
+      '#C29FED',
+      '#CF68C1',
+      '#D7905B',
+      '#F4CE74',
+    ],
+    all: [
+      '#41778B',
+      '#8DAEEF',
+      '#7847F4',
+      '#AA77DE',
+      '#A74E9B',
+      '#E4A175',
+      '#BE9D44',
+      '#87C9E3',
+      '#4D7FC9',
+      '#C3B6FB',
+      '#9643D7',
+      '#CF68C1',
+      '#AD7349',
+      '#F4CE74',
+    ],
+  },
   chartContainer: {
     borderRadius: '0px',
     padding: '0px',
@@ -139,7 +166,7 @@ export const DEFAULT_THEME: Theme = {
     showHorizontalLines: true,
     color: 'rgb(99, 115, 129)',
     horizontalOverflow: true,
-    horizontalMargin: 20,
+    horizontalMargin: 0,
   },
   xAxis: {
     showTicks: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,6 @@ export interface GradientStop {
   stopOpacity?: number;
 }
 
-export type SeriesColor = GradientStop[] | string;
-
 export type StringLabelFormatter = (
   value: string,
   index?: number,
@@ -60,6 +58,8 @@ export type SparkChartData = number | null;
 
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;
 export type NumberInterpolator = InterpolatorFn<readonly number[], number>;
+export type Color = string | GradientStop[];
+export type SeriesColor = Color;
 
 export interface XAxisOptions {
   labelFormatter?: StringLabelFormatter;
@@ -89,7 +89,7 @@ export interface GridTheme {
 export interface BarTheme {
   innerMargin: keyof typeof BarMargin;
   outerMargin: keyof typeof BarMargin;
-  color: string | GradientStop[];
+  color: Color;
   hasRoundedCorners: boolean;
   /**
    * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
@@ -120,14 +120,19 @@ export interface ChartContainerTheme {
 }
 
 export interface LineTheme {
-  color: string | GradientStop[];
+  color: Color;
   area: string | null;
-  sparkArea: string | GradientStop[] | null;
+  sparkArea: Color | null;
   hasSpline: boolean;
   style: LineStyle;
   hasPoint: boolean;
   width: number;
   pointStroke: string;
+}
+export interface SeriesColors {
+  upToFour: Color[];
+  fromFiveToSeven: Color[];
+  all: Color[];
 }
 
 export interface ColorPalette {
@@ -150,6 +155,7 @@ export interface PartialTheme {
   crossHair?: Partial<CrossHairTheme>;
   colorPalette?: Partial<ColorPalette>;
   legend?: Partial<Legend>;
+  seriesColors?: Partial<SeriesColors>;
 }
 
 export interface Theme {
@@ -162,4 +168,5 @@ export interface Theme {
   crossHair: CrossHairTheme;
   legend: Legend;
   colorPalette: ColorPalette;
+  seriesColors: SeriesColors;
 }


### PR DESCRIPTION
### What problem is this PR solving?

Consume ThemeProvider in StackedAreaChart.

Series are currently hardcoded so the only added prop is `theme` for `StackedAreaChart`. The `Chart` component now takes an array of colors, which can be overridden by `series.color`.

I know there's some discussion around hardcoded series colors that Miru and Krystal are working on, so that's the only open question I have around this PR.

⚠️ https://github.com/Shopify/polaris-viz/pull/456/files needs to be merged first.

### Reviewers’ :tophat: instructions

- Spot-check the `StackedAreaChart` story.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
