### PR TITLE
Allow each series to have any number of bars

### DIFF
--- a/src/components/HorizontalBarChart/components/GradientDefs.tsx
+++ b/src/components/HorizontalBarChart/components/GradientDefs.tsx
@@ -5,32 +5,25 @@ import type {Color, GradientStop} from '../../../types';
 import {isGradientType} from '../../../utilities';
 import {LinearGradient} from '../../LinearGradient';
 import {GRADIENT_ID, NEGATIVE_GRADIENT_ID} from '../constants';
+import type {ColorOverrides} from '../types';
 
 interface GradientDefsProps {
+  colorOverrides: ColorOverrides[];
   seriesColors: Color[];
 }
 
-export function GradientDefs({seriesColors}: GradientDefsProps) {
+export function GradientDefs({
+  colorOverrides,
+  seriesColors,
+}: GradientDefsProps) {
   return (
     <defs>
+      {colorOverrides.map(({id, color}) => {
+        return <Gradient key={id} id={id} color={color} />;
+      })}
       {seriesColors.map((color, index) => {
-        const gradient: GradientStop[] = isGradientType(color)
-          ? color
-          : [
-              {
-                color,
-                offset: 0,
-              },
-            ];
-        return (
-          <LinearGradient
-            gradient={gradient}
-            id={`${GRADIENT_ID}${index}`}
-            key={`${GRADIENT_ID}${index}`}
-            x2="100%"
-            y1="0%"
-          />
-        );
+        const id = `${GRADIENT_ID}${index}`;
+        return <Gradient key={id} id={id} color={color} />;
       })}
       <LinearGradient
         gradient={NEGATIVE_SINGLE_GRADIENT}
@@ -40,4 +33,16 @@ export function GradientDefs({seriesColors}: GradientDefsProps) {
       />
     </defs>
   );
+}
+
+function Gradient({id, color}: {id: string; color: Color}) {
+  const gradient: GradientStop[] = isGradientType(color)
+    ? color
+    : [
+        {
+          color,
+          offset: 0,
+        },
+      ];
+  return <LinearGradient gradient={gradient} id={id} x2="100%" y1="0%" />;
 }

--- a/src/components/HorizontalBarChart/components/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars.tsx
@@ -13,6 +13,7 @@ import {
   SPACE_BETWEEN_SINGLE,
 } from '../constants';
 import {useTheme} from '../../../hooks';
+import {getBarId} from '../utilities';
 
 import {Bar, RoundedBorder} from './Bar';
 import {Label} from './Label';
@@ -54,9 +55,10 @@ export function HorizontalBars({
       aria-label={ariaLabel}
       role="listitem"
     >
-      {series.map(({rawValue}, seriesIndex) => {
+      {series.map(({rawValue, color}, seriesIndex) => {
         const isNegative = rawValue < 0;
         const label = labelFormatter(rawValue);
+        const id = getBarId(groupIndex, seriesIndex);
 
         const labelWidth = getTextWidth({
           text: `${label}`,
@@ -74,16 +76,13 @@ export function HorizontalBars({
           : -(width + leftLabelOffset);
         const x = isNegative ? negativeX : width + BAR_LABEL_OFFSET;
         const ariaHidden = seriesIndex !== 0;
+        const barColor = color ? id : `${GRADIENT_ID}${seriesIndex}`;
 
         return (
-          <React.Fragment key={`series-${groupIndex}-${seriesIndex}`}>
+          <React.Fragment key={id}>
             <Bar
               animationDelay={animationDelay}
-              color={`url(#${
-                isNegative
-                  ? NEGATIVE_GRADIENT_ID
-                  : `${GRADIENT_ID}${seriesIndex}`
-              })`}
+              color={`url(#${isNegative ? NEGATIVE_GRADIENT_ID : barColor})`}
               height={barHeight}
               index={groupIndex}
               isAnimated={isAnimated}

--- a/src/components/HorizontalBarChart/components/StackedBar.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBar.tsx
@@ -2,9 +2,9 @@ import {animated, useSpring} from '@react-spring/web';
 import React from 'react';
 
 import {DataType} from '../../../types';
-import {GRADIENT_ID} from '../constants';
 
 interface StackedBarProps {
+  color: string;
   groupIndex: number;
   height: number;
   seriesIndex: number;
@@ -13,6 +13,7 @@ interface StackedBarProps {
 }
 
 export function StackedBar({
+  color,
   groupIndex,
   height,
   seriesIndex,
@@ -28,7 +29,7 @@ export function StackedBar({
     <animated.rect
       data-index={groupIndex}
       data-type={DataType.Bar}
-      fill={`url(#${GRADIENT_ID}${seriesIndex})`}
+      fill={`url(#${color})`}
       height={height}
       key={seriesIndex}
       style={{outline: 'none', transformOrigin: `${x}px 0px`}}

--- a/src/components/HorizontalBarChart/components/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars.tsx
@@ -4,7 +4,8 @@ import {animated, useSpring} from '@react-spring/web';
 
 import {BARS_TRANSITION_CONFIG} from '../../../constants';
 import type {Data} from '../types';
-import {LABEL_HEIGHT, STACKED_BAR_GAP} from '../constants';
+import {GRADIENT_ID, LABEL_HEIGHT, STACKED_BAR_GAP} from '../constants';
+import {getBarId} from '../utilities';
 
 import {StackedBar} from './StackedBar';
 
@@ -51,11 +52,13 @@ export function StackedBars({
 
   return (
     <animated.g aria-label={ariaLabel} role="listitem" style={{transform}}>
-      {series.map(({rawValue}, seriesIndex) => {
+      {series.map(({rawValue, color}, seriesIndex) => {
         const x = xOffsets[seriesIndex] + STACKED_BAR_GAP * seriesIndex;
+        const id = getBarId(groupIndex, seriesIndex);
 
         return (
           <StackedBar
+            color={color ? id : `${GRADIENT_ID}${seriesIndex}`}
             groupIndex={groupIndex}
             height={barHeight}
             key={seriesIndex}

--- a/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -92,6 +92,32 @@ MultiSeriesAllNegative.args = {
   isAnimated: false,
 };
 
+export const RandomSeriesAmounts: Story<HorizontalBarChartProps> = Template.bind(
+  {},
+);
+
+RandomSeriesAmounts.args = {
+  series: [
+    {name: 'One', data: [{rawValue: 5, label: 'Pickles'}]},
+    {
+      name: 'Two',
+      data: [
+        {rawValue: 5, label: 'Pickles'},
+        {rawValue: 3, label: 'Peppers'},
+      ],
+    },
+    {
+      name: 'Three',
+      data: [
+        {rawValue: 3, label: 'Pickles'},
+        {rawValue: 4, label: 'Peppers'},
+        {rawValue: 5, label: 'Bananas'},
+      ],
+    },
+  ],
+  isAnimated: false,
+};
+
 export const SingleBar: Story<HorizontalBarChartProps> = Template.bind({});
 
 SingleBar.args = {

--- a/src/components/HorizontalBarChart/types.ts
+++ b/src/components/HorizontalBarChart/types.ts
@@ -15,3 +15,8 @@ export interface Series {
   name: string;
   data: Data[];
 }
+
+export interface ColorOverrides {
+  id: string;
+  color: Color;
+}

--- a/src/components/HorizontalBarChart/utilities/getBarId.ts
+++ b/src/components/HorizontalBarChart/utilities/getBarId.ts
@@ -1,0 +1,3 @@
+export function getBarId(groupIndex: number, seriesIndex: number) {
+  return `series-${groupIndex}-${seriesIndex}`;
+}

--- a/src/components/HorizontalBarChart/utilities/index.ts
+++ b/src/components/HorizontalBarChart/utilities/index.ts
@@ -1,1 +1,2 @@
 export {getAlteredHorizontalBarPosition} from './getAlteredHorizontalBarPosition';
+export {getBarId} from './getBarId';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,5 +6,8 @@ export {usePrevious} from './use-previous';
 export {useResizeObserver} from './useResizeObserver';
 export {useTheme} from './useTheme';
 export {usePolarisVizContext} from './usePolarisVizContext';
-export {useThemeSeriesColors} from './use-theme-series-colors';
+export {
+  useThemeSeriesColors,
+  getSeriesColorsFromCount,
+} from './use-theme-series-colors';
 export {useLinearChartAnimations} from './use-linear-chart-animations';


### PR DESCRIPTION
### What problem is this PR solving?

Each series group should allow for a different number of bars than the other groups. This also moves the color overrides to each individual bar instead of just the first set.

### Reviewers’ :tophat: instructions

- Open http://localhost:6006/?path=/story/charts-horizontalbarchart--random-series-amounts

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
