### PR TITLE
Add animations to NormalizeStackedBarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- Added animations to `<NormalizedStackedBarChart />`.
+
 ## [0.23.0] - 2021-10-27
 
 ### Added
 
 - Added `<HorizontalBarChart />`.
 - Added `grid.showHorizontalLines` theme option to `<StackedAreaChart />`.
-### Fixed
-
-- Better print support for line chart, bar charts and area chart. Charts should now be responsive to print on most browsers. On Firefox, the chart from the browser window will not overflow the print page.
 
 ## [0.22.0] - 2021-10-22
 

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.scss
@@ -24,7 +24,7 @@
 }
 
 .VerticalBarContainer {
-  flex-direction: column;
+  flex-direction: column-reverse;
 }
 
 .HorizontalBarContainer {

--- a/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
+++ b/src/components/NormalizedStackedBarChart/NormalizedStackedBarChart.tsx
@@ -3,7 +3,7 @@ import {sum} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 
 import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
-import {useTheme} from '../../hooks';
+import {usePrefersReducedMotion, useTheme} from '../../hooks';
 import {classNames} from '../../utilities';
 
 import {BarSegment, BarLabel} from './components';
@@ -27,6 +27,7 @@ export function NormalizedStackedBarChart({
   const colors = getSeriesColorsFromCount(data.length, selectedTheme);
   const containsNegatives = data.some(({value}) => value < 0);
   const isDevelopment = process.env.NODE_ENV === 'development';
+  const {prefersReducedMotion} = usePrefersReducedMotion();
 
   if (isDevelopment && containsNegatives) {
     // eslint-disable-next-line no-console
@@ -47,6 +48,7 @@ export function NormalizedStackedBarChart({
   const xScale = scaleLinear().range([0, 100]).domain([0, totalValue]);
 
   const isVertical = orientation === 'vertical';
+  const bars = isVertical ? slicedData.reverse() : slicedData;
 
   return (
     <div
@@ -88,18 +90,26 @@ export function NormalizedStackedBarChart({
             : styles.HorizontalBarContainer,
         )}
       >
-        {slicedData.map(({value, label}, index) =>
-          value === 0 ? null : (
+        {bars.map(({value, label}, index) => {
+          if (value === 0) {
+            return null;
+          }
+
+          const colorIndex = isVertical ? bars.length - 1 - index : index;
+
+          return (
             <BarSegment
+              index={index}
+              isAnimated={!prefersReducedMotion}
               orientation={orientation}
               size={size}
               scale={xScale(value)}
-              key={`${label}-${value}`}
-              color={colors[index]}
+              key={`${label}`}
+              color={colors[colorIndex]}
               roundedCorners={selectedTheme.bar.hasRoundedCorners}
             />
-          ),
-        )}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.scss
@@ -16,10 +16,10 @@
 
 .vertical-RoundedCorners {
   &:first-of-type {
-    border-radius: 2px 2px 0 0;
+    border-radius: 0 0 2px 2px;
   }
   &:last-of-type {
-    border-radius: 0 0 2px 2px;
+    border-radius: 2px 2px 0 0;
   }
 }
 

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/BarSegment.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import {animated, useSpring} from '@react-spring/web';
 
+import {BARS_TRANSITION_CONFIG} from '../../../../constants';
 import {
   createCSSGradient,
   isGradientType,
@@ -7,10 +9,15 @@ import {
 } from '../../../../utilities';
 import type {Orientation, Size} from '../../types';
 import type {Color} from '../../../../types';
+import {useHasTimeoutFinished} from '../../../../hooks';
 
 import styles from './BarSegment.scss';
 
+const DELAY = 150;
+
 interface Props {
+  isAnimated: boolean;
+  index: number;
   scale: number;
   color: Color;
   size: Size;
@@ -20,6 +27,8 @@ interface Props {
 
 export function BarSegment({
   color,
+  index,
+  isAnimated,
   scale,
   size,
   orientation,
@@ -28,20 +37,35 @@ export function BarSegment({
   const scaleNeedsRounding = scale > 0 && scale < 1.5;
   const safeScale = scaleNeedsRounding ? 1.5 : scale;
 
-  const angle = orientation === 'horizontal' ? 90 : 0;
+  const delay = index * DELAY;
+  const angle = orientation === 'horizontal' ? 90 : 180;
+  const dimension = orientation === 'horizontal' ? 'width' : 'height';
+
+  const isMountDone = useHasTimeoutFinished(isAnimated ? delay : 0);
 
   const formattedColor = isGradientType(color)
     ? createCSSGradient(color, angle)
     : color;
 
+  const spring = useSpring({
+    from: {[dimension]: `0%`},
+    to: {[dimension]: `${safeScale}%`},
+    config: BARS_TRANSITION_CONFIG,
+    default: {immediate: !isAnimated},
+    delay: isMountDone ? 0 : delay,
+  });
+
   return (
-    <div
+    <animated.div
       className={classNames(
         styles.Segment,
         roundedCorners && styles[`${orientation}-RoundedCorners`],
         styles[`${orientation}-${size}`],
       )}
-      style={{flexBasis: `${safeScale}%`, background: formattedColor}}
+      style={{
+        [dimension]: isAnimated ? spring[dimension] : `${safeScale}%`,
+        background: formattedColor,
+      }}
     />
   );
 }

--- a/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
+++ b/src/components/NormalizedStackedBarChart/components/BarSegment/tests/BarSegment.test.tsx
@@ -10,6 +10,8 @@ describe('<BarSegment />', () => {
     size: 'small' as 'small',
     orientation: 'horizontal' as 'horizontal',
     roundedCorners: true,
+    index: 1,
+    isAnimated: false,
   };
 
   it('gives the child a horizontal small class name', () => {
@@ -33,7 +35,7 @@ describe('<BarSegment />', () => {
   it('does not round up a 0 scale', () => {
     const barSegment = mount(<BarSegment {...mockProps} scale={0} />);
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.width;
 
     expect(barSegmentFlex).toBe('0%');
   });
@@ -41,7 +43,7 @@ describe('<BarSegment />', () => {
   it('rounds up a scale above 0 and below 1.5', () => {
     const barSegment = mount(<BarSegment {...mockProps} scale={0.1} />);
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.width;
 
     expect(barSegmentFlex).toBe('1.5%');
   });
@@ -49,7 +51,7 @@ describe('<BarSegment />', () => {
   it('does not round up a scale above 1.5', () => {
     const barSegment = mount(<BarSegment {...mockProps} scale={1.51} />);
 
-    const barSegmentFlex = barSegment.find('div')!.props!.style!.flexBasis;
+    const barSegmentFlex = barSegment.find('div')!.props!.style!.width;
 
     expect(barSegmentFlex).toBe('1.51%');
   });

--- a/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
+++ b/src/components/NormalizedStackedBarChart/stories/NormalizedStackedBarChart.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {Story, Meta} from '@storybook/react';
 
 import {
@@ -71,4 +71,31 @@ VerticalSmall.args = {
   ...defaultProps,
   orientation: 'vertical' as 'vertical',
   size: 'small' as 'small',
+};
+
+export const DynamicData = () => {
+  const [data, setData] = useState(defaultProps.data);
+
+  const onClick = () => {
+    const newData = data.map((item) => {
+      const newValue = Math.floor(Math.random() * 200);
+      return {
+        ...item,
+        value: newValue,
+        formattedValue: `$${newValue}`,
+      };
+    });
+    setData(newData);
+  };
+
+  return (
+    <>
+      <NormalizedStackedBarChart
+        data={data}
+        orientation="horizontal"
+        size="small"
+      />
+      <button onClick={onClick}>Change Data</button>
+    </>
+  );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,4 @@ export {
 } from './use-theme-series-colors';
 export {useLinearChartAnimations} from './use-linear-chart-animations';
 export {usePrintResizing} from './use-print-resizing';
+export {useHasTimeoutFinished} from './useHasTimeoutFinished';

--- a/src/hooks/useHasTimeoutFinished.ts
+++ b/src/hooks/useHasTimeoutFinished.ts
@@ -1,0 +1,27 @@
+import {useEffect, useRef, useState} from 'react';
+
+export function useHasTimeoutFinished(time: number) {
+  const [timeoutComplete, setTimeoutComplete] = useState(false);
+  const timeoutRef = useRef<number>();
+
+  useEffect(() => {
+    if (time <= 0) {
+      return;
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setTimeoutComplete(true);
+      window.clearTimeout(timeoutRef.current);
+    }, time);
+
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, [time]);
+
+  if (time <= 0) {
+    return true;
+  }
+
+  return timeoutComplete;
+}


### PR DESCRIPTION
### What problem is this PR solving?

Adding mount and data change animations for `NormalizedStackedBarChart`.

https://user-images.githubusercontent.com/149873/135503582-7e732cc2-3a65-46cd-80d2-ba0c585eaa99.mp4

### Reviewers’ :tophat: instructions

- View all 3 `NormalizedStackedBarChart`. Animations should play.
- Set `Reduce Motion` in `Settings > Accessibility > Display`. Reload that stories. No animations should play.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
