### PR TITLE
Make grid of components responsive on Intro page

### DIFF
--- a/src/components/Intro/stories/Intro.stories.mdx
+++ b/src/components/Intro/stories/Intro.stories.mdx
@@ -37,7 +37,7 @@ import {ComponentContainer} from './components/ComponentContainer.tsx';
 
 <hr style={{margin: '32px 0'}} />
 
-<div style={{display: 'grid', gridGap: '20px', gridTemplateColumns: 'repeat(2, 1fr)'}}>
+<div style={{display: 'grid', gridGap: '20px', gridTemplateColumns: 'repeat(auto-fit, minmax(335px, 1fr))'}}>
 
   <PolarisVizProvider
     themes={{


### PR DESCRIPTION
### What problem is this PR solving?

<!-- Briefly describe what you want to achieve here. If this PR solves an issue, then remember to add `fix` or `solve` #issue in order to close it automatically (https://help.github.com/articles/closing-issues-using-keywords/). -->

Based on the [new docs 🎉](https://github.com/Shopify/polaris-viz/pull/565), I wanted to add a bit of responsiveness to the grid of components on the Intro page.

This change supports widths as small as 335px (iPhone X width). Anything smaller and there is overflow (like there is right now).

**Before**

https://user-images.githubusercontent.com/49090/135169788-2b99602d-3d04-4b53-a744-48c3f1d8510b.mp4

**After**

https://user-images.githubusercontent.com/49090/135169683-d147dd46-6522-466d-bfc5-17bd6b5fc169.mp4

### Reviewers’ :tophat: instructions

Check out this branch and run `yarn run storybook` and play around with the widths.

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- 🚫 Update the Changelog.
- 🚫 Update relevant documentation.
