### PR TITLE
Add underline back to link on Storybook intro page

### DIFF
--- a/src/components/Intro/stories/components/ComponentContainer.scss
+++ b/src/components/Intro/stories/components/ComponentContainer.scss
@@ -20,7 +20,6 @@
 
 .Link {
   color: white;
-  text-decoration: none;
 }
 
 .CenterChartContainer {


### PR DESCRIPTION
### What problem is this PR solving?

I find it hard to pick out the link to view the specific docs on the Intro page. I initially thought: "How do I view the docs?"

![](https://screenshot.click/21-09-06elh-k1sfc.png)

and I would like to think: "I can now find the docs"

![](https://screenshot.click/21-09-8nivd-jn3x8.png)

### Reviewers’ :tophat: instructions

1. `git fetch origin && git checkout add-underline-back-to-link`
1. `yarn run storybook`
1. `open https://polaris-viz.shopify.io/?path=%2Fstory%2Fdocs-intro--page`

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- 🚫 Update the Changelog.
- 🚫 Update relevant documentation.
