### PR TITLE
Align all yAxis labels right by default

### DIFF
--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -279,7 +279,7 @@ export function Chart({
             ticks={ticks}
             fontSize={fontSize}
             labelColor={yAxisOptions.labelColor}
-            textAlign={gridOptions.horizontalOverflow ? 'right' : 'left'}
+            textAlign={gridOptions.horizontalOverflow ? 'left' : 'right'}
             width={yAxisLabelWidth}
             backgroundColor={yAxisOptions.backgroundColor}
             outerMargin={gridOptions.horizontalMargin}


### PR DESCRIPTION
Fixes Shopify/polaris-viz/issues/514

### What problem is this PR solving?

`MultiSeriesBarChart` yAxis label logic was flipped from all the other components, making it `left` aligned by default.

### Reviewers’ :tophat: instructions

- Verify `MultiSeriesBarChart` yAxis labels are right aligned by default.

[![alt](https://screenshot.click/07-40-amb97-srgn8.png)](https://screenshot.click/07-40-amb97-srgn8.png)

Bonus points: Check all other components as well.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
