### PR TITLE
Simplify the tooltip positioning logic

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -11,12 +11,9 @@ import {eventPointNative} from '../../utilities';
 import {DataType, Dimensions} from '../../types';
 import {
   TOOLTIP_POSITION_DEFAULT_RETURN,
-  TooltipHorizontalOffset,
   TooltipPosition,
   TooltipPositionParams,
-  TooltipVerticalOffset,
   TooltipWrapper,
-  TOOLTIP_MARGIN,
 } from '../TooltipWrapper';
 
 import {getAlteredHorizontalBarPosition, getBarId} from './utilities';
@@ -31,11 +28,6 @@ import {
 import type {ColorOverrides, Series, XAxisOptions} from './types';
 import {useBarSizes, useDataForChart, useXScale} from './hooks';
 import styles from './Chart.scss';
-
-const TOOLTIP_POSITION = {
-  horizontal: TooltipHorizontalOffset.Right,
-  vertical: TooltipVerticalOffset.Above,
-};
 
 interface ChartProps {
   chartDimensions: Dimensions;
@@ -318,9 +310,8 @@ export function Chart({
       }, 0);
 
       return {
-        x: x + TOOLTIP_MARGIN,
+        x,
         y: groupHeight * index,
-        position: TOOLTIP_POSITION,
         activeIndex: index,
       };
     }
@@ -331,7 +322,6 @@ export function Chart({
     return {
       x: highestValue < 0 ? -x : x,
       y: groupHeight * index,
-      position: TOOLTIP_POSITION,
       activeIndex: index,
     };
   }

--- a/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -37,8 +37,6 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
   const {bandwidth, currentX, currentY, tooltipDimensions, chartDimensions} =
     props;
 
-  const yOffset = (bandwidth - tooltipDimensions.height) / 2;
-
   const isOutside = isOutsideBounds({
     x: currentX,
     y: currentY,
@@ -46,27 +44,40 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
     chartDimensions,
   });
 
-  let x = currentX;
-  let y = currentY;
+  if (!isOutside.right && !isOutside.bottom) {
+    const yOffset = (bandwidth - tooltipDimensions.height) / 2;
+    return {
+      x: currentX + TOOLTIP_MARGIN,
+      y: currentY + LABEL_HEIGHT + yOffset,
+    };
+  }
 
   if (isOutside.right) {
-    x = currentX - tooltipDimensions.width;
-    y = currentY - tooltipDimensions.height;
+    const x = currentX - tooltipDimensions.width;
+    const y =
+      currentY - tooltipDimensions.height + LABEL_HEIGHT - TOOLTIP_MARGIN;
+
+    if (y < 0) {
+      return {
+        x,
+        y: bandwidth + LABEL_HEIGHT + TOOLTIP_MARGIN,
+      };
+    }
+
+    return {
+      x,
+      y,
+    };
   }
 
   if (isOutside.bottom) {
-    x = currentX;
-    y = chartDimensions.height - tooltipDimensions.height + TOOLTIP_MARGIN;
+    return {
+      x: currentX + TOOLTIP_MARGIN,
+      y: chartDimensions.height - tooltipDimensions.height - LABEL_HEIGHT,
+    };
   }
 
-  if (y < 0) {
-    y += bandwidth;
-  }
-
-  return {
-    x: x + TOOLTIP_MARGIN,
-    y: y + LABEL_HEIGHT + yOffset,
-  };
+  return {x: currentX, y: currentY};
 }
 
 function isOutsideBounds({

--- a/src/components/TooltipWrapper/types.ts
+++ b/src/components/TooltipWrapper/types.ts
@@ -19,8 +19,8 @@ export interface TooltipPositionOffset {
 export interface TooltipPosition {
   x: number;
   y: number;
-  position: TooltipPositionOffset;
   activeIndex: number | null;
+  position?: TooltipPositionOffset;
 }
 
 export interface TooltipPositionParams {


### PR DESCRIPTION
### What problem is this PR solving?

The logic for positioning the tooltip only kinda worked, so this makes it work better for all situations and simplifies the code a bit without relying on overriding the `let` values so much.

### Reviewers’ :tophat: instructions

Check all the stories. The Tooltip should always be positioned away from the current hovered set.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
