### PR TITLE
Fixes Shopify/polaris-viz/issues/508

### DIFF
--- a/src/components/BarChart/Chart.scss
+++ b/src/components/BarChart/Chart.scss
@@ -2,3 +2,7 @@
   position: relative;
   user-select: none;
 }
+
+.SVG {
+  overflow: visible;
+}

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -7,9 +7,8 @@ import {
   LINE_HEIGHT,
   MIN_BAR_HEIGHT,
   BARS_TRANSITION_CONFIG,
-  MASK_HIGHLIGHT_COLOR,
-  MASK_SUBDUE_COLOR,
   XMLNS,
+  SUBDUE_OPACITY,
 } from '../../constants';
 import {
   eventPoint,
@@ -242,7 +241,6 @@ export function Chart({
   const {width, height} = chartDimensions;
 
   const gradientId = useMemo(() => uniqueId('gradient'), []);
-  const clipId = useMemo(() => uniqueId('clip'), []);
 
   const gradient = isGradientType(barTheme.color)
     ? barTheme.color
@@ -262,6 +260,7 @@ export function Chart({
       }}
     >
       <svg
+        className={styles.SVG}
         xmlns={XMLNS}
         width={width}
         height={height}
@@ -280,45 +279,47 @@ export function Chart({
             y1="100%"
             y2="0%"
           />
-
-          <mask id={clipId}>
-            <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
-              {transitions(({height}, item, _transition, index) => {
-                const xPosition = xScale(index.toString());
-                const ariaLabel = `${xAxisOptions.labelFormatter(
-                  data[index].label,
-                )}: ${yAxisOptions.labelFormatter(data[index].rawValue)}`;
-                const isSubdued = activeBar != null && index !== activeBar;
-                const annotation = annotationsLookupTable[index];
-
-                return (
-                  <g role="listitem" key={index}>
-                    <Bar
-                      height={height}
-                      key={index}
-                      x={xPosition == null ? 0 : xPosition}
-                      yScale={yScale}
-                      rawValue={item.rawValue}
-                      width={barWidth}
-                      color={
-                        isSubdued ? MASK_SUBDUE_COLOR : MASK_HIGHLIGHT_COLOR
-                      }
-                      onFocus={handleFocus}
-                      index={index}
-                      ariaLabel={`${ariaLabel} ${
-                        annotation ? annotation.ariaLabel : ''
-                      }`}
-                      tabIndex={0}
-                      role="img"
-                      hasRoundedCorners={barTheme.hasRoundedCorners}
-                      rotateZeroBars={rotateZeroBars}
-                    />
-                  </g>
-                );
-              })}
-            </g>
-          </mask>
         </defs>
+        <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
+          {transitions(({height}, item, _transition, index) => {
+            const xPosition = xScale(index.toString());
+            const ariaLabel = `${xAxisOptions.labelFormatter(
+              data[index].label,
+            )}: ${yAxisOptions.labelFormatter(data[index].rawValue)}`;
+            const isSubdued = activeBar != null && index !== activeBar;
+            const annotation = annotationsLookupTable[index];
+
+            const barColor =
+              typeof item.barColor === 'string' ? item.barColor : null;
+
+            return (
+              <g
+                role="listitem"
+                key={index}
+                style={{opacity: isSubdued ? SUBDUE_OPACITY : 1}}
+              >
+                <Bar
+                  height={height}
+                  key={index}
+                  x={xPosition == null ? 0 : xPosition}
+                  yScale={yScale}
+                  rawValue={item.rawValue}
+                  width={barWidth}
+                  color={barColor ?? `url(#${gradientId})`}
+                  onFocus={handleFocus}
+                  index={index}
+                  ariaLabel={`${ariaLabel} ${
+                    annotation ? annotation.ariaLabel : ''
+                  }`}
+                  tabIndex={0}
+                  role="img"
+                  hasRoundedCorners={barTheme.hasRoundedCorners}
+                  rotateZeroBars={rotateZeroBars}
+                />
+              </g>
+            );
+          })}
+        </g>
         <g
           transform={`translate(${chartStartPosition},${
             chartDimensions.height -
@@ -365,37 +366,6 @@ export function Chart({
             backgroundColor={yAxisTheme.backgroundColor}
             outerMargin={gridTheme.horizontalMargin}
           />
-        </g>
-
-        <g mask={`url(#${clipId})`}>
-          <rect
-            x="0"
-            y="0"
-            width={width}
-            height={height}
-            fill={`url(#${gradientId})`}
-          />
-          {transitions((_props, item, _transition, index) => {
-            const xPosition = xScale(index.toString());
-            const xPositionValue = xPosition == null ? 0 : xPosition;
-            const translateXValue = xPositionValue + chartStartPosition;
-
-            const barColor =
-              typeof item.barColor === 'string' ? item.barColor : null;
-
-            return barColor != null ? (
-              <rect
-                key={index}
-                transform={`translate(${translateXValue},${Margin.Top})`}
-                x="0"
-                y="0"
-                width={barWidth}
-                height={height}
-                fill={barColor}
-              />
-            ) : null;
-          })}
-          ;
         </g>
 
         <g transform={`translate(${chartStartPosition},${Margin.Top})`}>

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -11,11 +11,7 @@ import {
 import {mountWithProvider} from '../../../test-utilities';
 import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
-import {
-  MASK_SUBDUE_COLOR,
-  MASK_HIGHLIGHT_COLOR,
-  MIN_BAR_HEIGHT,
-} from '../../../constants';
+import {MIN_BAR_HEIGHT, SUBDUE_OPACITY} from '../../../constants';
 
 const fakeSVGEvent = {
   currentTarget: {
@@ -153,11 +149,13 @@ describe('Chart />', () => {
       const chart = mountWithProvider(<Chart {...mockProps} />);
 
       const svg = chart.find('svg')!;
-      expect(chart).toContainReactComponent(Bar, {color: MASK_HIGHLIGHT_COLOR});
+      expect(chart).toContainReactComponent('g', {style: {opacity: 1}});
 
       svg.trigger('onMouseMove', fakeSVGEvent);
 
-      expect(chart).toContainReactComponent(Bar, {color: MASK_SUBDUE_COLOR});
+      expect(chart).toContainReactComponent('g', {
+        style: {opacity: SUBDUE_OPACITY},
+      });
     });
 
     describe('rotateZeroBars', () => {
@@ -259,13 +257,7 @@ describe('Chart />', () => {
       };
       const chart = mountWithProvider(<Chart {...updatedProps} />);
 
-      expect(chart.find('rect', {fill: 'purple'})).not.toBeNull();
-    });
-
-    it('does not render when the barTheme.color does not exist', () => {
-      const chart = mountWithProvider(<Chart {...mockProps} />);
-
-      expect(chart.find('rect', {fill: 'purple'})).toBeNull();
+      expect(chart).toContainReactComponent(Bar, {color: 'purple'});
     });
   });
 

--- a/src/components/MultiSeriesBarChart/Chart.scss
+++ b/src/components/MultiSeriesBarChart/Chart.scss
@@ -2,3 +2,7 @@
   position: relative;
   user-select: none;
 }
+
+.SVG {
+  overflow: visible;
+}

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -230,6 +230,7 @@ export function Chart({
       }}
     >
       <svg
+        className={styles.SVG}
         xmlns={XMLNS}
         width={chartDimensions.width}
         height={chartDimensions.height}
@@ -316,7 +317,6 @@ export function Chart({
                     yScale={yScale}
                     data={item}
                     width={xScale.bandwidth()}
-                    height={drawableHeight}
                     colors={barColors}
                     onFocus={handleFocus}
                     barGroupIndex={index}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -10,8 +10,7 @@ import {BAR_SPACING} from '../../constants';
 import {
   MIN_BAR_HEIGHT,
   BARS_TRANSITION_CONFIG,
-  MASK_SUBDUE_COLOR,
-  MASK_HIGHLIGHT_COLOR,
+  SUBDUE_OPACITY,
 } from '../../../../constants';
 import {getAnimationTrail, uniqueId} from '../../../../utilities';
 
@@ -19,7 +18,6 @@ interface Props {
   x: number;
   yScale: ScaleLinear<number, number>;
   width: number;
-  height: number;
   data: number[];
   colors: Color[];
   isSubdued: boolean;
@@ -38,7 +36,6 @@ export function BarGroup({
   yScale,
   width,
   colors,
-  height,
   onFocus,
   barGroupIndex,
   ariaLabel,
@@ -93,39 +90,38 @@ export function BarGroup({
 
   return (
     <React.Fragment>
-      <mask id={maskId}>
-        {transitions(({height}, value, _transition, index) => {
-          const handleFocus = () => {
-            onFocus(barGroupIndex);
-          };
+      {transitions(({height}, value, _transition, index) => {
+        const handleFocus = () => {
+          onFocus(barGroupIndex);
+        };
 
-          const ariaEnabledBar = index === 0;
-          return (
-            <g
-              role={ariaEnabledBar ? 'listitem' : undefined}
-              aria-hidden={!ariaEnabledBar}
-              key={`${barGroupIndex}${index}`}
-            >
-              <Bar
-                height={height}
-                color={isSubdued ? MASK_SUBDUE_COLOR : MASK_HIGHLIGHT_COLOR}
-                x={x + (barWidth + BAR_SPACING) * index}
-                yScale={yScale}
-                rawValue={value}
-                width={barWidth}
-                index={index}
-                onFocus={handleFocus}
-                tabIndex={ariaEnabledBar ? 0 : -1}
-                role={ariaEnabledBar ? 'img' : undefined}
-                ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
-                hasRoundedCorners={hasRoundedCorners}
-                rotateZeroBars={rotateZeroBars}
-              />
-            </g>
-          );
-        })}
-      </mask>
-      <g mask={`url(#${maskId})`}>
+        const ariaEnabledBar = index === 0;
+        return (
+          <g
+            role={ariaEnabledBar ? 'listitem' : undefined}
+            aria-hidden={!ariaEnabledBar}
+            key={`${barGroupIndex}${index}`}
+            opacity={isSubdued ? SUBDUE_OPACITY : 1}
+          >
+            <Bar
+              height={height}
+              color={`url(#${gradientId}${index})`}
+              x={x + (barWidth + BAR_SPACING) * index}
+              yScale={yScale}
+              rawValue={value}
+              width={barWidth}
+              index={index}
+              onFocus={handleFocus}
+              tabIndex={ariaEnabledBar ? 0 : -1}
+              role={ariaEnabledBar ? 'img' : undefined}
+              ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
+              hasRoundedCorners={hasRoundedCorners}
+              rotateZeroBars={rotateZeroBars}
+            />
+          </g>
+        );
+      })}
+      <defs>
         {gradients.map((gradient, index) => {
           return (
             <g key={`${maskId}${index}`}>
@@ -133,18 +129,10 @@ export function BarGroup({
                 gradient={gradient}
                 id={`${gradientId}${index}`}
               />
-              <rect
-                x={x + (barWidth + BAR_SPACING) * index}
-                y={0}
-                width={barWidth}
-                height={height}
-                fill={`url(#${gradientId}${index})`}
-              />
-              ;
             </g>
           );
         })}
-      </g>
+      </defs>
     </React.Fragment>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,7 @@ export const MAX_TRAIL_DURATION = 500;
 
 export const MASK_HIGHLIGHT_COLOR = variables.colorWhite;
 export const MASK_SUBDUE_COLOR = '#434343';
+export const SUBDUE_OPACITY = 0.4;
 
 export const colorSky = variables.colorSky;
 export const colorWhite = variables.colorWhite;


### PR DESCRIPTION
### What problem is this PR solving?

The bezier-curve on the animation was pushing the bar outside the SVG and then back inside the bounds. Because we were using a mask, it was making the highest bars look cutoff for a second.

### Reviewers’ :tophat: instructions

- Load the MultiSeriesBarChart story: http://localhost:6006/?path=/story/charts-multiseriesbarchart--default
- The rounded corners on all the bars should stay rounded even at the top of the animation.

You can use the videos below to go frame by frame to see that issue, it can be a little hard to notice when the story loads.

[Before](https://screenshot.click/07-52-f868i-bnjde.mp4)

[After](https://screenshot.click/07-50-88vkm-2f5hi.mp4)

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
