### PR TITLE
[Line Chart] Allow prop to configure hiding xAxis labels

### DIFF
--- a/src/components/LineChart/LineChart.md
+++ b/src/components/LineChart/LineChart.md
@@ -127,6 +127,7 @@ const props = {
     xAxisLabels: xAxisLabels,
     labelFormatter: formatXAxisLabel,
     useMinimalLabels: true,
+    hide: false,
   },
   yAxisOptions: {
     labelFormatter: formatYAxisLabel,
@@ -151,6 +152,7 @@ interface LineChartProps {
     xAxisLabels: string[];
     labelFormatter?(value: string, index?: number, data?: string[]): string;
     useMinimalLabels?: boolean;
+    hide?: false,
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
@@ -302,6 +304,14 @@ Used to indicate to screenreaders that a chart with no data has been rendered, i
 #### xAxisOptions
 
 An object including the following proprties that define the appearance of the xAxis. Only xAxisLabels is mandatory.
+
+##### hide
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to hide the xAxis. If this prop is not provided, defaults to the theme option.
 
 ##### useMinimalLabels
 

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -133,6 +133,7 @@ export function LineChart({
     xAxisLabels: xAxisOptions.xAxisLabels,
     useMinimalLabels: xAxisOptions.useMinimalLabels ?? false,
     ...selectedTheme.xAxis,
+    hide: xAxisOptions.hide ?? selectedTheme.xAxis.hide,
   };
 
   const yAxisOptionsWithDefaults = {

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -129,11 +129,11 @@ SeriesColors.args = {
 
 export const HideXAxisLabels: Story<LineChartProps> = Template.bind({});
 HideXAxisLabels.args = {
-  theme: 'NoxAxisLabels',
   series,
   xAxisOptions: {
     xAxisLabels,
     labelFormatter: formatXAxisLabel,
+    hide: true,
   },
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   renderTooltipContent,

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -35,6 +35,7 @@ export interface XAxisOptions {
   labelFormatter: StringLabelFormatter;
   xAxisLabels: string[];
   useMinimalLabels: boolean;
+  hide: boolean;
 }
 
 export interface YAxisOptions {


### PR DESCRIPTION
### What problem is this PR solving?
We need to be able to hide the xAxis labels via props on the line chart in order to ship theming to web

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->
Check out this story http://localhost:6006/?path=/story/charts-linechart--hide-x-axis-labels
See that if you change the xAxisOption `hide` to `false`, the labels appear

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
