### PR TITLE
Fix bar chart and scale bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- Charts at very small sizes no longer get cut off at the bottom
 
 ## [0.21.1] - 2021-09-23
 

--- a/src/components/BarChart/Chart.scss
+++ b/src/components/BarChart/Chart.scss
@@ -2,3 +2,7 @@
   position: relative;
   user-select: none;
 }
+
+.Svg {
+  overflow: visible;
+}

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -256,9 +256,9 @@ export function Chart({
     >
       <svg
         xmlns={XMLNS}
-        viewBox={`0 ${BAR_ANIMATION_HEIGHT_BUFFER * -1} ${width} ${
-          height + BAR_ANIMATION_HEIGHT_BUFFER * 2
-        }`}
+        width={width}
+        height={height}
+        className={styles.Svg}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBar(null)}

--- a/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/BarChart/hooks/tests/use-y-scale.test.tsx
@@ -257,11 +257,11 @@ describe('useYScale', () => {
 
     mount(<TestComponent />);
 
-    // Check that it's called with the min and max data the first time
+    // Check that it's called with the min and max data
     expect(domainSpy).toHaveBeenNthCalledWith(1, [-89, 1000]);
 
     // Check that it's called with the first tick and max data the second time
-    expect(domainSpy).toHaveBeenNthCalledWith(2, [firstTick, 1000]);
+    expect(domainSpy).toHaveBeenNthCalledWith(2, [-89, 1000]);
   });
 
   describe('integersOnly', () => {

--- a/src/components/BarChart/hooks/use-y-scale.ts
+++ b/src/components/BarChart/hooks/use-y-scale.ts
@@ -44,7 +44,7 @@ export function useYScale({
     } else {
       const roundedDownMin = yScale.copy().nice(maxTicks).ticks(maxTicks)[0];
 
-      yScale.domain([roundedDownMin, max]);
+      yScale.domain([Math.min(roundedDownMin, min), max]);
     }
 
     const filteredTicks = integersOnly

--- a/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/LineChart/hooks/tests/use-y-scale.test.tsx
@@ -240,11 +240,11 @@ describe('useYScale', () => {
 
     mount(<TestComponent />);
 
-    // Check that it's called with the min and max data the first time
+    // Check that it's called with the min and max data
     expect(domainSpy).toHaveBeenNthCalledWith(1, [0, 10]);
 
     // Check that it's called with the first tick and max data the second time
-    expect(domainSpy).toHaveBeenNthCalledWith(2, [firstTick, 10]);
+    expect(domainSpy).toHaveBeenNthCalledWith(2, [0, 10]);
   });
 
   describe('integersOnly', () => {

--- a/src/components/LineChart/hooks/use-y-scale.ts
+++ b/src/components/LineChart/hooks/use-y-scale.ts
@@ -38,7 +38,7 @@ export function useYScale({
     } else {
       const roundedDownMin = yScale.copy().nice(maxTicks).ticks(maxTicks)[0];
 
-      yScale.domain([roundedDownMin, Math.max(0, maxY)]);
+      yScale.domain([Math.min(roundedDownMin, minY), Math.max(0, maxY)]);
     }
 
     const filteredTicks = integersOnly

--- a/src/components/MultiSeriesBarChart/Chart.scss
+++ b/src/components/MultiSeriesBarChart/Chart.scss
@@ -2,3 +2,7 @@
   position: relative;
   user-select: none;
 }
+
+.Svg {
+  overflow: visible;
+}

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -1,10 +1,6 @@
 import React, {useState, useMemo, useCallback} from 'react';
 
-import {
-  BarChartMargin as Margin,
-  XMLNS,
-  BAR_ANIMATION_HEIGHT_BUFFER,
-} from '../../constants';
+import {BarChartMargin as Margin, XMLNS} from '../../constants';
 import {
   TooltipContainer,
   TooltipPosition as TooltipContainerPosition,
@@ -248,9 +244,9 @@ export function Chart({
     >
       <svg
         xmlns={XMLNS}
-        viewBox={`0 ${BAR_ANIMATION_HEIGHT_BUFFER * -1} ${
-          chartDimensions.width
-        } ${chartDimensions.height + BAR_ANIMATION_HEIGHT_BUFFER * 2}`}
+        width={chartDimensions.width}
+        height={chartDimensions.height}
+        className={styles.Svg}
         onMouseMove={handleInteraction}
         onTouchMove={handleInteraction}
         onMouseLeave={() => setActiveBarGroup(null)}

--- a/src/components/MultiSeriesBarChart/hooks/tests/use-y-scale.test.tsx
+++ b/src/components/MultiSeriesBarChart/hooks/tests/use-y-scale.test.tsx
@@ -308,11 +308,11 @@ describe('useYScale', () => {
 
     mount(<TestComponent stackedValues={null} data={mockData} />);
 
-    // Check that it's called with the min and max data the first time
+    // Check that it's called with the min and max data
     expect(domainSpy).toHaveBeenNthCalledWith(1, [0, 30]);
 
     // Check that it's called with the first tick and max data the second time
-    expect(domainSpy).toHaveBeenNthCalledWith(2, [firstTick, 30]);
+    expect(domainSpy).toHaveBeenNthCalledWith(2, [0, 30]);
   });
 
   describe('integersOnly', () => {

--- a/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
+++ b/src/components/MultiSeriesBarChart/hooks/use-y-scale.ts
@@ -35,7 +35,7 @@ export function useYScale({
     } else {
       const roundedDownMin = yScale.copy().nice(maxTicks).ticks(maxTicks)[0];
 
-      yScale.domain([roundedDownMin, max]);
+      yScale.domain([Math.min(roundedDownMin, min), max]);
     }
 
     const filteredTicks = integersOnly


### PR DESCRIPTION
### What problem is this PR solving?
Fixes two bugs found while working on docs:
- our SVG viewbox changes, introduced to allow the bar chart to animate outside of the container, were causing the chart to be drawn outside of its container. To fix this, the viewbox is removed and we use overflow: visible instead.

- our scale meddling, to allow for the "overflow" look on charts, meant that in some rare cases we reduced the scale to below the minimum number being shown, which meant the bottom of some negative bars on bar charts could be cut off. To fix this, we make sure the rounded down minimum that can be applied to the scale is not lower than the actual minimum value of the chart.

| Before  |  After | 
|---|---|
| <img width="335" alt="Screen Shot 2021-09-24 at 4 47 34 PM" src="https://user-images.githubusercontent.com/12213371/134737900-eb87bbc4-158b-44fd-a0e0-f560d534c57f.png"> | <img width="336" alt="Screen Shot 2021-09-24 at 4 45 53 PM" src="https://user-images.githubusercontent.com/12213371/134737744-baff80f9-186f-43b6-bc22-a4c2e3ce7e40.png">  |

### Reviewers’ :tophat: instructions
Both problems are most easily reproduced when the charts are very small. To see the charts in a small size, change the height in the `preview.js` file. To modify the heights on the line chart or multiseries bar chart, you will also need to modify the height in the story's scss file.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog.

~- [ ] Update relevant documentation.~
