### PR TITLE
Disable animations globaly when Reduce Motion is true

### DIFF
--- a/src/components/Bar/Bar.tsx
+++ b/src/components/Bar/Bar.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react';
-import {animated, useSpring} from '@react-spring/web';
+import {animated, Globals, useSpring} from '@react-spring/web';
 
 import {ROUNDED_BAR_RADIUS, BARS_TRANSITION_CONFIG} from '../../constants';
 
@@ -20,7 +20,6 @@ interface Props {
   rotateZeroBars: boolean;
   animationDelay?: number;
   zeroPosition: number;
-  isAnimated?: boolean;
 }
 
 export const Bar = React.memo(function Bar({
@@ -38,7 +37,6 @@ export const Bar = React.memo(function Bar({
   rotateZeroBars,
   animationDelay = 0,
   zeroPosition,
-  isAnimated = true,
 }: Props) {
   const treatAsNegative = rawValue < 0 || (rawValue === 0 && rotateZeroBars);
 
@@ -87,9 +85,8 @@ export const Bar = React.memo(function Bar({
   const {transform} = useSpring({
     from: {transform: 'scaleY(0) translateZ(0)'},
     to: {transform: 'scaleY(1) translateZ(0)'},
-    delay: isAnimated ? animationDelay : 0,
+    delay: Globals.skipAnimation ? 0 : animationDelay,
     config: BARS_TRANSITION_CONFIG,
-    default: {immediate: !isAnimated},
   });
 
   return (

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -4,7 +4,7 @@ import {useDebouncedCallback} from 'use-debounce';
 import type {Dimensions, XAxisOptions, YAxisOptions} from '../../types';
 import {SkipLink} from '../SkipLink';
 import {uniqueId, normalizeData} from '../../utilities';
-import {useResizeObserver} from '../../hooks';
+import {useReducedMotion, useResizeObserver} from '../../hooks';
 import {ChartContainer} from '../ChartContainer';
 
 import {TooltipContent} from './components';
@@ -39,6 +39,8 @@ export function BarChart({
   yAxisOptions,
   theme,
 }: BarChartProps) {
+  useReducedMotion(isAnimated);
+
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
   );
@@ -166,7 +168,6 @@ export function BarChart({
             </SkipLink>
           )}
           <Chart
-            isAnimated={isAnimated}
             data={data}
             annotationsLookupTable={annotationsLookupTable}
             chartDimensions={chartDimensions}

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useMemo, useCallback} from 'react';
 
 import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
-import {usePrefersReducedMotion, useTheme} from '../../hooks';
+import {useTheme} from '../../hooks';
 import {
   BarChartMargin as Margin,
   LINE_HEIGHT,
@@ -60,7 +60,6 @@ interface Props {
   xAxisOptions: RequiredXAxis;
   yAxisOptions: Required<YAxisOptions>;
   emptyStateText?: string;
-  isAnimated?: boolean;
   theme?: string;
 }
 
@@ -70,7 +69,6 @@ export function Chart({
   chartDimensions,
   renderTooltipContent,
   emptyStateText,
-  isAnimated = false,
   xAxisOptions,
   yAxisOptions,
   theme,
@@ -81,7 +79,6 @@ export function Chart({
   const selectedTheme = useTheme(theme);
   const [seriesColor] = getSeriesColorsFromCount(1, selectedTheme);
 
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const [activeBar, setActiveBar] = useState<number | null>(null);
 
   const {minimalLabelIndexes} = useMinimalLabelIndexes({
@@ -229,8 +226,6 @@ export function Chart({
     },
     [chartStartPosition, xScale],
   );
-
-  const shouldAnimate = !prefersReducedMotion && isAnimated;
 
   const {width, height} = chartDimensions;
 
@@ -403,7 +398,6 @@ export function Chart({
                 xPosition={xPositionValue}
                 barWidth={barWidth}
                 drawableHeight={drawableHeight}
-                shouldAnimate={shouldAnimate}
                 width={annotation.width}
                 color={annotation.color}
                 xOffset={annotation.xOffset}

--- a/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
+++ b/src/components/BarChart/components/AnnotationLine/AnnotationLine.tsx
@@ -1,3 +1,4 @@
+import {Globals} from '@react-spring/web';
 import React from 'react';
 
 import {classNames, clamp} from '../../../../utilities';
@@ -11,7 +12,6 @@ export interface AnnotationLineProps extends Omit<Annotation, 'dataIndex'> {
   xPosition: number;
   barWidth: number;
   drawableHeight: number;
-  shouldAnimate?: boolean;
 }
 
 export function AnnotationLine({
@@ -19,7 +19,6 @@ export function AnnotationLine({
   barWidth,
   drawableHeight,
   width: annotationWidth,
-  shouldAnimate = false,
   color,
   xOffset = MEDIAN_OFFSET,
 }: AnnotationLineProps) {
@@ -33,7 +32,7 @@ export function AnnotationLine({
 
   return (
     <line
-      className={classNames(shouldAnimate && styles.AnimatedLine)}
+      className={classNames(!Globals.skipAnimation && styles.AnimatedLine)}
       stroke={color}
       strokeWidth={annotationWidth}
       x1={xValueClamped}

--- a/src/components/BarChart/components/AnnotationLine/tests/AnnotationLine.test.tsx
+++ b/src/components/BarChart/components/AnnotationLine/tests/AnnotationLine.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
+import {Globals} from '@react-spring/web';
 
 import {AnnotationLine} from '../AnnotationLine';
 
@@ -118,13 +119,13 @@ describe('<AnnotationLine />', () => {
     });
 
     it('animates when true', () => {
-      const props = {
-        ...mockProps,
-        shouldAnimate: true,
-      };
+      Globals.assign({
+        skipAnimation: false,
+      });
+
       const content = mount(
         <svg>
-          <AnnotationLine {...props} />
+          <AnnotationLine {...mockProps} />
         </svg>,
       );
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useMemo, useCallback} from 'react';
 import throttle from 'lodash.throttle';
 import {line} from 'd3-shape';
+import {Globals} from '@react-spring/web';
 
 import {
   curveStepRounded,
@@ -50,7 +51,6 @@ import styles from './Chart.scss';
 
 interface Props {
   dimensions: Dimensions;
-  isAnimated: boolean;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   series: SeriesWithDefaults[];
   xAxisOptions: XAxisOptions;
@@ -64,7 +64,6 @@ export function Chart({
   dimensions,
   renderTooltipContent,
   emptyStateText,
-  isAnimated,
   xAxisOptions,
   yAxisOptions,
   theme,
@@ -219,7 +218,7 @@ export function Chart({
       : tooltipDetails.index;
 
   const animatePoints =
-    isAnimated && longestSeriesLength <= MAX_ANIMATED_SERIES_LENGTH;
+    !Globals.skipAnimation && longestSeriesLength <= MAX_ANIMATED_SERIES_LENGTH;
 
   const {animatedCoordinates} = useLinearChartAnimations<SeriesWithDefaults>({
     series: reversedSeries,
@@ -417,7 +416,7 @@ export function Chart({
                 <Line
                   series={singleSeries}
                   color={lineColor}
-                  isAnimated={isAnimated}
+                  isAnimated={animatePoints}
                   index={index}
                   lineGenerator={lineGenerator}
                   theme={theme}

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -6,11 +6,7 @@ import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import type {Dimensions, GradientStop} from '../../types';
 import {isGradientType, changeColorOpacity, uniqueId} from '../../utilities';
 import {SkipLink} from '../SkipLink';
-import {
-  usePrefersReducedMotion,
-  useResizeObserver,
-  useTheme,
-} from '../../hooks';
+import {useReducedMotion, useResizeObserver, useTheme} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {
@@ -44,6 +40,8 @@ export function LineChart({
   yAxisOptions,
   theme,
 }: LineChartProps) {
+  useReducedMotion(isAnimated);
+
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(series, selectedTheme);
 
@@ -51,7 +49,6 @@ export function LineChart({
     null,
   );
   const {ref, setRef, entry} = useResizeObserver();
-  const {prefersReducedMotion} = usePrefersReducedMotion();
 
   const skipLinkAnchorId = useRef(uniqueId('lineChart'));
 
@@ -192,7 +189,6 @@ export function LineChart({
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
             dimensions={chartDimensions}
-            isAnimated={isAnimated && !prefersReducedMotion}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent

--- a/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/src/components/LineChart/stories/LineChart.stories.tsx
@@ -156,6 +156,7 @@ IntegersOnly.args = {
   },
   yAxisOptions: {integersOnly: true},
   renderTooltipContent,
+  isAnimated: true,
 };
 
 export const NoArea: Story<LineChartProps> = Template.bind({});

--- a/src/components/LineChart/tests/Chart.test.tsx
+++ b/src/components/LineChart/tests/Chart.test.tsx
@@ -11,6 +11,7 @@ import {line} from 'd3-shape';
 import {mountWithProvider} from 'test-utilities';
 import {HorizontalGridLines} from 'components/HorizontalGridLines';
 import {mockDefaultTheme} from 'test-utilities/mount-with-provider';
+import {Globals} from '@react-spring/web';
 
 import {LinearGradient} from '../../LinearGradient';
 import {Chart} from '../Chart';
@@ -216,8 +217,12 @@ describe('<Chart />', () => {
   });
 
   it('renders an additional <Point /> for each series if isAnimated is true', () => {
+    Globals.assign({
+      skipAnimation: false,
+    });
+
     const series = [primarySeries, {...primarySeries, name: 'A second series'}];
-    const chart = mount(<Chart {...mockProps} series={series} isAnimated />);
+    const chart = mount(<Chart {...mockProps} series={series} />);
 
     expect(chart).toContainReactComponentTimes(Point, 8 + series.length);
   });

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -43,7 +43,6 @@ interface Props {
   yAxisOptions: YAxisOptions;
   isStacked?: boolean;
   emptyStateText?: string;
-  isAnimated?: boolean;
   theme?: string;
 }
 
@@ -54,7 +53,6 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
   isStacked = false,
-  isAnimated = false,
   emptyStateText,
   theme,
 }: Props) {
@@ -319,7 +317,6 @@ export function Chart({
                 const ariaLabel = formatAriaLabel(accessibilityData[index]);
                 return (
                   <BarGroup
-                    isAnimated={isAnimated}
                     key={index}
                     x={xPosition == null ? 0 : xPosition}
                     isSubdued={

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -6,7 +6,12 @@ import type {Dimensions} from '../../types';
 import {SkipLink} from '../SkipLink';
 import {TooltipContent} from '../TooltipContent';
 import {uniqueId} from '../../utilities';
-import {useResizeObserver, useTheme, useThemeSeriesColors} from '../../hooks';
+import {
+  useReducedMotion,
+  useResizeObserver,
+  useTheme,
+  useThemeSeriesColors,
+} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {
@@ -40,6 +45,8 @@ export function MultiSeriesBarChart({
   emptyStateText,
   theme,
 }: MultiSeriesBarChartProps) {
+  useReducedMotion(isAnimated);
+
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(series, selectedTheme);
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
@@ -166,7 +173,6 @@ export function MultiSeriesBarChart({
             chartDimensions={chartDimensions}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
-            isAnimated={isAnimated}
             renderTooltipContent={
               renderTooltipContent != null
                 ? renderTooltipContent

--- a/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/MultiSeriesBarChart/components/BarGroup/BarGroup.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import type {Color} from 'types';
 
-import {usePrefersReducedMotion} from '../../../../hooks';
 import {Bar} from '../../../Bar';
 import {LinearGradient} from '../../../LinearGradient';
 import {BAR_SPACING} from '../../constants';
@@ -28,7 +27,6 @@ interface Props {
   onFocus: (index: number) => void;
   hasRoundedCorners: boolean;
   zeroAsMinHeight: boolean;
-  isAnimated?: boolean;
   rotateZeroBars?: boolean;
 }
 
@@ -45,10 +43,8 @@ export function BarGroup({
   hasRoundedCorners,
   isSubdued,
   zeroAsMinHeight,
-  isAnimated = false,
   rotateZeroBars = false,
 }: Props) {
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const barWidth = width / data.length - BAR_SPACING;
 
   const getBarHeight = useCallback(
@@ -62,8 +58,6 @@ export function BarGroup({
     },
     [yScale, zeroAsMinHeight],
   );
-
-  const shouldAnimate = !prefersReducedMotion && isAnimated;
 
   const gradientId = useMemo(() => uniqueId('gradient'), []);
   const maskId = useMemo(() => uniqueId('mask'), []);
@@ -111,7 +105,6 @@ export function BarGroup({
                 animationDelay={
                   barGroupIndex * (LOAD_ANIMATION_DURATION / data.length)
                 }
-                isAnimated={shouldAnimate}
               />
             </g>
           );

--- a/src/components/Sparkbar/Sparkbar.tsx
+++ b/src/components/Sparkbar/Sparkbar.tsx
@@ -2,14 +2,10 @@ import React, {useCallback, useState, useLayoutEffect, useMemo} from 'react';
 import {useDebouncedCallback} from 'use-debounce';
 import {scaleBand, scaleLinear} from 'd3-scale';
 import {line} from 'd3-shape';
-import {useTransition} from '@react-spring/web';
+import {Globals, useTransition} from '@react-spring/web';
 
 import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
-import {
-  usePrefersReducedMotion,
-  useResizeObserver,
-  useTheme,
-} from '../../hooks';
+import {useReducedMotion, useResizeObserver, useTheme} from '../../hooks';
 import {BARS_TRANSITION_CONFIG, XMLNS} from '../../constants';
 import type {Color, SparkChartData} from '../../types';
 import {uniqueId, getAnimationTrail, isGradientType} from '../../utilities';
@@ -71,13 +67,14 @@ export function Sparkbar({
   theme,
   barColor,
 }: SparkbarProps) {
+  useReducedMotion(isAnimated);
+
   const {
     ref: containerRef,
     setRef: setContainerRef,
     entry,
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const selectedTheme = useTheme(theme);
   const [seriesColor] = getSeriesColorsFromCount(1, selectedTheme);
 
@@ -164,8 +161,6 @@ export function Sparkbar({
     index,
   }));
 
-  const shouldAnimate = !prefersReducedMotion && isAnimated;
-
   const colorToUse = barColor ?? seriesColor;
 
   const color = isGradientType(colorToUse)
@@ -183,8 +178,7 @@ export function Sparkbar({
     leave: {height: 0},
     enter: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
     update: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
-    default: {immediate: !shouldAnimate},
-    trail: shouldAnimate ? getAnimationTrail(dataWithIndex.length) : 0,
+    trail: Globals.skipAnimation ? 0 : getAnimationTrail(dataWithIndex.length),
     config: BARS_TRANSITION_CONFIG,
   });
 

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -4,7 +4,7 @@ import {scaleLinear} from 'd3-scale';
 import type {Color, LineStyle} from 'types';
 
 import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
-import {useResizeObserver, useTheme} from '../../hooks';
+import {useReducedMotion, useResizeObserver, useTheme} from '../../hooks';
 import {XMLNS} from '../../constants';
 
 import styles from './Sparkline.scss';
@@ -40,6 +40,8 @@ export function Sparkline({
   isAnimated = false,
   theme,
 }: SparklineProps) {
+  useReducedMotion(isAnimated);
+
   const {
     ref: containerRef,
     setRef: setContainerRef,
@@ -168,7 +170,6 @@ export function Sparkline({
                 xScale={xScale}
                 yScale={yScale}
                 series={seriesWithColor}
-                isAnimated={isAnimated}
                 svgDimensions={svgDimensions}
                 theme={selectedTheme}
               />

--- a/src/components/Sparkline/components/Series/Series.tsx
+++ b/src/components/Sparkline/components/Series/Series.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import {area as areaShape, line} from 'd3-shape';
+import {Globals} from '@react-spring/web';
 
 import type {Color, GradientStop, Theme} from '../../../../types';
 import {LinearGradient} from '../../../LinearGradient';
@@ -10,7 +11,6 @@ import {
   isGradientType,
   classNames,
 } from '../../../../utilities';
-import {usePrefersReducedMotion} from '../../../../hooks';
 import type {SingleSeries, Coordinates} from '../../Sparkline';
 
 import styles from './Series.scss';
@@ -41,18 +41,15 @@ export function Series({
   xScale,
   yScale,
   series,
-  isAnimated,
   svgDimensions,
   theme,
 }: {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   series: SingleSeries;
-  isAnimated: boolean;
   svgDimensions: {width: number; height: number};
   theme: Theme;
 }) {
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const {
     area = theme.line.sparkArea,
     lineStyle = theme.line.style,
@@ -91,7 +88,6 @@ export function Series({
   const areaPath = areaGenerator(data);
 
   const id = useMemo(() => uniqueId('sparkline'), []);
-  const immediate = !isAnimated || prefersReducedMotion;
 
   const lineGradientColor = isGradientType(color!)
     ? color
@@ -149,7 +145,7 @@ export function Series({
         <path
           fill={`url(#area-${id})`}
           d={areaPath}
-          className={immediate ? undefined : styles.Area}
+          className={Globals.skipAnimation ? undefined : styles.Area}
         />
       )}
       <rect
@@ -163,7 +159,10 @@ export function Series({
             : `url(#line-${id})`
         }
         mask={`url(#mask-${`${id}`})`}
-        className={classNames(styles.Line, !immediate && styles.AnimatedLine)}
+        className={classNames(
+          styles.Line,
+          !Globals.skipAnimation && styles.AnimatedLine,
+        )}
       />
     </React.Fragment>
   );

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -1,12 +1,12 @@
 import React, {useState, useMemo, useRef} from 'react';
 import {line, stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
+import {Globals} from '@react-spring/web';
 
 import {LinearGradient} from '../LinearGradient';
 import {
   useLinearXAxisDetails,
   useLinearXScale,
   useLinearChartAnimations,
-  usePrefersReducedMotion,
   useTheme,
   useThemeSeriesColors,
 } from '../../hooks';
@@ -57,7 +57,6 @@ interface Props {
   formatYAxisLabel: NumberLabelFormatter;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   dimensions: Dimensions;
-  isAnimated: boolean;
   theme?: string;
 }
 
@@ -71,10 +70,8 @@ export function Chart({
   formatXAxisLabel,
   formatYAxisLabel,
   renderTooltipContent,
-  isAnimated,
   theme,
 }: Props) {
-  const {prefersReducedMotion} = usePrefersReducedMotion();
   const selectedTheme = useTheme(theme);
   const colors = useThemeSeriesColors(series, selectedTheme);
 
@@ -307,7 +304,6 @@ export function Chart({
           xScale={xScale}
           yScale={yScale}
           colors={colors}
-          isAnimated={isAnimated && !prefersReducedMotion}
           theme={theme}
         />
 
@@ -362,7 +358,7 @@ export function Chart({
                   onFocus={handleFocus}
                   index={stackIndex}
                   tabIndex={stackIndex === 0 ? 0 : -1}
-                  isAnimated={isAnimated && !prefersReducedMotion}
+                  isAnimated={!Globals.skipAnimation}
                 />
               </React.Fragment>
             );

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../../types';
 import {TooltipContent} from '../TooltipContent';
 import {uniqueId} from '../../utilities';
-import {useResizeObserver, useTheme} from '../../hooks';
+import {useReducedMotion, useResizeObserver, useTheme} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {Series, RenderTooltipContentData} from './types';
@@ -40,6 +40,8 @@ export function StackedAreaChart({
   skipLinkText,
   theme,
 }: StackedAreaChartProps) {
+  useReducedMotion(isAnimated);
+
   const selectedTheme = useTheme(theme);
 
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
@@ -166,7 +168,6 @@ export function StackedAreaChart({
                 ? renderTooltipContent
                 : renderDefaultTooltipContent
             }
-            isAnimated={isAnimated}
             theme={theme}
           />
         )}

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -28,7 +28,6 @@ interface Props {
   stackedValues: StackedSeries[];
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  isAnimated: boolean;
   theme?: string;
 }
 
@@ -40,7 +39,6 @@ export function Areas({
   xScale,
   yScale,
   colors,
-  isAnimated,
   theme,
 }: Props) {
   const selectedTheme = useTheme(theme);
@@ -53,7 +51,7 @@ export function Areas({
     from: {
       width: 0,
     },
-    immediate: !isAnimated || valuesHaveNotUpdated,
+    immediate: valuesHaveNotUpdated,
     reset: true,
   });
 

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -138,7 +138,6 @@ describe('<Chart />', () => {
       height: 218,
       transform: 'translate(16,8)',
       colors: ['purple', 'teal'],
-      isAnimated: true,
       stackedValues: expect.any(Object),
     });
   });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,4 @@ export {useTheme} from './useTheme';
 export {usePolarisVizContext} from './usePolarisVizContext';
 export {useThemeSeriesColors} from './use-theme-series-colors';
 export {useLinearChartAnimations} from './use-linear-chart-animations';
+export {useReducedMotion} from './useReducedMotion';

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,14 @@
+import {Globals} from '@react-spring/web';
+import {useEffect} from 'react';
+
+import {usePrefersReducedMotion} from './usePrefersReducedMotion';
+
+export function useReducedMotion(isAnimated = true) {
+  const {prefersReducedMotion} = usePrefersReducedMotion();
+
+  useEffect(() => {
+    Globals.assign({
+      skipAnimation: !isAnimated || prefersReducedMotion,
+    });
+  }, [isAnimated, prefersReducedMotion]);
+}


### PR DESCRIPTION
### What problem is this PR solving?

We can leverage the `react-spring Globals` object to disable animations for every component instead of having to do it for each instance of `useSpring`.

### Reviewers’ :tophat: instructions

Set `Reduce Motion` in `Settings > Accessibility > Display`.  to `false/unchecked`.

- View each component, if animations are enabled by default the animation should play.

Set `Reduce Motion` in `Settings > Accessibility > Display`.  to `true/check`.

- View each component, no animations should play.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
