### PR TITLE
Fix broken hide labels logic

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -43,7 +43,7 @@ interface ChartProps {
   isSimple: boolean;
   isStacked: boolean;
   series: Series[];
-  xAxisOptions: XAxisOptions;
+  xAxisOptions: Required<XAxisOptions>;
   theme?: string;
 }
 
@@ -106,7 +106,7 @@ export function Chart({
     tallestXAxisLabel,
   } = useBarSizes({
     chartDimensions,
-    isSimple,
+    isSimple: isSimple || xAxisOptions.hide,
     isStacked,
     labelFormatter,
     seriesLength: series.length,
@@ -162,7 +162,7 @@ export function Chart({
         width={chartDimensions.width}
         xmlns={XMLNS}
       >
-        {isSimple ?? xAxisOptions.hide === true ? null : (
+        {isSimple || xAxisOptions.hide === true ? null : (
           <React.Fragment>
             <VerticalGridLines
               seriesAreaHeight={seriesAreaHeight}

--- a/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -24,8 +24,9 @@ export function HorizontalBarChart({
   theme,
   xAxisOptions,
 }: HorizontalBarChartProps) {
-  const xAxisOptionsForChart = {
+  const xAxisOptionsForChart: Required<XAxisOptions> = {
     labelFormatter: (value: string) => value,
+    hide: false,
     ...xAxisOptions,
   };
 

--- a/src/components/HorizontalBarChart/components/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type {ScaleLinear} from 'd3-scale';
 
 import {FONT_SIZE} from '../../../constants';
-import type {Data, XAxisOptions} from '../types';
+import type {Data, LabelFormatter} from '../types';
 import {getTextWidth} from '../../../utilities';
 import {
   BAR_LABEL_OFFSET,
@@ -24,7 +24,7 @@ interface HorizontalBarProps {
   firstNonNegativeValue: number;
   groupIndex: number;
   isAnimated: boolean;
-  labelFormatter: XAxisOptions['labelFormatter'];
+  labelFormatter: LabelFormatter;
   series: Data[];
   isSimple: boolean;
   xScale: ScaleLinear<number, number>;

--- a/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
+++ b/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
@@ -3,14 +3,14 @@ import type {ScaleLinear} from 'd3-scale';
 
 import {MAX_X_AXIS_LINES} from '../../constants';
 import {FONT_SIZE, LINE_HEIGHT} from '../../../../constants';
-import type {XAxisOptions} from '../../types';
+import type {LabelFormatter} from '../../types';
 
 import styles from './XAxisLabels.scss';
 
 interface XAxisLabelsProps {
   bandwidth: number;
   color: string;
-  labelFormatter: XAxisOptions['labelFormatter'];
+  labelFormatter: LabelFormatter;
   seriesAreaHeight: number;
   tallestXAxisLabel: number;
   ticks: number[];

--- a/src/components/HorizontalBarChart/hooks/useBarSizes.ts
+++ b/src/components/HorizontalBarChart/hooks/useBarSizes.ts
@@ -11,13 +11,13 @@ import {
   SPACE_BETWEEN_SERIES_AND_LABELS,
   SPACE_BETWEEN_SETS,
 } from '../constants';
-import type {XAxisOptions} from '../types';
+import type {LabelFormatter} from '../types';
 
 interface Props {
   chartDimensions: Dimensions;
   isSimple: boolean;
   isStacked: boolean;
-  labelFormatter: XAxisOptions['labelFormatter'];
+  labelFormatter: LabelFormatter;
   seriesLength: number;
   singleBarCount: number;
   ticks: number[];

--- a/src/components/HorizontalBarChart/hooks/useDataForChart.ts
+++ b/src/components/HorizontalBarChart/hooks/useDataForChart.ts
@@ -3,12 +3,12 @@ import {useMemo} from 'react';
 import {FONT_SIZE} from '../../../constants';
 import {getTextWidth} from '../../../utilities';
 import {BAR_LABEL_OFFSET, FONT_SIZE_PADDING} from '../constants';
-import type {Series, XAxisOptions} from '../types';
+import type {LabelFormatter, Series} from '../types';
 
 interface Props {
   series: Series[];
   isSimple: boolean;
-  labelFormatter: XAxisOptions['labelFormatter'];
+  labelFormatter: LabelFormatter;
 }
 
 export function useDataForChart({labelFormatter, series, isSimple}: Props) {

--- a/src/components/HorizontalBarChart/types.ts
+++ b/src/components/HorizontalBarChart/types.ts
@@ -1,7 +1,9 @@
 import type {Color} from '../../types';
 
+export type LabelFormatter = (value: string | number) => string;
+
 export interface XAxisOptions {
-  labelFormatter: (value: string | number) => string;
+  labelFormatter?: LabelFormatter;
   hide?: boolean;
 }
 


### PR DESCRIPTION
### What problem is this PR solving?

The `xAxisOptions.hide` setting wasn't actually working.

Fixes: https://github.com/Shopify/polaris-viz/issues/621

### Reviewers’ :tophat: instructions

- Load a story and set `xAxisOptions.hide` to `true`

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
