### PR TITLE
Fix scaling and ticks for Stacked chart

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -93,11 +93,26 @@ export function Chart({
     return maxes;
   }, [series, areAllAllNegative]);
 
-  const {xScale, xScaleStacked, ticks} = useXScale({
+  const highestSumForStackedGroup = useMemo(() => {
+    if (!isStacked) {
+      return 0;
+    }
+    const numbers: number[] = [];
+
+    series.forEach(({data}) => {
+      const sum = data.reduce((prev, {rawValue}) => prev + rawValue, 0);
+      numbers.push(sum);
+    });
+
+    return Math.max(...numbers);
+  }, [series, isStacked]);
+
+  const {xScale, xScaleStacked, ticks, ticksStacked} = useXScale({
     allNumbers,
+    highestSumForStackedGroup,
     isStacked,
     maxWidth: chartDimensions.width - longestLabel,
-    seriesLength: series.length,
+    longestSeriesCount,
   });
 
   const firstNonNegativeValue = useMemo(() => {
@@ -124,7 +139,7 @@ export function Chart({
     labelFormatter,
     seriesLength: series.length,
     singleBarCount: longestSeriesCount,
-    ticks,
+    ticks: isStacked ? ticksStacked : ticks,
   });
 
   const getAriaLabel = useCallback(
@@ -196,8 +211,8 @@ export function Chart({
             <VerticalGridLines
               seriesAreaHeight={seriesAreaHeight}
               stroke={selectedTheme.grid.color}
-              ticks={ticks}
-              xScale={xScale}
+              ticks={isStacked ? ticksStacked : ticks}
+              xScale={isStacked ? xScaleStacked! : xScale}
             />
             <XAxisLabels
               bandwidth={bandwidth}
@@ -205,8 +220,8 @@ export function Chart({
               labelFormatter={labelFormatter}
               seriesAreaHeight={seriesAreaHeight}
               tallestXAxisLabel={tallestXAxisLabel}
-              ticks={ticks}
-              xScale={xScale}
+              ticks={isStacked ? ticksStacked : ticks}
+              xScale={isStacked ? xScaleStacked! : xScale}
             />
           </React.Fragment>
         )}

--- a/src/components/HorizontalBarChart/hooks/useBarSizes.ts
+++ b/src/components/HorizontalBarChart/hooks/useBarSizes.ts
@@ -60,7 +60,6 @@ export function useBarSizes({
 
   return useMemo(() => {
     const bottomPadding = isSimple ? 0 : PADDING_UNDER_LAST_GROUP;
-    const bandwidth = chartDimensions.width / ticks.length;
     // Push the container taller to line up last bar
     const simpleHeight = chartDimensions.height + SPACE_BETWEEN_SETS;
 
@@ -102,12 +101,12 @@ export function useBarSizes({
       totalChartHeight: chartHeight,
     };
   }, [
+    bandwidth,
     chartDimensions,
     isSimple,
     isStacked,
     seriesLength,
     singleBarCount,
     tallestXAxisLabel,
-    ticks,
   ]);
 }

--- a/src/components/HorizontalBarChart/hooks/useXScale.ts
+++ b/src/components/HorizontalBarChart/hooks/useXScale.ts
@@ -4,14 +4,16 @@ import {useMemo} from 'react';
 
 export function useXScale({
   allNumbers,
+  highestSumForStackedGroup,
   isStacked,
+  longestSeriesCount,
   maxWidth,
-  seriesLength,
 }: {
   allNumbers: number[];
+  highestSumForStackedGroup: number;
   isStacked: boolean;
+  longestSeriesCount: number;
   maxWidth: number;
-  seriesLength: number;
 }) {
   const xScale = useMemo(() => {
     return scaleLinear()
@@ -31,8 +33,16 @@ export function useXScale({
 
     return scaleLinear()
       .domain([0, ticks[ticks.length - 1]])
-      .range([0, maxWidth / seriesLength]);
-  }, [isStacked, maxWidth, seriesLength, ticks]);
+      .range([0, maxWidth / longestSeriesCount]);
+  }, [isStacked, maxWidth, longestSeriesCount, ticks]);
 
-  return {xScale, xScaleStacked, ticks};
+  const ticksStacked = useMemo(() => {
+    if (!isStacked) {
+      return [];
+    }
+
+    return scaleLinear().domain([0, highestSumForStackedGroup]).nice().ticks();
+  }, [highestSumForStackedGroup, isStacked]);
+
+  return {xScale, xScaleStacked, ticks, ticksStacked};
 }


### PR DESCRIPTION
### What problem is this PR solving?

The original scaling for the Stacked chart was A. using the wrong scale for the bars B. Showing values for the ticks that didn't make sense.

We're now using the sum of the longest group as the basis for the ticks.

### Reviewers’ :tophat: instructions

**Before**

![image](https://user-images.githubusercontent.com/149873/137775546-0b0f0e72-b8d2-41c0-91a1-44193de421f1.png)

**After**

![image](https://user-images.githubusercontent.com/149873/137775486-96e169b5-b89e-4863-9910-94c1c8044508.png)

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
