### PR TITLE
Append theme to gradient def so it's unique to the theme

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -268,6 +268,7 @@ export function Chart({
         <GradientDefs
           colorOverrides={seriesWithColorOverride}
           seriesColors={seriesColors}
+          theme={theme}
         />
 
         {transitions(({opacity, transform}, item, _transition, index) => {

--- a/src/components/HorizontalBarChart/components/GradientDefs.tsx
+++ b/src/components/HorizontalBarChart/components/GradientDefs.tsx
@@ -10,11 +10,13 @@ import type {ColorOverrides} from '../types';
 interface GradientDefsProps {
   colorOverrides: ColorOverrides[];
   seriesColors: Color[];
+  theme?: string;
 }
 
 export function GradientDefs({
   colorOverrides,
   seriesColors,
+  theme = 'Default',
 }: GradientDefsProps) {
   return (
     <defs>
@@ -22,7 +24,7 @@ export function GradientDefs({
         return <Gradient key={id} id={id} color={color} />;
       })}
       {seriesColors.map((color, index) => {
-        const id = `${GRADIENT_ID}${index}`;
+        const id = getGradientDefId(theme, index);
         return <Gradient key={id} id={id} color={color} />;
       })}
       <LinearGradient
@@ -45,4 +47,8 @@ function Gradient({id, color}: {id: string; color: Color}) {
         },
       ];
   return <LinearGradient gradient={gradient} id={id} x2="100%" y1="0%" />;
+}
+
+export function getGradientDefId(theme = 'Default', index: number) {
+  return `${theme}-${GRADIENT_ID}-${index}`;
 }

--- a/src/components/HorizontalBarChart/components/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars.tsx
@@ -7,7 +7,6 @@ import {getTextWidth} from '../../../utilities';
 import {
   BAR_LABEL_OFFSET,
   FONT_SIZE_PADDING,
-  GRADIENT_ID,
   LABEL_HEIGHT,
   NEGATIVE_GRADIENT_ID,
   SPACE_BETWEEN_SINGLE,
@@ -17,6 +16,7 @@ import {getBarId} from '../utilities';
 
 import {Bar, RoundedBorder} from './Bar';
 import {Label} from './Label';
+import {getGradientDefId} from './GradientDefs';
 
 interface HorizontalBarProps {
   areAllAllNegative: boolean;
@@ -78,7 +78,7 @@ export function HorizontalBars({
           : -(width + leftLabelOffset);
         const x = isNegative ? negativeX : width + BAR_LABEL_OFFSET;
         const ariaHidden = seriesIndex !== 0;
-        const barColor = color ? id : `${GRADIENT_ID}${seriesIndex}`;
+        const barColor = color ? id : getGradientDefId(theme, seriesIndex);
 
         return (
           <React.Fragment key={`series-${barColor}-${name}`}>


### PR DESCRIPTION
## What does this implement/fix?

Fixed a bug where the gradient def IDs were not specific enough and other charts, regardless of theme, would use the first rendered chart colors.

Before, the gradient def IDs were all based on index, so if another `HorizontalBarChart` was being rendered on the page, it would use the first instance of the def, not the current chart.

## What do the changes look like?
…

🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/138122170-03d37d9b-327a-4e88-a367-087c9fd53e64.png)|![image](https://user-images.githubusercontent.com/149873/138122111-b1a1ffa6-ae82-4a83-85ab-789b14ac2488.png)|
 
## Tophatting

Make the following change in `src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx#57`.

```
<>
  <div style={{height: CONTAINER_HEIGHT}}>
    <HorizontalBarChart {...args} theme="Order" />
  </div>
  <div style={{height: CONTAINER_HEIGHT}}>
    <HorizontalBarChart {...args} />
  </div>
</>
```

Make the following change in `src/components/PolarisVizProvider/PolarisVizProvider.tsx`

```
import React, {useMemo} from 'react';

import type {PartialTheme} from '../../types';
import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../../constants';
import {PolarisVizContext} from '../../utilities/polaris-viz-context';
import {createTheme, createThemes} from '../../utilities';

export interface PolarisVizProviderProps {
  children: React.ReactNode;
  themes?: {[key: string]: PartialTheme};
}

const createGradient = (color1: string, color2: string) => {
  return [
    {offset: 0, color: color2},
    {offset: 100, color: color1},
  ];
};

export function PolarisVizProvider({
  children,
  themes,
}: PolarisVizProviderProps) {
  const value = useMemo(() => {
    return {
      themes: createThemes({
        Default,
        Light,
        Order: createTheme({
          seriesColors: {
            single: createGradient('red', 'green'),
          },
        }),
        ...themes,
      }),
    };
  }, [themes]);

  return (
    <PolarisVizContext.Provider value={value}>
      {children}
    </PolarisVizContext.Provider>
  );
}
```

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
