### PR TITLE
[BarChart] Remove stray semicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - xAxis labels are no longer cut off on charts at small widths when they contain mostly numbers
 - Fixed measurement logic around labels for small charts.
+- Removed stray semi-colons in BarChart component
 
 ### Changed
 - Improved performance when mounting data sets in `<BarChart />` & `<MultiseriesBarChart />`.

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -389,7 +389,6 @@ export function Chart({
               />
             ) : null;
           })}
-          ;
         </g>
 
         <g transform={`translate(${chartStartPosition},${Margin.Top})`}>

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -132,7 +132,6 @@ export function BarGroup({
                 height={height + BAR_ANIMATION_HEIGHT_BUFFER * 2}
                 fill={`url(#${gradientId}${index})`}
               />
-              ;
             </g>
           );
         })}


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

I noticed some stray semi-colons (`;`) when I was trying to inspect the `BarChart`. Not sure if this is a cause of any problems, but I figured I'd put a PR just in case.

They were introduced during a revert. https://github.com/Shopify/polaris-viz/pull/525

**Screenshot**
<details><summary><em>(open for screenshot)</em></summary>

[![alt](https://screenshot.click/21-03-j1f6l-4v4c6.png)](https://screenshot.click/21-03-j1f6l-4v4c6.png)
</details>


### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
