### PR TITLE
Fix gradient direction of normalized stacked bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed the direction of the gradient on the horizontal `<NormalizedStackedBarChart />`
+
+
 ## [0.20.0] - 2021-09-10
 
 - Removed `tslib` as a dependency entirely. This change inlines the helpers used by TypeScript. The result is that the bundle is a little smaller (e.g. ~2KB after minification and gzip), and dependency issues become a non-problem.

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
@@ -28,7 +28,7 @@ export function BarSegment({
   const scaleNeedsRounding = scale > 0 && scale < 1.5;
   const safeScale = scaleNeedsRounding ? 1.5 : scale;
 
-  const angle = orientation === 'horizontal' ? -90 : 180;
+  const angle = orientation === 'horizontal' ? 90 : 180;
 
   const formattedColor = isGradientType(color)
     ? createCSSGradient(color, angle)


### PR DESCRIPTION
### What problem is this PR solving?

Flips the gradient direction for the normalized stacked bar chart, according to the UX review.
The gradient now goes from dark to light.

| Before  |  After |
|---|---|
|  <img width="1373" alt="Screen Shot 2021-09-13 at 12 17 54 PM" src="https://user-images.githubusercontent.com/12213371/133120722-7f265f7d-7a4c-4c18-bd26-28d2b1b4300c.png"> | 
<img width="1361" alt="Screen Shot 2021-09-13 at 12 19 34 PM" src="https://user-images.githubusercontent.com/12213371/133120718-90606bb1-7f8d-4178-9f67-463db119e0f2.png"> |

### Reviewers’ :tophat: instructions
Check the normalized stacked bar chart story http://localhost:6006/?path=/story/charts-normalizedstackedbarchart--default

### Before merging

- [x] Update the Changelog.

