### PR TITLE
Add method to remap MultiSeriesBarChart data to HorizontalBarChart data

### DIFF
--- a/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -8,6 +8,7 @@ import {
 
 import type {Series} from '../types';
 import {cleanNullData} from '../utilities/cleanNullData';
+import {formatDataFromMultiseries} from '../utilities';
 
 const LABELS = ['BCFM 2019', 'BCFM 2020', 'BCFM 2021'];
 
@@ -75,6 +76,51 @@ export const Default: Story<HorizontalBarChartProps> = Template.bind({});
 
 Default.args = {
   series: SERIES,
+};
+
+export const Massaged: Story<HorizontalBarChartProps> = Template.bind({});
+
+const MULTI_SERIES_BAR_CHART_DATA = [
+  {
+    name: 'Breakfast',
+    data: [
+      {label: 'Monday', rawValue: 3},
+      {label: 'Tuesday', rawValue: -7},
+      {label: 'Wednesday', rawValue: 4},
+      {label: 'Thursday', rawValue: 8},
+      {label: 'Friday', rawValue: 50},
+      {label: 'Saturday', rawValue: 0},
+      {label: 'Sunday', rawValue: 0.1},
+    ],
+  },
+  {
+    name: 'Lunch',
+    data: [
+      {label: 'Monday', rawValue: 4},
+      {label: 'Tuesday', rawValue: 0},
+      {label: 'Wednesday', rawValue: 5},
+      {label: 'Thursday', rawValue: 15},
+      {label: 'Friday', rawValue: 8},
+      {label: 'Saturday', rawValue: 50},
+      {label: 'Sunday', rawValue: 0.1},
+    ],
+  },
+  {
+    name: 'Dinner',
+    data: [
+      {label: 'Monday', rawValue: 7},
+      {label: 'Tuesday', rawValue: 0},
+      {label: 'Wednesday', rawValue: 6},
+      {label: 'Thursday', rawValue: 12},
+      {label: 'Friday', rawValue: 50},
+      {label: 'Saturday', rawValue: 5},
+      {label: 'Sunday', rawValue: 0.1},
+    ],
+  },
+];
+
+Massaged.args = {
+  series: formatDataFromMultiseries(MULTI_SERIES_BAR_CHART_DATA),
 };
 
 export const MultiSeriesAllNegative: Story<HorizontalBarChartProps> = Template.bind(

--- a/src/components/HorizontalBarChart/utilities/formatDataFromMultiseries.ts
+++ b/src/components/HorizontalBarChart/utilities/formatDataFromMultiseries.ts
@@ -1,0 +1,29 @@
+import type {Series} from '../types';
+import type {Series as MSBCSeries} from '../../MultiSeriesBarChart';
+
+export function formatDataFromMultiseries(series: MSBCSeries[]): Series[] {
+  const roots: Series[] = [];
+
+  series.forEach(({name, data}) => {
+    data.forEach(({label, rawValue}, index) => {
+      if (!roots[index]) {
+        roots.push({
+          name: label,
+          data: [
+            {
+              label: name,
+              rawValue,
+            },
+          ],
+        });
+      } else {
+        roots[index].data.push({
+          label: name,
+          rawValue,
+        });
+      }
+    });
+  });
+
+  return roots;
+}

--- a/src/components/HorizontalBarChart/utilities/index.ts
+++ b/src/components/HorizontalBarChart/utilities/index.ts
@@ -1,2 +1,3 @@
 export {getAlteredHorizontalBarPosition} from './getAlteredHorizontalBarPosition';
 export {getBarId} from './getBarId';
+export {formatDataFromMultiseries} from './formatDataFromMultiseries';

--- a/src/components/MultiSeriesBarChart/index.ts
+++ b/src/components/MultiSeriesBarChart/index.ts
@@ -1,2 +1,3 @@
 export {MultiSeriesBarChart} from './MultiSeriesBarChart';
 export type {MultiSeriesBarChartProps} from './MultiSeriesBarChart';
+export type {Series} from './types';


### PR DESCRIPTION
### What problem is this PR solving?

There is a disconnect between how the different charts have structured their data. After a chat with @pbojinov, it seems like the structure of the `<MultiSeriesBarChart />` was different than he would have expected it to be without seeing the API.

Until we have unify all the data structures, we want to find a way to make it easier on the consumer.

We have a few options:

### Leave it

Just make the consumer use the structure we already have, which means they may have to manipulate the data themselves.

**Pros**

- No work on our end

**Cons**

- More work the consumer. Manipulating data means more tech debt.

### Switch `<HorizontalBarChart />` to match `<MultiSeriesBarChart />`.

**Pros**

- Shared series structure

**Cons**

- The current `<MultiSeriesBarChart />` data structure makes it difficult to animate in/out new series items because of the way the data is nested.

### Provide a method that manipulates the data

This PR contains this solution. `formatDataFromMultiseries` takes in `<MultiSeriesBarChart />` series and converts it to what `<HorizontalBarChart />` expects. We can either export this out for @pbojinov, or `<HorizontalBarChart />` can accept `<MultiSeriesBarChart />` series structure and we can use `formatDataFromMultiseries` internally.

**Pros**

- Minimal changes.

**Cons**

- If we export it, we have to fix all instances when we unify all the data.

### Reviewers’ :tophat: instructions

- Open http://localhost:6006/?path=/story/charts-horizontalbarchart--massaged

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
