### PR TITLE
Update position on every move and fix issue with tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Circular dependency in `<LineChart />`
 - Theme.line.strokeColor now gets applied to StackedAreaChart
 - Theme.line.lineStyle and Theme.line.hasPoint now gets applied to Sparkline
+- Fixed issue with tooltips extended too far right when hovering last point.
 
 ## [0.21.2] - 2021-09-29
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -473,6 +473,7 @@ export function Chart({
       </svg>
 
       <TooltipWrapper
+        alwaysUpdatePosition
         chartDimensions={dimensions}
         focusElementDataType={DataType.Point}
         getMarkup={getTooltipMarkup}

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -406,6 +406,7 @@ export function Chart({
         </g>
       </svg>
       <TooltipWrapper
+        alwaysUpdatePosition
         chartDimensions={dimensions}
         focusElementDataType={DataType.Point}
         getMarkup={getTooltipMarkup}

--- a/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -20,6 +20,7 @@ interface TooltipWrapperProps {
   margin: Margin;
   parentRef: SVGSVGElement | null;
   focusElementDataType: DataType;
+  alwaysUpdatePosition?: boolean;
   bandwidth?: number;
   id?: string;
   onIndexChange?: (index: number | null) => void;
@@ -27,6 +28,7 @@ interface TooltipWrapperProps {
 
 export function TooltipWrapper(props: TooltipWrapperProps) {
   const {
+    alwaysUpdatePosition = false,
     bandwidth = 0,
     focusElementDataType,
     getPosition,
@@ -54,14 +56,17 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     (event: MouseEvent | TouchEvent) => {
       const newPosition = getPosition({event, eventType: 'mouse'});
 
-      if (activeIndexRef.current === newPosition.activeIndex) {
+      if (
+        !alwaysUpdatePosition &&
+        activeIndexRef.current === newPosition.activeIndex
+      ) {
         return;
       }
 
       setPosition(newPosition);
       onIndexChange?.(newPosition.activeIndex);
     },
-    [getPosition, onIndexChange],
+    [alwaysUpdatePosition, getPosition, onIndexChange],
   );
 
   const onMouseLeave = useCallback(() => {

--- a/src/components/TooltipWrapper/utilities.ts
+++ b/src/components/TooltipWrapper/utilities.ts
@@ -76,6 +76,10 @@ export function getAlteredPosition(
   if (newPosition.horizontal === TooltipHorizontalOffset.Left) {
     const left = getLeftPosition(x, props);
     x = left.value;
+
+    if (left.wasOutsideBounds) {
+      newPosition.horizontal = TooltipHorizontalOffset.Right;
+    }
   }
 
   if (newPosition.horizontal === TooltipHorizontalOffset.Right) {


### PR DESCRIPTION
### What problem is this PR solving?

We weren't correctly pushing tooltips that extended outside the right bounds back into the container.

Also, for `LineChart` and `StackedAreaChart` we were only updating the position when an index changed, but it makes more sense to allow the tooltip to follow the `mouseY` as well.

⚠️ NOTE: For very small screens were running into a case where the tooltips can push outside both the left and right bounds. We're not accounting for that case right now as it probably requires some bigger discussion on _how_ we want to display tooltips for very small screen sizes. cc @krystalcampioni @carysmills 

Fixes https://github.com/Shopify/core-issues/issues/30139

### Reviewers’ :tophat: instructions

- Load http://localhost:6006/iframe.html?id=charts-linechart--default&args=&viewMode=story\
- Open devtools and change the viewport size.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
