### PR TITLE
Add useWatchMedia & useCallbackRef hooks

### DIFF
--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -1,5 +1,4 @@
 import React, {useLayoutEffect, useRef, useState, useCallback} from 'react';
-import {useDebouncedCallback} from 'use-debounce';
 
 import {ChartContainer} from '../../components/ChartContainer';
 import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
@@ -8,6 +7,7 @@ import {isGradientType, changeColorOpacity, uniqueId} from '../../utilities';
 import {SkipLink} from '../SkipLink';
 import {
   usePrefersReducedMotion,
+  useResizeChartForPrint,
   useResizeObserver,
   useTheme,
 } from '../../hooks';
@@ -72,59 +72,11 @@ export function LineChart({
     }
   }, [entry]);
 
-  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
-    updateDimensions();
-  }, 100);
-
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && ref != null) {
-        setChartDimensions(ref.getBoundingClientRect());
-      }
-    },
-    [ref],
-  );
+  useResizeChartForPrint(ref, chartDimensions, setChartDimensions);
 
   useLayoutEffect(() => {
     updateDimensions();
-
-    const isServer = typeof window === 'undefined';
-
-    if (!isServer) {
-      window.addEventListener('resize', debouncedUpdateDimensions);
-
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
-    }
-
-    return () => {
-      if (!isServer) {
-        window.removeEventListener('resize', debouncedUpdateDimensions);
-
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
-      }
-    };
-  }, [
-    entry,
-    updateDimensions,
-    debouncedUpdateDimensions,
-    handlePrintMediaQueryChange,
-  ]);
+  }, [updateDimensions]);
 
   const xAxisOptionsWithDefaults: XAxisOptions = {
     labelFormatter: (value: string) => value,

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -1,5 +1,4 @@
 import React, {useLayoutEffect, useRef, useState, useCallback} from 'react';
-import {useDebouncedCallback} from 'use-debounce';
 
 import {SkipLink} from '../SkipLink';
 import type {
@@ -9,7 +8,7 @@ import type {
 } from '../../types';
 import {TooltipContent} from '../TooltipContent';
 import {uniqueId} from '../../utilities';
-import {useResizeObserver, useTheme} from '../../hooks';
+import {useResizeChartForPrint, useResizeObserver, useTheme} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {Series, RenderTooltipContentData} from './types';
@@ -67,56 +66,11 @@ export function StackedAreaChart({
     }
   }, [entry]);
 
-  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
-    updateDimensions();
-  }, 100);
-
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && ref != null) {
-        setChartDimensions(ref.getBoundingClientRect());
-      }
-    },
-    [ref],
-  );
+  useResizeChartForPrint(ref, chartDimensions, setChartDimensions);
 
   useLayoutEffect(() => {
     updateDimensions();
-    const isServer = typeof window === 'undefined';
-
-    if (!isServer) {
-      window.addEventListener('resize', debouncedUpdateDimensions);
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
-    }
-
-    return () => {
-      if (!isServer) {
-        window.removeEventListener('resize', debouncedUpdateDimensions);
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
-      }
-    };
-  }, [
-    entry,
-    debouncedUpdateDimensions,
-    updateDimensions,
-    handlePrintMediaQueryChange,
-  ]);
+  }, [entry, updateDimensions]);
 
   if (series.length === 0) {
     return null;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,5 @@ export {useTheme} from './useTheme';
 export {usePolarisVizContext} from './usePolarisVizContext';
 export {useThemeSeriesColors} from './use-theme-series-colors';
 export {useLinearChartAnimations} from './use-linear-chart-animations';
+export {useCallbackRef} from './useCallbackRef';
+export {useWatchPrintMedia, useResizeChartForPrint} from './useWatchPrintMedia';

--- a/src/hooks/useCallbackRef.ts
+++ b/src/hooks/useCallbackRef.ts
@@ -1,0 +1,34 @@
+import {useRef} from 'react';
+
+type BasicFunction = (...args: any[]) => void;
+
+// Returns a callback function that doesn't change it's reference,
+// but will always call the latest callback.
+//
+// Allows us to pass a basic function to the hook without
+// having to wrap it in a useCallback.
+export function useCallbackRef<T extends BasicFunction>(callback: T): T {
+  const callbackRef = useRef<T>(null as any);
+
+  if (!callbackRef.current) {
+    callbackRef.current = Proxy.create<T>();
+  }
+
+  Proxy.update(callbackRef.current, callback);
+
+  return callbackRef.current;
+}
+
+const Proxy = {
+  create<T extends BasicFunction>(): T {
+    const proxy: any = (...args: any[]) => {
+      return proxy.callback(...args);
+    };
+
+    return proxy;
+  },
+
+  update(proxy: any, callback: BasicFunction) {
+    proxy.callback = callback;
+  },
+};

--- a/src/hooks/useWatchPrintMedia.ts
+++ b/src/hooks/useWatchPrintMedia.ts
@@ -1,0 +1,67 @@
+import {Dispatch, SetStateAction, useEffect, useRef} from 'react';
+import type {Dimensions} from 'types';
+
+import {useCallbackRef} from './useCallbackRef';
+
+// Watch for media query changes on the window.
+export function useWatchPrintMedia(
+  callback: (event: MediaQueryListEvent) => void,
+) {
+  const callbackRef = useCallbackRef(callback);
+
+  useEffect(() => {
+    const isServer = typeof window === 'undefined';
+    const matchMedia = window.matchMedia('print');
+
+    if (!isServer) {
+      if (typeof matchMedia.addEventListener === 'function') {
+        matchMedia.addEventListener('change', callbackRef);
+      } else if (typeof matchMedia.addListener === 'function') {
+        matchMedia.addListener(callbackRef);
+      }
+    }
+
+    return () => {
+      if (!isServer) {
+        if (typeof matchMedia.addEventListener === 'function') {
+          matchMedia.removeEventListener('change', callbackRef);
+        } else if (typeof matchMedia.addListener === 'function') {
+          matchMedia.removeListener(callbackRef);
+        }
+      }
+    };
+  }, [callbackRef]);
+}
+
+export const IS_SAFARI =
+  navigator.userAgent.includes('Safari') &&
+  navigator.vendor.includes('Apple Computer');
+
+// Resize charts when the user is trying to print the screen.
+// Chart is sized onbeforeprint and then resized to it's original
+// position onafterprint.
+export function useResizeChartForPrint(
+  ref: HTMLElement | null,
+  dimensions: Dimensions | null,
+  setDimensions: Dispatch<SetStateAction<Dimensions | null>>,
+) {
+  const previousSizeRef = useRef<Dimensions | null>(null);
+
+  useWatchPrintMedia((event: MediaQueryListEvent) => {
+    if (!ref) {
+      return;
+    }
+
+    if (event.matches) {
+      previousSizeRef.current = dimensions;
+
+      if (IS_SAFARI) {
+        setTimeout(() => setDimensions(ref.getBoundingClientRect()));
+      } else {
+        setDimensions(ref.getBoundingClientRect());
+      }
+    } else {
+      setDimensions(previousSizeRef.current);
+    }
+  });
+}


### PR DESCRIPTION
### What problem is this PR solving?

The "print" media check was duplicated over multiple components. This unifies it into `useWatchMedia` & 
`useResizeChartForPrint` hooks.

### Reviewers’ :tophat: instructions

- Load each component and resize the window. 
  - The charts should resize along with the window size.
- In Chrome & Safari, load a story in the fill window view and print a component. 
  - Component should be full size of the printed page.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
