### PR TITLE
Bar chart mount animation performance

### DIFF
--- a/src/components/Bar/tests/Bar.test.tsx
+++ b/src/components/Bar/tests/Bar.test.tsx
@@ -21,6 +21,7 @@ const defaultProps = {
   onFocus: jest.fn(),
   tabIndex: 0,
   rotateZeroBars: false,
+  zeroPosition: 0,
 };
 
 describe('<Bar/>', () => {

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type {SpringValue} from '@react-spring/web';
 import {YAxis, TooltipContainer, BarChartXAxis, Bar} from 'components';
 import {HorizontalGridLines} from 'components/HorizontalGridLines';
 import {mockDefaultTheme} from 'test-utilities/mount-with-provider';
@@ -259,9 +258,9 @@ describe('Chart />', () => {
         ZERO_AS_MIN_HEIGHT_THEME,
       );
 
-      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+      const barHeight = chart.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
+      expect(barHeight).toBe(MIN_BAR_HEIGHT);
     });
 
     it('does not pass the min bar height to 0 bars if false', () => {
@@ -269,9 +268,9 @@ describe('Chart />', () => {
         <Chart {...mockProps} data={[{rawValue: 0, label: 'data'}]} />,
       );
 
-      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+      const barHeight = chart.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(0);
+      expect(barHeight).toBe(0);
     });
 
     it('sets rotateZeroBars to false if false', () => {
@@ -301,9 +300,9 @@ describe('Chart />', () => {
         />,
       );
 
-      const barHeight = chart.find(Bar)!.props.height as SpringValue;
+      const barHeight = chart.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
+      expect(barHeight).toBe(MIN_BAR_HEIGHT);
     });
   });
 

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -1,6 +1,10 @@
 import React, {useState, useMemo, useCallback} from 'react';
 
-import {BarChartMargin as Margin, XMLNS} from '../../constants';
+import {
+  BarChartMargin as Margin,
+  XMLNS,
+  BAR_ANIMATION_HEIGHT_BUFFER,
+} from '../../constants';
 import {
   TooltipContainer,
   TooltipPosition as TooltipContainerPosition,
@@ -244,8 +248,9 @@ export function Chart({
     >
       <svg
         xmlns={XMLNS}
-        width={chartDimensions.width}
-        height={chartDimensions.height}
+        viewBox={`0 ${BAR_ANIMATION_HEIGHT_BUFFER * -1} ${
+          chartDimensions.width
+        } ${chartDimensions.height + BAR_ANIMATION_HEIGHT_BUFFER * 2}`}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBarGroup(null)}

--- a/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
-import type {SpringValue} from '@react-spring/web';
 
 import {BAR_SPACING} from '../../../constants';
 import {MIN_BAR_HEIGHT} from '../../../../../constants';
@@ -79,9 +78,9 @@ describe('<BarGroup/>', () => {
         </svg>,
       );
 
-      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+      const barHeight = barGroup.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
+      expect(barHeight).toBe(MIN_BAR_HEIGHT);
     });
 
     it('does not pass the min bar height to 0 bars if false', () => {
@@ -91,9 +90,9 @@ describe('<BarGroup/>', () => {
         </svg>,
       );
 
-      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+      const barHeight = barGroup.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(0);
+      expect(barHeight).toBe(0);
     });
 
     it('passes the min bar height to non-zero bar if false', () => {
@@ -103,9 +102,9 @@ describe('<BarGroup/>', () => {
         </svg>,
       );
 
-      const barHeight = barGroup.find(Bar)!.props.height as SpringValue;
+      const barHeight = barGroup.find(Bar)!.props.height;
 
-      expect(barHeight.get()).toBe(MIN_BAR_HEIGHT);
+      expect(barHeight).toBe(MIN_BAR_HEIGHT);
     });
   });
 

--- a/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
+++ b/src/components/MultiSeriesBarChart/stories/MultiSeriesBarChart.stories.tsx
@@ -380,6 +380,7 @@ NegativeOnly.args = {
       }),
     },
   ],
+  isAnimated: true,
   xAxisOptions: {labels},
   yAxisOptions: {integersOnly: true},
 };

--- a/src/components/Point/Point.tsx
+++ b/src/components/Point/Point.tsx
@@ -3,7 +3,7 @@ import type {ActiveTooltip} from 'types';
 import {useSpring, animated, Interpolation} from '@react-spring/web';
 
 import {classNames} from '../../utilities';
-import {animationDurationBase} from '../../constants';
+import {BASE_ANIMATION_DURATION} from '../../constants';
 
 import styles from './Point.scss';
 
@@ -55,7 +55,7 @@ export const Point = React.memo(function Point({
     from: {
       animatedRadius: 0,
     },
-    config: {duration: animationDurationBase},
+    config: {duration: BASE_ANIMATION_DURATION},
     default: {immediate: !isAnimated},
   });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -251,5 +251,8 @@ export const LIGHT_THEME: Theme = {
   },
 };
 
-export const animationDurationBase = 200;
+export const BASE_ANIMATION_DURATION = 200;
 export const XMLNS = 'http://www.w3.org/2000/svg';
+
+export const LOAD_ANIMATION_DURATION = 500;
+export const BAR_ANIMATION_HEIGHT_BUFFER = 20;


### PR DESCRIPTION
### What problem is this PR solving?

Our bar chart feels quite sluggish for large data sets. This branch aims to improve the performance of the loading animation by:

- removing `useTransition` from the list in favour of  `useSpring` in each bar. `useTransition` is by design heavier than `useSpring` as it has to keep watching for changes on a list, diffing new and old items to animate whatever has changed. It also works by temporarily duplicating each node for enter/leave animations. `useSpring` is much simpler, basically a timer that updates some value in the specified way.

- Applying CSS transforms to each bar instead of animating the SVG path, to take advantage of hardware acceleration 


<img width="1001" alt="Screen Shot 2021-09-16 at 10 17 46 AM" src="https://user-images.githubusercontent.com/4037781/133629300-3b5421ff-2dd5-465a-acee-ce1faa53f6c9.png">
<img width="999" alt="Screen Shot 2021-09-16 at 10 16 36 AM" src="https://user-images.githubusercontent.com/4037781/133629327-a61508e3-8928-4551-9da1-97b7656ac38a.png">

### Reviewers’ :tophat: instructions

As mentioned on https://github.com/Shopify/polaris-viz/pull/478, this PR is a proof of concept for improving the performance of mounting the bars. If we decide to move forwards, we need to update other charts that consume <Bar/>

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
