### PR TITLE
Tweaks based on UX review: NormalizedStackedBar + Sparkline

### DIFF
--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
@@ -96,6 +96,7 @@ export function NormalizedStackedBarChart({
               scale={xScale(value)}
               key={`${label}-${value}`}
               color={colors[index]}
+              roundedCorners={selectedTheme.bar.hasRoundedCorners}
             />
           ),
         )}

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
@@ -5,6 +5,24 @@
   }
 }
 
+.horizontal-RoundedCorners {
+  &:first-of-type {
+    border-radius: 2px 0 0 2px;
+  }
+  &:last-of-type {
+    border-radius: 0 2px 2px 0;
+  }
+}
+
+.vertical-RoundedCorners {
+  &:first-of-type {
+    border-radius: 2px 2px 0 0;
+  }
+  &:last-of-type {
+    border-radius: 0 0 2px 2px;
+  }
+}
+
 .horizontal-small {
   height: 16px;
 }

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
@@ -15,9 +15,16 @@ interface Props {
   color: Color;
   size: Size;
   orientation: Orientation;
+  roundedCorners: boolean;
 }
 
-export function BarSegment({color, scale, size, orientation}: Props) {
+export function BarSegment({
+  color,
+  scale,
+  size,
+  orientation,
+  roundedCorners,
+}: Props) {
   const scaleNeedsRounding = scale > 0 && scale < 1.5;
   const safeScale = scaleNeedsRounding ? 1.5 : scale;
 
@@ -29,7 +36,11 @@ export function BarSegment({color, scale, size, orientation}: Props) {
 
   return (
     <div
-      className={classNames(styles.Segment, styles[`${orientation}-${size}`])}
+      className={classNames(
+        styles.Segment,
+        roundedCorners && styles[`${orientation}-RoundedCorners`],
+        styles[`${orientation}-${size}`],
+      )}
       style={{flexBasis: `${safeScale}%`, background: formattedColor}}
     />
   );

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
@@ -4,45 +4,34 @@ import {mount} from '@shopify/react-testing';
 import {BarSegment} from '../BarSegment';
 
 describe('<BarSegment />', () => {
+  const mockProps = {
+    scale: 64,
+    color: 'rgb(255, 255, 255)',
+    size: 'small' as 'small',
+    orientation: 'horizontal' as 'horizontal',
+    roundedCorners: true,
+  };
+
   it('gives the child a horizontal small class name', () => {
-    const barSegment = mount(
-      <BarSegment
-        scale={64}
-        color="rgb(255, 255, 255)"
-        size="small"
-        orientation="horizontal"
-      />,
-    );
+    const barSegment = mount(<BarSegment {...mockProps} />);
 
     expect(barSegment).toContainReactComponent('div', {
-      className: 'Segment horizontal-small',
+      className: 'Segment horizontal-RoundedCorners horizontal-small',
     });
   });
 
   it('gives the child a vertical small class name', () => {
     const barSegment = mount(
-      <BarSegment
-        scale={64}
-        color="rgb(255, 255, 255)"
-        size="small"
-        orientation="vertical"
-      />,
+      <BarSegment {...mockProps} orientation="vertical" />,
     );
 
     expect(barSegment).toContainReactComponent('div', {
-      className: 'Segment vertical-small',
+      className: 'Segment vertical-RoundedCorners vertical-small',
     });
   });
 
   it('does not round up a 0 scale', () => {
-    const barSegment = mount(
-      <BarSegment
-        scale={0}
-        color="rgb(255, 255, 255)"
-        size="small"
-        orientation="horizontal"
-      />,
-    );
+    const barSegment = mount(<BarSegment {...mockProps} scale={0} />);
 
     const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 
@@ -50,14 +39,7 @@ describe('<BarSegment />', () => {
   });
 
   it('rounds up a scale above 0 and below 1.5', () => {
-    const barSegment = mount(
-      <BarSegment
-        scale={0.1}
-        color="rgb(255, 255, 255)"
-        size="small"
-        orientation="horizontal"
-      />,
-    );
+    const barSegment = mount(<BarSegment {...mockProps} scale={0.1} />);
 
     const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 
@@ -65,14 +47,7 @@ describe('<BarSegment />', () => {
   });
 
   it('does not round up a scale above 1.5', () => {
-    const barSegment = mount(
-      <BarSegment
-        scale={1.51}
-        color="rgb(255, 255, 255)"
-        size="small"
-        orientation="horizontal"
-      />,
-    );
+    const barSegment = mount(<BarSegment {...mockProps} scale={1.51} />);
 
     const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
 

--- a/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
+++ b/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
@@ -77,7 +77,7 @@ const defaultProps = {
     },
   ],
   orientation: 'horizontal',
-  size: 'large',
+  size: 'small',
   theme: 'Default',
 };
 

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -163,7 +163,7 @@ export function Sparkline({
                 yScale={yScale}
                 series={seriesWithColor}
                 isAnimated={isAnimated}
-                height={height}
+                svgDimensions={svgDimensions}
                 theme={selectedTheme}
               />
             </g>

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -52,7 +52,7 @@ const mockProps = {
   yScale,
   series: mockSeries,
   isAnimated: false,
-  height: 250,
+  svgDimensions: {height: 250, width: 250},
   hasSpline: false,
   theme: {
     line: {sparkArea: null, style: 'solid', color: 'red', hasPoint: true},

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -5,7 +5,6 @@ import {Sparkline, SparklineProps} from '../..';
 
 const series = [
   {
-    areaStyle: 'gradient',
     hasPoint: true,
     data: [
       {x: 0, y: 100},
@@ -22,9 +21,9 @@ const series = [
     ],
   },
   {
-    areaStyle: 'none',
     lineStyle: 'dashed',
     hasPoint: false,
+    area: null,
     data: [
       {x: 0, y: 200},
       {x: 1, y: 200},
@@ -127,6 +126,7 @@ OffsetAndNulls.args = {
     {
       color: 'rgb(255, 85, 70)',
       lineStyle: 'dashed',
+      area: null,
       hasPoint: false,
       data: [
         {x: 0, y: 20},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,7 @@ export const MASK_SUBDUE_COLOR = '#434343';
 
 export const colorSky = variables.colorSky;
 export const colorWhite = variables.colorWhite;
+export const colorBlack = variables.colorBlack;
 export const colorPurpleDark = variables.colorPurpleDark;
 export const colorBlue = variables.colorBlue;
 export const colorTeal = variables.colorTeal;
@@ -115,7 +116,10 @@ export const DEFAULT_THEME: Theme = {
     backgroundColor: variables.colorGray01,
   },
   line: {
-    sparkArea: null,
+    sparkArea: [
+      {offset: 0, color: 'rgba(92, 105, 208, 0)'},
+      {offset: 100, color: 'rgba(92, 105, 208, 0.15)'},
+    ],
     hasSpline: true,
     style: 'solid',
     hasPoint: true,

--- a/src/styles/shared/_variables.scss
+++ b/src/styles/shared/_variables.scss
@@ -10,6 +10,7 @@ $duration-slower: 400;
 $duration-slowest: 500;
 
 $color-white: rgb(255, 255, 255);
+$color-black: rgb(0, 0, 0);
 $color-sky-dark: rgb(196, 205, 213);
 $color-sky: rgb(223, 227, 232);
 $color-ink: rgb(33, 43, 54);
@@ -93,6 +94,7 @@ $font-stack-base: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI'
   spacingLoose: strip-unit($spacing-loose);
   spacingExtraLoose: strip-unit($spacing-extra-loose);
   colorWhite: $color-white;
+  colorBlack: $color-black;
   colorSky: $color-sky;
   colorSkyDark: $color-sky-dark;
   colorInkLight: $color-ink-light;


### PR DESCRIPTION
### What problem is this PR solving?
Part of https://github.com/Shopify/polaris-viz/issues/465

Some tweaks from UX review:

| Change | | 
|---|---|
| Add default sparkArea color  | <img width="177" alt="Screen Shot 2021-08-25 at 4 18 32 PM" src="https://user-images.githubusercontent.com/12213371/130858808-f42d5ce3-de1b-4a14-87f7-edfab6b767d9.png">| 
| Fix Sparkline point showing line behind it  | <img width="36" alt="Screen Shot 2021-08-25 at 4 21 45 PM" src="https://user-images.githubusercontent.com/12213371/130859221-4d5b14f7-9e63-43c2-ab06-6afcde87a920.png"> |
| Add rounded bar theme to normalized stacked bar  | <img width="771" alt="Screen Shot 2021-08-25 at 4 22 47 PM" src="https://user-images.githubusercontent.com/12213371/130859331-24caf5d9-f5e4-46e5-a356-9d7b17278172.png"> |  

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
