### PR TITLE
Use default theme color for axis labels

### DIFF
--- a/src/components/LinearXAxis/LinearXAxis.tsx
+++ b/src/components/LinearXAxis/LinearXAxis.tsx
@@ -8,8 +8,8 @@ import {
   DIAGONAL_ANGLE,
   LINE_HEIGHT,
   BELOW_X_AXIS_MARGIN,
+  DEFAULT_THEME,
   DEFAULT_GREY_LABEL,
-  colorSky,
 } from '../../constants';
 
 import styles from './LinearXAxis.scss';
@@ -64,7 +64,7 @@ function Axis({
   ariaHidden,
   showGridLines = true,
   showTicks = true,
-  gridColor = colorSky,
+  gridColor = DEFAULT_THEME.grid.color,
   labelColor = DEFAULT_GREY_LABEL,
 }: Props) {
   const {


### PR DESCRIPTION
### What problem is this PR solving?

Use the default color from the theme instead of the old color for axis labels.

### Reviewers’ :tophat: instructions

- [ ] Open the `Line` story, everything should look fine. 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
