### PR TITLE
use different color for single series charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## [0.19.1] - 2021-09-09
+### Added
+
+- Added `seriesColors.single`  in theme definition
 
 ## [0.19.0-9] - 2021-09-08
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -65,8 +65,15 @@ const createGradient = (color1: string, color2: string) => {
   ];
 };
 
+const NEUTRAL_SINGLE_GRADIENT = [
+  {offset: 0, color: variables.colorIndigo90},
+  {offset: 85, color: variables.colorBlue90},
+  {offset: 100, color: variables.colorBlue70},
+];
+
 export const DEFAULT_THEME: Theme = {
   seriesColors: {
+    single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
       createGradient(variables.colorIndigo70, variables.colorIndigo90),
       createGradient(variables.colorBlue70, variables.colorBlue90),
@@ -160,6 +167,7 @@ export const DEFAULT_THEME: Theme = {
 
 export const LIGHT_THEME: Theme = {
   seriesColors: {
+    single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
       createGradient(variables.colorIndigo70, variables.colorIndigo90),
       createGradient(variables.colorBlue70, variables.colorBlue90),

--- a/src/hooks/use-theme-series-colors.ts
+++ b/src/hooks/use-theme-series-colors.ts
@@ -56,6 +56,10 @@ export function getSeriesColorsFromCount(
 }
 
 export function getSeriesColors(count: number, selectedTheme: Theme): Color[] {
+  if (count === 1) {
+    return [selectedTheme.seriesColors.single];
+  }
+
   if (count <= 4) {
     return selectedTheme.seriesColors.upToFour;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface TooltipTheme {
   labelColor: string;
 }
 export interface SeriesColors {
+  single: Color;
   upToFour: Color[];
   fromFiveToSeven: Color[];
   all: Color[];


### PR DESCRIPTION
### What problem is this PR solving?
Apply a different default gradient for charts with a single series:

<img width="829" alt="Screen Shot 2021-09-09 at 11 19 26 AM" src="https://user-images.githubusercontent.com/4037781/132714203-e38bee4e-c5dd-4c02-9459-6791d9c9ff3d.png">



### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
