### PR TITLE
Revert #511 and fix animation issue

### DIFF
--- a/src/components/BarChart/Chart.scss
+++ b/src/components/BarChart/Chart.scss
@@ -2,7 +2,3 @@
   position: relative;
   user-select: none;
 }
-
-.SVG {
-  overflow: visible;
-}

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -11,7 +11,11 @@ import {
 import {mountWithProvider} from '../../../test-utilities';
 import {AnnotationLine} from '../components';
 import {Chart} from '../Chart';
-import {MIN_BAR_HEIGHT, SUBDUE_OPACITY} from '../../../constants';
+import {
+  MASK_SUBDUE_COLOR,
+  MASK_HIGHLIGHT_COLOR,
+  MIN_BAR_HEIGHT,
+} from '../../../constants';
 
 const fakeSVGEvent = {
   currentTarget: {
@@ -149,13 +153,11 @@ describe('Chart />', () => {
       const chart = mountWithProvider(<Chart {...mockProps} />);
 
       const svg = chart.find('svg')!;
-      expect(chart).toContainReactComponent('g', {style: {opacity: 1}});
+      expect(chart).toContainReactComponent(Bar, {color: MASK_HIGHLIGHT_COLOR});
 
       svg.trigger('onMouseMove', fakeSVGEvent);
 
-      expect(chart).toContainReactComponent('g', {
-        style: {opacity: SUBDUE_OPACITY},
-      });
+      expect(chart).toContainReactComponent(Bar, {color: MASK_SUBDUE_COLOR});
     });
 
     describe('rotateZeroBars', () => {
@@ -257,7 +259,13 @@ describe('Chart />', () => {
       };
       const chart = mountWithProvider(<Chart {...updatedProps} />);
 
-      expect(chart).toContainReactComponent(Bar, {color: 'purple'});
+      expect(chart.find('rect', {fill: 'purple'})).not.toBeNull();
+    });
+
+    it('does not render when the barTheme.color does not exist', () => {
+      const chart = mountWithProvider(<Chart {...mockProps} />);
+
+      expect(chart.find('rect', {fill: 'purple'})).toBeNull();
     });
   });
 

--- a/src/components/MultiSeriesBarChart/Chart.scss
+++ b/src/components/MultiSeriesBarChart/Chart.scss
@@ -2,7 +2,3 @@
   position: relative;
   user-select: none;
 }
-
-.SVG {
-  overflow: visible;
-}

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -230,7 +230,6 @@ export function Chart({
       }}
     >
       <svg
-        className={styles.SVG}
         xmlns={XMLNS}
         width={chartDimensions.width}
         height={chartDimensions.height}
@@ -240,6 +239,7 @@ export function Chart({
         onTouchEnd={() => setActiveBarGroup(null)}
         role={emptyState ? 'img' : 'list'}
         aria-label={emptyState ? emptyStateText : undefined}
+        style={{overflow: 'visible'}}
       >
         <g
           transform={`translate(${chartStartPosition},${
@@ -317,6 +317,7 @@ export function Chart({
                     yScale={yScale}
                     data={item}
                     width={xScale.bandwidth()}
+                    height={drawableHeight}
                     colors={barColors}
                     onFocus={handleFocus}
                     barGroupIndex={index}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -10,7 +10,9 @@ import {BAR_SPACING} from '../../constants';
 import {
   MIN_BAR_HEIGHT,
   BARS_TRANSITION_CONFIG,
-  SUBDUE_OPACITY,
+  MASK_SUBDUE_COLOR,
+  MASK_HIGHLIGHT_COLOR,
+  BAR_ANIMATION_Y_OFFSET,
 } from '../../../../constants';
 import {getAnimationTrail, uniqueId} from '../../../../utilities';
 
@@ -18,6 +20,7 @@ interface Props {
   x: number;
   yScale: ScaleLinear<number, number>;
   width: number;
+  height: number;
   data: number[];
   colors: Color[];
   isSubdued: boolean;
@@ -36,6 +39,7 @@ export function BarGroup({
   yScale,
   width,
   colors,
+  height,
   onFocus,
   barGroupIndex,
   ariaLabel,
@@ -90,38 +94,39 @@ export function BarGroup({
 
   return (
     <React.Fragment>
-      {transitions(({height}, value, _transition, index) => {
-        const handleFocus = () => {
-          onFocus(barGroupIndex);
-        };
+      <mask id={maskId}>
+        {transitions(({height}, value, _transition, index) => {
+          const handleFocus = () => {
+            onFocus(barGroupIndex);
+          };
 
-        const ariaEnabledBar = index === 0;
-        return (
-          <g
-            role={ariaEnabledBar ? 'listitem' : undefined}
-            aria-hidden={!ariaEnabledBar}
-            key={`${barGroupIndex}${index}`}
-            opacity={isSubdued ? SUBDUE_OPACITY : 1}
-          >
-            <Bar
-              height={height}
-              color={`url(#${gradientId}${index})`}
-              x={x + (barWidth + BAR_SPACING) * index}
-              yScale={yScale}
-              rawValue={value}
-              width={barWidth}
-              index={index}
-              onFocus={handleFocus}
-              tabIndex={ariaEnabledBar ? 0 : -1}
-              role={ariaEnabledBar ? 'img' : undefined}
-              ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
-              hasRoundedCorners={hasRoundedCorners}
-              rotateZeroBars={rotateZeroBars}
-            />
-          </g>
-        );
-      })}
-      <defs>
+          const ariaEnabledBar = index === 0;
+          return (
+            <g
+              role={ariaEnabledBar ? 'listitem' : undefined}
+              aria-hidden={!ariaEnabledBar}
+              key={`${barGroupIndex}${index}`}
+            >
+              <Bar
+                height={height}
+                color={isSubdued ? MASK_SUBDUE_COLOR : MASK_HIGHLIGHT_COLOR}
+                x={x + (barWidth + BAR_SPACING) * index}
+                yScale={yScale}
+                rawValue={value}
+                width={barWidth}
+                index={index}
+                onFocus={handleFocus}
+                tabIndex={ariaEnabledBar ? 0 : -1}
+                role={ariaEnabledBar ? 'img' : undefined}
+                ariaLabel={ariaEnabledBar ? ariaLabel : undefined}
+                hasRoundedCorners={hasRoundedCorners}
+                rotateZeroBars={rotateZeroBars}
+              />
+            </g>
+          );
+        })}
+      </mask>
+      <g mask={`url(#${maskId})`}>
         {gradients.map((gradient, index) => {
           return (
             <g key={`${maskId}${index}`}>
@@ -129,10 +134,18 @@ export function BarGroup({
                 gradient={gradient}
                 id={`${gradientId}${index}`}
               />
+              <rect
+                x={x + (barWidth + BAR_SPACING) * index}
+                y={-BAR_ANIMATION_Y_OFFSET}
+                width={barWidth}
+                height={height + BAR_ANIMATION_Y_OFFSET}
+                fill={`url(#${gradientId}${index})`}
+              />
+              ;
             </g>
           );
         })}
-      </defs>
+      </g>
     </React.Fragment>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const ROUNDED_BAR_RADIUS = 4;
 export const MIN_BAR_HEIGHT = 2;
 export const EMPTY_STATE_CHART_MIN = 0;
 export const EMPTY_STATE_CHART_MAX = 10;
+export const BAR_ANIMATION_Y_OFFSET = 15;
 
 export const DEFAULT_GREY_LABEL = 'rgb(99, 115, 129)';
 export const DEFAULT_CROSSHAIR_COLOR = variables.colorSky;
@@ -47,7 +48,6 @@ export const MAX_TRAIL_DURATION = 500;
 
 export const MASK_HIGHLIGHT_COLOR = variables.colorWhite;
 export const MASK_SUBDUE_COLOR = '#434343';
-export const SUBDUE_OPACITY = 0.4;
 
 export const colorSky = variables.colorSky;
 export const colorWhite = variables.colorWhite;


### PR DESCRIPTION
### What problem is this PR solving?

Reverts https://github.com/Shopify/polaris-viz/pull/511 to fix an issue with gradients using the individual bar sizes instead of overall container size.

It also applies the correct fix that doesn't require removing the mask.

### Reviewers’ :tophat: instructions

Check `BarChart` and `MultiSeriesBarChart`. Everything should look correct and rounded corners should not be cut off on intro animation. 

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
