### PR TITLE
Change HorizontalBarChart to use fixed height

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -28,7 +28,6 @@ import {
   VerticalGridLines,
   XAxisLabels,
 } from './components';
-import {Size, Sizes} from './types';
 import type {Series, XAxisOptions, YAxisOptions} from './types';
 import {useBarSizes, useDataForChart, useXScale} from './hooks';
 import styles from './Chart.scss';
@@ -46,7 +45,6 @@ interface ChartProps {
   series: Series[];
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
-  size?: Sizes;
   theme?: string;
 }
 
@@ -56,7 +54,6 @@ export function Chart({
   isSimple,
   isStacked,
   series,
-  size = Size.Medium,
   theme,
   xAxisOptions,
   yAxisOptions,
@@ -101,15 +98,15 @@ export function Chart({
     return xScale(value);
   }, [xScale, ticks]);
 
-  const {barHeight, groupHeight, chartHeight, bandwidth} = useBarSizes({
-    chartDimensions,
-    isSimple,
-    isStacked,
-    singleBarCount: series[0].data.length,
-    size,
-    seriesLength: series.length,
-    ticksCount: ticks.length,
-  });
+  const {barHeight, groupHeight, groupBarsAreaHeight, chartHeight, bandwidth} =
+    useBarSizes({
+      chartDimensions,
+      isSimple,
+      isStacked,
+      singleBarCount: series[0].data.length,
+      seriesLength: series.length,
+      ticksCount: ticks.length,
+    });
 
   const getAriaLabel = useCallback(
     (label: string, seriesIndex: number) => {
@@ -148,12 +145,12 @@ export function Chart({
       className={styles.ChartContainer}
       style={{
         width: chartDimensions.width,
-        height: chartHeight,
+        height: chartDimensions.height,
       }}
     >
       <svg
         className={styles.SVG}
-        height={chartHeight}
+        height={chartDimensions.height}
         ref={setSvgRef}
         role="list"
         width={chartDimensions.width}
@@ -212,9 +209,9 @@ export function Chart({
                 <StackedBars
                   animationDelay={animationDelay}
                   ariaLabel={ariaLabel}
+                  barHeight={barHeight}
                   groupIndex={index}
                   series={item.data}
-                  size={size}
                   xScale={xScaleStacked}
                 />
               ) : (
@@ -238,7 +235,7 @@ export function Chart({
         })}
       </svg>
       <TooltipWrapper
-        bandwidth={bandwidth}
+        bandwidth={groupBarsAreaHeight}
         chartDimensions={chartDimensions}
         focusElementDataType={DataType.Bar}
         getAlteredPosition={getAlteredHorizontalBarPosition}

--- a/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -5,7 +5,7 @@ import {useResizeObserver} from '../../hooks';
 import type {Dimensions} from '../../types';
 
 import {Chart} from './Chart';
-import {Series, Size, XAxisOptions, YAxisOptions} from './types';
+import type {Series, XAxisOptions, YAxisOptions} from './types';
 
 export interface HorizontalBarChartProps {
   series: Series[];
@@ -14,7 +14,6 @@ export interface HorizontalBarChartProps {
   isAnimated?: boolean;
   isSimple?: boolean;
   isStacked?: boolean;
-  size?: Size;
   theme?: string;
 }
 
@@ -23,7 +22,6 @@ export function HorizontalBarChart({
   isSimple = false,
   isStacked = false,
   series,
-  size = Size.Small,
   theme,
   xAxisOptions,
   yAxisOptions,
@@ -68,7 +66,6 @@ export function HorizontalBarChart({
           isSimple={isSimple}
           isStacked={isStacked}
           series={series}
-          size={size}
           theme={theme}
           xAxisOptions={xAxisOptionsForChart}
           yAxisOptions={yAxisOptions}

--- a/src/components/HorizontalBarChart/components/StackedBar.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBar.tsx
@@ -2,21 +2,20 @@ import {animated, useSpring} from '@react-spring/web';
 import React from 'react';
 
 import {DataType} from '../../../types';
-import {GRADIENT_ID, SIZES} from '../constants';
-import type {Size} from '../types';
+import {GRADIENT_ID} from '../constants';
 
 interface StackedBarProps {
   groupIndex: number;
+  height: number;
   seriesIndex: number;
-  size: Size;
   width: number;
   x: number;
 }
 
 export function StackedBar({
   groupIndex,
+  height,
   seriesIndex,
-  size,
   width,
   x,
 }: StackedBarProps) {
@@ -30,7 +29,7 @@ export function StackedBar({
       data-index={groupIndex}
       data-type={DataType.Bar}
       fill={`url(#${GRADIENT_ID}${seriesIndex})`}
-      height={SIZES[size]}
+      height={height}
       key={seriesIndex}
       style={{outline: 'none', transformOrigin: `${x}px 0px`}}
       tabIndex={seriesIndex === 0 ? 0 : -1}

--- a/src/components/HorizontalBarChart/components/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars.tsx
@@ -4,7 +4,6 @@ import {animated, useSpring} from '@react-spring/web';
 
 import {BARS_TRANSITION_CONFIG} from '../../../constants';
 import type {Data} from '../types';
-import {Size} from '../types';
 import {LABEL_HEIGHT, STACKED_BAR_GAP} from '../constants';
 
 import {StackedBar} from './StackedBar';
@@ -12,18 +11,18 @@ import {StackedBar} from './StackedBar';
 export interface StackedBarsProps {
   animationDelay: number;
   ariaLabel: string;
+  barHeight: number;
   groupIndex: number;
   series: Data[];
-  size: Size;
   xScale: ScaleLinear<number, number>;
 }
 
 export function StackedBars({
   animationDelay,
   ariaLabel,
+  barHeight,
   groupIndex,
   series,
-  size = Size.Small,
   xScale,
 }: StackedBarsProps) {
   const xOffsets = useMemo(() => {
@@ -58,9 +57,9 @@ export function StackedBars({
         return (
           <StackedBar
             groupIndex={groupIndex}
+            height={barHeight}
             key={seriesIndex}
             seriesIndex={seriesIndex}
-            size={size}
             width={xScale(rawValue)}
             x={x}
           />

--- a/src/components/HorizontalBarChart/constants.ts
+++ b/src/components/HorizontalBarChart/constants.ts
@@ -1,5 +1,3 @@
-import {Size} from './types';
-
 export const LABEL_HEIGHT = 24;
 export const SPACE_BETWEEN_SETS = 16;
 export const SPACE_BETWEEN_SINGLE = 2;
@@ -9,9 +7,4 @@ export const NEGATIVE_GRADIENT_ID = 'grad-negative';
 export const GRADIENT_ID = 'grad-';
 export const FONT_SIZE_PADDING = 1;
 export const STACKED_BAR_GAP = 2;
-
-export const SIZES: {[key in Size]: number} = {
-  [Size.Small]: 6,
-  [Size.Medium]: 16,
-  [Size.Large]: 26,
-};
+export const MIN_BAR_HEIGHT = 6;

--- a/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -6,9 +6,7 @@ import {
   HorizontalBarChartProps,
 } from '../HorizontalBarChart';
 
-import {ChartContainer} from '../../ChartContainer';
 import type {Series} from '../types';
-import {Size} from '../types';
 
 const LABELS = ['BCFM 2019', 'BCFM 2020', 'BCFM 2021'];
 
@@ -40,13 +38,13 @@ const SERIES = buildSeries([
   [48, 8, 50],
   [1, 5, 5],
 ]);
+const CONTAINER_HEIGHT = 500;
 
 const SINGLE_SERIES = buildSeries([3, 7, 4, 8, 4, 1, 4, 6]);
 
 export default {
   title: 'Charts/HorizontalBarChart',
   component: HorizontalBarChart,
-  decorators: [(Story: any) => <ChartContainer>{Story()}</ChartContainer>],
   parameters: {
     previewHeight: 'auto',
   },
@@ -55,7 +53,21 @@ export default {
 const Template: Story<HorizontalBarChartProps> = (
   args: HorizontalBarChartProps,
 ) => {
-  return <HorizontalBarChart {...args} />;
+  return (
+    <div style={{height: CONTAINER_HEIGHT}}>
+      <HorizontalBarChart {...args} />
+    </div>
+  );
+};
+
+const SimpleTemplate: Story<HorizontalBarChartProps> = (
+  args: HorizontalBarChartProps,
+) => {
+  return (
+    <div style={{height: CONTAINER_HEIGHT}}>
+      <HorizontalBarChart isSimple={true} {...args} />
+    </div>
+  );
 };
 
 export const Default: Story<HorizontalBarChartProps> = Template.bind({});
@@ -97,7 +109,6 @@ export const SingleBarNegative: Story<HorizontalBarChartProps> = Template.bind(
 SingleBarNegative.args = {
   series: buildSeries([13, -10, -30, 8, 47, 1]),
   yAxisOptions: {labels: LABELS},
-  size: Size.Medium,
 };
 
 export const SingleBarAllNegative: Story<HorizontalBarChartProps> = Template.bind(
@@ -126,7 +137,6 @@ ColorOverrides.args = {
     },
   ],
   yAxisOptions: {labels: LABELS},
-  size: Size.Medium,
 };
 
 export const LongLabels: Story<HorizontalBarChartProps> = Template.bind({});
@@ -137,12 +147,6 @@ LongLabels.args = {
     labelFormatter: (value) => `${value} pickled peppers and pickles`,
   },
   yAxisOptions: {labels: LABELS},
-};
-
-const SimpleTemplate: Story<HorizontalBarChartProps> = (
-  args: HorizontalBarChartProps,
-) => {
-  return <HorizontalBarChart isSimple={true} {...args} />;
 };
 
 export const SimpleHorizontalChart: Story<HorizontalBarChartProps> = SimpleTemplate.bind(
@@ -194,7 +198,6 @@ export const SimpleNegative: Story<HorizontalBarChartProps> = SimpleTemplate.bin
 SimpleNegative.args = {
   series: buildSeries([1300, -1000, -3000, 800, 4700, 100]),
   yAxisOptions: {labels: LABELS},
-  size: Size.Medium,
 };
 
 export const SimpleAllNegative: Story<HorizontalBarChartProps> = SimpleTemplate.bind(
@@ -204,7 +207,6 @@ export const SimpleAllNegative: Story<HorizontalBarChartProps> = SimpleTemplate.
 SimpleAllNegative.args = {
   series: buildSeries([-13, -7, -10, -8, -47, -1]),
   yAxisOptions: {labels: LABELS},
-  size: Size.Medium,
 };
 
 export const Stacked: Story<HorizontalBarChartProps> = Template.bind({});
@@ -213,7 +215,6 @@ Stacked.args = {
   series: SERIES,
   yAxisOptions: {labels: LABELS},
   isStacked: true,
-  size: Size.Large,
 };
 
 export const SimpleStacked: Story<HorizontalBarChartProps> = SimpleTemplate.bind(
@@ -224,7 +225,6 @@ SimpleStacked.args = {
   series: SERIES,
   yAxisOptions: {labels: LABELS},
   isStacked: true,
-  size: Size.Large,
 };
 
 export const Sorting = () => {
@@ -252,7 +252,6 @@ export const Sorting = () => {
     <>
       <SimpleHorizontalChart
         series={[...data].splice(0, 5)}
-        size={Size.Large}
         yAxisOptions={{labels: LABELS}}
       />
       <button onClick={onClick} style={{marginRight: 10}}>

--- a/src/components/HorizontalBarChart/types.ts
+++ b/src/components/HorizontalBarChart/types.ts
@@ -19,10 +19,3 @@ export interface Series {
   data: Data[];
   color?: Color;
 }
-
-export enum Size {
-  Small,
-  Medium,
-  Large,
-}
-export type Sizes = Size;

--- a/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -3,6 +3,7 @@ import {
   AlteredPositionReturn,
   TOOLTIP_MARGIN,
 } from '../../../components/TooltipWrapper';
+import {LABEL_HEIGHT} from '../constants';
 
 export function getAlteredHorizontalBarPosition(
   props: AlteredPositionProps,
@@ -18,16 +19,22 @@ function getNegativeOffset(props: AlteredPositionProps): AlteredPositionReturn {
   const {currentX, currentY, tooltipDimensions} = props;
 
   const flippedX = currentX * -1;
+  const yOffset = (props.bandwidth - tooltipDimensions.height) / 2;
 
   if (flippedX - tooltipDimensions.width < 0) {
     return {x: flippedX, y: currentY - tooltipDimensions.height};
   }
 
-  return {x: flippedX - tooltipDimensions.width - TOOLTIP_MARGIN, y: currentY};
+  return {
+    x: flippedX - tooltipDimensions.width - TOOLTIP_MARGIN,
+    y: currentY + LABEL_HEIGHT + yOffset,
+  };
 }
 
 function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
   const {currentX, currentY, tooltipDimensions, chartDimensions} = props;
+
+  const yOffset = (props.bandwidth - tooltipDimensions.height) / 2;
 
   if (
     currentX + TOOLTIP_MARGIN + tooltipDimensions.width >
@@ -48,6 +55,6 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
 
   return {
     x: currentX + TOOLTIP_MARGIN,
-    y: currentY,
+    y: currentY + LABEL_HEIGHT + yOffset,
   };
 }


### PR DESCRIPTION
### What problem is this PR solving?

To align with the other components we want the HorizontalBarChart to use a fixed height and size the bars accordingly instead of setting the individual bar height and allowing the height to be fluid.

### Reviewers’ :tophat: instructions

- Change the height values in the story: https://github.com/Shopify/polaris-viz/compare/envex/horizontal-bar-chart...envex/hbc-fixed-height?expand=1#diff-cc56ed59efb766ead34c7c8439e7f3017be00da5d0cb8aec9cb9a2ab2583e2a9R56

Note: If a chart gets too short to display the minimum bar size, we warn the user that the chart will not look correct.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
