### PR TITLE
Add GH action to deploy

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,25 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Install and Build 🔧
+        run:
+          yarn
+          yarn run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages-test # The branch the action should deploy to.
+          FOLDER: docs-build # The folder that the build-storybook script generates files.
+          CLEAN: true # Automatically remove deleted files from the deploy branch
+          TARGET_FOLDER: docs # The folder that we serve our Storybook files from

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-consumer": "node ./scripts/build-consumer",
     "prepublish": "in-publish && yarn run build || :",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook -o docs-build",
     "add:story": "node ./.storybook/cli.js"
   },
   "size-limit": [


### PR DESCRIPTION
### What problem is this PR solving?
Add GH Action to deploy Storybook to GH Pages
Storybook will deploy to GH Pages on merge to master

### Reviewers’ :tophat: instructions
N/A

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
