### PR TITLE
Cleanup of types and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@
 ### Added
 
 - `PolarisVizProvider` to support theming charts
-- The`theme` to prop to `<BarChart />`, `<LineChart />`, `<Sparkline />` and `<Sparkbar />`
-- `<Sparkline />` now supports the dotted line style
-- `<Sparkline />` and `<Sparkbar />` support gradient fills
+- The `theme` to prop to `<BarChart />`, `<LineChart />`, `<Sparkline />`, `<StackedAreaChart />` and `<Sparkbar />`
+- `<Sparkline />` supports the dotted line style
+- `<Sparkline />`, `<StackedAreaChart />` and `<Sparkbar />` support gradient fills
 - `<Legend />` text is now configurable via the theme
+
 
 ### Removed
 
 - Polaris Tokens strings are no longer accepted as colors. Any valid CSS color can now be provided as a color to charts, and in some cases gradients can be specified by supplying an array of gradient stops.
 - `barOptions`, `gridOptions`, `xAxisOptions.showTicks`, `xAxisOptions.labelColor` and `yAxisOptions.labelColor` from `BarChartProps` and `LineChartProps`.
 - `barFillStyle` and `color` props are removed from the `<Sparkbar />` component and are inherited from the chart's theme
+- `opacity` prop from `<StackedAreaChart />`. Opaque colors can now be directly specified in the series color prop or theme.
 - `colors` prop from  `<NormalizedStackedBarChart />`
 
 ### Changed

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -33,34 +33,19 @@ const props = {
     {label: 'Saturday', rawValue: 30},
     {label: 'Sunday', rawValue: 10},
   ],
-  barOptions: {
-    color: [
-      {offset: 0, color: 'rgba(152, 107, 255, 0.8)'},
-      {offset: 100, color: 'rgba(58, 164, 246, 0.8)'},
-    ],
-    hasRoundedCorners: true,
-    outerMargin: 'Medium',
-  },
   skipLinkText: 'Skip chart content',
   xAxisOptions: {
     useMinimalLabels: true,
     labelColor: 'rgb(220, 220, 220)',
-    showTicks: false,
   },
   yAxisOptions: {
-    backgroundColor: 'rgb(31, 31, 37)',
-    labelColor: 'rgb(220, 220, 220)',
     integersOnly: true,
     labelFormatter: formatYAxisLabel,
-  },
-  gridOptions: {
-    color: 'rgb(65, 66, 71)',
-    horizontalOverflow: true,
-    horizontalMargin: 20,
   },
   isAnimated: true,
   renderTooltipContent: {renderTooltipContent},
   skipLinkText: 'Skip chart content',
+  theme: 'Default'
 };
 
 return <BarChart {...props} />;
@@ -88,28 +73,12 @@ interface BarChartProps {
   }): React.ReactNode;
   skipLinkText?: string;
   emptyStateText?: string;
-  barOptions?: {
-    innerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
-    outerMargin?: 'Small' | 'Medium' | 'Large' | 'None';
-    color?: Color;
-    hasRoundedCorners?: boolean;
-    zeroAsMinHeight?: boolean;
-  };
-  gridOptions?: {
-    showHorizontalLines?: boolean;
-    color?: string;
-    horizontalOverflow?: boolean;
-    horizontalMargin?: number;
-  };
   xAxisOptions?: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
-    showTicks?: boolean;
-    labelColor?: string;
     useMinimalLabels?: boolean;
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
-    backgroundColor?: string;
     integersOnly?: boolean;
   };
   annotations?: {
@@ -123,6 +92,7 @@ interface BarChartProps {
       value: string;
     };
   }[];
+  theme?: string;
 }
 ```
 
@@ -185,85 +155,13 @@ If provided, renders a `<SkipLink/>` button with the string. Use this for charts
 
 Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the data prop could be an empty array.
 
-#### barOptions
+#### theme
 
-An optional object including the following proprties that define the appearance of the bar.
+| type     | default     |
+| -------- | ----------- |
+| `string` | `Default` |
 
-##### innerMargin
-
-| type                                       | default  |
-| ------------------------------------------ | -------- |
-| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `Medium` |
-
-This sets the margin between each of the bars. A value of `None` will make the bars look as if they are one continuous element. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingInner) for more info.
-
-##### outerMargin
-
-| type                                       | default |
-| ------------------------------------------ | ------- |
-| `'Small' \| 'Medium' \| 'Large' \| 'None'` | `None`  |
-
-This sets the margin before and after all bars. A value of `None` will have bars start at the Y axis and end at the edge of the chart. See [documentation](https://github.com/d3/d3-scale/blob/master/README.md#band_paddingOuter) for more info.
-
-##### color
-
-| type    | default   |
-| ------- | --------- |
-| `Color` | |
-
-The bar fill color. This accepts any CSS color.
-
-##### hasRoundedCorners
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Rounds the top corners of each bar, in the case of positive numbers. Rounds the bottom corners for negatives.
-
-##### zeroAsMinHeight (deprecated)
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Shows a min height bar for zero values. This prop is experimental and not ready for general use. If you want to use this, come talk to us in [#polaris-data-viz](https://shopify.slack.com/archives/CNB58FZ34).
-
-#### gridOptions
-
-An object including the following optional proprties that define the grid.
-
-##### showHorizontalLines
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `true`  |
-
-Whether to show lines extending from the yAxis labels through the chart.
-
-##### horizontalOverflow
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `false` |
-
-Whether the lines should extend through the width of the entire chart.
-
-##### horizontalMargin
-
-| type     | default |
-| -------- | ------- |
-| `number` | `0`     |
-
-Margin to display on the left and right of the chart.
-
-##### color
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `"rgb(223, 227, 232)"` |
-
-The color of the grid lines.
+The theme controls the visual appearance of the chart, its axis and grid.
 
 #### xAxisOptions
 
@@ -275,14 +173,6 @@ The color of the grid lines.
 
 This accepts a function that is called to format the labels when the chart draws its X axis.
 
-##### labelColor
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `'rgb(223, 227, 232)'` |
-
-The color used for axis labels.
-
 ##### useMinimalLabels
 
 | type      | default |
@@ -290,14 +180,6 @@ The color used for axis labels.
 | `boolean` | `false` |
 
 If set to true, a chart with more than three xAxis labels will show a maximum of three labels. This option is useful when timeseries data is displayed.
-
-##### showTicks
-
-| type      | default |
-| --------- | ------- |
-| `boolean` | `true`  |
-
-Whether to show ticks connecting the xAxis labels to their corresponding grid line.
 
 #### yAxisOptions
 
@@ -308,22 +190,6 @@ Whether to show ticks connecting the xAxis labels to their corresponding grid li
 | `(value: number): string` | `(value) => value.toString()` |
 
 This accepts a function that is called when the Y value (`rawValue`) is formatted for the tooltip and for the Y Axis.
-
-##### labelColor
-
-| type     | default                |
-| -------- | ---------------------- |
-| `string` | `'rgb(223, 227, 232)'` |
-
-The color used for axis labels.
-
-##### backgroundColor
-
-| type     | default       |
-| -------- | ------------- |
-| `string` | `transparant` |
-
-The color used behind axis labels.
 
 ##### integersOnly
 

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -1,7 +1,7 @@
-import type {GradientStop} from 'types';
+import type {Color} from 'types';
 
 export interface BarChartData {
-  barColor?: string | GradientStop;
+  barColor?: Color;
   label: string;
   rawValue: number;
 }

--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -6,14 +6,14 @@ import type {
   Data,
   NullableData,
   LineStyle,
-  SeriesColor,
+  Color,
 } from '../../types';
 import {LinePreview} from '../LinePreview';
 import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './Legend.scss';
 
-type LegendData = Required<DataSeries<Data | NullableData, SeriesColor>>;
+type LegendData = Required<DataSeries<Data | NullableData, Color>>;
 
 interface LegendProps extends Omit<LegendData, 'data'> {
   lineStyle?: LineStyle;

--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -175,7 +175,7 @@ The `Series` type gives the user a lot of flexibility to define exactly what eac
     label: string;
     rawValue: number;
   }[];
-  color?: SeriesColor;
+  color?: Color;
   lineStyle?: LineStyle;
   areaColor?: string;
 }
@@ -351,6 +351,6 @@ Only use whole numbers for y axis ticks.
 
 | type      | default |
 | --------- | ------- |
-| `string` | `default` |
+| `string` | `Default` |
 
 The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider. Individual line styles can be overwritten as part of the series prop.

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {LineStyle, SeriesColor} from 'types';
+import type {LineStyle, Color} from 'types';
 
 import {LinePreview} from '../../../LinePreview';
 
@@ -11,7 +11,7 @@ interface TooltipData {
     label: string;
     value: string;
   };
-  color: SeriesColor;
+  color: Color;
   lineStyle: LineStyle;
 }
 

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 
 import {TooltipContent} from '../components/TooltipContent/TooltipContent';
 import {LineChartProps} from '../LineChart';
-import {
-  DEFAULT_CROSSHAIR_COLOR,
-  DEFAULT_GREY_LABEL,
-  colorWhite,
-  colorSky,
-  colorSkyDark,
-} from '../../../constants';
+import {colorSkyDark} from '../../../constants';
 
 export const gradient = [
   {
@@ -119,36 +113,4 @@ export const renderTooltipContent: LineChartProps['renderTooltipContent'] = ({
   );
 
   return <TooltipContent data={formattedData} />;
-};
-
-export const defaultProps = {
-  series,
-  isAnimated: true,
-  renderTooltipContent,
-  crossHairOptions: {
-    color: DEFAULT_CROSSHAIR_COLOR,
-    opacity: 1,
-  },
-  gridOptions: {
-    showVerticalLines: true,
-    showHorizontalLines: true,
-    color: colorSky,
-    horizontalOverflow: false,
-    horizontalMargin: 0,
-  },
-  lineOptions: {hasSpline: false, width: 2, pointStroke: colorWhite},
-  xAxisOptions: {
-    xAxisLabels,
-    hideXAxisLabels: false,
-    showTicks: true,
-    labelColor: DEFAULT_GREY_LABEL,
-    useMinimalLabels: false,
-    labelFormatter: (value: string) => formatXAxisLabel(value),
-  },
-  yAxisOptions: {
-    labelFormatter: (value: number) => value.toString(),
-    labelColor: DEFAULT_GREY_LABEL,
-    backgroundColor: 'transparent',
-    integersOnly: false,
-  },
 };

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -4,15 +4,15 @@ import type {
   LineStyle,
   StringLabelFormatter,
   NumberLabelFormatter,
-  SeriesColor,
+  Color,
 } from '../../types';
 
-export interface Series extends DataSeries<Data, SeriesColor> {
+export interface Series extends DataSeries<Data, Color> {
   areaColor?: string | null;
   lineStyle?: LineStyle;
 }
 
-export type SeriesWithDefaults = Required<DataSeries<Data, SeriesColor>> & {
+export type SeriesWithDefaults = Required<DataSeries<Data, Color>> & {
   lineStyle: LineStyle;
   areaColor?: string | null;
 };
@@ -23,7 +23,7 @@ export interface TooltipData {
     label: string;
     value: number;
   };
-  color: SeriesColor;
+  color: Color;
   lineStyle: LineStyle;
 }
 

--- a/src/components/LinePreview/LinePreview.tsx
+++ b/src/components/LinePreview/LinePreview.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import type {SeriesColor} from 'types';
+import type {Color} from 'types';
 
 import {isGradientType, uniqueId} from '../../utilities';
 import type {LineStyle} from '../../types';
@@ -13,7 +13,7 @@ import {
 } from './constants';
 
 interface Props {
-  color: SeriesColor;
+  color: Color;
   lineStyle: LineStyle;
 }
 

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
-import type {SeriesColor} from 'types';
+import type {Color} from 'types';
 import {useTransition} from '@react-spring/web';
 
 import {usePrefersReducedMotion} from '../../../../hooks';
@@ -21,7 +21,7 @@ interface Props {
   width: number;
   height: number;
   data: number[];
-  colors: SeriesColor[];
+  colors: Color[];
   isSubdued: boolean;
   barGroupIndex: number;
   ariaLabel: string;

--- a/src/components/MultiSeriesBarChart/components/StackedBarGroup/types.ts
+++ b/src/components/MultiSeriesBarChart/components/StackedBarGroup/types.ts
@@ -1,14 +1,14 @@
 import type {ScaleLinear, ScaleBand} from 'd3-scale';
 
 import type {StackSeries} from '../../types';
-import type {SeriesColor} from '../../../../types';
+import type {Color} from '../../../../types';
 
 export interface StackedBarGroupProps {
   groupIndex: number;
   data: StackSeries;
   yScale: ScaleLinear<number, number>;
   xScale: ScaleBand<string>;
-  colors: SeriesColor[];
+  colors: Color[];
   activeBarGroup: number | null;
   accessibilityData: {
     title: string;

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -5,10 +5,10 @@ import type {
   NumberLabelFormatter,
   DataSeries,
   Data,
-  SeriesColor,
+  Color,
 } from '../../types';
 
-export type Series = DataSeries<Data, SeriesColor>;
+export type Series = DataSeries<Data, Color>;
 
 export type StackSeries = ShapeSeries<
   {
@@ -19,7 +19,7 @@ export type StackSeries = ShapeSeries<
 
 export interface RenderTooltipContentData {
   data: {
-    color: SeriesColor;
+    color: Color;
     label: string;
     value: number;
   }[];

--- a/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarLabel/BarLabel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {createCSSGradient, isGradientType} from '../../../../utilities';
-import type {GradientStop, Legend} from '../../../../types';
+import type {Color, Legend} from '../../../../types';
 import {
   ComparisonMetric,
   ComparisonMetricShape,
@@ -13,7 +13,7 @@ import styles from './BarLabel.scss';
 export interface Props {
   label: string;
   value: string;
-  color: string | GradientStop[];
+  color: Color;
   comparisonMetric?: ComparisonMetricShape;
   legendColors: Legend;
   orientation: Orientation;

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
@@ -3,13 +3,13 @@ import {classNames} from '@shopify/css-utilities';
 
 import {createCSSGradient, isGradientType} from '../../../../utilities';
 import type {Orientation, Size} from '../../types';
-import type {GradientStop} from '../../../../types';
+import type {Color} from '../../../../types';
 
 import styles from './BarSegment.scss';
 
 interface Props {
   scale: number;
-  color: string | GradientStop[];
+  color: Color;
   size: Size;
   orientation: Orientation;
 }

--- a/src/components/Sparkbar/Sparkbar.md
+++ b/src/components/Sparkbar/Sparkbar.md
@@ -9,7 +9,7 @@ Used in small sizes to give an overview of how a metric has performed over time.
 ```tsx
 
   const props = {
-    theme: 'default',
+    theme: 'Default',
     data: [
       3, 7, 7, 5, 33, 2, 3, 0, 3, 5, 6, 6, 23, 5, 8, 1, 3, 12,
     ],
@@ -85,7 +85,7 @@ The prop to determine the chart's bars. Null bars will not be plotted. Bars with
 
 | type     | default |
 | -------- | ------- |
-| `string` | `default`|
+| `string` | `Default`|
 
 The theme that the chart will inherit its color and container styles from.
 

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -75,6 +75,7 @@ const props = {
   ],
   hasSpline: true,
   isAnimated: true,
+  theme: 'Default'
 };
 
 return (
@@ -194,6 +195,6 @@ Determines whether to animate the chart on state changes.
 
 | type      | default |
 | --------- | ------- |
-| `string` | `default` |
+| `string` | `Default` |
 
 The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider. Individual line styles can be overwritten as part of the series prop.

--- a/src/components/SquareColorPreview/SquareColorPreview.tsx
+++ b/src/components/SquareColorPreview/SquareColorPreview.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import type {SeriesColor} from 'types';
+import type {Color} from 'types';
 
 import {isGradientType, createCSSGradient} from '../../utilities';
 
 import styles from './SquareColorPreview.scss';
 
 export interface SquareColorPreviewProps {
-  color: SeriesColor;
+  color: Color;
 }
 
 export function SquareColorPreview({color}: SquareColorPreviewProps) {

--- a/src/components/SquareColorPreview/stories/SquareColorPreview.stories.tsx
+++ b/src/components/SquareColorPreview/stories/SquareColorPreview.stories.tsx
@@ -10,7 +10,7 @@ export default {
   argTypes: {
     color: {
       description:
-        'The color to be displayed in the square. [SeriesColor type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L2)',
+        'The CSS color or gradient array color to be displayed in the square.',
     },
   },
   parameters: {

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -50,7 +50,6 @@ interface Props {
   formatYAxisLabel: NumberLabelFormatter;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   dimensions: Dimensions;
-  opacity: number;
   isAnimated: boolean;
   theme?: string;
 }
@@ -62,7 +61,6 @@ export function Chart({
   formatXAxisLabel,
   formatYAxisLabel,
   renderTooltipContent,
-  opacity,
   isAnimated,
   theme,
 }: Props) {
@@ -242,7 +240,6 @@ export function Chart({
           xScale={xScale}
           yScale={yScale}
           colors={colors}
-          opacity={opacity}
           isAnimated={isAnimated && !prefersReducedMotion}
         />
 

--- a/src/components/StackedAreaChart/StackedAreaChart.md
+++ b/src/components/StackedAreaChart/StackedAreaChart.md
@@ -98,6 +98,7 @@ interface StackedAreaChartProps {
   formatYAxisLabel?(value: number): string;
   renderTooltipContent?: (data: RenderTooltipContentData): React.ReactNode;
   skipLinkText?: string;
+  theme?: string;
 }
 ```
 

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -21,7 +21,6 @@ export interface StackedAreaChartProps {
   renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
   xAxisLabels: string[];
   series: Series[];
-  opacity?: number;
   isAnimated?: boolean;
   skipLinkText?: string;
   theme?: string;
@@ -33,7 +32,6 @@ export function StackedAreaChart({
   formatXAxisLabel = (value) => value.toString(),
   formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
-  opacity = 1,
   isAnimated = false,
   skipLinkText,
   theme,
@@ -158,7 +156,6 @@ export function StackedAreaChart({
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
-            opacity={opacity}
             isAnimated={isAnimated}
             theme={theme}
           />

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -24,7 +24,6 @@ interface Props {
   stackedValues: StackedSeries[];
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  opacity: number;
   isAnimated: boolean;
 }
 
@@ -36,7 +35,6 @@ export function Areas({
   xScale,
   yScale,
   colors,
-  opacity,
   isAnimated,
 }: Props) {
   const prevstackedValues = usePrevious(stackedValues);
@@ -100,7 +98,6 @@ export function Areas({
                 fill={`url(#area-${id}-${index})`}
                 stroke={`url(#area-${id}-${index})`}
                 strokeWidth="0.1"
-                opacity={opacity}
               />
             </React.Fragment>
           );

--- a/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -18,7 +18,6 @@ describe('<StackedAreas />', () => {
     height: 50,
     transform: '',
     colors: ['red', 'purple'],
-    opacity: 1,
     xScale: scaleLinear(),
     yScale: scaleLinear(),
     isAnimated: true,
@@ -94,7 +93,6 @@ describe('<StackedAreas />', () => {
       fill: 'url(#area-stackedAreas-1-0)',
       stroke: 'url(#area-stackedAreas-1-0)',
       strokeWidth: '0.1',
-      opacity: 1,
     });
   });
 });

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -51,10 +51,6 @@ export default {
     xAxisLabels: {
       description: 'The labels to display on the x axis of the chart.',
     },
-    opacity: {
-      description:
-        'Determines the opacity of all area shapes. Consider reducing the opacity below 1 if seeing the grid lines behind the areas is important to your use case.',
-    },
     isAnimated: {
       description:
         'Whether to animate the chart when it is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.',
@@ -97,7 +93,6 @@ const defaultProps = {
   formatYAxisLabel: formatYAxisLabel,
   isAnimated: true,
   theme: 'Default',
-  opacity: 1,
 };
 
 const Template: Story<StackedAreaChartProps> = (

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -66,7 +66,6 @@ describe('<Chart />', () => {
     ],
     xAxisLabels: ['Day 1', 'Day 2'],
     dimensions: {width: 500, height: 250},
-    opacity: 1,
     isAnimated: true,
     formatXAxisLabel: (val: string) => val,
     formatYAxisLabel: (val: number) => val.toString(),
@@ -126,7 +125,6 @@ describe('<Chart />', () => {
       height: 218,
       transform: 'translate(16,8)',
       colors: ['purple', 'teal'],
-      opacity: 1,
       isAnimated: true,
       stackedValues: expect.any(Object),
     });

--- a/src/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/TooltipContent/TooltipContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import type {SeriesColor} from 'types';
+import type {Color} from 'types';
 
 import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './TooltipContent.scss';
 
 interface TooltipData {
-  color: SeriesColor;
+  color: Color;
   label: string;
   value: string;
 }

--- a/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
+++ b/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
@@ -5,13 +5,13 @@ import type {
   DataSeries,
   NullableData,
   Data,
-  SeriesColor,
+  Color,
 } from '../../types';
 
 import styles from './VisuallyHiddenRows.scss';
 
 interface Props {
-  series: DataSeries<Data | NullableData, SeriesColor>[];
+  series: DataSeries<Data | NullableData, Color>[];
   xAxisLabels: string[];
   formatYAxisLabel: NumberLabelFormatter;
 }

--- a/src/hooks/useLinearXAxisDetails.ts
+++ b/src/hooks/useLinearXAxisDetails.ts
@@ -23,7 +23,7 @@ import type {
   NullableData,
   Data,
   DataSeries,
-  SeriesColor,
+  Color,
   YAxisTick,
 } from '../types';
 
@@ -37,7 +37,7 @@ function getDatumSpace(width: number, numberOfTicks: number) {
 }
 
 export interface ChartDetails {
-  series: DataSeries<Data | NullableData, SeriesColor>[];
+  series: DataSeries<Data | NullableData, Color>[];
   fontSize: number;
   width: number;
   formatXAxisLabel: StringLabelFormatter;

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,6 @@ export type SparkChartData = number | null;
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;
 export type NumberInterpolator = InterpolatorFn<readonly number[], number>;
 export type Color = string | GradientStop[];
-export type SeriesColor = Color;
 
 export interface XAxisOptions {
   labelFormatter?: StringLabelFormatter;
@@ -136,7 +135,7 @@ export interface SeriesColors {
 }
 
 export interface ColorPalette {
-  colors: (string | GradientStop[])[];
+  colors: Color[];
 }
 
 export interface Legend {

--- a/src/utilities/is-gradient-type.ts
+++ b/src/utilities/is-gradient-type.ts
@@ -1,4 +1,4 @@
-import type {GradientStop, SeriesColor} from '../types';
+import type {GradientStop, Color} from '../types';
 
 function isGradientStopType(item: any): item is GradientStop {
   return (
@@ -9,7 +9,7 @@ function isGradientStopType(item: any): item is GradientStop {
   );
 }
 
-export function isGradientType(color: SeriesColor): color is GradientStop[] {
+export function isGradientType(color: Color): color is GradientStop[] {
   return (
     Array.isArray(color) && color.every((item) => isGradientStopType(item))
   );


### PR DESCRIPTION
### What problem is this PR solving?
Part of https://github.com/Shopify/polaris-viz/issues/479
Just tidying up some of our work so far. Here are some highlights:
- removed the opacity prop on the StachedAreaChart since we can use rgba values now, so it seems unnecessary and like an outlier from the rest of our charts
- replaced `SeriesColor` with `Color` and updated some places that should use the type
- got rid of old props from docs

### Reviewers’ :tophat: instructions
Make sure I didn't break the components 🙃 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
