### PR TITLE
Force dashed/dotted lines to theme color & remove them from series count

### DIFF
--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
+import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import {useTheme} from '../../hooks';
 import type {
   DataSeries,
@@ -16,24 +16,25 @@ import styles from './Legend.scss';
 
 type LegendData = DataSeries<Data | NullableData, Color>;
 
-interface LegendProps extends Omit<LegendData, 'data'> {
+interface LegendSeries extends LegendData {
   lineStyle?: LineStyle;
-  data?: (Data | NullableData)[];
 }
 
 export interface Props {
-  series: LegendProps[];
+  series: LegendSeries[];
   theme?: string;
 }
 
 export function Legend({series, theme}: Props) {
   const selectedTheme = useTheme(theme);
-  const seriesColors = getSeriesColorsFromCount(series.length, selectedTheme);
+  const seriesColors = useThemeSeriesColors(series, selectedTheme);
   const {labelColor} = selectedTheme.legend;
   return (
     <div className={styles.Container} aria-hidden>
       {series.map(({name, color, lineStyle}, index) => {
-        const itemColor = color ?? seriesColors[index];
+        const isComparisonPeriod = lineStyle && lineStyle !== 'solid';
+        const itemColor =
+          color == null || isComparisonPeriod ? seriesColors[index] : color;
 
         return (
           <div className={styles.Series} key={`${name}-${index}`}>

--- a/src/components/Legend/stories/Legend.stories.tsx
+++ b/src/components/Legend/stories/Legend.stories.tsx
@@ -58,7 +58,7 @@ export const LineLegend: Story<LegendProps> = Template.bind({});
 LineLegend.args = {
   series: [
     {lineStyle: 'solid', name: 'Sales'},
-    {lineStyle: 'solid', name: 'Visits'},
+    {lineStyle: 'dashed', name: 'Visits'},
   ],
 };
 
@@ -67,5 +67,6 @@ ColorOverrides.args = {
   series: [
     {name: 'Sales', color: 'red'},
     {name: 'Visits', color: 'purple'},
+    {name: 'Comparison', color: 'yellow', lineStyle: 'dashed'},
   ],
 };

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -182,7 +182,7 @@ export function LineChart({
       // so it has to come last
       color: isSolidLine
         ? series.color ?? seriesColors[index]
-        : selectedTheme.line.dottedStrokeColor,
+        : seriesColors[index],
     };
   });
 

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -3,7 +3,7 @@ import {useDebouncedCallback} from 'use-debounce';
 import {scaleLinear} from 'd3-scale';
 import type {Color, LineStyle} from 'types';
 
-import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
+import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import {useResizeObserver, useTheme} from '../../hooks';
 import {XMLNS} from '../../constants';
 
@@ -47,7 +47,7 @@ export function Sparkline({
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const selectedTheme = useTheme(theme);
-  const seriesColors = getSeriesColorsFromCount(series.length, selectedTheme);
+  const seriesColors = useThemeSeriesColors(series, selectedTheme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
     if (entry == null) return;


### PR DESCRIPTION
### What problem is this PR solving?

When getting the correct series colors (for line charts) from the current series count, we were including all series but we really only want to include solid lines.

In `useThemeSeriesColors` we're now going to filter out `dashed/dotted` lines from the count and force all non-solid lines to use the `line.dottedStrokeColor` from the theme. This ensures that all "comparison" lines will use the theme colors everywhere.

### Reviewers’ :tophat: instructions

- View all the `<Legend>` stories. All dashed lines should use the grey theme color.
- Spot check `<SparkLine>`, `<SparkBar>` & `<LineChart>` stories.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
