### PR TITLE
Fix labels using wrong axis color

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -201,7 +201,7 @@ export function Chart({
             />
             <XAxisLabels
               bandwidth={bandwidth}
-              color={selectedTheme.yAxis.labelColor}
+              color={selectedTheme.xAxis.labelColor}
               labelFormatter={labelFormatter}
               seriesAreaHeight={seriesAreaHeight}
               tallestXAxisLabel={tallestXAxisLabel}
@@ -240,7 +240,7 @@ export function Chart({
             >
               <GroupLabel
                 areAllAllNegative={areAllAllNegative}
-                color={selectedTheme.xAxis.labelColor}
+                color={selectedTheme.yAxis.labelColor}
                 label={name}
               />
 


### PR DESCRIPTION
### What problem is this PR solving?

![image](https://user-images.githubusercontent.com/149873/137794634-17e4e7e9-2220-408d-bfa1-00966d42c518.png)

We were asked by another team if we could support changing the colors of the labels like `14.8k sessions`. While looking we realized that the label axis' were backwards.

### Reviewers’ :tophat: instructions

- Change the theme value for `xAxis.labelColor` to `red` here: https://github.com/Shopify/polaris-viz/blob/4c0b083607ca4520ed142a569066c2be8dc8e8a7/src/constants.ts#L150

**Simple Chart**

![image](https://user-images.githubusercontent.com/149873/137795048-7e74edbd-5eaf-49a6-b891-01b45ac21e5f.png)

**Complex Chart**

![image](https://user-images.githubusercontent.com/149873/137795077-2a60d574-9f69-4b82-a7d8-c1c01c3d50ea.png)

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog.

- [ ] Update relevant documentation.
