### PR TITLE
Fix label measurements for numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Hiding the xAxis is now possible on the `<BarChart />`, `<MultiseriesBarChart />` and `<StackedAreaChart />`
 
+### Fixed
+- xAxis labels are no longer cut off on charts at small widths when they contain mostly numbers
+
 
 ## [0.20.3] - 2021-09-14
 - Fixed the direction of the gradient on the horizontal `<NormalizedStackedBarChart />` legend

--- a/src/components/BarChartXAxis/BarChartXAxis.scss
+++ b/src/components/BarChartXAxis/BarChartXAxis.scss
@@ -4,6 +4,7 @@
   text-align: center;
   line-height: 1;
   word-break: break-word;
+  font-feature-settings: 'tnum';
 }
 
 .DiagonalText {

--- a/src/components/LinearXAxis/LinearXAxis.scss
+++ b/src/components/LinearXAxis/LinearXAxis.scss
@@ -3,6 +3,7 @@
 .Text {
   line-height: 1;
   word-break: break-word;
+  font-feature-settings: 'tnum';
 }
 
 .DiagonalText {

--- a/src/components/YAxis/YAxis.tsx
+++ b/src/components/YAxis/YAxis.tsx
@@ -41,6 +41,7 @@ function Axis({ticks, fontSize = FONT_SIZE, width, textAlign, theme}: Props) {
                 background: selectedTheme.yAxis.backgroundColor,
                 padding: PADDING_SIZE,
                 whiteSpace: 'nowrap',
+                fontFeatureSettings: 'tnum',
               }}
             >
               {formattedValue}

--- a/src/utilities/get-text-container-height.ts
+++ b/src/utilities/get-text-container-height.ts
@@ -8,17 +8,18 @@ export function getTextContainerHeight({
   containerWidth: number;
 }) {
   const container = document.createElement('div');
-  container.style.fontSize = `${fontSize}px`;
-  container.style.display = 'inline-block';
-  container.style.visibility = 'hidden';
-  container.style.width = `${containerWidth}px`;
-  container.style.wordBreak = 'break-word';
-  container.style.lineHeight = '1';
+
+  container.style.cssText = `font-size: ${fontSize}px;
+  width: ${containerWidth}px;
+  display: 'inline-block';
+  word-break: break-word;
+  line-height: 1;
+  font-feature-settings: 'tnum';
+  visibility: hidden;`;
+
   document.body.appendChild(container);
   container.innerText = text;
   const height = container.clientHeight;
-
   document.body.removeChild(container);
-
   return height;
 }

--- a/src/utilities/get-text-width.ts
+++ b/src/utilities/get-text-width.ts
@@ -6,13 +6,15 @@ export function getTextWidth({
   fontSize: number;
 }) {
   const paragraph = document.createElement('p');
-  paragraph.style.fontSize = `${fontSize}px`;
-  paragraph.style.display = 'inline-block';
-  paragraph.style.visibility = 'hidden';
+
+  paragraph.style.cssText = `font-size: ${fontSize}px;
+  display: inline-block;
+  font-feature-settings: 'tnum';
+  visibility: hidden`;
+
   document.body.appendChild(paragraph);
   paragraph.innerText = text;
   const width = paragraph.clientWidth;
-
   document.body.removeChild(paragraph);
   return width;
 }


### PR DESCRIPTION
### What problem is this PR solving?

We added a performance-saving change, which was to measure less labels and just use the one with the longest length to figure out the widest label. the issue with this is, particularly with labels with many numbers in them, there can be a lot of variation in terms of how wide those characters are. I think the answer is to use `tnum` font feature and reflect this in our label math as well. 

| Before  | After  |  
|---|---|
| <img width="334" alt="Screen Shot 2021-09-22 at 12 34 09 PM" src="https://user-images.githubusercontent.com/12213371/134387716-d5add2d2-d684-49f0-8ecf-403bc871ce6c.png">  | <img width="295" alt="Screen Shot 2021-09-22 at 12 34 37 PM" src="https://user-images.githubusercontent.com/12213371/134387708-378b06a3-fcef-4f52-badd-bc8a7c667a3c.png">  | 
|  <img width="337" alt="Screen Shot 2021-09-22 at 12 34 18 PM" src="https://user-images.githubusercontent.com/12213371/134387715-7c6448bc-743b-44c3-bd99-1acfb0da42d4.png"> |  <img width="281" alt="Screen Shot 2021-09-22 at 12 34 30 PM" src="https://user-images.githubusercontent.com/12213371/134387713-1bbaf44c-44c0-4bbc-ad98-215997090880.png"> | 

### Reviewers’ :tophat: instructions
Review all our stories for charts with axis labels and ensure they look good at different widths

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

~- [ ] Update relevant documentation.~
