### PR TITLE
Add Light theme

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,7 +9,10 @@ module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(ts|tsx)'],
   addons: [
     '@storybook/addon-links',
-    {name: '@storybook/addon-essentials', options: {docs: true}},
+    {
+      name: '@storybook/addon-essentials',
+      options: {docs: true, backgrounds: false},
+    },
   ],
   typescript: {
     // also valid 'react-docgen-typescript' | false

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,19 +1,8 @@
 import React from 'react';
 import {PolarisVizProvider} from '../src/components';
+import {DEFAULT_THEME, LIGHT_THEME} from '../src/constants';
+import {useTheme} from '../src/hooks';
 export const parameters = {
-  backgrounds: {
-    default: 'dark',
-    values: [
-      {
-        name: 'light',
-        value: '#FFF',
-      },
-      {
-        name: 'dark',
-        value: '#1f1f25',
-      },
-    ],
-  },
   options: {
     storySort: {
       order: ['Providers', 'Charts', 'Subcomponents'],
@@ -22,18 +11,16 @@ export const parameters = {
 };
 
 export const decorators = [
-  (Story) => (
-    <div
-      style={{
-        padding: '20px',
-        boxSizing: 'border-box',
-        height: '400px',
-        overflow: 'hidden',
-      }}
-    >
+  (Story, context) => {
+    return (
       <PolarisVizProvider
         themes={{
           Default: {
+            chartContainer: {
+              padding: '20px',
+            },
+          },
+          Light: {
             chartContainer: {
               padding: '20px',
             },
@@ -52,8 +39,41 @@ export const decorators = [
           },
         }}
       >
-        <Story />
+        <Container theme={context.args.theme}>
+          <Story />
+        </Container>
       </PolarisVizProvider>
-    </div>
-  ),
+    );
+  },
 ];
+
+interface ContainerProps {
+  theme: string;
+}
+
+const Container = ({children, theme}: ContainerProps) => {
+  const selectedTheme = useTheme(theme);
+
+  return (
+    <div
+      style={{
+        padding: 'calc(1rem + 20px)',
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+        margin: '-1rem',
+        background: selectedTheme.chartContainer.backgroundColor,
+        minHeight: '100vh',
+      }}
+    >
+      <div
+        style={{
+          boxSizing: 'border-box',
+          height: '400px',
+          overflow: 'hidden',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/documentation/code/BarChartDemo.tsx
+++ b/documentation/code/BarChartDemo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {BarChart, BarChartTooltipContent} from '../../src/components';
 
-export function BarChartDemo({theme = 'Default'}) {
+export function BarChartDemo() {
   document.body.style.fontFamily =
     "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif";
 
@@ -64,7 +64,6 @@ export function BarChartDemo({theme = 'Default'}) {
 
   return (
     <BarChart
-      theme={theme}
       data={data}
       xAxisOptions={{
         labelFormatter: formatXAxisLabel,

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -45,7 +45,6 @@ const props = {
   isAnimated: true,
   renderTooltipContent: {renderTooltipContent},
   skipLinkText: 'Skip chart content',
-  theme: 'Default'
 };
 
 return <BarChart {...props} />;

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -45,7 +45,7 @@ export function BarChart({
     integersOnly: false,
     labelFormatter: (value: number) => value.toString(),
   },
-  theme = 'Default',
+  theme,
 }: BarChartProps) {
   const selectedTheme = useTheme(theme);
   const [seriesColor] = getSeriesColorsFromCount(1, selectedTheme);

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -4,6 +4,7 @@ import {Story, Meta} from '@storybook/react';
 import {BarChart, BarChartProps, PolarisVizProvider} from '../../../components';
 
 import {formatXAxisLabel, defaultProps} from './utils.stories';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 const tooltipContent = {
   empty: undefined,
@@ -95,6 +96,7 @@ export default {
     yAxisOptions: {
       description: 'An object used to configure the yAxis and its labels.',
     },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 

--- a/src/components/BarChart/stories/utils.stories.tsx
+++ b/src/components/BarChart/stories/utils.stories.tsx
@@ -18,25 +18,6 @@ export function formatXAxisLabel(value: string) {
   });
 }
 
-const purple = '#5052b3';
-const negativePurple = '#39337f';
-const green = '#1bbe9e';
-
-const barGradient = [
-  {
-    color: negativePurple,
-    offset: 0,
-  },
-  {
-    color: purple,
-    offset: 50,
-  },
-  {
-    color: green,
-    offset: 100,
-  },
-];
-
 export const defaultProps = {
   data: [
     {rawValue: 324.19, label: '2020-01-01T12:00:00Z'},

--- a/src/components/Legend/stories/Legend.stories.tsx
+++ b/src/components/Legend/stories/Legend.stories.tsx
@@ -35,7 +35,6 @@ const Template: Story<LegendProps> = (args: LegendProps) => {
 
 export const SquareLegend = Template.bind({});
 SquareLegend.args = {
-  theme: 'Default',
   series: [
     {name: 'Sales', color: 'red'},
     {name: 'Visits', color: 'purple'},
@@ -44,7 +43,6 @@ SquareLegend.args = {
 
 export const GradientSquareLegend = Template.bind({});
 GradientSquareLegend.args = {
-  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -65,7 +63,6 @@ GradientSquareLegend.args = {
 
 export const GradientLineLegend = Template.bind({});
 GradientLineLegend.args = {
-  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -88,7 +85,6 @@ GradientLineLegend.args = {
 
 export const DottedLineLegend = Template.bind({});
 DottedLineLegend.args = {
-  theme: 'Default',
   series: [
     {lineStyle: 'dotted', name: 'Sales', color: 'red'},
     {lineStyle: 'dotted', name: 'Visits', color: 'purple'},
@@ -97,7 +93,6 @@ DottedLineLegend.args = {
 
 export const DashedLineLegend = Template.bind({});
 DashedLineLegend.args = {
-  theme: 'Default',
   series: [
     {lineStyle: 'dashed', name: 'Sales', color: 'red'},
     {lineStyle: 'dashed', name: 'Visits', color: 'purple'},
@@ -106,7 +101,6 @@ DashedLineLegend.args = {
 
 export const LineLegend = Template.bind({});
 LineLegend.args = {
-  theme: 'Default',
   series: [
     {lineStyle: 'solid', name: 'Sales', color: 'red'},
     {lineStyle: 'solid', name: 'Visits', color: 'purple'},

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -13,6 +13,7 @@ import {
   seriesUsingSeriesColors,
 } from './utils.stories';
 import {colorTeal} from '../../../constants';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 const tooltipContent = {
   empty: undefined,
@@ -51,9 +52,6 @@ export default {
     },
   },
   argTypes: {
-    theme: {
-      description: 'The theme that the chart will inherit its styles from',
-    },
     series: {
       description:
         'The `Series` type gives the user the flexibility to define exactly what each series/line should look like, as well as providing the data to be plotted.',
@@ -91,6 +89,7 @@ export default {
       description:
         'An object of optional proprties that define the appearance of the yAxis.',
     },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 
@@ -101,7 +100,7 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
 export const InsightsStyle = Template.bind({});
 InsightsStyle.args = {
   series,
-  theme: 'Default',
+
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
@@ -116,7 +115,7 @@ InsightsStyle.args = {
 export const SeriesColors = Template.bind({});
 SeriesColors.args = {
   series: seriesUsingSeriesColors,
-  theme: 'Default',
+
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
@@ -154,7 +153,6 @@ NoOverflowStyle.args = {
 
 export const IntegersOnly = Template.bind({});
 IntegersOnly.args = {
-  theme: 'Default',
   series: [
     {
       name: 'Integers Only',
@@ -179,7 +177,6 @@ IntegersOnly.args = {
 
 export const NoArea = Template.bind({});
 NoArea.args = {
-  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -205,7 +202,6 @@ NoArea.args = {
 
 export const SolidColor = Template.bind({});
 SolidColor.args = {
-  theme: 'Default',
   series: [
     {
       name: 'Sales',
@@ -231,7 +227,6 @@ SolidColor.args = {
 export const LargeDataSet = Template.bind({});
 
 LargeDataSet.args = {
-  theme: 'Default',
   series: [
     {
       name: 'series 1',

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -9,6 +9,7 @@ import {
 import styles from './MultiSeriesBarChart.stories.scss';
 import {SquareColorPreview} from '../../SquareColorPreview';
 import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 const tooltipContent = {
   empty: undefined,
@@ -149,6 +150,7 @@ export default {
       description:
         'This accepts a function that is called to render the tooltip content. By default it calls `formatYAxisLabel` to format the the tooltip value and passes it to `<TooltipContent />`. [RenderTooltipContentData type definition.]()',
     },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 

--- a/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
+++ b/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
@@ -5,6 +5,7 @@ import {
   NormalizedStackedBarChart,
   NormalizedStackedBarChartProps,
 } from '../NormalizedStackedBarChart';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 export default {
   title: 'Charts/NormalizedStackedBarChart',
@@ -25,10 +26,7 @@ export default {
     },
     orientation: {description: 'Determines the orientation of the chart.'},
     size: {description: 'Determines the width of the chart.'},
-    theme: {
-      description:
-        'The theme prop determines the colors of the bars, the background of the chart and the appearance of the legend.',
-    },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 
@@ -78,7 +76,6 @@ const defaultProps = {
   ],
   orientation: 'horizontal',
   size: 'small',
-  theme: 'Default',
 };
 
 export const Default = Template.bind({});

--- a/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo} from 'react';
 
 import type {PartialTheme} from '../../types';
-import {DEFAULT_THEME as Default} from '../../constants';
+import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../../constants';
 import {PolarisVizContext} from '../../utilities/polaris-viz-context';
 import {createThemes} from '../../utilities';
 
@@ -18,6 +18,7 @@ export function PolarisVizProvider({
     return {
       themes: createThemes({
         Default,
+        Light,
         ...themes,
       }),
     };

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import {Story, Meta} from '@storybook/react';
 
 import {Sparkbar, SparkbarProps} from '../Sparkbar';
-import {DEFAULT_THEME, VIZ_GRADIENT_COLOR} from '../../../constants';
+import {DEFAULT_THEME} from '../../../constants';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 export default {
   title: 'Charts/Sparkbar',
@@ -22,10 +23,6 @@ export default {
     ),
   ],
   argTypes: {
-    theme: {
-      description:
-        'The theme that the chart will inherit its color and container styles from',
-    },
     data: {
       description:
         "The prop to determine the chart's bars. Null bars will not be plotted. Bars with the value of `0` will render a very small bar to indicate the presence of the value. [SparkChartData type definition.]()",
@@ -49,6 +46,7 @@ export default {
     isAnimated: {
       description: 'Determines whether to animate the chart on state changes.',
     },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 

--- a/src/components/Sparkline/Sparkline.md
+++ b/src/components/Sparkline/Sparkline.md
@@ -75,7 +75,6 @@ const props = {
   ],
   hasSpline: true,
   isAnimated: true,
-  theme: 'Default'
 };
 
 return (

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Story, Meta} from '@storybook/react';
 
 import {Sparkline, SparklineProps} from '../..';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 const series = [
   {
@@ -58,10 +59,6 @@ export default {
     ),
   ],
   argTypes: {
-    theme: {
-      description:
-        'The theme that the chart will inherit its color, container and line styles from',
-    },
     series: {
       description:
         'The sparkline can show one data series or a set of comparison data series. Each series is configured by the series item in the array. [Series type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/Sparkline/Sparkline.tsx#L21)',
@@ -73,6 +70,7 @@ export default {
     isAnimated: {
       description: 'Determines whether to animate the chart on state changes.',
     },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -5,6 +5,7 @@ import {StackedAreaChart, StackedAreaChartProps} from '../StackedAreaChart';
 
 import {data, labels, formatYAxisLabel} from './utils.stories';
 import {colorPurpleDark, colorTeal} from '../../../constants';
+import {THEME_CONTROL_ARGS} from '../../../storybook';
 
 const tooltipContent = {
   empty: undefined,
@@ -76,9 +77,7 @@ export default {
       description:
         'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
     },
-    theme: {
-      description: 'The theme that the chart will inherit its styles from',
-    },
+    theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
 
@@ -88,7 +87,6 @@ const defaultProps = {
   xAxisLabels: labels,
   formatYAxisLabel: formatYAxisLabel,
   isAnimated: true,
-  theme: 'Default',
 };
 
 const Template: Story<StackedAreaChartProps> = (

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -71,7 +71,6 @@ describe('<Chart />', () => {
     formatYAxisLabel: (val: number) => val.toString(),
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
     colors: ['purple', 'teal'],
-    theme: 'Default',
   };
 
   it('renders an SVG', () => {

--- a/src/components/TooltipContainer/TooltipContainer.scss
+++ b/src/components/TooltipContainer/TooltipContainer.scss
@@ -2,4 +2,6 @@
   position: absolute;
   pointer-events: none;
   max-width: 70%;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.2), 0 2px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
 }

--- a/src/components/TooltipContent/TooltipContent.scss
+++ b/src/components/TooltipContent/TooltipContent.scss
@@ -8,7 +8,6 @@
   column-gap: $spacing-tight;
   row-gap: $spacing-tight;
   background: $color-white;
-  border-radius: 4px;
   padding: $spacing-loose;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,14 +106,14 @@ export const DEFAULT_THEME: Theme = {
     ],
   },
   tooltip: {
-    backgroundColor: variables.colorGray03,
-    valueColor: variables.colorGray15,
-    labelColor: variables.colorGray13,
+    backgroundColor: variables.colorGray150,
+    valueColor: variables.colorGray00,
+    labelColor: variables.colorGray30,
   },
   chartContainer: {
     borderRadius: '0px',
     padding: '0px',
-    backgroundColor: variables.colorGray01,
+    backgroundColor: variables.colorGray160,
   },
   line: {
     sparkArea: [
@@ -124,7 +124,7 @@ export const DEFAULT_THEME: Theme = {
     style: 'solid',
     hasPoint: true,
     width: 2,
-    pointStroke: variables.colorGray15,
+    pointStroke: variables.colorGray160,
     dottedStrokeColor: variables.colorDarkComparison,
   },
   bar: {
@@ -136,29 +136,122 @@ export const DEFAULT_THEME: Theme = {
   grid: {
     showVerticalLines: false,
     showHorizontalLines: true,
-    color: variables.colorGray05,
+    color: variables.colorGray140,
     horizontalOverflow: false,
     horizontalMargin: 0,
   },
   xAxis: {
     showTicks: false,
-    labelColor: variables.colorGray13,
+    labelColor: variables.colorGray30,
     hide: false,
   },
   yAxis: {
-    backgroundColor: variables.colorGray01,
-    labelColor: variables.colorGray13,
+    backgroundColor: variables.colorGray160,
+    labelColor: variables.colorGray30,
   },
   crossHair: {
-    color: 'rgb(139, 159, 176)',
+    color: variables.colorGray70,
     width: 1,
   },
   legend: {
-    labelColor: '#DADADD',
-    valueColor: '#fff',
+    labelColor: variables.colorGray30,
+    valueColor: variables.colorGray00,
     trendIndicator: {
-      positive: '#00A47C',
-      negative: '#EC6E6E',
+      positive: '#039c86',
+      negative: '#f24f62',
+      neutral: '#8C9196',
+    },
+  },
+};
+
+export const LIGHT_THEME: Theme = {
+  seriesColors: {
+    upToFour: [
+      createGradient(variables.colorIndigo70, variables.colorIndigo90),
+      createGradient(variables.colorBlue70, variables.colorBlue90),
+      createGradient(variables.colorMagenta70, variables.colorMagenta90),
+      createGradient(variables.colorTeal70, variables.colorTeal90),
+    ],
+    fromFiveToSeven: [
+      createGradient(variables.colorTeal70, variables.colorTeal90),
+      createGradient(variables.colorBlue70, variables.colorBlue90),
+      createGradient(variables.colorIndigo70, variables.colorIndigo90),
+      createGradient(variables.colorPurple70, variables.colorPurple90),
+      createGradient(variables.colorMagenta70, variables.colorMagenta90),
+      createGradient(variables.colorOrange70, variables.colorOrange90),
+      createGradient(variables.colorYellow70, variables.colorYellow90),
+    ],
+    all: [
+      variables.colorTeal90,
+      variables.colorBlue70,
+      variables.colorIndigo90,
+      variables.colorPurple70,
+      variables.colorMagenta90,
+      variables.colorOrange80,
+      variables.colorYellow50,
+      variables.colorTeal70,
+      variables.colorBlue80,
+      variables.colorIndigo70,
+      variables.colorPurple90,
+      variables.colorMagenta70,
+      variables.colorOrange110,
+      variables.colorYellow70,
+    ],
+  },
+  tooltip: {
+    backgroundColor: variables.colorGray00,
+    valueColor: variables.colorGray160,
+    labelColor: variables.colorGray100,
+  },
+  chartContainer: {
+    borderRadius: '0px',
+    padding: '0px',
+    backgroundColor: variables.colorGray00,
+  },
+  line: {
+    sparkArea: [
+      {offset: 0, color: 'rgba(92, 105, 208, 0)'},
+      {offset: 100, color: 'rgba(92, 105, 208, 0.15)'},
+    ],
+    hasSpline: true,
+    style: 'solid',
+    hasPoint: true,
+    width: 2,
+    pointStroke: variables.colorGray00,
+    dottedStrokeColor: variables.colorLightComparison,
+  },
+  bar: {
+    hasRoundedCorners: true,
+    innerMargin: 'Medium',
+    outerMargin: 'Medium',
+    zeroAsMinHeight: false,
+  },
+  grid: {
+    showVerticalLines: false,
+    showHorizontalLines: true,
+    color: variables.colorGray20,
+    horizontalOverflow: false,
+    horizontalMargin: 0,
+  },
+  xAxis: {
+    showTicks: false,
+    labelColor: variables.colorGray80,
+    hide: false,
+  },
+  yAxis: {
+    backgroundColor: variables.colorGray00,
+    labelColor: variables.colorGray80,
+  },
+  crossHair: {
+    color: variables.colorGray40,
+    width: 1,
+  },
+  legend: {
+    valueColor: variables.colorGray160,
+    labelColor: variables.colorGray100,
+    trendIndicator: {
+      positive: '#119d7f',
+      negative: '#eb4c5e',
       neutral: '#8C9196',
     },
   },

--- a/src/hooks/tests/usePolarisVizContext.test.tsx
+++ b/src/hooks/tests/usePolarisVizContext.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {mountWithProvider} from '../../test-utilities';
-import {DEFAULT_THEME} from '../../constants';
+import {DEFAULT_THEME, LIGHT_THEME} from '../../constants';
 import {usePolarisVizContext} from '../usePolarisVizContext';
 
 describe('usePolarisVizContext', () => {
@@ -17,6 +17,7 @@ describe('usePolarisVizContext', () => {
     expect(mockComponent.text()).toBe(
       JSON.stringify({
         Default: DEFAULT_THEME,
+        Light: LIGHT_THEME,
       }),
     );
   });
@@ -41,6 +42,7 @@ describe('usePolarisVizContext', () => {
             backgroundColor: 'purple',
           },
         },
+        Light: LIGHT_THEME,
       }),
     );
   });
@@ -59,6 +61,7 @@ describe('usePolarisVizContext', () => {
     expect(mockComponent.text()).toBe(
       JSON.stringify({
         Default: DEFAULT_THEME,
+        Light: LIGHT_THEME,
         SomeOtherTheme: {
           ...DEFAULT_THEME,
           chartContainer: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ export type {
   PolarisVizProviderProps,
 } from './components';
 
-export {DEFAULT_THEME as PolarisVizTheme} from './constants';
+export {
+  DEFAULT_THEME as PolarisVizDefaultTheme,
+  LIGHT_THEME as PolarisVizLightheme,
+} from './constants';
 
 export {createTheme} from './utilities/create-themes';
 

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -1,3 +1,8 @@
 export const getDataPoint = (limit = 1000) => {
   return Math.random() * limit;
 };
+
+export const THEME_CONTROL_ARGS = {
+  description: 'The theme that the chart will inherit its styles from',
+  control: {type: 'select', options: ['Default', 'Light']},
+};

--- a/src/styles/shared/_variables.scss
+++ b/src/styles/shared/_variables.scss
@@ -24,14 +24,26 @@ $negative-color: rgb(215, 44, 13);
 // Colors are named non-sequencial numbers
 // so it matches the UX Color Matrix
 // stylelint-disable color-no-hex
-$color-dark-comparison: #90b0df;
+$color-dark-comparison: rgba(144, 176, 223, 0.6);
+$color-light-comparison: #6793cc;
 
-$color-gray-01: #1f1f25;
-$color-gray-03: #2e2e36;
-$color-gray-05: #43434e;
-$color-gray-06: #4b4b57;
-$color-gray-13: #dadadd;
-$color-gray-15: #ffffff;
+$color-gray-00: #ffffff;
+$color-gray-10: #f6f6f7;
+$color-gray-20: #eeeeef;
+$color-gray-30: #dadadd;
+$color-gray-40: #cbcbcf;
+$color-gray-50: #bdbdc2;
+$color-gray-60: #b0b0b6;
+$color-gray-70: #9d9da5;
+$color-gray-80: #909099;
+$color-gray-90: #82828c;
+$color-gray-100: #70707b;
+$color-gray-110: #5e5e69;
+$color-gray-120: #545460;
+$color-gray-130: #4b4b57;
+$color-gray-140: #43434e;
+$color-gray-150: #2e2e36;
+$color-gray-160: #1f1f25;
 
 $color-indigo-40: #c5b7fe;
 $color-indigo-70: #997afc;
@@ -55,11 +67,16 @@ $color-purple-90: #9f41dc;
 
 $color-orange-50: #ec9d71;
 $color-orange-60: #df8b55;
+$color-orange-70: #ca7d4a;
 $color-orange-80: #b66e3f;
+$color-orange-90: #a26134;
+$color-orange-110: #7a4621;
 
 $color-yellow-20: #fae275;
 $color-yellow-40: #d1c256;
+$color-yellow-50: #bdb24e;
 $color-yellow-70: #97933e;
+$color-yellow-90: #74742c;
 
 // -----
 
@@ -107,13 +124,25 @@ $font-stack-base: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI'
 
   // NEW COLORS
   colorDarkComparison: $color-dark-comparison;
+  colorLightComparison: $color-light-comparison;
 
-  colorGray01: $color-gray-01;
-  colorGray03: $color-gray-03;
-  colorGray05: $color-gray-05;
-  colorGray06: $color-gray-06;
-  colorGray13: $color-gray-13;
-  colorGray15: $color-gray-15;
+  colorGray00: $color-gray-00;
+  colorGray10: $color-gray-10;
+  colorGray20: $color-gray-20;
+  colorGray30: $color-gray-30;
+  colorGray40: $color-gray-40;
+  colorGray50: $color-gray-50;
+  colorGray60: $color-gray-60;
+  colorGray70: $color-gray-70;
+  colorGray80: $color-gray-80;
+  colorGray90: $color-gray-90;
+  colorGray100: $color-gray-100;
+  colorGray110: $color-gray-110;
+  colorGray120: $color-gray-120;
+  colorGray130: $color-gray-130;
+  colorGray140: $color-gray-140;
+  colorGray150: $color-gray-150;
+  colorGray160: $color-gray-160;
 
   colorIndigo40: $color-indigo-40;
   colorIndigo70: $color-indigo-70;
@@ -137,9 +166,13 @@ $font-stack-base: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI'
 
   colorOrange50: $color-orange-50;
   colorOrange60: $color-orange-60;
+  colorOrange70: $color-orange-70;
   colorOrange80: $color-orange-80;
+  colorOrange90: $color-orange-90;
+  colorOrange110: $color-orange-110;
 
   colorYellow20: $color-yellow-20;
   colorYellow40: $color-yellow-40;
   colorYellow70: $color-yellow-70;
+  colorYellow90: $color-yellow-90;
 }

--- a/src/utilities/create-themes.ts
+++ b/src/utilities/create-themes.ts
@@ -1,5 +1,10 @@
 import type {Theme, PartialTheme} from '../types';
-import {DEFAULT_THEME} from '../constants';
+import {DEFAULT_THEME, LIGHT_THEME} from '../constants';
+
+const BASE_THEMES: {[key: string]: Theme} = {
+  Default: DEFAULT_THEME,
+  Light: LIGHT_THEME,
+};
 
 export const createTheme = (
   theme: PartialTheme,
@@ -8,7 +13,7 @@ export const createTheme = (
   const themeKeys = Object.keys(baseTheme);
 
   return themeKeys.reduce((accumulator: any, key: keyof Theme) => {
-    const defaultValue = DEFAULT_THEME[key];
+    const defaultValue = baseTheme[key];
     const value = theme[key];
 
     if (
@@ -19,7 +24,7 @@ export const createTheme = (
       accumulator[key] = value == null ? defaultValue : value;
     } else {
       accumulator[key] = {
-        ...DEFAULT_THEME[key],
+        ...baseTheme[key],
         ...theme[key],
       };
     }
@@ -29,7 +34,10 @@ export const createTheme = (
 
 export const createThemes = (themeRecord: {[key: string]: PartialTheme}) => {
   return Object.keys(themeRecord).reduce((accumulator, themeName) => {
-    accumulator[themeName] = createTheme(themeRecord[themeName]);
+    accumulator[themeName] = createTheme(
+      themeRecord[themeName],
+      BASE_THEMES[themeName],
+    );
     return accumulator;
   }, {} as {[key: string]: Theme});
 };

--- a/src/utilities/polaris-viz-context.ts
+++ b/src/utilities/polaris-viz-context.ts
@@ -1,12 +1,13 @@
 import {createContext} from 'react';
 
 import type {Theme} from '../types';
-import {DEFAULT_THEME as Default} from '../constants';
+import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../constants';
 
 export const PolarisVizContext = createContext<{
   themes: {[key: string]: Theme};
 }>({
   themes: {
     Default,
+    Light,
   },
 });


### PR DESCRIPTION
### What problem is this PR solving?

Adding a `Light` theme for consumers that don't currently use the default/dark theme.

### Reviewers’ :tophat: instructions

- [ ] View each story and change the `theme` prop to `Light`.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
