### PR TITLE
Fix default sparkbar color

### DIFF
--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -77,7 +77,7 @@ export function Sparkbar({
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const selectedTheme = useTheme(theme);
-  const [seriesColor] = getSeriesColorsFromCount(data.length, selectedTheme);
+  const [seriesColor] = getSeriesColorsFromCount(1, selectedTheme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
     if (entry == null) return;


### PR DESCRIPTION
### What problem is this PR solving?

The sparkbar was counting each data point as a different series, and thus using the wrong default color:

<img width="239" alt="Screen Shot 2021-09-08 at 4 09 42 PM" src="https://user-images.githubusercontent.com/4037781/132578300-5ad907ac-6fca-4b3d-a320-c4a7ed72e351.png">
<img width="263" alt="Screen Shot 2021-09-08 at 4 09 12 PM" src="https://user-images.githubusercontent.com/4037781/132578310-fff0abd7-cb8d-471f-9173-a9a641beb1fc.png">



### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
