### PR TITLE
Hide xaxis option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Hiding the xAxis is now possible on the `<BarChart />`, `<MultiseriesBarChart />` and `<StackedAreaChart />`
+
+
 ## [0.20.3] - 2021-09-14
 - Fixed the direction of the gradient on the horizontal `<NormalizedStackedBarChart />` legend
 - Remove change that made data required in `<Legend />` props

--- a/src/components/BarChart/BarChart.md
+++ b/src/components/BarChart/BarChart.md
@@ -37,6 +37,7 @@ const props = {
   xAxisOptions: {
     useMinimalLabels: true,
     labelColor: 'rgb(220, 220, 220)',
+    hide: false,
   },
   yAxisOptions: {
     integersOnly: true,
@@ -75,6 +76,7 @@ interface BarChartProps {
   xAxisOptions?: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
     useMinimalLabels?: boolean;
+    hide?: boolean;
   };
   yAxisOptions?: {
     labelFormatter?(value: number): string;
@@ -163,6 +165,14 @@ Used to indicate to screenreaders that a chart with no data has been rendered, i
 The theme controls the visual appearance of the chart, its axis and grid.
 
 #### xAxisOptions
+
+##### hide
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to hide the xAxis visually, but not for screenreaders.
 
 ##### labelFormatter
 

--- a/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/src/components/BarChart/stories/BarChart.stories.tsx
@@ -115,6 +115,14 @@ Default.args = {
   },
 };
 
+export const NoXAxis: Story<BarChartProps> = Template.bind({});
+NoXAxis.args = {
+  ...defaultProps,
+  xAxisOptions: {
+    hide: true,
+  },
+};
+
 export const Annotations: Story<BarChartProps> = Template.bind({});
 Annotations.args = {
   ...defaultProps,

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -62,6 +62,7 @@ describe('Chart />', () => {
     xAxisOptions: {
       labelFormatter: (value: string) => value.toString(),
       useMinimalLabels: false,
+      hide: false,
     },
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
@@ -78,6 +79,16 @@ describe('Chart />', () => {
     it('renders', () => {
       const barChart = mountWithProvider(<Chart {...mockProps} />);
       expect(barChart).toContainReactComponent(BarChartXAxis);
+    });
+
+    it('does not render if hidden', () => {
+      const barChart = mountWithProvider(
+        <Chart
+          {...mockProps}
+          xAxisOptions={{...mockProps.xAxisOptions, hide: true}}
+        />,
+      );
+      expect(barChart).not.toContainReactComponent(BarChartXAxis);
     });
   });
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -53,9 +53,8 @@ interface Props {
   isAnimated: boolean;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   series: SeriesWithDefaults[];
-  xAxisOptions: Required<XAxisOptions>;
+  xAxisOptions: XAxisOptions;
   yAxisOptions: Required<YAxisOptions>;
-
   emptyStateText?: string;
   theme?: string;
 }
@@ -329,22 +328,24 @@ export function Chart({
         onMouseLeave={() => handleMouseInteraction(null)}
         aria-label={emptyState ? emptyStateText : undefined}
       >
-        <g
-          transform={`translate(${dataStartPosition},${
-            dimensions.height - marginBottom
-          })`}
-        >
-          <LinearXAxis
-            xAxisDetails={xAxisDetails}
-            xScale={xScale}
-            labels={hideXAxis ? null : formattedLabels}
-            drawableWidth={drawableWidth}
-            fontSize={fontSize}
-            drawableHeight={drawableHeight}
-            ariaHidden
-            theme={theme}
-          />
-        </g>
+        {xAxisOptions.hide ? null : (
+          <g
+            transform={`translate(${dataStartPosition},${
+              dimensions.height - marginBottom
+            })`}
+          >
+            <LinearXAxis
+              xAxisDetails={xAxisDetails}
+              xScale={xScale}
+              labels={hideXAxis ? null : formattedLabels}
+              drawableWidth={drawableWidth}
+              fontSize={fontSize}
+              drawableHeight={drawableHeight}
+              ariaHidden
+              theme={theme}
+            />
+          </g>
+        )}
 
         {selectedTheme.grid.showHorizontalLines ? (
           <HorizontalGridLines

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -126,8 +126,7 @@ export function LineChart({
     handlePrintMediaQueryChange,
   ]);
 
-  const xAxisOptionsWithDefaults: Required<XAxisOptions> = {
-    hide: false,
+  const xAxisOptionsWithDefaults: XAxisOptions = {
     labelFormatter: (value: string) => value,
     useMinimalLabels: false,
     xAxisLabels: [],

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -127,6 +127,17 @@ describe('<Chart />', () => {
       });
     });
 
+    it('does not render a <LinearXAxis /> if it is hidden', () => {
+      const chart = mount(
+        <Chart
+          {...mockProps}
+          xAxisOptions={{...mockProps.xAxisOptions, hide: true}}
+        />,
+      );
+
+      expect(chart).not.toContainReactComponent(LinearXAxis);
+    });
+
     it('passes formatted labels to the <LinearXAxis>, formatting them with formatXAxisLabel', () => {
       const chart = mount(
         <Chart

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -35,7 +35,7 @@ export interface XAxisOptions {
   labelFormatter: StringLabelFormatter;
   xAxisLabels: string[];
   useMinimalLabels: boolean;
-  hide: boolean;
+  hide?: boolean;
 }
 
 export interface YAxisOptions {

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -41,7 +41,6 @@ interface Props {
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
-
   isStacked?: boolean;
   emptyStateText?: string;
   isAnimated?: boolean;
@@ -115,17 +114,20 @@ export function Chart({
     [selectedTheme.bar.zeroAsMinHeight, series],
   );
 
+  const hideXAxis = xAxisOptions.hide ?? selectedTheme.xAxis.hide;
+
   const xAxisDetails = useMemo(
     () =>
       getBarXAxisDetails({
         yAxisLabelWidth,
-        xLabels: formattedXAxisLabels,
+        xLabels: hideXAxis ? [] : formattedXAxisLabels,
         fontSize,
         width: chartDimensions.width - selectedTheme.grid.horizontalMargin * 2,
         innerMargin: BarMargin[selectedTheme.bar.innerMargin],
         outerMargin: BarMargin[selectedTheme.bar.outerMargin],
       }),
     [
+      hideXAxis,
       yAxisLabelWidth,
       formattedXAxisLabels,
       fontSize,
@@ -251,20 +253,22 @@ export function Chart({
         role={emptyState ? 'img' : 'list'}
         aria-label={emptyState ? emptyStateText : undefined}
       >
-        <g
-          transform={`translate(${chartStartPosition},${
-            chartDimensions.height - Margin.Bottom - maxXLabelHeight
-          })`}
-          aria-hidden="true"
-        >
-          <BarChartXAxis
-            labels={xAxisLabels}
-            xScale={xScale}
-            xAxisDetails={xAxisDetails}
-            fontSize={fontSize}
-            theme={theme}
-          />
-        </g>
+        {hideXAxis ? null : (
+          <g
+            transform={`translate(${chartStartPosition},${
+              chartDimensions.height - Margin.Bottom - maxXLabelHeight
+            })`}
+            aria-hidden="true"
+          >
+            <BarChartXAxis
+              labels={xAxisLabels}
+              xScale={xScale}
+              xAxisDetails={xAxisDetails}
+              fontSize={fontSize}
+              theme={theme}
+            />
+          </g>
+        )}
 
         {selectedTheme.grid.showHorizontalLines ? (
           <HorizontalGridLines

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.md
@@ -122,6 +122,7 @@ interface MultiSeriesBarChartProps {
   xAxisOptions: {
     labelFormatter?(value: string, index?: number, data?: string[]): string;
     labels: string[];
+    hide?: boolean;
   };
   yAxisOptions: {
     labelFormatter?(value: number): string;
@@ -239,6 +240,14 @@ This accepts a function that is called to render the tooltip content. By default
 #### xAxisOptions
 
 An object including the following proprties that define the appearance of the xAxis. Only labels is mandatory.
+
+##### hide
+
+| type      | default |
+| --------- | ------- |
+| `boolean` | `false` |
+
+Whether to hide the xAxis visually, not for screenreaders.
 
 ##### labelFormatter
 

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -122,7 +122,7 @@ export function MultiSeriesBarChart({
     handlePrintMediaQueryChange,
   ]);
 
-  const xAxisOptionsWithDefaults: Required<XAxisOptions> = {
+  const xAxisOptionsWithDefaults: XAxisOptions = {
     labelFormatter: (value: string) => value,
     labels: [],
     ...xAxisOptions,

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -229,6 +229,12 @@ NoOverflowStyle.args = {
   xAxisOptions: {labels},
 };
 
+export const NoXAxis = Template.bind({});
+NoXAxis.args = {
+  series: series,
+  xAxisOptions: {labels, hide: true},
+};
+
 const WithoutRoundedCornersTemplate: Story<MultiSeriesBarChartProps> = (
   args: MultiSeriesBarChartProps,
 ) => {

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -74,6 +74,7 @@ describe('Chart />', () => {
       showTicks: true,
       labels: ['stuff 1', 'stuff 2', 'stuff 3'],
       labelColor: 'red',
+      hide: false,
     },
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
@@ -92,6 +93,16 @@ describe('Chart />', () => {
   it('renders an BarChartXAxis', () => {
     const chart = mount(<Chart {...mockProps} />);
     expect(chart).toContainReactComponent(BarChartXAxis);
+  });
+
+  it('does not render BarChartXAxis if it is hidden', () => {
+    const chart = mount(
+      <Chart
+        {...mockProps}
+        xAxisOptions={{...mockProps.xAxisOptions, hide: true}}
+      />,
+    );
+    expect(chart).not.toContainReactComponent(BarChartXAxis);
   });
 
   it('renders an yAxis', () => {

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -52,6 +52,7 @@ export interface BarOptions {
 export interface XAxisOptions {
   labelFormatter: StringLabelFormatter;
   labels: string[];
+  hide?: boolean;
 }
 
 export interface YAxisOptions {

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -50,6 +50,7 @@ import type {Series, RenderTooltipContentData} from './types';
 import styles from './Chart.scss';
 
 interface Props {
+  hideXAxis: boolean;
   xAxisLabels: string[];
   series: Series[];
   formatXAxisLabel: StringLabelFormatter;
@@ -63,6 +64,7 @@ interface Props {
 type SeriesForAnimation = Required<Partial<DataSeries<Data, null>>>;
 
 export function Chart({
+  hideXAxis,
   xAxisLabels,
   series,
   dimensions,
@@ -133,7 +135,7 @@ export function Chart({
   const formattedXAxisLabels = xAxisLabels.map(formatXAxisLabel);
 
   const marginBottom =
-    xAxisLabels == null
+    xAxisLabels == null || hideXAxis
       ? SPACING_TIGHT
       : xAxisDetails.maxXLabelHeight + Number(Margin.Bottom);
 
@@ -252,22 +254,24 @@ export function Chart({
         onMouseLeave={() => setActivePointIndex(null)}
         role="table"
       >
-        <g
-          transform={`translate(${dataStartPosition},${
-            dimensions.height - marginBottom
-          })`}
-        >
-          <LinearXAxis
-            xScale={xScale}
-            labels={formattedXAxisLabels}
-            xAxisDetails={xAxisDetails}
-            drawableHeight={drawableHeight}
-            fontSize={fontSize}
-            drawableWidth={drawableWidth}
-            ariaHidden
-            theme={theme}
-          />
-        </g>
+        {hideXAxis ? null : (
+          <g
+            transform={`translate(${dataStartPosition},${
+              dimensions.height - marginBottom
+            })`}
+          >
+            <LinearXAxis
+              xScale={xScale}
+              labels={hideXAxis ? null : formattedXAxisLabels}
+              xAxisDetails={xAxisDetails}
+              drawableHeight={drawableHeight}
+              fontSize={fontSize}
+              drawableWidth={drawableWidth}
+              ariaHidden
+              theme={theme}
+            />
+          </g>
+        )}
 
         <g transform={`translate(0,${Margin.Top})`}>
           <YAxis

--- a/src/components/StackedAreaChart/StackedAreaChart.md
+++ b/src/components/StackedAreaChart/StackedAreaChart.md
@@ -167,6 +167,16 @@ The distinction between the `RenderTooltipContentData` and series `Data` types i
 
 The prop to determine the chart's drawn area. Each `Series` object corresponds to an area drawn on the chart, and is explained in greater detail [above](#series).
 
+### xAxisOptions: labels
+
+| type       | default |
+| ---------- | ------- |
+| `string[]` | `[]`    |
+
+The labels to display on the x axis of the chart and used for screen readers. If no labels are passed, there are no labels rendered on the x axis of the chart.
+
+### Optional Props
+
 #### theme
 
 | type      | default |
@@ -175,9 +185,7 @@ The prop to determine the chart's drawn area. Each `Series` object corresponds t
 
 The theme that the chart will inherit its styles from. Additional themes must be provided to the theme provider.
 
-### Optional Props
-
-#### formatXAxisLabel
+#### xAxisOptions: formatLabel
 
 | type                                                        | default                       |
 | ----------------------------------------------------------- | ----------------------------- |
@@ -185,29 +193,13 @@ The theme that the chart will inherit its styles from. Additional themes must be
 
 This accepts a function that is called to format the labels when the chart draws its X axis. This is only called if there is a value passed in for `xAxisLabels`.
 
-#### formatYAxisLabel
+#### yAxisOptions: formatLabel
 
 | type                       | default                       |
 | -------------------------- | ----------------------------- |
 | `(value: number): string;` | `(value) => value.toString()` |
 
 The `formatYAxisLabel` function formats the values displayed on the yAxis and in the tooltip.
-
-### xAxisLabels
-
-| type       | default |
-| ---------- | ------- |
-| `string[]` | `[]`    |
-
-The labels to display on the x axis of the chart. If no labels are passed, there are no labels rendered on the x axis of the chart.
-
-### opacity
-
-| type     | default |
-| -------- | ------- |
-| `number` | `1`     |
-
-Determines the opacity of all area shapes. Consider reducing the opacity below 1 if seeing the grid lines behind the areas is important to your use case.
 
 ### isAnimated
 

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -16,10 +16,15 @@ import type {Series, RenderTooltipContentData} from './types';
 import styles from './Chart.scss';
 
 export interface StackedAreaChartProps {
-  formatXAxisLabel?: StringLabelFormatter;
-  formatYAxisLabel?: NumberLabelFormatter;
   renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
-  xAxisLabels: string[];
+  xAxisOptions: {
+    labels: string[];
+    formatLabel?: StringLabelFormatter;
+    hide?: boolean;
+  };
+  yAxisOptions?: {
+    formatLabel?: NumberLabelFormatter;
+  };
   series: Series[];
   isAnimated?: boolean;
   skipLinkText?: string;
@@ -27,10 +32,9 @@ export interface StackedAreaChartProps {
 }
 
 export function StackedAreaChart({
-  xAxisLabels,
+  xAxisOptions,
+  yAxisOptions,
   series,
-  formatXAxisLabel = (value) => value.toString(),
-  formatYAxisLabel = (value) => value.toString(),
   renderTooltipContent,
   isAnimated = false,
   skipLinkText,
@@ -118,6 +122,11 @@ export function StackedAreaChart({
     return null;
   }
 
+  const yFormatter =
+    yAxisOptions?.formatLabel ?? ((value: number) => value.toString());
+
+  const xFormatter = xAxisOptions.formatLabel ?? ((value: string) => value);
+
   function renderDefaultTooltipContent({
     title,
     data,
@@ -125,7 +134,7 @@ export function StackedAreaChart({
     const formattedData = data.map(({color, label, value}) => ({
       color,
       label,
-      value: formatYAxisLabel(value),
+      value: yFormatter(value),
     }));
 
     return <TooltipContent theme={theme} title={title} data={formattedData} />;
@@ -146,10 +155,11 @@ export function StackedAreaChart({
       >
         {chartDimensions == null ? null : (
           <Chart
-            xAxisLabels={xAxisLabels}
+            xAxisLabels={xAxisOptions.labels}
+            hideXAxis={xAxisOptions.hide ?? selectedTheme.xAxis.hide}
             series={series}
-            formatXAxisLabel={formatXAxisLabel}
-            formatYAxisLabel={formatYAxisLabel}
+            formatXAxisLabel={xFormatter}
+            formatYAxisLabel={yFormatter}
             dimensions={chartDimensions}
             renderTooltipContent={
               renderTooltipContent != null

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -45,20 +45,17 @@ export default {
       description:
         'The `Series` type gives the user flexibility to define what each series/area should look like, as well as providing the data to be plotted. [Series type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/StackedAreaChart/types.ts#L3)',
     },
-    xAxisLabels: {
-      description: 'The labels to display on the x axis of the chart.',
+    xAxisOptions: {
+      description:
+        'The labels to display on the x axis of the chart, label formatter and other configuration of its appearance.',
     },
     isAnimated: {
       description:
         'Whether to animate the chart when it is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.',
     },
-    formatXAxisLabel: {
+    yAxisOptions: {
       description:
-        'This accepts a function that is called to format the labels when the chart draws its X axis. This is only called if there is a value passed in for `xAxisLabels`. [StringLabelFormatter type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L108)',
-    },
-    formatYAxisLabel: {
-      description:
-        'The `formatYAxisLabel` function formats the values displayed on the yAxis and in the tooltip. [NumberLabelFormatter type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L114)',
+        'An object containing the `formatYAxisLabel` function, which formats the values displayed on the yAxis and in the tooltip. [NumberLabelFormatter type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L114)',
     },
     renderTooltipContent: {
       options: Object.keys(tooltipContent),
@@ -84,8 +81,8 @@ export default {
 const defaultProps = {
   series: data,
   skipLinkText: 'Skip chart content',
-  xAxisLabels: labels,
-  formatYAxisLabel: formatYAxisLabel,
+  xAxisOptions: {labels},
+  yAxisOptions: {formatLabel: formatYAxisLabel},
   isAnimated: true,
 };
 
@@ -97,12 +94,20 @@ const Template: Story<StackedAreaChartProps> = (
 export const Default: Story<StackedAreaChartProps> = Template.bind({});
 Default.args = defaultProps;
 
+export const HideXAxis: Story<StackedAreaChartProps> = Template.bind({});
+HideXAxis.args = {
+  ...defaultProps,
+  xAxisOptions: {...defaultProps.xAxisOptions, hide: true},
+};
+
 export const Gradients: Story<StackedAreaChartProps> = Template.bind({});
 Gradients.args = {
   ...defaultProps,
-  xAxisLabels: Array(5)
-    .fill(null)
-    .map(() => 'label'),
+  xAxisOptions: {
+    labels: Array(5)
+      .fill(null)
+      .map(() => 'label'),
+  },
   series: [
     {
       name: 'One',
@@ -137,9 +142,11 @@ Gradients.args = {
 export const LargeVolume: Story<StackedAreaChartProps> = Template.bind({});
 LargeVolume.args = {
   ...defaultProps,
-  xAxisLabels: Array(2000)
-    .fill(null)
-    .map(() => 'label'),
+  xAxisOptions: {
+    labels: Array(2000)
+      .fill(null)
+      .map(() => 'label'),
+  },
   series: [
     {
       name: 'First-time',
@@ -171,9 +178,11 @@ LargeVolume.args = {
 export const MediumVolume: Story<StackedAreaChartProps> = Template.bind({});
 MediumVolume.args = {
   ...defaultProps,
-  xAxisLabels: Array(10)
-    .fill(null)
-    .map(() => 'label'),
+  xAxisOptions: {
+    labels: Array(10)
+      .fill(null)
+      .map(() => 'label'),
+  },
   series: [
     {
       name: 'One',

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -73,6 +73,7 @@ describe('<Chart />', () => {
       },
     ],
     xAxisLabels: ['Day 1', 'Day 2'],
+    hideXAxis: false,
     dimensions: {width: 500, height: 250},
     isAnimated: true,
     formatXAxisLabel: (val: string) => val,
@@ -101,6 +102,11 @@ describe('<Chart />', () => {
       fontSize: 12,
       drawableWidth: 480,
     });
+  });
+
+  it('does not render LinearAxis labels if the axis is hidden', () => {
+    const chart = mount(<Chart {...mockProps} hideXAxis />);
+    expect(chart).not.toContainReactComponent(LinearXAxis);
   });
 
   it('formats the x axis labels before passing them to the LinearAxis', () => {

--- a/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
+++ b/src/components/StackedAreaChart/tests/StackedAreaChart.test.tsx
@@ -39,7 +39,10 @@ const xAxisLabels = ['1', '2', '3', '4', '5', '6', '7'];
 describe('<AreaChart />', () => {
   it('renders a <Chart />', () => {
     const areaChart = mount(
-      <StackedAreaChart series={mockData} xAxisLabels={xAxisLabels} />,
+      <StackedAreaChart
+        series={mockData}
+        xAxisOptions={{labels: xAxisLabels}}
+      />,
     );
 
     expect(areaChart).toContainReactComponent(Chart);
@@ -50,7 +53,7 @@ describe('<AreaChart />', () => {
       const areaChart = mount(
         <StackedAreaChart
           series={mockData}
-          xAxisLabels={xAxisLabels}
+          xAxisOptions={{labels: xAxisLabels}}
           skipLinkText="Skip chart content"
         />,
       );
@@ -64,7 +67,7 @@ describe('<AreaChart />', () => {
       const areaChart = mount(
         <StackedAreaChart
           series={mockData}
-          xAxisLabels={xAxisLabels}
+          xAxisOptions={{labels: xAxisLabels}}
           skipLinkText=""
         />,
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type Color = string | GradientStop[];
 export interface XAxisOptions {
   labelFormatter?: StringLabelFormatter;
   useMinimalLabels?: boolean;
+  hide?: boolean;
 }
 export interface YAxisOptions {
   labelFormatter?: NumberLabelFormatter;


### PR DESCRIPTION
### What problem is this PR solving?
Resolves https://github.com/Shopify/polaris-viz/issues/467

For consistency, allows an option for all charts with xAxis to disable them. This was already possible on the line chart, but not the other charts.

As a result of this change, I also brought the StackedAreaChart props more in line with the other components, with xAxisOptions and yAxisOptions.

I also realized that for the LineChart, we were still rendering the xAxis even when it wasn't shown, so I have changed that to match the approach on the other charts, which is not to render the xAxis if it is hidden.

Given that our cleanup of the theme work is still underway, there is some inconsistency in terms of the props that are passed down to the Chart components.

| Line chart  | Bar chart  | Multiseries bar chart  | Area chart  |  
|---|---|---|---|
| <img width="1451" alt="Screen Shot 2021-09-14 at 1 17 57 PM" src="https://user-images.githubusercontent.com/12213371/133303934-1378329b-7864-4e10-8117-ba9c9034431e.png">  | <img width="1424" alt="Screen Shot 2021-09-14 at 1 17 49 PM" src="https://user-images.githubusercontent.com/12213371/133303936-1b15c93a-6273-435e-b73a-2263895b89d2.png">  | <img width="1442" alt="Screen Shot 2021-09-14 at 1 18 03 PM" src="https://user-images.githubusercontent.com/12213371/133303932-110882f4-d29a-4e11-ad6b-054367fee560.png">  |  <img width="1448" alt="Screen Shot 2021-09-14 at 1 18 11 PM" src="https://user-images.githubusercontent.com/12213371/133303930-48c5ffed-662f-426d-b88b-826e3b5f9047.png"> |  

### Reviewers’ :tophat: instructions
Check that the line chart, bar chart, multiseries bar chart and stacked area chart all hide and show the xAxis labels as expected, whether configured via the theme or props.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [x] Update relevant documentation.
