### PR TITLE
Assume no lineStyle means solid line

### DIFF
--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -164,7 +164,8 @@ export function LineChart({
   const seriesWithDefaults = series.map<SeriesWithDefaults>((series, index) => {
     const seriesColor = seriesColors[index];
 
-    const isSolidLine = series.lineStyle === 'solid';
+    const isSolidLine =
+      series.lineStyle == null || series.lineStyle === 'solid';
 
     const areaColor = isGradientType(seriesColor)
       ? (seriesColor[seriesColor.length - 1] as GradientStop).color

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type {LineStyle, Color} from 'types';
 
+import {getSeriesColorsFromCount} from '../../../../hooks/use-theme-series-colors';
 import {useTheme} from '../../../../hooks';
 import {LinePreview} from '../../../LinePreview';
 
@@ -10,9 +11,9 @@ interface TooltipData {
   name: string;
   point: {
     label: string;
-    value: string;
+    value: string | number;
   };
-  color: Color;
+  color?: Color;
   lineStyle: LineStyle;
 }
 
@@ -22,7 +23,10 @@ export interface TooltipContentProps {
 }
 
 export function TooltipContent({data, theme}: TooltipContentProps) {
-  const {tooltip} = useTheme(theme);
+  const selectedTheme = useTheme(theme);
+  const seriesColor = getSeriesColorsFromCount(data.length, selectedTheme);
+
+  const {tooltip} = selectedTheme;
   return (
     <div
       className={styles.Container}
@@ -34,7 +38,10 @@ export function TooltipContent({data, theme}: TooltipContentProps) {
       {data.map(({name, point: {label, value}, color, lineStyle}, index) => {
         return (
           <React.Fragment key={`${name}-${index}`}>
-            <LinePreview color={color} lineStyle={lineStyle} />
+            <LinePreview
+              color={color ?? seriesColor[index]}
+              lineStyle={lineStyle}
+            />
             <p className={styles.Name}>{label}</p>
             <p
               style={{

--- a/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
+++ b/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
@@ -37,35 +37,45 @@ const Template: Story<TooltipContentProps> = (args: TooltipContentProps) => {
   );
 };
 
-export const Default = Template.bind({});
+export const Default: Story<TooltipContentProps> = Template.bind({});
 
 Default.args = {
   data: [
     {
       name: 'Primary',
       point: {label: 'Sept. 10, 1989', value: 28},
-      color: 'red',
       lineStyle: 'solid',
     },
   ],
 };
 
-export const DashedLine = Template.bind({});
+export const DashedLine: Story<TooltipContentProps> = Template.bind({});
 
 DashedLine.args = {
   data: [
     {
       name: 'Primary',
       point: {label: 'Sept. 10, 1989', value: 28},
-      color: 'red',
       lineStyle: 'dashed',
     },
   ],
 };
 
-export const DottedLine = Template.bind({});
+export const DottedLine: Story<TooltipContentProps> = Template.bind({});
 
 DottedLine.args = {
+  data: [
+    {
+      name: 'Primary',
+      point: {label: 'Sept. 10, 1989', value: 28},
+      lineStyle: 'dotted',
+    },
+  ],
+};
+
+export const ColorOverride: Story<TooltipContentProps> = Template.bind({});
+
+ColorOverride.args = {
   data: [
     {
       name: 'Primary',

--- a/src/components/LineChart/stories/utils.stories.tsx
+++ b/src/components/LineChart/stories/utils.stories.tsx
@@ -38,7 +38,6 @@ export const series = [
       {rawValue: 129, label: '2020-04-14T12:00:00'},
     ],
     color: gradient,
-    lineStyle: 'solid' as 'solid',
     areaColor: 'rgba(92,105,208,0.5)',
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,4 +36,4 @@ export {
 
 export {createTheme} from './utilities/create-themes';
 
-export type {GradientStop} from './types';
+export type {GradientStop, Color} from './types';


### PR DESCRIPTION
### What problem is this PR solving?

- When checking if a line was solid or not, we were only checking if it `=== 'solid'` but we also want to allow the value to be null.
- Update LineChartTooltopContent to use seriesColors.

### Reviewers’ :tophat: instructions

- View the line chart examples, all lines should default to series colors and not the dotted line color.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
