### PR TITLE
Apply themes to tooltip containers, update Dark Mode colors

### DIFF
--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -48,7 +48,7 @@ export function BarChart({
   theme = 'Default',
 }: BarChartProps) {
   const selectedTheme = useTheme(theme);
-  const [seriesColor] = getSeriesColorsFromCount(data.length, selectedTheme);
+  const [seriesColor] = getSeriesColorsFromCount(1, selectedTheme);
 
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
@@ -170,6 +170,7 @@ export function BarChart({
         label={formattedLabel}
         value={formattedValue}
         annotation={annotation}
+        theme={theme}
       />
     );
   }

--- a/src/components/BarChart/components/TooltipContent/TooltipContent.scss
+++ b/src/components/BarChart/components/TooltipContent/TooltipContent.scss
@@ -6,7 +6,6 @@
   grid-template-columns: 1fr auto;
   grid-gap: $spacing-tight;
   background: $color-white;
-  border: 1px solid $color-sky-dark;
   border-radius: 4px;
-  padding: $spacing-tight;
+  padding: $spacing-loose;
 }

--- a/src/components/BarChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/BarChart/components/TooltipContent/TooltipContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {useTheme} from '../../../../hooks';
 import type {Annotation} from '../../types';
 
 import styles from './TooltipContent.scss';
@@ -8,23 +9,45 @@ export interface TooltipContentProps {
   label: string;
   value: string;
   annotation?: Annotation;
+  theme?: string;
 }
 
 export function TooltipContent({
   label,
   value,
   annotation,
+  theme,
 }: TooltipContentProps) {
+  const {tooltip} = useTheme(theme);
+
   return (
-    <div className={styles.Container}>
+    <div
+      className={styles.Container}
+      style={{
+        background: tooltip.backgroundColor,
+        color: tooltip.labelColor,
+      }}
+    >
       {annotation != null && annotation.tooltipData != null ? (
         <React.Fragment>
-          <strong>{annotation.tooltipData.label}</strong>
-          {annotation.tooltipData.value}
+          {annotation.tooltipData.label}
+          <strong
+            style={{
+              color: tooltip.valueColor,
+            }}
+          >
+            {annotation.tooltipData.value}
+          </strong>
         </React.Fragment>
       ) : null}
-      <strong>{label}</strong>
-      {value}
+      {label}
+      <strong
+        style={{
+          color: tooltip.valueColor,
+        }}
+      >
+        {value}
+      </strong>
     </div>
   );
 }

--- a/src/components/BarChart/components/TooltipContent/stories/BarChartTooltipContent.stories.tsx
+++ b/src/components/BarChart/components/TooltipContent/stories/BarChartTooltipContent.stories.tsx
@@ -33,7 +33,7 @@ export default {
 
 const Template: Story<TooltipContentProps> = (args: TooltipContentProps) => {
   return (
-    <div style={{width: 125}}>
+    <div style={{width: 165}}>
       <BarChartTooltipContent {...args} />
     </div>
   );

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -158,7 +158,7 @@ export function LineChart({
         },
       }),
     );
-    return <TooltipContent data={formattedData} />;
+    return <TooltipContent theme={theme} data={formattedData} />;
   }
 
   const seriesWithDefaults = series.map<SeriesWithDefaults>((series, index) => {

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.scss
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.scss
@@ -1,11 +1,11 @@
 @import '../../../../styles/common';
 
 .Name {
-  @include tooltip-emphasis;
   margin: 0;
 }
 
 .Value {
+  @include tooltip-emphasis;
   font-feature-settings: 'tnum';
   margin: 0;
   padding-left: $spacing-extra-tight;
@@ -20,7 +20,6 @@
   column-gap: $spacing-tight;
   row-gap: $spacing-tight;
   background: $color-white;
-  border: 1px solid $color-sky-dark;
   border-radius: 4px;
-  padding: $spacing-tight;
+  padding: $spacing-loose;
 }

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type {LineStyle, Color} from 'types';
 
+import {useTheme} from '../../../../hooks';
 import {LinePreview} from '../../../LinePreview';
 
 import styles from './TooltipContent.scss';
@@ -17,17 +18,32 @@ interface TooltipData {
 
 export interface TooltipContentProps {
   data: TooltipData[];
+  theme?: string;
 }
 
-export function TooltipContent({data}: TooltipContentProps) {
+export function TooltipContent({data, theme}: TooltipContentProps) {
+  const {tooltip} = useTheme(theme);
   return (
-    <div className={styles.Container}>
+    <div
+      className={styles.Container}
+      style={{
+        background: tooltip.backgroundColor,
+        color: tooltip.labelColor,
+      }}
+    >
       {data.map(({name, point: {label, value}, color, lineStyle}, index) => {
         return (
           <React.Fragment key={`${name}-${index}`}>
             <LinePreview color={color} lineStyle={lineStyle} />
             <p className={styles.Name}>{label}</p>
-            <p className={styles.Value}>{value}</p>
+            <p
+              style={{
+                color: tooltip.valueColor,
+              }}
+              className={styles.Value}
+            >
+              {value}
+            </p>
           </React.Fragment>
         );
       })}

--- a/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
+++ b/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
@@ -31,7 +31,7 @@ export default {
 
 const Template: Story<TooltipContentProps> = (args: TooltipContentProps) => {
   return (
-    <div style={{width: 180}}>
+    <div style={{width: 190}}>
       <LineChartTooltipContent {...args} />
     </div>
   );

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -151,7 +151,7 @@ export function MultiSeriesBarChart({
       value: yAxisOptionsWithDefaults.labelFormatter(value),
     }));
 
-    return <TooltipContent data={formattedData} />;
+    return <TooltipContent theme={theme} data={formattedData} />;
   }
 
   const seriesWithDefaults = series.map((series, index) => ({

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {sum} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 
+import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
 import {useTheme} from '../../hooks';
 import {classNames} from '../../utilities';
 
@@ -23,6 +24,7 @@ export function NormalizedStackedBarChart({
   theme,
 }: NormalizedStackedBarChartProps) {
   const selectedTheme = useTheme(theme);
+  const colors = getSeriesColorsFromCount(data.length, selectedTheme);
   const containsNegatives = data.some(({value}) => value < 0);
   const isDevelopment = process.env.NODE_ENV === 'development';
 
@@ -45,7 +47,6 @@ export function NormalizedStackedBarChart({
   const xScale = scaleLinear().range([0, 100]).domain([0, totalValue]);
 
   const isVertical = orientation === 'vertical';
-  const {colors} = selectedTheme.colorPalette;
 
   return (
     <div

--- a/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
+++ b/src/components/NormalizedStackedBarChart/tests/NormalizedStackedBarChart.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {NormalizedStackedBarChart} from 'components';
 
+import {mountWithProvider} from '../../../test-utilities';
 import {BarSegment, BarLabel} from '../components';
 
 describe('<NormalizedBarChart />', () => {
@@ -141,12 +142,20 @@ describe('<NormalizedBarChart />', () => {
 
   describe('Colors', () => {
     it('inherits colors from the theme', () => {
-      const barChart = mount(<NormalizedStackedBarChart {...mockProps} />);
+      const barChart = mountWithProvider(
+        <NormalizedStackedBarChart {...mockProps} />,
+        {
+          themes: {
+            Default: {
+              seriesColors: {
+                upToFour: ['#00A', '#00B', '#00C', '#00D'],
+              },
+            },
+          },
+        },
+      );
 
-      expect(barChart.find(BarSegment)!.props.color).toStrictEqual([
-        {color: '#936DFF', offset: 0},
-        {color: '#7C44F8', offset: 100},
-      ]);
+      expect(barChart.find(BarSegment)!.props.color).toStrictEqual('#00A');
     });
   });
 

--- a/src/components/PolarisVizProvider/stories/PolarisVizProvider.stories.tsx
+++ b/src/components/PolarisVizProvider/stories/PolarisVizProvider.stories.tsx
@@ -87,6 +87,11 @@ export const OverwrittenDefault = Template.bind({});
 OverwrittenDefault.args = {
   themes: {
     Default: {
+      tooltip: {
+        backgroundColor: '#F6F6F7',
+        labelColor: 'black',
+        valueColor: 'black',
+      },
       chartContainer: {
         padding: '10px',
         borderRadius: '5px',
@@ -142,11 +147,13 @@ MultipleThemes.args = {
         padding: '20px',
         borderRadius: '5px',
       },
+      seriesColors: {
+        upToFour: ['#00ff64'],
+      },
       bar: {
         hasRoundedCorners: false,
         innerMargin: 'Large',
         outerMargin: 'Large',
-        color: '#00ff64',
       },
       grid: {
         showVerticalLines: true,
@@ -164,6 +171,9 @@ MultipleThemes.args = {
       },
     },
     AngryRed: {
+      seriesColors: {
+        upToFour: ['#ff0025'],
+      },
       chartContainer: {
         padding: '20px',
         borderRadius: '5px',
@@ -172,7 +182,6 @@ MultipleThemes.args = {
         hasRoundedCorners: false,
         innerMargin: 'Large',
         outerMargin: 'Large',
-        color: '#ff0025',
       },
       grid: {
         showVerticalLines: true,

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -128,7 +128,7 @@ export function StackedAreaChart({
       value: formatYAxisLabel(value),
     }));
 
-    return <TooltipContent title={title} data={formattedData} />;
+    return <TooltipContent theme={theme} title={title} data={formattedData} />;
   }
 
   return (

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -4,11 +4,7 @@ import {Story, Meta} from '@storybook/react';
 import {StackedAreaChart, StackedAreaChartProps} from '../StackedAreaChart';
 
 import {data, labels, formatYAxisLabel} from './utils.stories';
-import {
-  colorPurpleDark,
-  colorTeal,
-  VIZ_GRADIENT_COLOR,
-} from '../../../constants';
+import {colorPurpleDark, colorTeal} from '../../../constants';
 
 const tooltipContent = {
   empty: undefined,
@@ -120,7 +116,16 @@ Gradients.args = {
             label: Math.random().toString(),
           };
         }),
-      color: VIZ_GRADIENT_COLOR.negative.down,
+      color: [
+        {
+          offset: 0,
+          color: 'red',
+        },
+        {
+          offset: 100,
+          color: 'blue',
+        },
+      ],
     },
     {
       name: 'Two',

--- a/src/components/TooltipContent/TooltipContent.scss
+++ b/src/components/TooltipContent/TooltipContent.scss
@@ -8,13 +8,11 @@
   column-gap: $spacing-tight;
   row-gap: $spacing-tight;
   background: $color-white;
-  border: 1px solid $color-sky-dark;
   border-radius: 4px;
-  padding: $spacing-tight;
+  padding: $spacing-loose;
 }
 
 .Title {
-  @include tooltip-emphasis;
   text-align: center;
   grid-column: 1 / span 3;
   margin-bottom: $spacing-extra-tight;
@@ -22,10 +20,10 @@
 
 .Label {
   margin: 0;
-  @include tooltip-emphasis;
 }
 
 .Value {
+  @include tooltip-emphasis;
   font-feature-settings: 'tnum';
   margin: 0;
   padding-left: $spacing-extra-tight;

--- a/src/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/TooltipContent/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type {Color} from 'types';
 
+import {useTheme} from '../../hooks';
 import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './TooltipContent.scss';
@@ -18,17 +19,38 @@ export interface TooltipContentProps {
     label: string;
     value: string;
   };
+  theme?: string;
 }
 
-export function TooltipContent({title, data, total}: TooltipContentProps) {
+export function TooltipContent({
+  title,
+  data,
+  total,
+  theme,
+}: TooltipContentProps) {
+  const {tooltip} = useTheme(theme);
+
   return (
-    <div className={styles.Container}>
+    <div
+      className={styles.Container}
+      style={{
+        background: tooltip.backgroundColor,
+        color: tooltip.labelColor,
+      }}
+    >
       {title == null ? null : <div className={styles.Title}>{title}</div>}
       {data.map(({color, label, value}, index) => (
         <React.Fragment key={`${label}-${index}`}>
           <SquareColorPreview color={color} />
           <p className={styles.Label}>{label}</p>
-          <p className={styles.Value}>{value}</p>
+          <p
+            className={styles.Value}
+            style={{
+              color: tooltip.valueColor,
+            }}
+          >
+            {value}
+          </p>
         </React.Fragment>
       ))}
       {total == null ? null : (

--- a/src/components/TooltipContent/stories/TooltipContent.stories.tsx
+++ b/src/components/TooltipContent/stories/TooltipContent.stories.tsx
@@ -32,7 +32,7 @@ export default {
 
 const Template: Story<TooltipContentProps> = (args: TooltipContentProps) => {
   return (
-    <div style={{width: 150}}>
+    <div style={{width: 170}}>
       <GeneralTooltip {...args} />
     </div>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,17 +54,6 @@ export const MAX_TRAIL_DURATION = 500;
 export const MASK_HIGHLIGHT_COLOR = variables.colorWhite;
 export const MASK_SUBDUE_COLOR = '#434343';
 
-const POSITIVE_COLOR = `rgba(46, 237, 145, 0.8)`;
-const PRIMARY_NEUTRAL_COLOR = `rgba(152, 107, 255, 0.8)`;
-const SECONDARY_NEUTRAL_COLOR = `rgba(58, 164, 246, 0.8)`;
-const NEGATIVE_COLOR = `rgba(236, 110, 110, 0.8)`;
-const COMPARISON_COLOR = `rgba(144, 176, 223, 0.6)`;
-
-export const PRIMARY_COLOR = 'rgb(0,161,159)';
-export const SECONDARY_COLOR = 'rgb(41,35,112)';
-export const TERTIARY_COLOR = 'rgb(13,140,237)';
-export const QUARTERNARY_COLOR = 'rgb(157,53,193)';
-
 export const colorSky = variables.colorSky;
 export const colorWhite = variables.colorWhite;
 export const colorPurpleDark = variables.colorPurpleDark;
@@ -74,75 +63,56 @@ export const colorSkyDark = variables.colorSkyDark;
 export const positiveColor = variables.positiveColor;
 export const negativeColor = variables.negativeColor;
 
-const VIZ_COMPARISON_GRADIENT = [
-  {offset: 0, color: COMPARISON_COLOR},
-  {offset: 100, color: COMPARISON_COLOR},
-];
-
-export const VIZ_GRADIENT_COLOR = {
-  positive: {
-    comparison: VIZ_COMPARISON_GRADIENT,
-    up: [
-      {offset: 0, color: PRIMARY_NEUTRAL_COLOR},
-      {offset: 60, color: SECONDARY_NEUTRAL_COLOR},
-      {offset: 100, color: POSITIVE_COLOR},
-    ],
-  },
-  negative: {
-    comparison: VIZ_COMPARISON_GRADIENT,
-    up: [
-      {offset: 0, color: SECONDARY_NEUTRAL_COLOR},
-      {offset: 60, color: PRIMARY_NEUTRAL_COLOR},
-      {offset: 100, color: NEGATIVE_COLOR},
-    ],
-    down: [
-      {offset: 0, color: NEGATIVE_COLOR},
-      {offset: 60, color: PRIMARY_NEUTRAL_COLOR},
-      {offset: 100, color: SECONDARY_NEUTRAL_COLOR},
-    ],
-  },
-  neutral: {
-    up: [
-      {offset: 0, color: PRIMARY_NEUTRAL_COLOR},
-      {offset: 100, color: SECONDARY_NEUTRAL_COLOR},
-    ],
-    comparison: VIZ_COMPARISON_GRADIENT,
-  },
+const createGradient = (color1: string, color2: string) => {
+  return [
+    {offset: 0, color: color2},
+    {offset: 100, color: color1},
+  ];
 };
 
 export const DEFAULT_THEME: Theme = {
   seriesColors: {
-    upToFour: ['#9479F7', '#578FE1', '#CF68C1', '#5B97AD'],
+    upToFour: [
+      createGradient(variables.colorIndigo70, variables.colorIndigo90),
+      createGradient(variables.colorBlue70, variables.colorBlue90),
+      createGradient(variables.colorMagenta70, variables.colorMagenta90),
+      createGradient(variables.colorTeal70, variables.colorTeal90),
+    ],
     fromFiveToSeven: [
-      '#5B97AD',
-      '#578FE1',
-      '#9479F7',
-      '#C29FED',
-      '#CF68C1',
-      '#D7905B',
-      '#F4CE74',
+      createGradient(variables.colorTeal70, variables.colorTeal90),
+      createGradient(variables.colorBlue70, variables.colorBlue90),
+      createGradient(variables.colorIndigo70, variables.colorIndigo90),
+      createGradient(variables.colorPurple50, variables.colorPurple70),
+      createGradient(variables.colorMagenta70, variables.colorMagenta90),
+      createGradient(variables.colorOrange60, variables.colorOrange80),
+      createGradient(variables.colorYellow20, variables.colorYellow40),
     ],
     all: [
-      '#41778B',
-      '#8DAEEF',
-      '#7847F4',
-      '#AA77DE',
-      '#A74E9B',
-      '#E4A175',
-      '#BE9D44',
-      '#87C9E3',
-      '#4D7FC9',
-      '#C3B6FB',
-      '#9643D7',
-      '#CF68C1',
-      '#AD7349',
-      '#F4CE74',
+      variables.colorTeal90,
+      variables.colorBlue50,
+      variables.colorIndigo90,
+      variables.colorPurple70,
+      variables.colorMagenta90,
+      variables.colorOrange50,
+      variables.colorYellow70,
+      variables.colorTeal40,
+      variables.colorBlue80,
+      variables.colorIndigo40,
+      variables.colorPurple90,
+      variables.colorMagenta70,
+      variables.colorOrange80,
+      variables.colorYellow20,
     ],
+  },
+  tooltip: {
+    backgroundColor: variables.colorGray03,
+    valueColor: variables.colorGray15,
+    labelColor: variables.colorGray13,
   },
   chartContainer: {
     borderRadius: '0px',
     padding: '0px',
-    backgroundColor: '#1f1f25',
+    backgroundColor: variables.colorGray01,
   },
   line: {
     sparkArea: null,
@@ -150,8 +120,8 @@ export const DEFAULT_THEME: Theme = {
     style: 'solid',
     hasPoint: true,
     width: 2,
-    pointStroke: 'white',
-    dottedStrokeColor: 'rgba(144, 176, 223, 60)',
+    pointStroke: variables.colorGray15,
+    dottedStrokeColor: variables.colorDarkComparison,
   },
   bar: {
     hasRoundedCorners: true,
@@ -162,42 +132,22 @@ export const DEFAULT_THEME: Theme = {
   grid: {
     showVerticalLines: false,
     showHorizontalLines: true,
-    color: '#43434E',
+    color: variables.colorGray05,
     horizontalOverflow: false,
     horizontalMargin: 0,
   },
   xAxis: {
     showTicks: false,
-    labelColor: '#DCDCDC',
+    labelColor: variables.colorGray13,
     hide: false,
   },
   yAxis: {
-    backgroundColor: '#1f1f25',
-    labelColor: '#DCDCDC',
+    backgroundColor: variables.colorGray01,
+    labelColor: variables.colorGray13,
   },
   crossHair: {
     color: 'rgb(139, 159, 176)',
     width: 1,
-  },
-  colorPalette: {
-    colors: [
-      [
-        {offset: 0, color: '#936DFF'},
-        {offset: 100, color: '#7C44F8'},
-      ],
-      [
-        {offset: 0, color: '#6285FF'},
-        {offset: 100, color: '#3B66FF'},
-      ],
-      [
-        {offset: 0, color: '#34A9BF'},
-        {offset: 100, color: '#0194AF'},
-      ],
-      [
-        {offset: 0, color: '#E564D3'},
-        {offset: 100, color: '#DC42C3'},
-      ],
-    ],
   },
   legend: {
     labelColor: '#DADADD',

--- a/src/styles/shared/_variables.scss
+++ b/src/styles/shared/_variables.scss
@@ -20,6 +20,48 @@ $color-teal: rgb(71, 193, 191);
 $positive-color: rgb(0, 128, 96);
 $negative-color: rgb(215, 44, 13);
 
+// Colors are named non-sequencial numbers
+// so it matches the UX Color Matrix
+// stylelint-disable color-no-hex
+$color-dark-comparison: #90b0df;
+
+$color-gray-01: #1f1f25;
+$color-gray-03: #2e2e36;
+$color-gray-05: #43434e;
+$color-gray-06: #4b4b57;
+$color-gray-13: #dadadd;
+$color-gray-15: #ffffff;
+
+$color-indigo-40: #c5b7fe;
+$color-indigo-70: #997afc;
+$color-indigo-90: #7f4afa;
+
+$color-blue-50: #88b1f2;
+$color-blue-70: #4b92e5;
+$color-blue-80: #4282cd;
+$color-blue-90: #3672bb;
+
+$color-teal-40: #79cce5;
+$color-teal-70: #4c9aaf;
+$color-teal-90: #33798c;
+
+$color-magenta-70: #da62c4;
+$color-magenta-90: #b1489e;
+
+$color-purple-50: #c89ef1;
+$color-purple-70: #b176e2;
+$color-purple-90: #9f41dc;
+
+$color-orange-50: #ec9d71;
+$color-orange-60: #df8b55;
+$color-orange-80: #b66e3f;
+
+$color-yellow-20: #fae275;
+$color-yellow-40: #d1c256;
+$color-yellow-70: #97933e;
+
+// -----
+
 $spacing-extra-tight: 4px;
 $spacing-tight: 8px;
 $spacing-base-tight: 12px;
@@ -60,4 +102,42 @@ $font-stack-base: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI'
   colorTeal: $color-teal;
   positiveColor: $positive-color;
   negativeColor: $negative-color;
+
+  // NEW COLORS
+  colorDarkComparison: $color-dark-comparison;
+
+  colorGray01: $color-gray-01;
+  colorGray03: $color-gray-03;
+  colorGray05: $color-gray-05;
+  colorGray06: $color-gray-06;
+  colorGray13: $color-gray-13;
+  colorGray15: $color-gray-15;
+
+  colorIndigo40: $color-indigo-40;
+  colorIndigo70: $color-indigo-70;
+  colorIndigo90: $color-indigo-90;
+
+  colorBlue50: $color-blue-50;
+  colorBlue70: $color-blue-70;
+  colorBlue80: $color-blue-80;
+  colorBlue90: $color-blue-90;
+
+  colorTeal40: $color-teal-40;
+  colorTeal70: $color-teal-70;
+  colorTeal90: $color-teal-90;
+
+  colorMagenta70: $color-magenta-70;
+  colorMagenta90: $color-magenta-90;
+
+  colorPurple50: $color-purple-50;
+  colorPurple70: $color-purple-70;
+  colorPurple90: $color-purple-90;
+
+  colorOrange50: $color-orange-50;
+  colorOrange60: $color-orange-60;
+  colorOrange80: $color-orange-80;
+
+  colorYellow20: $color-yellow-20;
+  colorYellow40: $color-yellow-40;
+  colorYellow70: $color-yellow-70;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,16 +126,17 @@ export interface LineTheme {
   pointStroke: string;
   dottedStrokeColor: string;
 }
+
+export interface TooltipTheme {
+  backgroundColor: string;
+  valueColor: string;
+  labelColor: string;
+}
 export interface SeriesColors {
   upToFour: Color[];
   fromFiveToSeven: Color[];
   all: Color[];
 }
-
-export interface ColorPalette {
-  colors: Color[];
-}
-
 export interface Legend {
   labelColor: string;
   valueColor: string;
@@ -150,9 +151,9 @@ export interface PartialTheme {
   xAxis?: Partial<XAxisTheme>;
   yAxis?: Partial<YAxisTheme>;
   crossHair?: Partial<CrossHairTheme>;
-  colorPalette?: Partial<ColorPalette>;
   legend?: Partial<Legend>;
   seriesColors?: Partial<SeriesColors>;
+  tooltip?: Partial<TooltipTheme>;
 }
 
 export interface Theme {
@@ -164,6 +165,6 @@ export interface Theme {
   line: LineTheme;
   crossHair: CrossHairTheme;
   legend: Legend;
-  colorPalette: ColorPalette;
   seriesColors: SeriesColors;
+  tooltip: TooltipTheme;
 }


### PR DESCRIPTION
### What problem is this PR solving?
- Updates the colors of the `Default` theme to match the latest pallete defined
- Allow	tooltips to be customized thorugh themes, so we have light tooltips for light themes and dark tooltips for dark themes

Relates to:  https://github.com/Shopify/polaris-viz/issues/465

<img width="949" alt="Screen Shot 2021-08-27 at 3 23 58 PM" src="https://user-images.githubusercontent.com/4037781/131178682-02e3c193-d317-4275-a341-68c0deab18be.png">

<img width="702" alt="Screen Shot 2021-08-27 at 3 14 44 PM" src="https://user-images.githubusercontent.com/4037781/131178630-a22d25c5-600f-4350-a60c-2dbc32f83845.png">




### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
