### PR TITLE
Discussion: Wrap SVG text

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "d3-path": "1",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.7",
+    "d3plus-text": "^1.0.2",
     "fast-deep-equal": "^3.1.3",
     "lodash.throttle": "^4.1.1",
     "use-debounce": "^3.3.0"

--- a/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
+++ b/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import type {ScaleLinear} from 'd3-scale';
 
-import {MAX_X_AXIS_LINES, SPACE_BETWEEN_CHART_AND_AXIS} from '../../constants';
-import {FONT_SIZE, LINE_HEIGHT} from '../../../../constants';
+import {SPACE_BETWEEN_CHART_AND_AXIS} from '../../constants';
+import {TextAlignment} from '../../../../types';
+import {WrappedText} from '../../../WrappedText';
 import type {LabelFormatter} from '../../types';
-
-import styles from './XAxisLabels.scss';
 
 interface XAxisLabelsProps {
   bandwidth: number;
@@ -19,11 +18,11 @@ interface XAxisLabelsProps {
 
 function getTextAlign({isFirst, isLast}: {isFirst: boolean; isLast: boolean}) {
   if (isFirst) {
-    return 'left';
+    return TextAlignment.Left;
   } else if (isLast) {
-    return 'right';
+    return TextAlignment.Right;
   } else {
-    return 'center';
+    return TextAlignment.Center;
   }
 }
 
@@ -43,37 +42,24 @@ export const XAxisLabels = ({
     >
       {ticks.map((value, index) => {
         const label = labelFormatter(value);
-        const isFirstItem = index === 0;
-        const isLastItem = index === ticks.length - 1;
+        const isFirst = index === 0;
+        const isLast = index === ticks.length - 1;
         const textOffset = bandwidth / 2;
 
-        const width = isFirstItem || isLastItem ? bandwidth / 2 : bandwidth;
+        const width = isFirst || isLast ? bandwidth / 2 : bandwidth;
 
         return (
-          <foreignObject
-            transform={`translate(${
-              isFirstItem ? 0 : xScale(value) - textOffset
-            },0)`}
+          <WrappedText
+            color={color}
             height={tallestXAxisLabel}
-            width={width}
             key={index}
-          >
-            <div
-              className={styles.Text}
-              style={{
-                fontSize: `${FONT_SIZE}px`,
-                color,
-                textAlign: getTextAlign({
-                  isFirst: isFirstItem,
-                  isLast: isLastItem,
-                }),
-                maxHeight: LINE_HEIGHT * MAX_X_AXIS_LINES,
-                padding: isFirstItem || isLastItem ? 0 : '0 10px',
-              }}
-            >
-              {label}
-            </div>
-          </foreignObject>
+            text={label}
+            transform={`translate(${
+              isFirst ? 0 : xScale(value) - textOffset
+            },0)`}
+            width={width}
+            align={getTextAlign({isFirst, isLast})}
+          />
         );
       })}
     </g>

--- a/src/components/HorizontalBarChart/constants.ts
+++ b/src/components/HorizontalBarChart/constants.ts
@@ -9,3 +9,5 @@ export const STACKED_BAR_GAP = 2;
 export const MIN_BAR_HEIGHT = 6;
 export const MAX_X_AXIS_LINES = 3;
 export const SPACE_BETWEEN_CHART_AND_AXIS = 10;
+export const PADDING_UNDER_LAST_GROUP = 10;
+export const SPACE_BETWEEN_SERIES_AND_LABELS = 12;

--- a/src/components/HorizontalBarChart/hooks/useBarSizes.ts
+++ b/src/components/HorizontalBarChart/hooks/useBarSizes.ts
@@ -1,11 +1,10 @@
 import {useMemo} from 'react';
 
 import {clamp, getTextHeight} from '../../../utilities';
-import {FONT_SIZE, LINE_HEIGHT} from '../../../constants';
+import {FONT_SIZE, LINE_HEIGHT, MAX_X_AXIS_LINES} from '../../../constants';
 import type {Dimensions} from '../../../types';
 import {
   LABEL_HEIGHT,
-  MAX_X_AXIS_LINES,
   MIN_BAR_HEIGHT,
   SPACE_BETWEEN_CHART_AND_AXIS,
   SPACE_BETWEEN_SETS,

--- a/src/components/WrappedText/WrappedText.tsx
+++ b/src/components/WrappedText/WrappedText.tsx
@@ -1,0 +1,75 @@
+import React, {useMemo} from 'react';
+import {textWrap} from 'd3plus-text';
+
+import {TextAlignment} from '../../types';
+import {MAX_X_AXIS_LINES, FONT_SIZE, LINE_HEIGHT} from '../../constants';
+
+interface WrappedTextProps {
+  align: TextAlignment;
+  color: string;
+  height: number;
+  text: string;
+  transform: string;
+  width: number;
+  fontSize?: number;
+  lineHeight?: number;
+  maxLines?: number;
+}
+
+function getAlignmentOffset(align: TextAlignment, x: number) {
+  switch (align) {
+    case TextAlignment.Left:
+      return 0;
+    case TextAlignment.Center:
+      return x / 2;
+    case TextAlignment.Right:
+      return x;
+  }
+}
+
+export function WrappedText({
+  align,
+  color,
+  fontSize = FONT_SIZE,
+  height,
+  lineHeight = LINE_HEIGHT,
+  maxLines = MAX_X_AXIS_LINES,
+  text,
+  transform,
+  width,
+}: WrappedTextProps) {
+  const wrapper = useMemo(() => {
+    return textWrap()
+      .overflow(false)
+      .fontSize(fontSize)
+      .maxLines(maxLines)
+      .lineHeight(lineHeight)
+      .width(width);
+  }, [width, maxLines, fontSize, lineHeight]);
+
+  const wrappedData = wrapper(text);
+  const lineCount = wrappedData.lines.length - 1;
+
+  return (
+    <text
+      fill={color}
+      transform={transform}
+      height={height}
+      width={width}
+      fontSize={`${FONT_SIZE}px`}
+    >
+      {wrappedData.lines.map((text: string, index: number) => {
+        const addEllipsis = wrappedData.truncated && lineCount === index;
+
+        const label = addEllipsis ? `${text.slice(0, -3)}...` : text;
+        const x = getAlignmentOffset(align, width - wrappedData.widths[index]);
+
+        return (
+          <tspan key={text} x={x} dy={LINE_HEIGHT}>
+            {label}
+          </tspan>
+        );
+      })}
+    </text>
+  );
+}

--- a/src/components/WrappedText/index.ts
+++ b/src/components/WrappedText/index.ts
@@ -1,0 +1,1 @@
+export {WrappedText} from './WrappedText';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,3 +33,4 @@ export type {PolarisVizProviderProps} from './PolarisVizProvider';
 export {TooltipWrapper} from './TooltipWrapper';
 export {HorizontalBarChart} from './HorizontalBarChart';
 export type {HorizontalBarChartProps} from './HorizontalBarChart';
+export {WrappedText} from './WrappedText';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -272,3 +272,4 @@ export const LOAD_ANIMATION_DURATION = 500;
 export const BAR_ANIMATION_HEIGHT_BUFFER = 20;
 export const DEFAULT_BORDER_RADIUS = 3;
 export const MIN_WIDTH_BORDER_RADIUS = 2;
+export const MAX_X_AXIS_LINES = 3;

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,3 +185,9 @@ export enum DataType {
   BarGroup = 'BarGroup',
   Bar = 'Bar',
 }
+
+export enum TextAlignment {
+  Left,
+  Center,
+  Right,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6348,12 +6348,12 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-d3-array@2.4.0, d3-array@^1.2.0:
+d3-array@2.4.0, d3-array@^1.2.0, d3-array@^2.11.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
   integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
 
-d3-collection@1:
+d3-collection@1, d3-collection@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
@@ -6362,6 +6362,21 @@ d3-color@1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.0.tgz#89c45a995ed773b13314f06460df26d60ba0ecaf"
   integrity sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==
+
+"d3-color@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
+"d3-dispatch@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
+  integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
+
+"d3-ease@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-2.0.0.tgz#fd1762bfca00dae4bacea504b1d628ff290ac563"
+  integrity sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==
 
 d3-format@1:
   version "1.4.3"
@@ -6374,6 +6389,13 @@ d3-interpolate@1:
   integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
   dependencies:
     d3-color "1"
+
+"d3-interpolate@1 - 2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
+  dependencies:
+    d3-color "1 - 2"
 
 d3-path@1:
   version "1.0.9"
@@ -6393,6 +6415,11 @@ d3-scale@^1.0.7:
     d3-time "1"
     d3-time-format "2"
 
+d3-selection@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0.tgz#94a11638ea2141b7565f883780dabc7ef6a61066"
+  integrity sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==
+
 d3-shape@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
@@ -6411,6 +6438,44 @@ d3-time@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
+
+"d3-timer@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
+  integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
+
+d3-transition@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-2.0.0.tgz#366ef70c22ef88d1e34105f507516991a291c94c"
+  integrity sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==
+  dependencies:
+    d3-color "1 - 2"
+    d3-dispatch "1 - 2"
+    d3-ease "1 - 2"
+    d3-interpolate "1 - 2"
+    d3-timer "1 - 2"
+
+d3plus-common@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3plus-common/-/d3plus-common-1.0.5.tgz#4203c6ba59d6ca1b2f4c575d75a24ce35ab95416"
+  integrity sha512-RrWIUMIUrVO5o0u0Mt626pYCzxRbZ1oMwq6wIHn9Tuzu5zRFtGARkCkq1OwGnaHxcoQmtdlXbNky8zDh2zkUbw==
+  dependencies:
+    d3-array "^2.11.0"
+    d3-collection "^1.0.7"
+    d3-selection "^2.0.0"
+    d3-transition "^2.0.0"
+    iso639-codes "^1.0.1"
+    windows-locale "^1.0.1"
+
+d3plus-text@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d3plus-text/-/d3plus-text-1.0.2.tgz#053df832ae509144eed4ed5e8b5318a271d6789d"
+  integrity sha512-bcg71Ggii/NJAKvM4O+UfT/OCDsD2lcdczZXg6vh6v7t/5mhfWdT3bgjjSxMiruIKYNAaDil664Li9WcxRQeyw==
+  dependencies:
+    d3-array "^2.11.0"
+    d3-selection "^2.0.0"
+    d3-transition "^2.0.0"
+    d3plus-common "^1.0.0"
 
 damerau-levenshtein@^1.0.6:
   version "1.0.7"
@@ -9512,6 +9577,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+iso639-codes@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/iso639-codes/-/iso639-codes-1.0.1.tgz#674a45cdabbfdf3719b8b971b93ca1eedbbb4a1d"
+  integrity sha512-jdTSv8yn6D7GODDrRtuWG7y3du3aoa+ki5H8h/Y48/NleNAd7Fw/M2niTTLXGH4QnqhJ98hg1JMQtP9csQ31Lg==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -16282,6 +16352,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+windows-locale@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/windows-locale/-/windows-locale-1.1.2.tgz#742953cc20b5b0c21d2d2eeb2a8ede437e251cb0"
+  integrity sha512-/UYu06jpOUHdyuenDMhf0xEwMWIBrTCu6R3uw7jBkyzQ76Qjvz8Al29NFMasHmM520v/APFIIhGSYOvUbqrqlQ==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### What problem is this PR solving?

Exploring ways to use the SVG `<text>` object so that we can properly import our SVGs into apps like Figma.

We currently use `<foreignObject>` and html so we can leverage the CSS text wrapping for free. This approach is not supported by design apps like Figma, so the text doesn't render.

In order to use the Polaris Viz to Figma plugin, we need to use SVG `<text>`.

There is a package called `d3plus` that we can use to split text strings based on container width. 

The entire bundle is `200.8kB` minified, but the `textWrap()` method that we only need is `4.5kB` so we may be able to treeshake it to save some size.

https://bundlephobia.com/package/d3plus-text@1.0.2

### Reviewers’ :tophat: instructions

- Load up http://localhost:6006/?path=/story/charts-horizontalbarchart--long-labels and resize the page. All the labels should be correctly positioned and truncated.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
