### PR TITLE
Properly apply gradient to Sparkbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 - Fixed the direction of the gradient on the horizontal `<NormalizedStackedBarChart />`
+- Gradient not being applied properly to `<Sparkbar>`
+
+### Changed
+- Individual bar colors can no longer be overwritten in  `<Sparkbar>`, but the bar color over all can be overwritten by using the `barColor` prop
 
 
 ## [0.20.0] - 2021-09-10

--- a/src/components/Sparkbar/Sparkbar.md
+++ b/src/components/Sparkbar/Sparkbar.md
@@ -33,7 +33,7 @@ Used in small sizes to give an overview of how a metric has performed over time.
       {x: 16, y: 4.2},
       {x: 17, y: 4.2},
     ],
-    color: 'green',
+    barColor: 'green',
     dataOffsetRight: 12,
     dataOffsetLeft: 12,
     isAnimated: true,
@@ -88,6 +88,14 @@ The prop to determine the chart's bars. Null bars will not be plotted. Bars with
 | `string` | `Default`|
 
 The theme that the chart will inherit its color and container styles from.
+
+#### barColor
+
+| type     | default |
+| -------- | ------- |
+| `Color` | `undefined`|
+
+If provided, will overwrite the theme's bar color.
 
 #### comparison
 

--- a/src/components/Sparkbar/stories/Sparkbar.stories.tsx
+++ b/src/components/Sparkbar/stories/Sparkbar.stories.tsx
@@ -46,6 +46,9 @@ export default {
     isAnimated: {
       description: 'Determines whether to animate the chart on state changes.',
     },
+    barColor: {
+      description: 'If provided, overwrites the theme bar color.',
+    },
     theme: THEME_CONTROL_ARGS,
   },
 } as Meta;
@@ -64,7 +67,7 @@ const defaultProps = {
     {value: 400},
     {value: 400},
     {value: 100},
-    {value: 200},
+    {value: 2000},
     {value: 800},
     {value: 900},
     {value: 200},
@@ -90,9 +93,6 @@ const defaultProps = {
 export const Default: Story<SparkbarProps> = Template.bind({});
 Default.args = defaultProps;
 
-export const Positive: Story<SparkbarProps> = Template.bind({});
-Positive.args = {...defaultProps, theme: 'Positive'};
-
 export const OffsetAndNulls: Story<SparkbarProps> = Template.bind({});
 OffsetAndNulls.args = {
   ...defaultProps,
@@ -113,22 +113,5 @@ OffsetAndNulls.args = {
   ],
 };
 
-export const OverriddenColors: Story<SparkbarProps> = Template.bind({});
-OverriddenColors.args = {
-  ...defaultProps,
-  dataOffsetLeft: 10,
-  dataOffsetRight: 20,
-  data: [
-    {value: 100},
-    {value: 200, color: 'red'},
-    {value: 300},
-    {value: 400},
-    {value: 400, color: DEFAULT_THEME.seriesColors.upToFour[0]},
-    {value: 100},
-    {value: 200},
-    {value: 800, color: '#99ccbb'},
-    {value: 900},
-    {value: 200},
-    {value: 400},
-  ],
-};
+export const OverwrittenBarColor: Story<SparkbarProps> = Template.bind({});
+OverwrittenBarColor.args = {...defaultProps, barColor: 'green'};

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,6 @@ export interface Dimensions {
 
 export interface SparkChartData {
   value: number | null;
-  color?: Color;
 }
 
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;


### PR DESCRIPTION
### What problem is this PR solving?
- Remove ability to overwrite individual bars
- Allow bar color to be overwritten by Sparkbar prop

| Before  | After  |
|---|---|
| <img width="197" alt="Screen Shot 2021-09-13 at 12 04 28 PM" src="https://user-images.githubusercontent.com/12213371/133118250-ff6f57bf-745b-4d49-b951-9900c476c184.png">  |  <img width="183" alt="Screen Shot 2021-09-13 at 12 03 07 PM" src="https://user-images.githubusercontent.com/12213371/133118251-4e9de7a1-e5ed-42fa-a664-fbd73939997e.png">|


### Reviewers’ :tophat: instructions
Check the Sparkbar stories to ensure the colors are applied as expected

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

- [x] Update relevant documentation.
