### PR TITLE
Setup react-docgen-typescript and change BarChart

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,11 +15,7 @@ module.exports = {
     },
   ],
   typescript: {
-    // also valid 'react-docgen-typescript' | false
-    // reactDocgen: 'react-docgen-typescript',
-    // There is an issue with TypeScript 4.3 and React Doc Gen
-    // https://github.com/styleguidist/react-docgen-typescript/issues/356
-    reactDocgen: 'none',
+    reactDocgen: 'react-docgen-typescript',
   },
   webpackFinal: (config) => {
     const isProduction = config.mode === 'production';

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -39,7 +39,7 @@ export const decorators = [
           },
         }}
       >
-        <Container theme={context.args.theme}>
+        <Container theme={context.args.theme} viewMode={context.viewMode}>
           <Story />
         </Container>
       </PolarisVizProvider>
@@ -49,9 +49,10 @@ export const decorators = [
 
 interface ContainerProps {
   theme: string;
+  viewMode: String;
 }
 
-const Container = ({children, theme}: ContainerProps) => {
+const Container = ({children, theme, viewMode}: ContainerProps) => {
   const selectedTheme = useTheme(theme);
 
   return (
@@ -62,7 +63,7 @@ const Container = ({children, theme}: ContainerProps) => {
         overflow: 'hidden',
         margin: '-1rem',
         background: selectedTheme.chartContainer.backgroundColor,
-        minHeight: '100vh',
+        minHeight: viewMode !== 'docs' ? '100vh' : undefined,
       }}
     >
       <div

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -19,17 +19,48 @@ import type {
 } from './types';
 
 export interface BarChartProps {
+  /** Data represented as bars */
   data: BarChartData[];
+  /** An array of annotations to show on the chart. */
   annotations?: Annotation[];
+  /**
+   * If provided, renders a `<SkipLink/>` button with the string.
+   *
+   * Use this for charts with large data sets, so keyboard users
+   * can skip all the tabbable data points in the chart.
+   * */
   skipLinkText?: string;
+  /**
+   * Used to indicate to screenreaders that a chart with no data has been rendered,
+   * in the case that an empty array is passed as the data.
+   *
+   * It is strongly recommended that this is included if the data prop could
+   * be an empty array.
+   * */
   emptyStateText?: string;
+  /**
+   * Whether to animate the bars when the chart is initially rendered and its data is updated.
+   *
+   * Even if `isAnimated` is set to true, animations will not be
+   * displayed for users with reduced motion preferences.
+   * */
   isAnimated?: boolean;
+  /**
+   * Accepts a function that renders the tooltip content.
+   *
+   * By default it calls `formatXAxisLabel` and `formatYAxisLabel` to format
+   * the the tooltip values and passes them to `<BarChartTooltipContent />`
+   */
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
+  /** An object used to configure the xAxis and its labels. */
   xAxisOptions?: XAxisOptions;
+  /** An object used to configure the yAxis and its labels. */
   yAxisOptions?: YAxisOptions;
+  /** The theme that the chart will inherit its styles from */
   theme?: string;
 }
 
+/** Used to show comparison across categories or time. */
 export function BarChart({
   data,
   annotations,

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -26,12 +26,6 @@ export default {
   title: 'Charts/BarChart',
   component: BarChart,
   parameters: {
-    docs: {
-      description: {
-        component:
-          'Used to show comparison across categories or time. <br /> This component inherits its height and width from its container.',
-      },
-    },
     controls: {
       sort: 'requiredFirst',
       expanded: true,
@@ -42,8 +36,6 @@ export default {
       control: {
         type: 'select',
       },
-      description:
-        'An array of annotations to show on the chart. [Annotation type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L61)',
       options: ['No annotation', 'Annotation on second bar'],
       mapping: {
         'No annotation': undefined,
@@ -63,8 +55,6 @@ export default {
       },
     },
     renderTooltipContent: {
-      description:
-        'Accepts a function that renders the tooltip content. By default it calls `formatXAxisLabel` and `formatYAxisLabel` to format the the tooltip values and passes them to `<BarChartTooltipContent />`. [RenderTooltipContentData type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/BarChart/types.ts#L23)',
       options: Object.keys(tooltipContent),
       mapping: tooltipContent,
       control: {
@@ -74,27 +64,6 @@ export default {
           Annotation: 'Custom',
         },
       },
-    },
-    data: {
-      description: 'Data represented as bars. Required.',
-    },
-    emptyStateText: {
-      description:
-        'Used to indicate to screenreaders that a chart with no data has been rendered, in the case that an empty array is passed as the data. It is strongly recommended that this is included if the data prop could be an empty array.',
-    },
-    isAnimated: {
-      description:
-        'Whether to animate the bars when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.',
-    },
-    skipLinkText: {
-      description:
-        'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
-    },
-    xAxisOptions: {
-      description: 'An object used to configure the xAxis and its labels.',
-    },
-    yAxisOptions: {
-      description: 'An object used to configure the yAxis and its labels.',
     },
     theme: THEME_CONTROL_ARGS,
   },

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -3,6 +3,5 @@ export const getDataPoint = (limit = 1000) => {
 };
 
 export const THEME_CONTROL_ARGS = {
-  description: 'The theme that the chart will inherit its styles from',
   control: {type: 'select', options: ['Default', 'Light']},
 };


### PR DESCRIPTION
### What problem is this PR solving?

We're exploring using `react-typescript-docgen` to manage our documentation in storybook.

**Pros**

- "Living" documentation. We only have to update in a single place.
- Automatic story controls generated for each type.
- Types automatically added alongside documentation

**Cons**

- Advanced controls options still need to be manage in each individual story. 
- Shared props like `theme` need to have their description duplicated for each component. I don't know if there's a way we can share this.
- Somewhat locked into storybook unless we spend dev time to extract the documentation data elsewhere.

![image](https://user-images.githubusercontent.com/149873/132373421-972494b0-11c0-494f-8969-251cd695c90a.png)


### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
