### PR TITLE
Add ability to override sparkbar colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed
 - `<BarChart />`, `<LineChart />`, `<Sparkline />`, `<NormalizedStackedBarChart />`, `<MultiSeriesBarChart />` and `<Sparkbar />` styles now are defined through themes in `PolarisVizProvider` instead of props. For more details check the [migration guide](https://docs.google.com/document/d/1VxfcgBbTNwjmYix1jGuDMgqDgIdehTgQbVZpER7djeU/edit?usp=sharing)
 - change indicators on the  `<NormalizedStackedBarChart />` can now have their colors configured externally, which applies the color to the metric and percentage change
+- `SparkChartData` now accepts `value` and `color` properties, instead of `number | null`, to allow individual bars to override the `seriesColors`.
 
 ### Fixed
 - `<NormalizedStackedBarChart />` no longer overflows its container by a few pixels

--- a/documentation/code/SparkbarDemo.tsx
+++ b/documentation/code/SparkbarDemo.tsx
@@ -16,7 +16,19 @@ export function SparkbarDemo() {
         <div style={{width: 200, height: 150}}>
           <Sparkbar
             isAnimated
-            data={[100, 200, 300, 400, 400, 1000, 200, 800, 900, 200, 400]}
+            data={[
+              {value: 100},
+              {value: 200},
+              {value: 300},
+              {value: 400},
+              {value: 400},
+              {value: 1000},
+              {value: 200},
+              {value: 800},
+              {value: 900},
+              {value: 200},
+              {value: 400},
+            ]}
             comparison={[
               {x: 0, y: 500},
               {x: 1, y: 500},

--- a/src/components/Sparkbar/components/Bar/Bar.tsx
+++ b/src/components/Sparkbar/components/Bar/Bar.tsx
@@ -2,19 +2,18 @@ import React, {useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import {animated, SpringValue} from '@react-spring/web';
 
-import type {SparkChartData} from '../../../../types';
-
 interface Props {
   x: number;
   yScale: ScaleLinear<number, number>;
-  rawValue: SparkChartData;
+  value: number | null;
   width: number;
   height?: SpringValue<number> | number;
+  fill: string;
 }
 
-export function Bar({x, rawValue, yScale, width, height}: Props) {
+export function Bar({x, value, yScale, width, height, fill}: Props) {
   const zeroScale = yScale(0);
-  const isNegative = rawValue != null && rawValue < 0;
+  const isNegative = value != null && value < 0;
   const rotation = isNegative ? 'rotate(180deg)' : 'rotate(0deg)';
   const xPosition = isNegative ? x + width : x;
 
@@ -84,9 +83,9 @@ export function Bar({x, rawValue, yScale, width, height}: Props) {
     return height.to(calculatePath);
   }, [height, width]);
 
-  if (rawValue == null || width < 0) {
+  if (value == null || width < 0) {
     return null;
   }
 
-  return <animated.path d={path} style={style} />;
+  return <animated.path d={path} style={style} fill={fill} />;
 }

--- a/src/components/Sparkbar/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Sparkbar/components/Bar/tests/Bar.test.tsx
@@ -15,9 +15,10 @@ describe('<Bar/>', () => {
         <Bar
           height={100}
           x={0}
-          rawValue={1000}
+          value={1000}
           width={100}
           yScale={scaleBand() as any}
+          fill="red"
         />
       </svg>,
     );
@@ -35,9 +36,10 @@ describe('<Bar/>', () => {
         <Bar
           height={49}
           x={0}
-          rawValue={1}
+          value={1}
           width={100}
           yScale={scaleBand() as any}
+          fill="red"
         />
       </svg>,
     );
@@ -55,9 +57,10 @@ describe('<Bar/>', () => {
         <Bar
           height={0}
           x={0}
-          rawValue={0}
+          value={0}
           width={100}
           yScale={scaleBand() as any}
+          fill="red"
         />
       </svg>,
     );

--- a/src/components/Sparkbar/components/tests/Bar.test.tsx
+++ b/src/components/Sparkbar/components/tests/Bar.test.tsx
@@ -5,14 +5,15 @@ import {scaleLinear} from 'd3-scale';
 import {Bar} from '../Bar';
 
 describe('<Bar/>', () => {
-  it('renders null if the rawValue is null', () => {
+  it('renders null if the value is null', () => {
     const wrapper = mount(
       <Bar
-        rawValue={null}
+        value={null}
         x={0}
         yScale={scaleLinear()}
         width={10}
         height={0}
+        fill="red"
       />,
     );
 

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Story, Meta} from '@storybook/react';
 
 import {Sparkbar, SparkbarProps} from '../Sparkbar';
+import {DEFAULT_THEME, VIZ_GRADIENT_COLOR} from '../../../constants';
 
 export default {
   title: 'Charts/Sparkbar',
@@ -58,7 +59,19 @@ const Template: Story<SparkbarProps> = (args: SparkbarProps) => {
 const comparisonValue = 2000;
 const defaultProps = {
   isAnimated: true,
-  data: [100, 200, 300, 400, 400, 1000, 200, 800, 900, 200, 400],
+  data: [
+    {value: 100},
+    {value: 200},
+    {value: 300},
+    {value: 400},
+    {value: 400},
+    {value: 100},
+    {value: 200},
+    {value: 800},
+    {value: 900},
+    {value: 200},
+    {value: 400},
+  ],
   comparison: [
     {x: 0, y: comparisonValue},
     {x: 1, y: comparisonValue},
@@ -87,5 +100,37 @@ OffsetAndNulls.args = {
   ...defaultProps,
   dataOffsetLeft: 10,
   dataOffsetRight: 20,
-  data: [100, 200, -300, null, 400, 0, 0, 400, 700, 900, 500],
+  data: [
+    {value: 100},
+    {value: 200},
+    {value: -300},
+    {value: null},
+    {value: 400},
+    {value: 0},
+    {value: 0},
+    {value: 400},
+    {value: 700},
+    {value: 900},
+    {value: 500},
+  ],
+};
+
+export const OverriddenColors = Template.bind({});
+OverriddenColors.args = {
+  ...defaultProps,
+  dataOffsetLeft: 10,
+  dataOffsetRight: 20,
+  data: [
+    {value: 100},
+    {value: 200, color: 'red'},
+    {value: 300},
+    {value: 400},
+    {value: 400, color: DEFAULT_THEME.seriesColors.upToFour[0]},
+    {value: 100},
+    {value: 200},
+    {value: 800, color: '#99ccbb'},
+    {value: 900},
+    {value: 200},
+    {value: 400},
+  ],
 };

--- a/src/components/Sparkbar/tests/Sparkbar.test.tsx
+++ b/src/components/Sparkbar/tests/Sparkbar.test.tsx
@@ -5,7 +5,7 @@ import {scaleBand} from 'd3-scale';
 import {Sparkbar} from '../Sparkbar';
 import {LinearGradient} from '../../LinearGradient';
 
-const sampleData = [100, 200, 300, 500];
+const sampleData = [{value: 100}, {value: 200}, {value: 300}, {value: 500}];
 const sampleComparison = [
   {x: 0, y: 300},
   {x: 1, y: 300},
@@ -36,12 +36,6 @@ describe('<Sparkbar/>', () => {
     const wrapper = mount(<Sparkbar data={sampleData} />);
 
     expect(wrapper).toContainReactComponent(LinearGradient);
-  });
-
-  it('renders a mask', () => {
-    const wrapper = mount(<Sparkbar data={sampleData} />);
-
-    expect(wrapper).toContainReactComponent('mask');
   });
 
   it('renders an accessibility label', () => {

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useLayoutEffect, useCallback} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
-import type {Color, LineStyle, SparkChartData} from 'types';
+import type {Color, LineStyle} from 'types';
 
 import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
 import {useResizeObserver, useTheme} from '../../hooks';
@@ -14,7 +14,7 @@ const SVG_MARGIN = 2;
 
 export interface Coordinates {
   x: number;
-  y: SparkChartData;
+  y: number | null;
 }
 
 export interface SingleSeries {

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -128,7 +128,11 @@ export function Series({
       </defs>
 
       <path
-        stroke={`url(#line-${id})`}
+        stroke={
+          series.lineStyle && series.lineStyle !== 'solid'
+            ? theme.line.dottedStrokeColor
+            : `url(#line-${id})`
+        }
         d={lineShape}
         fill="none"
         strokeLinejoin="round"

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,10 @@ export interface Dimensions {
   height: number;
 }
 
-export type SparkChartData = number | null;
+export interface SparkChartData {
+  value: number | null;
+  color?: Color;
+}
 
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;
 export type NumberInterpolator = InterpolatorFn<readonly number[], number>;


### PR DESCRIPTION
### What problem is this PR solving?

When we implemented theming, we introduced a concept of `seriesColors` that would be used by default if a user didn't provide an override on the `series` data itself. This removed the `barFillStyle` prop that was previously used.

@blboyle also asked if we could allow users to override individual bar colors.

@krystalcampioni @carysmills Are we ok with changing the data format and updating the migration document, or should I try and take an approach that doesn't change the data structure?

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
