### PR TITLE
Use types so storybook will error

### DIFF
--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -104,7 +104,7 @@ const Template: Story<BarChartProps> = (args: BarChartProps) => {
   return <BarChart {...args} />;
 };
 
-export const Default = Template.bind({});
+export const Default: Story<BarChartProps> = Template.bind({});
 Default.args = {
   ...defaultProps,
   xAxisOptions: {
@@ -115,7 +115,7 @@ Default.args = {
   },
 };
 
-export const Annotations = Template.bind({});
+export const Annotations: Story<BarChartProps> = Template.bind({});
 Annotations.args = {
   ...defaultProps,
   data: [
@@ -155,7 +155,7 @@ Annotations.args = {
   ],
 };
 
-export const LastBarTreatment = Template.bind({});
+export const LastBarTreatment: Story<BarChartProps> = Template.bind({});
 LastBarTreatment.args = {
   ...defaultProps,
   data: [
@@ -175,7 +175,7 @@ LastBarTreatment.args = {
   ],
 };
 
-export const MinimalLabels = Template.bind({});
+export const MinimalLabels: Story<BarChartProps> = Template.bind({});
 MinimalLabels.args = {
   ...defaultProps,
   data: [
@@ -217,7 +217,7 @@ MinimalLabels.args = {
   },
 };
 
-export const IntegersOnly = Template.bind({});
+export const IntegersOnly: Story<BarChartProps> = Template.bind({});
 IntegersOnly.args = {
   ...defaultProps,
   data: [
@@ -234,7 +234,7 @@ IntegersOnly.args = {
   },
 };
 
-export const LargeVolume = Template.bind({});
+export const LargeVolume: Story<BarChartProps> = Template.bind({});
 LargeVolume.args = {
   ...defaultProps,
   data: Array(1000)
@@ -246,25 +246,6 @@ LargeVolume.args = {
       };
     }),
 };
-
-const SolidColorsTemplate: Story<BarChartProps> = (args: BarChartProps) => {
-  return (
-    <PolarisVizProvider
-      themes={{
-        Default: {
-          bar: {
-            color: 'yellow',
-          },
-        },
-      }}
-    >
-      <BarChart {...args} />
-    </PolarisVizProvider>
-  );
-};
-
-export const SolidColors = SolidColorsTemplate.bind({});
-SolidColors.args = defaultProps;
 
 const NonRoundCornersTemplate: Story<BarChartProps> = (args: BarChartProps) => {
   return (

--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -14,14 +14,14 @@ import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './Legend.scss';
 
-type LegendData = Required<DataSeries<Data | NullableData, Color>>;
+type LegendData = DataSeries<Data | NullableData, Color>;
 
 interface LegendProps extends Omit<LegendData, 'data'> {
   lineStyle?: LineStyle;
   data?: (Data | NullableData)[];
 }
 
-interface Props {
+export interface Props {
   series: LegendProps[];
   theme?: string;
 }

--- a/src/components/Legend/index.ts
+++ b/src/components/Legend/index.ts
@@ -1,1 +1,2 @@
 export {Legend} from './Legend';
+export type {Props as LegendProps} from './Legend';

--- a/src/components/Legend/stories/Legend.stories.tsx
+++ b/src/components/Legend/stories/Legend.stories.tsx
@@ -33,12 +33,12 @@ const Template: Story<LegendProps> = (args: LegendProps) => {
   );
 };
 
-export const SquareLegend = Template.bind({});
+export const SquareLegend: Story<LegendProps> = Template.bind({});
 SquareLegend.args = {
   series: [{name: 'Sales'}, {name: 'Visits'}],
 };
 
-export const DottedLineLegend = Template.bind({});
+export const DottedLineLegend: Story<LegendProps> = Template.bind({});
 DottedLineLegend.args = {
   series: [
     {lineStyle: 'dotted', name: 'Sales'},
@@ -46,7 +46,7 @@ DottedLineLegend.args = {
   ],
 };
 
-export const DashedLineLegend = Template.bind({});
+export const DashedLineLegend: Story<LegendProps> = Template.bind({});
 DashedLineLegend.args = {
   series: [
     {lineStyle: 'dashed', name: 'Sales'},
@@ -54,7 +54,7 @@ DashedLineLegend.args = {
   ],
 };
 
-export const LineLegend = Template.bind({});
+export const LineLegend: Story<LegendProps> = Template.bind({});
 LineLegend.args = {
   series: [
     {lineStyle: 'solid', name: 'Sales'},
@@ -62,7 +62,7 @@ LineLegend.args = {
   ],
 };
 
-export const ColorOverrides = Template.bind({});
+export const ColorOverrides: Story<LegendProps> = Template.bind({});
 ColorOverrides.args = {
   series: [
     {name: 'Sales', color: 'red'},

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -97,7 +97,7 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return <LineChart {...args} />;
 };
 
-export const InsightsStyle = Template.bind({});
+export const InsightsStyle: Story<LineChartProps> = Template.bind({});
 InsightsStyle.args = {
   series,
 
@@ -112,7 +112,7 @@ InsightsStyle.args = {
   isAnimated: true,
 };
 
-export const SeriesColors = Template.bind({});
+export const SeriesColors: Story<LineChartProps> = Template.bind({});
 SeriesColors.args = {
   series: seriesUsingSeriesColors,
 
@@ -127,7 +127,7 @@ SeriesColors.args = {
   isAnimated: true,
 };
 
-export const HideXAxisLabels = Template.bind({});
+export const HideXAxisLabels: Story<LineChartProps> = Template.bind({});
 HideXAxisLabels.args = {
   theme: 'NoxAxisLabels',
   series,
@@ -139,7 +139,7 @@ HideXAxisLabels.args = {
   renderTooltipContent,
 };
 
-export const NoOverflowStyle = Template.bind({});
+export const NoOverflowStyle: Story<LineChartProps> = Template.bind({});
 NoOverflowStyle.args = {
   theme: 'NoOverflow',
   series,
@@ -151,7 +151,7 @@ NoOverflowStyle.args = {
   renderTooltipContent,
 };
 
-export const IntegersOnly = Template.bind({});
+export const IntegersOnly: Story<LineChartProps> = Template.bind({});
 IntegersOnly.args = {
   series: [
     {
@@ -175,7 +175,7 @@ IntegersOnly.args = {
   renderTooltipContent,
 };
 
-export const NoArea = Template.bind({});
+export const NoArea: Story<LineChartProps> = Template.bind({});
 NoArea.args = {
   series: [
     {
@@ -190,7 +190,6 @@ NoArea.args = {
         {rawValue: 5, label: '2020-04-07T12:00:00'},
       ],
       color: gradient,
-      area: null,
     },
   ],
   xAxisOptions: {
@@ -200,7 +199,7 @@ NoArea.args = {
   renderTooltipContent,
 };
 
-export const SolidColor = Template.bind({});
+export const SolidColor: Story<LineChartProps> = Template.bind({});
 SolidColor.args = {
   series: [
     {
@@ -224,7 +223,7 @@ SolidColor.args = {
   renderTooltipContent,
 };
 
-export const LargeDataSet = Template.bind({});
+export const LargeDataSet: Story<LineChartProps> = Template.bind({});
 
 LargeDataSet.args = {
   series: [

--- a/src/components/LinearGradient/stories/LinearGradient.stories.tsx
+++ b/src/components/LinearGradient/stories/LinearGradient.stories.tsx
@@ -56,7 +56,7 @@ const Template: Story<LinearGradientProps> = (args) => (
   </svg>
 );
 
-export const Default = Template.bind({});
+export const Default: Story<LinearGradientProps> = Template.bind({});
 
 const purple = '#5052b3';
 const negativePurple = '#39337f';

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -196,7 +196,7 @@ const gradientSeries = series
   }))
   .filter((_, index) => index < 2);
 
-export const Default = Template.bind({});
+export const Default: Story<MultiSeriesBarChartProps> = Template.bind({});
 
 Default.args = {
   series: series,
@@ -247,13 +247,15 @@ const WithoutRoundedCornersTemplate: Story<MultiSeriesBarChartProps> = (
   );
 };
 
-export const WithoutRoundedCorners = WithoutRoundedCornersTemplate.bind({});
+export const WithoutRoundedCorners: Story<MultiSeriesBarChartProps> = WithoutRoundedCornersTemplate.bind(
+  {},
+);
 WithoutRoundedCorners.args = {
   series: series,
   xAxisOptions: {labels},
 };
 
-export const Stacked = Template.bind({});
+export const Stacked: Story<MultiSeriesBarChartProps> = Template.bind({});
 Stacked.args = {
   series: series,
   xAxisOptions: {labels},
@@ -262,7 +264,9 @@ Stacked.args = {
   },
 };
 
-export const OverwrittenSeriesColors = Template.bind({});
+export const OverwrittenSeriesColors: Story<MultiSeriesBarChartProps> = Template.bind(
+  {},
+);
 OverwrittenSeriesColors.args = {
   series: gradientSeries,
   xAxisOptions: {labels},
@@ -271,7 +275,7 @@ OverwrittenSeriesColors.args = {
   },
 };
 
-export const IntegersOnly = Template.bind({});
+export const IntegersOnly: Story<MultiSeriesBarChartProps> = Template.bind({});
 IntegersOnly.args = {
   series: [
     {
@@ -315,7 +319,7 @@ IntegersOnly.args = {
   yAxisOptions: {integersOnly: true},
 };
 
-export const LargeVolume = Template.bind({});
+export const LargeVolume: Story<MultiSeriesBarChartProps> = Template.bind({});
 LargeVolume.args = {
   series: [
     {

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -87,13 +87,13 @@ const defaultProps = {
     'A bar chart showing orders over time for the past 11 weeks. The minimum is 100 orders and the maximum is 1,000 orders, compared to an average of 500 orders during previous 11-week period.',
 };
 
-export const Default = Template.bind({});
+export const Default: Story<SparkbarProps> = Template.bind({});
 Default.args = defaultProps;
 
-export const Positive = Template.bind({});
+export const Positive: Story<SparkbarProps> = Template.bind({});
 Positive.args = {...defaultProps, theme: 'Positive'};
 
-export const OffsetAndNulls = Template.bind({});
+export const OffsetAndNulls: Story<SparkbarProps> = Template.bind({});
 OffsetAndNulls.args = {
   ...defaultProps,
   dataOffsetLeft: 10,
@@ -113,7 +113,7 @@ OffsetAndNulls.args = {
   ],
 };
 
-export const OverriddenColors = Template.bind({});
+export const OverriddenColors: Story<SparkbarProps> = Template.bind({});
 OverriddenColors.args = {
   ...defaultProps,
   dataOffsetLeft: 10,

--- a/src/components/Sparkline/stories/Sparkline.stories.tsx
+++ b/src/components/Sparkline/stories/Sparkline.stories.tsx
@@ -87,16 +87,16 @@ const defaultProps = {
   accessibilityLabel: 'Customer growth over time',
 };
 
-export const InsightsStyle = Template.bind({});
+export const InsightsStyle: Story<SparklineProps> = Template.bind({});
 InsightsStyle.args = defaultProps;
 
-export const withoutSpline = Template.bind({});
+export const withoutSpline: Story<SparklineProps> = Template.bind({});
 withoutSpline.args = {
   ...defaultProps,
   theme: 'NoSpline',
 };
 
-export const OffsetAndNulls = Template.bind({});
+export const OffsetAndNulls: Story<SparklineProps> = Template.bind({});
 OffsetAndNulls.args = {
   ...defaultProps,
   series: [

--- a/src/components/SquareColorPreview/stories/SquareColorPreview.stories.tsx
+++ b/src/components/SquareColorPreview/stories/SquareColorPreview.stories.tsx
@@ -33,7 +33,7 @@ const Template: Story<SquareColorPreviewProps> = (
   return <SquareColorPreview {...args} />;
 };
 
-export const Solid = Template.bind({});
+export const Solid: Story<SquareColorPreviewProps> = Template.bind({});
 
 Solid.args = {
   color: colorTeal,
@@ -43,7 +43,7 @@ const purple = '#5052b3';
 const negativePurple = '#39337f';
 const green = '#1bbe9e';
 
-export const Gradient = Template.bind({});
+export const Gradient: Story<SquareColorPreviewProps> = Template.bind({});
 
 Gradient.args = {
   color: [

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -94,10 +94,10 @@ const Template: Story<StackedAreaChartProps> = (
 ) => {
   return <StackedAreaChart {...args} />;
 };
-export const Default = Template.bind({});
+export const Default: Story<StackedAreaChartProps> = Template.bind({});
 Default.args = defaultProps;
 
-export const Gradients = Template.bind({});
+export const Gradients: Story<StackedAreaChartProps> = Template.bind({});
 Gradients.args = {
   ...defaultProps,
   xAxisLabels: Array(5)
@@ -139,7 +139,7 @@ Gradients.args = {
   ],
 };
 
-export const LargeVolume = Template.bind({});
+export const LargeVolume: Story<StackedAreaChartProps> = Template.bind({});
 LargeVolume.args = {
   ...defaultProps,
   xAxisLabels: Array(2000)
@@ -173,7 +173,7 @@ LargeVolume.args = {
   ],
 };
 
-export const MediumVolume = Template.bind({});
+export const MediumVolume: Story<StackedAreaChartProps> = Template.bind({});
 MediumVolume.args = {
   ...defaultProps,
   xAxisLabels: Array(10)

--- a/src/components/StackedAreaChart/types.ts
+++ b/src/components/StackedAreaChart/types.ts
@@ -1,6 +1,6 @@
-import type {Color, DataSeries, NullableData} from '../../types';
+import type {Color, Data, DataSeries} from '../../types';
 
-export interface Series extends DataSeries<NullableData, string> {}
+export type Series = DataSeries<Data, Color>;
 
 export interface RenderTooltipContentData {
   title: string;

--- a/src/components/TooltipContent/stories/TooltipContent.stories.tsx
+++ b/src/components/TooltipContent/stories/TooltipContent.stories.tsx
@@ -47,7 +47,7 @@ const defaultProps = {
   ],
 };
 
-export const Default = Template.bind({});
+export const Default: Story<TooltipContentProps> = Template.bind({});
 
 Default.args = {
   ...defaultProps,
@@ -55,12 +55,12 @@ Default.args = {
   title: undefined,
 };
 
-export const WithTitle = Template.bind({});
+export const WithTitle: Story<TooltipContentProps> = Template.bind({});
 
 WithTitle.args = {
   ...defaultProps,
   total: undefined,
 };
 
-export const WithTotal = Template.bind({});
+export const WithTotal: Story<TooltipContentProps> = Template.bind({});
 WithTotal.args = defaultProps;


### PR DESCRIPTION
### What problem is this PR solving?

Set `color` to optional in `Legend`. Added types to storybook stories so they'll error on bad data.

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
