### PR TITLE
Document theme definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 - Circular dependency in `<LineChart />`
-
+- Theme.line.strokeColor now gets applied to StackedAreaChart
+- Theme.line.lineStyle and Theme.line.hasPoint now gets applied to Sparkline
 
 ## [0.21.2] - 2021-09-29
 

--- a/documentation/utilities/index.ts
+++ b/documentation/utilities/index.ts
@@ -36,12 +36,15 @@ export const generateLabels = (dataLength: number) => {
     });
 };
 
-export const generateMultipleSeries = (quantity: number) => {
+export const generateMultipleSeries = (
+  quantity: number,
+  dataSetLength = 10,
+) => {
   return Array(quantity)
     .fill(null)
     .map((_, index) => ({
       name: `Series ${index}`,
-      data: generateDataSet(10),
+      data: generateDataSet(dataSetLength),
     }));
 };
 

--- a/src/components/Docs/stories/CustomizingThemes.stories.mdx
+++ b/src/components/Docs/stories/CustomizingThemes.stories.mdx
@@ -1,7 +1,13 @@
 import {Meta} from '@storybook/addon-docs/blocks';
-import {BarChart, LineChart, Sparkline} from '../../../../src/components';
+
 import {PolarisVizProvider} from '../../PolarisVizProvider';
-import {ComponentContainer, Title} from './components';
+import {
+  ComponentContainer,
+  Title,
+  SampleSparkline,
+  SampleLineChart,
+  SampleBarchart,
+} from './components';
 import {SPARKLINE_SERIES} from '../../../../documentation/utilities';
 
 <Meta
@@ -118,15 +124,7 @@ export const App = () => {
     center
     chart={
       <div style={{width: '350px', height: '140px'}}>
-            <BarChart
-      data={[
-        {rawValue: 324.19, label: 'Jan. 1'},
-        {rawValue: 613.29, label: 'Jan. 2'},
-        {rawValue: 1000, label: 'Jan. 3'},
-        {rawValue: 432, label: 'Jan. 4'},
-        {rawValue: 1, label: 'Jan. 5'},
-      ]}
-    />
+        <SampleBarchart />
       </div>
     }
     codeSample={"<BarChart series={...}/>"}
@@ -135,24 +133,7 @@ export const App = () => {
     center
     chart={
       <div style={{width: '350px', height: '140px'}}>
-      <LineChart
-      isAnimated
-      series={[
-        {
-          name: 'Sales',
-          data: [
-            {rawValue: 324.19, label: '2020-01-01'},
-            {rawValue: 613.29, label: '2020-01-02'},
-            {rawValue: -422.79, label: '2020-01-03'},
-            {rawValue: 0, label: '2020-01-04'},
-            {rawValue: 1, label: '2020-01-05'},
-          ],
-        },
-      ]}
-      xAxisOptions={{
-        xAxisLabels: ['Jan. 1', 'Jan. 2', 'Jan. 3', 'Jan. 4', 'Jan. 5'],
-      }}
-    />
+        <SampleLineChart />
       </div>
     }
     codeSample={"<LineChart series={...}/>"}
@@ -237,7 +218,7 @@ export const App = () => {
     center
     chart={
       <div style={{width: '250px', height: '140px'}}>
-        <Sparkline series={SPARKLINE_SERIES} theme="AngryRed" />
+        <SampleSparkline theme="AngryRed" />
       </div>
     }
     codeSample={"<Sparkline series={...} theme='AngryRed'/>"}
@@ -247,7 +228,7 @@ export const App = () => {
     center
     chart={
       <div style={{width: '250px', height: '140px'}}>
-        <Sparkline series={SPARKLINE_SERIES} theme="HappyGreen" />
+        <SampleSparkline theme="HappyGreen" />
       </div>
     }
     codeSample={"<Sparkline series={...} theme='HappyGreen'/>"}

--- a/src/components/Docs/stories/ThemeDefinition.stories.mdx
+++ b/src/components/Docs/stories/ThemeDefinition.stories.mdx
@@ -1,0 +1,901 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks';
+
+import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {
+  Divider,
+  ComponentContainer,
+  Title,
+  ExamplesGrid,
+  SampleSparkbar,
+  SampleSparkline,
+  SampleBarchart,
+  SampleMultiseriesBarChart,
+  PropertyTable,
+  SampleLineChart,
+  SampleStackedAreaChart,
+  SampleNormalizedStackedBarChart,
+} from './components';
+
+<Meta
+  title="Docs/Themes/Theme Definition"
+  parameters={{
+    viewMode: 'docs',
+    docsOnly: true,
+  }}
+/>
+
+<PolarisVizProvider
+    themes={{
+      Default: {
+        chartContainer: {
+          padding: '20px',
+        }
+      },
+      Light: {
+        chartContainer: {
+          padding: '20px',
+        }
+      },
+    }}>
+
+<div style={{ margin: '0 auto', maxWidth: '800px', color: 'white'}}>
+<Title>✍️ Theme Definition</Title>
+
+<p>
+  In the <code>Theme</code> type definition, you'll find multiple properties;
+  some apply changes to all charts globally, while others only apply to a
+  specific chart type.
+</p>
+
+```tsx
+export interface Theme {
+  chartContainer: ChartContainerTheme;
+  bar: BarTheme;
+  grid: GridTheme;
+  xAxis: XAxisTheme;
+  yAxis: YAxisTheme;
+  line: LineTheme;
+  crossHair: CrossHairTheme;
+  legend: Legend;
+  seriesColors: SeriesColors;
+  tooltip: TooltipTheme;
+}
+```
+
+<Divider />
+<Title type="h2">🌎 Global properties</Title>
+
+<Title type="h3">
+  <code>chartContainer</code>
+</Title>
+
+| property                                    | type                | description                                                                                    |
+| ------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| <code>chartContainer.borderRadius</code>    | <code>string</code> | a CSS <code>border-radius</code> string that gets applied to the element wrapping the chart    |
+| <code>chartContainer.padding</code>         | <code>string</code> | a CSS <code>padding</code> string that gets applied to the element wrapping the chart          |
+| <code>chartContainer.backgroundColor</code> | <code>string</code> | a CSS <code>background-color</code> string that gets applied to the element wrapping the chart |
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        chartContainer: {
+          borderRadius: '0',
+          padding: '0',
+          backgroundColor: 'black'
+        }
+      }
+    }}>
+      <Sparkline series={data} />
+    </PolarisVizProvider>
+    `}
+  theme="Light"
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            chartContainer: {
+              borderRadius: '0',
+              padding: '0',
+              backgroundColor: 'black',
+            },
+          },
+        }}
+      >
+        <SampleSparkline />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+  <ComponentContainer
+    codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        chartContainer: {
+          borderRadius: '8px',
+          padding: '20px',
+          backgroundColor: '#dde2e9'
+        }
+      }
+    }}>
+      <Sparkline series={data} />
+    </PolarisVizProvider>
+    `}
+    theme="Light"
+    center
+    chart={
+      <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider themes={{
+        Default: {
+          chartContainer: {
+            borderRadius: '8px',
+            padding: '20px',
+            backgroundColor: '#dde2e9'
+          }
+        }
+      }}>
+        <SampleSparkline/>
+    </PolarisVizProvider>
+      </div>
+    }
+  />
+</ExamplesGrid>
+
+<Divider />
+<Title type="h2">📍 Local properties</Title>
+{/* =================== bar ================ */}
+<Title type="h3">
+  <code>bar</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="bar.hasRoundedCorners"
+    type="boolean"
+    description="determines whether the bar should have sharp or round corners"
+    chartsAffected={[
+      'BarChart',
+      'MultiSeriesBarChart',
+      'NormalizedStackedBarChart',
+    ]}
+  />
+  <PropertyTable.Row
+    property="bar.innerMargin"
+    type={['"Small"', '"Medium"', '"Large"', '"None"']}
+    description="determines how big the gaps between bars should be"
+    chartsAffected={['BarChart']}
+  />
+  <PropertyTable.Row
+    property="bar.outerMargin"
+    type={['"Small"', '"Medium"', '"Large"', '"None"']}
+    description="determines how big the gaps from the left edge of the chart until the
+        first bar, and the right edge until the last bar should be"
+    chartsAffected={['BarChart']}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        bar: {
+          hasRoundedCorders: true,
+          innerMargin: 'Large',
+          outerMargin: 'Large',
+        }
+      }
+    }}>
+      <BarChart data={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            bar: {
+              hasRoundedCorders: false,
+            },
+          },
+        }}
+      >
+        <SampleBarchart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        bar: {
+          hasRoundedCorders: false,
+        },
+      }
+    }}>
+      <MultiSeriesBarChart series={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            bar: {
+              hasRoundedCorders: true,
+              innerMargin: 'Large',
+              outerMargin: 'Large',
+            },
+          },
+        }}
+      >
+        <SampleMultiseriesBarChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+<Divider noLine/>
+{/* =================== grid ================ */}
+<Title type="h3">
+  <code>grid</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="grid.showHorizontalLines"
+    type="boolean"
+    description="determines whether or not to show horizontal grid lines"
+    chartsAffected={['BarChart', 'LineChart', 'MultiSeriesBarChart']}
+  />
+  <PropertyTable.Row
+    property="grid.showVerticalLines"
+    type="boolean"
+    description="determines whether or not to show vertical grid lines"
+    chartsAffected={['StackedAreaChart', 'LineChart']}
+  />
+  <PropertyTable.Row
+    property="grid.horizontalOverflow"
+    type="boolean"
+    description="determines whether or not to extend the grid horizontally to the edge of the chart"
+    chartsAffected={['BarChart', 'LineChart', 'MultiSeriesBarChart']}
+  />
+  <PropertyTable.Row
+    property="grid.color"
+    type="string"
+    description="a CSS color string that gets applied to the grid lines"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+  <PropertyTable.Row
+    property="grid.horizontalMargin"
+    type="number"
+    description="the number of pixels between the left and right edges of the grid and the edges of the chart container"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        grid: {
+          showHorizontalLines: false,
+        }
+      }
+    }}>
+      <BarChart data={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            grid: {
+              showHorizontalLines: false,
+            },
+          },
+        }}
+      >
+        <SampleBarchart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        grid: {
+          showHorizontalLines: true,
+          showVerticalLines: true,
+        },
+      }
+    }}>
+      <StackedAreaChart series={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            grid: {
+              showVerticalLines: true,
+            },
+          },
+        }}
+      >
+        <SampleStackedAreaChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        grid: {
+          showVerticalLines: true,
+          showHorizontalLines: true,
+          horizontalOverflow: false,
+          color: 'lime',
+          horizontalMargin: 50,
+        },
+      }
+    }}>
+      <StackedAreaChart series={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  theme="Light"
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            grid: {
+              showVerticalLines: true,
+              showHorizontalLines: true,
+              horizontalOverflow: false,
+              color: 'lime',
+              horizontalMargin: 50,
+            },
+          },
+        }}
+      >
+        <SampleLineChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        grid: {
+          showVerticalLines: true,
+          showHorizontalLines: true,
+          horizontalOverflow: true,
+          color: 'lime',
+          horizontalMargin: 50,
+        },
+      }
+    }}>
+      <StackedAreaChart series={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  theme="Light"
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            grid: {
+              showVerticalLines: true,
+              showHorizontalLines: true,
+              horizontalOverflow: true,
+              color: 'lime',
+              horizontalMargin: 50,
+            },
+          },
+        }}
+      >
+        <SampleLineChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+{/* =================== xAxis ================ */}
+<Divider noLine/>
+<Title type="h3">
+  <code>xAxis</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="xAxis.showTicks"
+    type="boolean"
+    description="determines wether or not to show the ticks vertical lines indicating the labels on the X Axis"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+  <PropertyTable.Row
+    property="xAxis.labelColor"
+    type="string"
+    description="a CSS color string applied to the labels on the X Axis"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+  <PropertyTable.Row
+    property="xAxis.hide"
+    type="boolean"
+    z
+    description="determines wether or not to show the X Axis"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        xAxis: {
+          showTicks: false,
+        }
+      }
+    }}>
+      <BarChart data={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            xAxis: {
+              showTicks: false,
+            },
+          },
+        }}
+      >
+        <SampleBarchart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        xAxis: {
+          showTicks: true,
+          labelColor: 'lime',
+        }
+      }
+    }}>
+      <BarChart data={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            xAxis: {
+              showTicks: true,
+              labelColor: 'lime',
+            },
+          },
+        }}
+      >
+        <SampleBarchart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        xAxis: {
+          hide: true,
+        }
+      }
+    }}>
+      <BarChart data={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            xAxis: {
+              hide: true,
+            },
+          },
+        }}
+      >
+        <SampleBarchart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+{/* =================== yAxis ================ */}
+<Divider noLine/>
+<Title type="h3">
+  <code>yAxis</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="yAxis.labelColor"
+    type="string"
+    description="a CSS color string applied to the labels on the Y Axis"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+  <PropertyTable.Row
+    property="yAxis.backgroundColor"
+    type="string"
+    description="a CSS color string applied to the label backgrounds on the Y Axis"
+    chartsAffected={[
+      'BarChart',
+      'LineChart',
+      'MultiSeriesBarChart',
+      'StackedAreaChart',
+    ]}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        yAxis: {
+          labelColor: 'lime',
+          backgroundColor: 'black'
+        }
+      }
+    }}>
+      <StackedAreaChart series={data} />
+    </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            yAxis: {
+              labelColor: 'lime',
+              backgroundColor: 'black',
+            },
+          },
+        }}
+      >
+        <SampleStackedAreaChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+</ExamplesGrid>
+{/* =================== line ================ */}
+<Divider noLine />
+<Title type="h3">
+  <code>line</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="line.sparkArea"
+    type="string"
+    description="a CSS color string applied to the area under the line of Sparklines"
+    chartsAffected={['Sparkline']}
+  />
+  <PropertyTable.Row
+    property="line.hasSpline"
+    type="boolean"
+    description="determines wether or not to use curved lines"
+    chartsAffected={['LineChart', 'StackedAreaChart', 'Sparkline']}
+  />
+  <PropertyTable.Row
+    property="line.style"
+    type={['"solid"', '"dashed"', '"dotted"']}
+    description="determines wether or not to use curved lines"
+    chartsAffected={['LineChart', 'Sparkline']}
+  />
+  <PropertyTable.Row
+    property="line.hasPoint"
+    type={'boolean'}
+    description="determines wether or not to show a circle at the end of the line. Does not get applied on non-solid lines"
+    chartsAffected={['Sparkline']}
+  />
+  <PropertyTable.Row
+    property="line.width"
+    type={'number'}
+    description="Value in pixels used to determine the thickness of series lines"
+    chartsAffected={['LineChart', 'StackedAreaChart']}
+  />
+  <PropertyTable.Row
+    property="line.pointStroke"
+    type={'string'}
+    description="CSS color string used on the stroke around the point displayed when hovering the chart"
+    chartsAffected={['LineChart', 'StackedAreaChart']}
+  />
+  <PropertyTable.Row
+    property="line.dottedStrokeColor"
+    type={'string'}
+    description="CSS color string used on the stroke of dotted comparison lines"
+    chartsAffected={['Sparkline', 'Sparkbar', 'LineChart']}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        line: {
+          sparkArea: 'rgba(250,50,250,0.2)',
+          hasSpline: true,
+          hasPoint: true,
+          dottedStrokeColor: 'lime'
+        }
+      }
+    }}>
+    <Sparkline series={data} />
+  </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            line: {
+              sparkArea: 'rgba(250,50,250,0.2)',
+              hasSpline: true,
+              hasPoint: true,
+              dottedStrokeColor: 'lime',
+            },
+          },
+        }}
+      >
+        <SampleSparkline />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        line: {
+          hasSpline: false,
+          style: 'dotted'
+          width: 5,
+          pointStroke: 'lime',
+        }
+      }
+    }}>
+    <LineChart series={data} />
+  </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            line: {
+              hasSpline: false,
+              style: 'dotted',
+              width: 5,
+              pointStroke: 'lime',
+            },
+          },
+        }}
+      >
+        <SampleLineChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+</ExamplesGrid>
+{/* =================== crossHair ================ */}
+<Divider noLine />
+<Title type="h3">
+  <code>crossHair</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="crossHair.color"
+    type="string"
+    description="a CSS color string applied to crosshair displayed when hovering charts"
+    chartsAffected={['LineChart', 'StackedAreaChart']}
+  />
+  <PropertyTable.Row
+    property="crossHair.width"
+    type="number"
+    description="determines how thick the crosshair displayed when hovering charts should be"
+    chartsAffected={['LineChart', 'StackedAreaChart']}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        crossHair: {
+          color: 'lime',
+          width: 10,
+        }
+      }
+    }}>
+    <LineChart series={data} />
+  </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            crossHair: {
+              color: 'lime',
+              width: 10,
+            },
+          },
+        }}
+      >
+        <SampleLineChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+</ExamplesGrid>
+{/* =================== legend ================ */}
+<Divider noLine />
+<Title type="h3">
+  <code>legend</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="legend.labelColor"
+    type="string"
+    description="a CSS color string applied to the labels in legends"
+    chartsAffected={['NormalizedStackedBarChart', 'Legend']}
+  />
+  <PropertyTable.Row
+    property="legend.labelColor"
+    type="string"
+    description="a CSS color string applied to the values in legends"
+    chartsAffected={['NormalizedStackedBarChart', 'Legend']}
+  />
+  <PropertyTable.Row
+    property="legend.trendIndicator"
+    type={`{positive: string; negative: string; neutral: string}`}
+    description="an object describing the colors to be used in the chevrons that indicate positive, negative and neutral trends "
+    chartsAffected={['NormalizedStackedBarChart', 'Legend']}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid>
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        crossHair: {
+          color: 'lime',
+          width: 10,
+        }
+      }
+    }}>
+    <LineChart series={data} />
+  </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '320px', height: '180px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            legend: {
+              labelColor: 'lime',
+              valueColor: 'yellow'
+            },
+          },
+        }}
+      >
+        <SampleNormalizedStackedBarChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+</ExamplesGrid>
+{/* =================== crossHair ================ */}
+</div>
+</PolarisVizProvider>

--- a/src/components/Docs/stories/ThemesDefaultAndLight.stories.mdx
+++ b/src/components/Docs/stories/ThemesDefaultAndLight.stories.mdx
@@ -1,9 +1,7 @@
 import {Meta} from '@storybook/addon-docs/blocks';
 
-import {Sparkline} from '../../../../src/components';
 import {PolarisVizProvider} from '../../PolarisVizProvider';
-import {ComponentContainer, Title} from './components';
-import {SPARKLINE_SERIES} from '../../../../documentation/utilities';
+import {ComponentContainer, Title, SampleSparkline} from './components';
 
 <Meta
   title="Docs/Themes/Default and Light"
@@ -57,7 +55,7 @@ import {SPARKLINE_SERIES} from '../../../../documentation/utilities';
     center
     chart={
       <div style={{width: '250px', height: '140px'}}>
-        <Sparkline series={SPARKLINE_SERIES} />
+        <SampleSparkline />
       </div>
     }
     codeSample={'<Sparkline />'}
@@ -74,7 +72,7 @@ import {SPARKLINE_SERIES} from '../../../../documentation/utilities';
     center
     chart={
       <div style={{width: '250px', height: '140px'}}>
-        <Sparkline series={SPARKLINE_SERIES} theme="Light" />
+        <SampleSparkline theme="Light" />
       </div>
     }
     codeSample={"<Sparkline theme='Light'/>"}

--- a/src/components/Docs/stories/components/ExamplesGrid/ExamplesGrid.tsx
+++ b/src/components/Docs/stories/components/ExamplesGrid/ExamplesGrid.tsx
@@ -6,7 +6,8 @@ export function ExamplesGrid({children}: {children: ReactChildren}) {
       style={{
         display: 'grid',
         gridGap: '20px',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+        gridTemplateColumns: 'repeat(2, minmax(250px, 1fr))',
+        gridTemplateRows: '1fr',
       }}
     >
       {children}

--- a/src/components/Docs/stories/components/PropertyTable/PropertyTable.scss
+++ b/src/components/Docs/stories/components/PropertyTable/PropertyTable.scss
@@ -1,0 +1,67 @@
+// stylelint-disable
+// 🔨 copy from storybook table styles
+.PropertyTable {
+  font-family: 'Nunito Sans', -apple-system, '.SFNSText-Regular',
+    'San Francisco', BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Helvetica,
+    Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-overflow-scrolling: touch;
+  margin: 16px 0;
+  font-size: 14px;
+  line-height: 24px;
+  padding: 0;
+  border-collapse: collapse;
+
+  tr {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    margin: 0;
+    padding: 0;
+  }
+
+  tr:nth-of-type(2n) {
+    background-color: #444444;
+  }
+
+  tr td {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+    margin: 0;
+    padding: 6px 13px;
+  }
+
+  th {
+    font-weight: bold;
+    color: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    margin: 0;
+    padding: 6px 13px;
+  }
+
+  code {
+    font-family: 'Operator Mono', 'Fira Code Retina', 'Fira Code',
+      'FiraCode-Retina', 'Andale Mono', 'Lucida Console', Consolas, Monaco,
+      monospace;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    display: inline-block;
+    padding-left: 2px;
+    padding-right: 2px;
+    vertical-align: baseline;
+    color: inherit;
+    line-height: 1;
+    margin: 0 2px;
+    padding: 3px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+    border: 1px solid #444444;
+    color: rgba(255, 255, 255, 0.7);
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+}
+
+.typeArray {
+  white-space: pre-wrap;
+  min-width: 90px;
+}

--- a/src/components/Docs/stories/components/PropertyTable/PropertyTable.tsx
+++ b/src/components/Docs/stories/components/PropertyTable/PropertyTable.tsx
@@ -1,0 +1,80 @@
+import React, {ReactChildren} from 'react';
+
+import styles from './PropertyTable.scss';
+
+export function PropertyTable({
+  children,
+  global = false,
+}: {
+  children: ReactChildren;
+  global: boolean;
+}) {
+  return (
+    <table className={styles.PropertyTable} style={{width: '100%'}}>
+      <colgroup>
+        <col span={1} style={{width: '1%'}} />
+        <col span={1} style={{width: '1%'}} />
+        <col span={1} style={{width: '50%'}} />
+        <col span={1} style={{width: '1%'}} />
+      </colgroup>
+
+      <thead>
+        <tr>
+          <th>property</th>
+          <th>type</th>
+          <th>description</th>
+          {!global && <th>components affected</th>}
+        </tr>
+      </thead>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+// eslint-disable-next-line react/display-name
+PropertyTable.Row = ({
+  property,
+  type,
+  description,
+  chartsAffected,
+}: {
+  property: string;
+  type: string | string[];
+  description: string;
+  chartsAffected?: string[];
+}) => {
+  return (
+    <tr>
+      <td>
+        <code>{property}</code>
+      </td>
+      <td>
+        {Array.isArray(type) ? (
+          <div className={styles.typeArray}>
+            {type.map((i, index) => {
+              return (
+                <span key={`${i}${index}`}>
+                  <code>{i}</code>
+                  {index === type.length - 1 ? null : (
+                    // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
+                    <React.Fragment>{'|\n'}</React.Fragment>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <code>{type}</code>
+        )}
+      </td>
+      <td>{description}</td>
+      {chartsAffected && (
+        <td>
+          {chartsAffected.map((chart, index) => (
+            <code key={`${chart}${index}`}>{chart}</code>
+          ))}
+        </td>
+      )}
+    </tr>
+  );
+};

--- a/src/components/Docs/stories/components/PropertyTable/index.tsx
+++ b/src/components/Docs/stories/components/PropertyTable/index.tsx
@@ -1,0 +1,1 @@
+export {PropertyTable} from './PropertyTable';

--- a/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/src/components/Docs/stories/components/SampleComponents.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+
+import {
+  Sparkbar,
+  Sparkline,
+  BarChart,
+  LineChart,
+  MultiSeriesBarChart,
+  StackedAreaChart,
+  NormalizedStackedBarChart,
+} from '../../../../components';
+import {
+  generateMultipleSeries,
+  generateLabels,
+} from '../../../../../documentation/utilities';
+
+export const SampleSparkbar = ({theme} = {theme: 'Default'}) => {
+  return (
+    <Sparkbar
+      theme={theme}
+      data={[
+        {value: 100},
+        {value: 200},
+        {value: 300},
+        {value: 400},
+        {value: 400},
+        {value: 100},
+        {value: 2000},
+        {value: 800},
+        {value: 900},
+        {value: 200},
+        {value: 400},
+      ]}
+    />
+  );
+};
+
+export const SampleSparkline = ({theme} = {theme: 'Default'}) => {
+  return (
+    <Sparkline
+      theme={theme}
+      series={[
+        {
+          data: [
+            {x: 0, y: 100},
+            {x: 1, y: 200},
+            {x: 2, y: 300},
+            {x: 3, y: 400},
+            {x: 4, y: 400},
+            {x: 5, y: 1000},
+            {x: 6, y: 200},
+            {x: 7, y: 800},
+            {x: 8, y: 900},
+            {x: 9, y: 200},
+            {x: 10, y: 400},
+          ],
+        },
+        {
+          lineStyle: 'dashed',
+          data: [
+            {x: 0, y: 200},
+            {x: 1, y: 200},
+            {x: 2, y: 200},
+            {x: 3, y: 200},
+            {x: 4, y: 200},
+            {x: 5, y: 200},
+            {x: 6, y: 200},
+            {x: 7, y: 200},
+            {x: 8, y: 200},
+            {x: 9, y: 200},
+            {x: 10, y: 200},
+          ],
+        },
+      ]}
+    />
+  );
+};
+
+export const SampleLineChart = ({theme} = {theme: 'Default'}) => {
+  return (
+    <LineChart
+      theme={theme}
+      isAnimated
+      series={[
+        {
+          name: 'Sales',
+          data: [
+            {rawValue: 324.19, label: '2020-01-01'},
+            {rawValue: 613.29, label: '2020-01-02'},
+            {rawValue: -422.79, label: '2020-01-03'},
+            {rawValue: 0, label: '2020-01-04'},
+            {rawValue: 1, label: '2020-01-05'},
+          ],
+        },
+      ]}
+      xAxisOptions={{
+        xAxisLabels: ['Jan. 1', 'Jan. 2', 'Jan. 3', 'Jan. 4', 'Jan. 5'],
+      }}
+    />
+  );
+};
+
+export const SampleBarchart = ({theme} = {theme: 'Default'}) => {
+  return (
+    <BarChart
+      theme={theme}
+      data={[
+        {rawValue: 324.19, label: 'Jan. 1'},
+        {rawValue: 613.29, label: 'Jan. 2'},
+        {rawValue: 1000, label: 'Jan. 3'},
+        {rawValue: 432, label: 'Jan. 4'},
+        {rawValue: 1, label: 'Jan. 5'},
+      ]}
+    />
+  );
+};
+
+export const SampleMultiseriesBarChart = ({theme} = {theme: 'Default'}) => {
+  return (
+    <MultiSeriesBarChart
+      series={generateMultipleSeries(3)}
+      xAxisOptions={{
+        labels: generateLabels(2),
+      }}
+      theme={theme}
+    />
+  );
+};
+
+export const SampleStackedAreaChart = ({theme} = {theme: 'Default'}) => {
+  return (
+    <StackedAreaChart
+      series={generateMultipleSeries(3, 3)}
+      xAxisOptions={{
+        labels: generateLabels(3),
+      }}
+      theme={theme}
+    />
+  );
+};
+
+export const SampleNormalizedStackedBarChart = (
+  {theme} = {theme: 'Default'},
+) => {
+  return (
+    <NormalizedStackedBarChart
+      orientation="vertical"
+      theme={theme}
+      data={[
+        {
+          label: 'Direct',
+          value: 200,
+          formattedValue: '$200',
+        },
+        {
+          label: 'Facebook',
+          value: 100,
+          formattedValue: '$100',
+        },
+        {
+          label: 'Twitter',
+          value: 100,
+          formattedValue: '$100',
+        },
+        {
+          label: 'Google',
+          value: 20,
+          formattedValue: '$20',
+        },
+      ]}
+    />
+  );
+};

--- a/src/components/Docs/stories/components/Title/Title.scss
+++ b/src/components/Docs/stories/components/Title/Title.scss
@@ -12,9 +12,14 @@
 
 .h1,
 .h2,
-.h3 {
+.h3,
+.h4 {
   position: relative;
   color: white;
+
+  > code {
+    font-weight: 200;
+  }
 }
 
 .h1,
@@ -29,4 +34,9 @@
 .h3,
 .h3 > code {
   font-size: 22px;
+}
+
+.h4,
+.h4 > code {
+  font-size: 18px;
 }

--- a/src/components/Docs/stories/components/Title/Title.tsx
+++ b/src/components/Docs/stories/components/Title/Title.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 
+import {uniqueId} from '../../../../../utilities';
 import {copyTextToClipboard} from '../../../../../../documentation/utilities';
 
 import styles from './Title.scss';
@@ -11,7 +12,7 @@ export function Title({
   type: string;
   children: React.ReactChildren;
 }) {
-  const slug = children.toString().replace(/\s/g, '');
+  const id = useMemo(() => uniqueId('titleAnchor'), []);
 
   const markup = useMemo(() => {
     switch (type) {
@@ -24,6 +25,9 @@ export function Title({
       case 'h3':
         return <h3 className={styles.h3}>{children}</h3>;
         break;
+      case 'h4':
+        return <h4 className={styles.h4}>{children}</h4>;
+        break;
 
       default:
         return children;
@@ -33,7 +37,7 @@ export function Title({
 
   const handleInteraction = (event: any) => {
     event.preventDefault();
-    const url = `${window.location.href}#${slug}`.replace(
+    const url = `${window.location.href}#${id}`.replace(
       'iframe.html?id=',
       '?path=/docs/',
     );
@@ -42,8 +46,8 @@ export function Title({
   return (
     <a
       className={styles.TitleAnchor}
-      id={slug}
-      href={`#${slug}`}
+      id={id}
+      href={`#${id}`}
       onClick={handleInteraction}
     >
       {markup}

--- a/src/components/Docs/stories/components/index.ts
+++ b/src/components/Docs/stories/components/index.ts
@@ -3,3 +3,13 @@ export {LogoHeader} from './LogoHeader';
 export {Title} from './Title';
 export {Divider} from './Divider';
 export {ExamplesGrid} from './ExamplesGrid';
+export {PropertyTable} from './PropertyTable';
+export {
+  SampleSparkbar,
+  SampleSparkline,
+  SampleLineChart,
+  SampleBarchart,
+  SampleMultiseriesBarChart,
+  SampleStackedAreaChart,
+  SampleNormalizedStackedBarChart,
+} from './SampleComponents';

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -146,8 +146,8 @@ export function Sparkline({
       <svg xmlns={XMLNS} aria-hidden width={width} height={height}>
         {series.map((singleSeries, index) => {
           const {
-            lineStyle,
-            hasPoint,
+            lineStyle = selectedTheme.line.style,
+            hasPoint = selectedTheme.line.hasPoint,
             offsetRight = 0,
             offsetLeft = 0,
           } = singleSeries;

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -368,7 +368,7 @@ export function Chart({
                   </defs>
                 )}
                 <Point
-                  stroke={colorWhite}
+                  stroke={selectedTheme.line.pointStroke}
                   color={pointColor}
                   cx={getXPosition({isCrosshair: false, index: stackIndex})}
                   cy={animatedYPostion}
@@ -389,7 +389,7 @@ export function Chart({
               <Point
                 dataType={DataType.Point}
                 key={`point-${dataIndex}-${x}}`}
-                stroke={colorWhite}
+                stroke={selectedTheme.line.pointStroke}
                 color={colorWhite}
                 cx={xScale(dataIndex)}
                 cy={yScale(y)}


### PR DESCRIPTION
### What problem is this PR solving?

Part 2 of https://github.com/Shopify/polaris-viz/issues/575

- Documents most of the `Theme` type definition.

⚠️ Still pending: `seriesColors` and `tooltip`; will be tackled in follow up PR


- Creates utility components for the Storybook docs

### Reviewers’ :tophat: instructions

<!-- Tophatting instructions, and/ or what you want reviewers to concentrate on. -->

<!-- If you have some code in your Sandbox consider sharing it to help others 🎩 -->

<!--
<details>
</details>
 -->

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
