### PR TITLE
SeriesColors audit

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useLayoutEffect, useRef, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 
+import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
 import {Dimensions, BarMargin} from '../../types';
 import {SkipLink} from '../SkipLink';
 import {uniqueId, normalizeData} from '../../utilities';
@@ -47,6 +48,7 @@ export function BarChart({
   theme = 'Default',
 }: BarChartProps) {
   const selectedTheme = useTheme(theme);
+  const [seriesColor] = getSeriesColorsFromCount(data.length, selectedTheme);
 
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
@@ -151,6 +153,7 @@ export function BarChart({
 
   const barThemeWithMargins = {
     ...selectedTheme.bar,
+    color: seriesColor,
     innerMargin: BarMargin[selectedTheme.bar.innerMargin],
     outerMargin: BarMargin[selectedTheme.bar.outerMargin],
   };

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -33,6 +33,7 @@ import type {
   YAxisTheme,
   XAxisOptions,
   YAxisOptions,
+  Color,
 } from '../../types';
 
 import {AnnotationLine} from './components';
@@ -49,6 +50,7 @@ type BarThemeWithNumericMargins = Omit<
   BarTheme,
   'innerMargin' | 'outerMargin'
 > & {
+  color: Color;
   innerMargin: number;
   outerMargin: number;
 };

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -8,8 +8,8 @@ import {
   uniqueId,
   clamp,
   isGradientType,
-  makeColorOpaque,
-  makeGradientOpaque,
+  changeColorOpacity,
+  changeGradientOpacity,
 } from '../../utilities';
 import {useLinearXAxisDetails, useLinearXScale} from '../../hooks';
 import {
@@ -455,7 +455,7 @@ export function Chart({
 
             const pointColor = isGradientType(color)
               ? `url(#${pointGradientId})`
-              : makeColorOpaque(color);
+              : changeColorOpacity(color);
 
             return (
               <React.Fragment key={`${name}-${index}`}>
@@ -463,7 +463,7 @@ export function Chart({
                   <defs>
                     <LinearGradient
                       id={pointGradientId}
-                      gradient={makeGradientOpaque(color)}
+                      gradient={changeGradientOpacity(color)}
                       gradientUnits="userSpaceOnUse"
                       y1="100%"
                       y2="0%"

--- a/src/components/LineChart/components/Line/tests/Line.test.tsx
+++ b/src/components/LineChart/components/Line/tests/Line.test.tsx
@@ -39,6 +39,7 @@ const mockProps = {
     hasPoint: false,
     width: 10,
     pointStroke: 'red',
+    dottedStrokeColor: '#ffffff',
   },
   color,
 };

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -10,6 +10,7 @@ import {
   formatYAxisLabel,
   renderTooltipContent,
   gradient,
+  seriesUsingSeriesColors,
 } from './utils.stories';
 import {colorTeal} from '../../../constants';
 
@@ -100,6 +101,21 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
 export const InsightsStyle = Template.bind({});
 InsightsStyle.args = {
   series,
+  theme: 'Default',
+  xAxisOptions: {
+    xAxisLabels,
+    labelFormatter: formatXAxisLabel,
+  },
+  yAxisOptions: {
+    labelFormatter: formatYAxisLabel,
+  },
+  renderTooltipContent,
+  isAnimated: true,
+};
+
+export const SeriesColors = Template.bind({});
+SeriesColors.args = {
+  series: seriesUsingSeriesColors,
   theme: 'Default',
   xAxisOptions: {
     xAxisLabels,

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -65,6 +65,49 @@ export const series = [
   },
 ];
 
+export const seriesUsingSeriesColors = [
+  {
+    name: 'Apr 01–Apr 14, 2020',
+    data: [
+      {rawValue: 333, label: '2020-04-01T12:00:00'},
+      {rawValue: 797, label: '2020-04-02T12:00:00'},
+      {rawValue: 234, label: '2020-04-03T12:00:00'},
+      {rawValue: 534, label: '2020-04-04T12:00:00'},
+      {rawValue: -132, label: '2020-04-05T12:00:00'},
+      {rawValue: 159, label: '2020-04-06T12:00:00'},
+      {rawValue: 239, label: '2020-04-07T12:00:00'},
+      {rawValue: 708, label: '2020-04-08T12:00:00'},
+      {rawValue: 234, label: '2020-04-09T12:00:00'},
+      {rawValue: 645, label: '2020-04-10T12:00:00'},
+      {rawValue: 543, label: '2020-04-11T12:00:00'},
+      {rawValue: 89, label: '2020-04-12T12:00:00'},
+      {rawValue: 849, label: '2020-04-13T12:00:00'},
+      {rawValue: 129, label: '2020-04-14T12:00:00'},
+    ],
+    lineStyle: 'solid' as 'solid',
+  },
+  {
+    name: 'Mar 01–Mar 14, 2020',
+    data: [
+      {rawValue: 709, label: '2020-03-02T12:00:00'},
+      {rawValue: 238, label: '2020-03-01T12:00:00'},
+      {rawValue: 190, label: '2020-03-03T12:00:00'},
+      {rawValue: 90, label: '2020-03-04T12:00:00'},
+      {rawValue: 237, label: '2020-03-05T12:00:00'},
+      {rawValue: 580, label: '2020-03-07T12:00:00'},
+      {rawValue: 172, label: '2020-03-06T12:00:00'},
+      {rawValue: 12, label: '2020-03-08T12:00:00'},
+      {rawValue: 390, label: '2020-03-09T12:00:00'},
+      {rawValue: 43, label: '2020-03-10T12:00:00'},
+      {rawValue: 710, label: '2020-03-11T12:00:00'},
+      {rawValue: 791, label: '2020-03-12T12:00:00'},
+      {rawValue: 623, label: '2020-03-13T12:00:00'},
+      {rawValue: 21, label: '2020-03-14T12:00:00'},
+    ],
+    lineStyle: 'dotted' as 'dotted',
+  },
+];
+
 export const xAxisLabels = series[0].data.map(({label}) => label);
 
 export function formatXAxisLabel(value: string) {

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -62,6 +62,7 @@ const lineOptions = {
   hasPoint: false,
   width: 2,
   pointStroke: '#fff',
+  dottedStrokeColor: '#fff',
 };
 
 const yAxisOptions = {

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -4,6 +4,7 @@ import {scaleBand, scaleLinear} from 'd3-scale';
 import {line} from 'd3-shape';
 import {useTransition} from '@react-spring/web';
 
+import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
 import {
   usePrefersReducedMotion,
   useResizeObserver,
@@ -76,6 +77,7 @@ export function Sparkbar({
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const selectedTheme = useTheme(theme);
+  const [seriesColor] = getSeriesColorsFromCount(data.length, selectedTheme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
     if (entry == null) return;
@@ -144,13 +146,11 @@ export function Sparkbar({
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
-  const color = selectedTheme.bar.color;
-
-  const barColor = isGradientType(color)
-    ? color
+  const barColor = isGradientType(seriesColor)
+    ? seriesColor
     : [
         {
-          color,
+          color: seriesColor,
           offset: 0,
         },
       ];

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -3,6 +3,7 @@ import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
 import type {Color, LineStyle, SparkChartData} from 'types';
 
+import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
 import {useResizeObserver, useTheme} from '../../hooks';
 
 import styles from './Sparkline.scss';
@@ -45,6 +46,7 @@ export function Sparkline({
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const selectedTheme = useTheme(theme);
+  const seriesColors = getSeriesColorsFromCount(series.length, selectedTheme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
     if (entry == null) return;
@@ -148,12 +150,17 @@ export function Sparkline({
             .range([offsetLeft + SVG_MARGIN, width - offsetRight - SVG_MARGIN])
             .domain([minXValues, maxXValues]);
 
+          const seriesWithColor = {
+            color: seriesColors[index],
+            ...singleSeries,
+          };
+
           return (
             <g key={index}>
               <Series
                 xScale={xScale}
                 yScale={yScale}
-                series={singleSeries}
+                series={seriesWithColor}
                 isAnimated={isAnimated}
                 height={height}
                 theme={selectedTheme}

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -56,9 +56,9 @@ export function Series({
   const {
     area = theme.line.sparkArea,
     lineStyle = theme.line.style,
-    color = theme.line.color,
     hasPoint = theme.line.hasPoint,
     data,
+    color,
   } = series;
 
   const lineGenerator = line<Coordinates>()
@@ -93,7 +93,7 @@ export function Series({
   const id = useMemo(() => uniqueId('sparkline'), []);
   const immediate = !isAnimated || prefersReducedMotion;
 
-  const lineGradientColor = isGradientType(color)
+  const lineGradientColor = isGradientType(color!)
     ? color
     : [
         {
@@ -113,7 +113,7 @@ export function Series({
       <defs>
         <LinearGradient
           id={`line-${id}`}
-          gradient={lineGradientColor}
+          gradient={lineGradientColor as GradientStop[]}
           gradientUnits="userSpaceOnUse"
           y1="100%"
           y2="0%"

--- a/src/components/Sparkline/components/Series/tests/Series.test.tsx
+++ b/src/components/Sparkline/components/Series/tests/Series.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
 import {area} from 'd3-shape';
-import type {Theme} from 'types';
 
 import {LinearGradient} from '../../../../LinearGradient';
 import {Series} from '../Series';
@@ -57,7 +56,7 @@ const mockProps = {
   hasSpline: false,
   theme: {
     line: {sparkArea: null, style: 'solid', color: 'red', hasPoint: true},
-  } as Theme,
+  } as any,
 };
 
 jest.mock('utilities/unique-id', () => ({

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -21,8 +21,8 @@ import {TooltipContainer} from '../TooltipContainer';
 import {
   eventPoint,
   isGradientType,
-  makeColorOpaque,
-  makeGradientOpaque,
+  changeColorOpacity,
+  changeGradientOpacity,
   uniqueId,
 } from '../../utilities';
 import {YAxis} from '../YAxis';
@@ -204,6 +204,7 @@ export function Chart({
             labelColor={selectedTheme.xAxis.labelColor}
             showTicks={selectedTheme.xAxis.showTicks}
             gridColor={selectedTheme.grid.color}
+            showGridLines={selectedTheme.grid.showVerticalLines}
           />
         </g>
 
@@ -263,7 +264,7 @@ export function Chart({
 
               const pointColor = isGradientType(color)
                 ? `url(#${id})`
-                : makeColorOpaque(color);
+                : changeColorOpacity(color);
 
               return (
                 <React.Fragment key={index}>
@@ -271,7 +272,7 @@ export function Chart({
                     <defs>
                       <LinearGradient
                         id={id}
-                        gradient={makeGradientOpaque(color)}
+                        gradient={changeGradientOpacity(color)}
                         gradientUnits="userSpaceOnUse"
                         y1="100%"
                         y2="0%"

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -6,7 +6,11 @@ import type {ScaleLinear} from 'd3-scale';
 import type {Color, GradientStop} from 'types';
 
 import {LinearGradient} from '../../../LinearGradient';
-import {isGradientType, uniqueId} from '../../../../utilities';
+import {
+  curveStepRounded,
+  isGradientType,
+  uniqueId,
+} from '../../../../utilities';
 import {usePrevious} from '../../../../hooks';
 
 type StackedSeries = Series<
@@ -56,7 +60,8 @@ export function Areas({
     )
     .x((_, index) => xScale(index))
     .y0(([firstPoint]) => yScale(firstPoint))
-    .y1(([, lastPoint]) => yScale(lastPoint));
+    .y1(([, lastPoint]) => yScale(lastPoint))
+    .curve(curveStepRounded);
 
   const id = useMemo(() => uniqueId('stackedAreas'), []);
 

--- a/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -81,6 +81,10 @@ describe('<StackedAreas />', () => {
   });
 
   it('generates props for the paths', () => {
+    // eslint-disable-next-line id-length
+    const d =
+      'M250,250L250,250C250,250,250,250,250,250L250,250L250,250L250,250C250,250,250,250,250,250L250,250Z';
+
     const stackedArea = mount(
       <svg>
         <StackedAreas {...mockProps} />
@@ -89,7 +93,7 @@ describe('<StackedAreas />', () => {
 
     expect(stackedArea).toContainReactComponent('path', {
       // eslint-disable-next-line id-length
-      d: 'M250,250L250,250L250,250L250,250Z',
+      d,
       fill: 'url(#area-stackedAreas-1-0)',
       stroke: 'url(#area-stackedAreas-1-0)',
       strokeWidth: '0.1',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -145,17 +145,15 @@ export const DEFAULT_THEME: Theme = {
     backgroundColor: '#1f1f25',
   },
   line: {
-    color: VIZ_GRADIENT_COLOR.neutral.up,
-    area: null,
     sparkArea: null,
     hasSpline: true,
     style: 'solid',
     hasPoint: true,
     width: 2,
     pointStroke: 'white',
+    dottedStrokeColor: 'rgba(144, 176, 223, 60)',
   },
   bar: {
-    color: VIZ_GRADIENT_COLOR.neutral.up,
     hasRoundedCorners: true,
     innerMargin: 'Medium',
     outerMargin: 'Medium',
@@ -164,18 +162,18 @@ export const DEFAULT_THEME: Theme = {
   grid: {
     showVerticalLines: false,
     showHorizontalLines: true,
-    color: 'rgb(99, 115, 129)',
-    horizontalOverflow: true,
+    color: '#43434E',
+    horizontalOverflow: false,
     horizontalMargin: 0,
   },
   xAxis: {
     showTicks: false,
-    labelColor: 'rgb(220, 220, 220)',
+    labelColor: '#DCDCDC',
     hide: false,
   },
   yAxis: {
     backgroundColor: '#1f1f25',
-    labelColor: 'rgb(220, 220, 220)',
+    labelColor: '#DCDCDC',
   },
   crossHair: {
     color: 'rgb(139, 159, 176)',

--- a/src/hooks/tests/use-theme-series-colors.test.tsx
+++ b/src/hooks/tests/use-theme-series-colors.test.tsx
@@ -5,6 +5,7 @@ import type {Theme} from '../../types';
 import {
   useThemeSeriesColors,
   getSeriesColors,
+  getSeriesColorsFromCount,
 } from '../use-theme-series-colors';
 
 const SELECTED_THEME = {
@@ -45,118 +46,147 @@ describe('useThemeSeriesColors', () => {
     spy.mockReset();
   });
 
-  it('builds a simple array with no overrides', () => {
-    function MockComponent() {
-      const colors = useThemeSeriesColors(
-        [
-          {
-            name: 'First-time',
+  describe('useThemeSeriesColors', () => {
+    it('builds a simple array with no overrides', () => {
+      function MockComponent() {
+        const colors = useThemeSeriesColors(
+          [
+            {
+              name: 'First-time',
+              data: [{label: 'January', rawValue: 4237}],
+            },
+            {
+              name: 'Returning',
+              data: [{label: 'January', rawValue: 5663}],
+            },
+          ],
+          SELECTED_THEME as Theme,
+        );
+        spy(colors);
+        return null;
+      }
+
+      mount(<MockComponent />);
+
+      expect(spy).toHaveBeenCalledWith(['#9479F7', '#578FE1']);
+    });
+
+    it('builds a simple array with overrides', () => {
+      function MockComponent() {
+        const colors = useThemeSeriesColors(
+          [
+            {
+              name: 'First-time',
+              data: [{label: 'January', rawValue: 4237}],
+            },
+            {
+              name: 'Returning',
+              data: [{label: 'January', rawValue: 5663}],
+              color: '#ff1111',
+            },
+          ],
+          SELECTED_THEME,
+        );
+        spy(colors);
+        return null;
+      }
+
+      mount(<MockComponent />);
+
+      expect(spy).toHaveBeenCalledWith(['#9479F7', '#ff1111']);
+    });
+
+    it('builds big array with no overrides', () => {
+      const series = Array(10)
+        .fill(null)
+        .map((index) => {
+          return {
+            name: index,
             data: [{label: 'January', rawValue: 4237}],
-          },
-          {
-            name: 'Returning',
-            data: [{label: 'January', rawValue: 5663}],
-          },
-        ],
-        SELECTED_THEME as Theme,
-      );
-      spy(colors);
-      return null;
-    }
+          };
+        });
 
-    mount(<MockComponent />);
+      function MockComponent() {
+        const colors = useThemeSeriesColors(series, SELECTED_THEME);
+        spy(colors);
+        return null;
+      }
 
-    expect(spy).toHaveBeenCalledWith(['#9479F7', '#578FE1']);
-  });
+      mount(<MockComponent />);
 
-  it('builds a simple array with overrides', () => {
-    function MockComponent() {
-      const colors = useThemeSeriesColors(
-        [
-          {
-            name: 'First-time',
+      expect(spy).toHaveBeenCalledWith([
+        '#41778B',
+        '#8DAEEF',
+        '#7847F4',
+        '#AA77DE',
+        '#A74E9B',
+        '#E4A175',
+        '#BE9D44',
+        '#87C9E3',
+        '#4D7FC9',
+        '#C3B6FB',
+      ]);
+    });
+
+    it('builds big array with overrides', () => {
+      const series = Array(10)
+        .fill(null)
+        .map((_, index) => {
+          return {
+            name: `${index}`,
             data: [{label: 'January', rawValue: 4237}],
-          },
-          {
-            name: 'Returning',
-            data: [{label: 'January', rawValue: 5663}],
-            color: '#ff1111',
-          },
-        ],
-        SELECTED_THEME,
-      );
-      spy(colors);
-      return null;
-    }
+            color: index === 5 ? '#ff1111' : undefined,
+          };
+        });
 
-    mount(<MockComponent />);
+      function MockComponent() {
+        const colors = useThemeSeriesColors(series, SELECTED_THEME);
+        spy(colors);
+        return null;
+      }
 
-    expect(spy).toHaveBeenCalledWith(['#9479F7', '#ff1111']);
+      mount(<MockComponent />);
+
+      expect(spy).toHaveBeenCalledWith([
+        '#41778B',
+        '#8DAEEF',
+        '#7847F4',
+        '#AA77DE',
+        '#A74E9B',
+        '#ff1111',
+        '#E4A175',
+        '#BE9D44',
+        '#87C9E3',
+        '#4D7FC9',
+      ]);
+    });
   });
 
-  it('builds big array with no overrides', () => {
-    const series = Array(10)
-      .fill(null)
-      .map((index) => {
-        return {
-          name: index,
-          data: [{label: 'January', rawValue: 4237}],
-        };
-      });
-
-    function MockComponent() {
-      const colors = useThemeSeriesColors(series, SELECTED_THEME);
-      spy(colors);
-      return null;
-    }
-
-    mount(<MockComponent />);
-
-    expect(spy).toHaveBeenCalledWith([
-      '#41778B',
-      '#8DAEEF',
-      '#7847F4',
-      '#AA77DE',
-      '#A74E9B',
-      '#E4A175',
-      '#BE9D44',
-      '#87C9E3',
-      '#4D7FC9',
-      '#C3B6FB',
-    ]);
-  });
-
-  it('builds big array with overrides', () => {
-    const series = Array(10)
-      .fill(null)
-      .map((_, index) => {
-        return {
-          name: `${index}`,
-          data: [{label: 'January', rawValue: 4237}],
-          color: index === 5 ? '#ff1111' : undefined,
-        };
-      });
-
-    function MockComponent() {
-      const colors = useThemeSeriesColors(series, SELECTED_THEME);
-      spy(colors);
-      return null;
-    }
-
-    mount(<MockComponent />);
-
-    expect(spy).toHaveBeenCalledWith([
-      '#41778B',
-      '#8DAEEF',
-      '#7847F4',
-      '#AA77DE',
-      '#A74E9B',
-      '#ff1111',
-      '#E4A175',
-      '#BE9D44',
-      '#87C9E3',
-      '#4D7FC9',
-    ]);
+  describe('getSeriesColorsFromCount', () => {
+    it('builds big array', () => {
+      expect(getSeriesColorsFromCount(20, SELECTED_THEME)).toStrictEqual([
+        '#41778B',
+        '#8DAEEF',
+        '#7847F4',
+        '#AA77DE',
+        '#A74E9B',
+        '#E4A175',
+        '#BE9D44',
+        '#87C9E3',
+        '#4D7FC9',
+        '#C3B6FB',
+        '#9643D7',
+        '#CF68C1',
+        '#AD7349',
+        '#F4CE74',
+        '#41778B',
+        '#8DAEEF',
+        '#7847F4',
+        '#AA77DE',
+        '#A74E9B',
+        '#E4A175',
+      ]);
+    });
   });
 
   describe('getSeriesColors', () => {

--- a/src/hooks/use-theme-series-colors.ts
+++ b/src/hooks/use-theme-series-colors.ts
@@ -34,6 +34,27 @@ export function useThemeSeriesColors(
   }, [series, selectedTheme]);
 }
 
+export function getSeriesColorsFromCount(
+  count: number,
+  selectedTheme: Theme,
+): Color[] {
+  const seriesColors = getSeriesColors(count, selectedTheme);
+
+  let lastUsedColorIndex = -1;
+
+  return [...Array.from({length: count})].map(() => {
+    lastUsedColorIndex += 1;
+
+    // Once we've hit the last item in the array,
+    // reset the count and grab the first color.
+    if (lastUsedColorIndex === seriesColors.length) {
+      lastUsedColorIndex = 0;
+    }
+
+    return seriesColors[lastUsedColorIndex];
+  });
+}
+
 export function getSeriesColors(count: number, selectedTheme: Theme): Color[] {
   if (count <= 4) {
     return selectedTheme.seriesColors.upToFour;

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,6 @@ export interface GridTheme {
 export interface BarTheme {
   innerMargin: keyof typeof BarMargin;
   outerMargin: keyof typeof BarMargin;
-  color: Color;
   hasRoundedCorners: boolean;
   /**
    * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
@@ -119,14 +118,13 @@ export interface ChartContainerTheme {
 }
 
 export interface LineTheme {
-  color: Color;
-  area: string | null;
   sparkArea: Color | null;
   hasSpline: boolean;
   style: LineStyle;
   hasPoint: boolean;
   width: number;
   pointStroke: string;
+  dottedStrokeColor: string;
 }
 export interface SeriesColors {
   upToFour: Color[];

--- a/src/utilities/change-color-opacity.ts
+++ b/src/utilities/change-color-opacity.ts
@@ -2,21 +2,21 @@ import {color as d3Color} from 'd3-color';
 
 import type {GradientStop} from '../types';
 
-export function makeColorOpaque(color: string): string {
+export function changeColorOpacity(color: string, opacity = 1): string {
   const rgbColor = d3Color(color);
 
   if (rgbColor == null) {
     throw new Error('Color value is not valid.');
   }
 
-  rgbColor.opacity = 1;
+  rgbColor.opacity = opacity;
 
   return rgbColor.toString();
 }
 
-export function makeGradientOpaque(gradient: GradientStop[]) {
+export function changeGradientOpacity(gradient: GradientStop[], opacity = 1) {
   return gradient.map(({offset, color}) => ({
     offset,
-    color: makeColorOpaque(color),
+    color: changeColorOpacity(color, opacity),
   }));
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -17,8 +17,11 @@ export {normalizeData} from './normalize-data';
 export {createCSSGradient} from './create-css-gradient';
 export {shouldRoundScaleUp} from './should-round-scale-up';
 export {curveStepRounded} from './curve-step-rounded';
-export {makeColorOpaque, makeGradientOpaque} from './make-color-opaque';
 export {shouldRotateZeroBars} from './should-rotate-zero-bars';
 export {isNumber} from './is-number';
 export {createTheme, createThemes} from './create-themes';
 export {PolarisVizContext} from './polaris-viz-context';
+export {
+  changeColorOpacity,
+  changeGradientOpacity,
+} from './change-color-opacity';

--- a/src/utilities/tests/change-color-opacity.test.ts
+++ b/src/utilities/tests/change-color-opacity.test.ts
@@ -1,26 +1,39 @@
 import {color} from 'd3-color';
 
-import {makeColorOpaque, makeGradientOpaque} from '../make-color-opaque';
+import {
+  changeColorOpacity,
+  changeGradientOpacity,
+} from '../change-color-opacity';
 
 jest.mock('d3-color', () => ({
   color: jest.fn(() => null),
 }));
 
-describe('makeColorOpaque', () => {
+describe('changeColorOpacity', () => {
   it('throws an error if d3Color returns null', () => {
     expect(() => {
-      makeColorOpaque('rgb(255, 255, 255)');
+      changeColorOpacity('rgb(255, 255, 255)');
     }).toThrow('Color value is not valid.');
+  });
+
+  it('correctly changes a colors opacity', () => {
+    (color as jest.Mock).mockImplementation(
+      jest.requireActual('d3-color').color,
+    );
+
+    expect(changeColorOpacity('#ffffff', 0.5)).toStrictEqual(
+      'rgba(255, 255, 255, 0.5)',
+    );
   });
 });
 
-describe('makeGradientOpaque', () => {
+describe('changeGradientOpacity', () => {
   it('returns the gradient with opaque colours', () => {
     (color as jest.Mock).mockImplementation(
       jest.requireActual('d3-color').color,
     );
 
-    const gradient = makeGradientOpaque([
+    const gradient = changeGradientOpacity([
       {color: 'rgba(255, 0, 0, 0.5)', offset: 1},
       {color: 'rgba(123, 123, 123, 0.5)', offset: 2},
     ]);


### PR DESCRIPTION
### What problem is this PR solving?

https://github.com/Shopify/polaris-viz/issues/464

We're going through all the existing components to ensure that we're using `seriesColors` everywhere.

### Reviewers’ :tophat: instructions

- [ ] Load up each component and visually inspect that each is defaulting to `seriesColors`.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
