### PR TITLE
Fix bug with all 0 spark line data

### DIFF
--- a/src/components/Sparkline/components/Series/Series.scss
+++ b/src/components/Sparkline/components/Series/Series.scss
@@ -4,11 +4,6 @@ $animation-duration: 500ms;
   animation: reveal $animation-duration ease-in-out 1;
 }
 
-.Line {
-  fill: none;
-  stroke: 1.5;
-}
-
 .Area {
   opacity: 0;
   animation: fadeIn $animation-duration ease-in-out 1 forwards;

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -2,7 +2,6 @@ import React, {useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import {area as areaShape, line} from 'd3-shape';
 
-import {colorWhite, colorBlack} from '../../../../constants';
 import type {Color, GradientStop, Theme} from '../../../../types';
 import {LinearGradient} from '../../../LinearGradient';
 import {
@@ -111,7 +110,6 @@ export function Series({
 
   const showPoint = hasPoint && lastLinePointCoordinates != null;
   const {x: lastX = 0, y: lastY = 0} = lastLinePointCoordinates ?? {};
-  const seriesIsAllZeros = data.every(({y}) => y === 0);
 
   return (
     <React.Fragment>
@@ -131,38 +129,21 @@ export function Series({
           />
         )}
 
-        {showPoint ? (
-          <React.Fragment>
-            <circle cx={lastX} cy={lastY} r={POINT_RADIUS} id={`point-${id}`} />
-
-            <mask id={`mask-${id}`}>
-              <rect
-                x="0"
-                y="0"
-                width={svgDimensions.width}
-                height={svgDimensions.height}
-                fill={colorWhite}
-              />
-              <use href={`#point-${id}`} fill={colorBlack} />
-            </mask>
-          </React.Fragment>
-        ) : null}
+        <React.Fragment>
+          <mask id={`mask-${id}`}>
+            <path
+              d={lineShape}
+              stroke="white"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              style={{strokeDasharray: StrokeDasharray[lineStyle]}}
+            />
+            {showPoint && (
+              <circle cx={lastX} cy={lastY} r={POINT_RADIUS} fill="white" />
+            )}
+          </mask>
+        </React.Fragment>
       </defs>
-
-      <path
-        stroke={
-          series.lineStyle && series.lineStyle !== 'solid'
-            ? theme.line.dottedStrokeColor
-            : `url(#line-${id})`
-        }
-        d={lineShape}
-        fill="none"
-        strokeLinejoin="round"
-        strokeLinecap="round"
-        className={classNames(styles.Line, !immediate && styles.AnimatedLine)}
-        style={{strokeDasharray: StrokeDasharray[lineStyle]}}
-        mask={seriesIsAllZeros ? undefined : `url(#mask-${`${id}`})`}
-      />
 
       {area === null ? null : (
         <path
@@ -171,14 +152,19 @@ export function Series({
           className={immediate ? undefined : styles.Area}
         />
       )}
-
-      {showPoint ? (
-        <use
-          href={`#point-${id}`}
-          fill={`url(#line-${id})`}
-          className={styles.Point}
-        />
-      ) : null}
+      <rect
+        x="0"
+        y="0"
+        width={svgDimensions.width}
+        height={svgDimensions.height}
+        fill={
+          series.lineStyle && series.lineStyle !== 'solid'
+            ? theme.line.dottedStrokeColor
+            : `url(#line-${id})`
+        }
+        mask={`url(#mask-${`${id}`})`}
+        className={classNames(styles.Line, !immediate && styles.AnimatedLine)}
+      />
     </React.Fragment>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,15 +48,10 @@ export const MAX_TRAIL_DURATION = 500;
 export const MASK_HIGHLIGHT_COLOR = variables.colorWhite;
 export const MASK_SUBDUE_COLOR = '#434343';
 
-export const colorSky = variables.colorSky;
 export const colorWhite = variables.colorWhite;
 export const colorBlack = variables.colorBlack;
 export const colorPurpleDark = variables.colorPurpleDark;
-export const colorBlue = variables.colorBlue;
 export const colorTeal = variables.colorTeal;
-export const colorSkyDark = variables.colorSkyDark;
-export const positiveColor = variables.positiveColor;
-export const negativeColor = variables.negativeColor;
 
 const createGradient = (color1: string, color2: string) => {
   return [


### PR DESCRIPTION
### What problem is this PR solving?

When rendering data that is zero-ish, there was a bug with our SVG masks that caused the lines to not render.

https://github.com/Shopify/polaris-viz/pull/531/files

Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1080516&q=svg%20mask&can=2

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
