### PR TITLE
Only show negative bar color for series with single values

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -8,6 +8,7 @@ import {
   BarChartMargin as Margin,
   HORIZONTAL_BAR_GROUP_DELAY,
   BARS_SORT_TRANSITION_CONFIG,
+  NEGATIVE_SINGLE_GRADIENT,
 } from '../../constants';
 import {eventPointNative} from '../../utilities';
 import {DataType, Dimensions} from '../../types';
@@ -155,12 +156,18 @@ export function Chart({
         return null;
       }
 
+      const hasSingleBar = series[activeIndex].data.length === 1;
+
       const data = series[activeIndex].data.map(
         ({rawValue, label, color}, index) => {
+          const isNegative = hasSingleBar && rawValue < 0;
+
           return {
             label,
             value: labelFormatter(rawValue),
-            color: color ?? seriesColors[index],
+            color: isNegative
+              ? NEGATIVE_SINGLE_GRADIENT
+              : color ?? seriesColors[index],
           };
         },
       );

--- a/src/components/HorizontalBarChart/components/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars.tsx
@@ -50,6 +50,7 @@ export function HorizontalBars({
   name,
 }: HorizontalBarProps) {
   const selectedTheme = useTheme(theme);
+  const hasSingleBar = series.length === 1;
 
   return (
     <g
@@ -84,7 +85,11 @@ export function HorizontalBars({
           <React.Fragment key={`series-${barColor}-${name}`}>
             <Bar
               animationDelay={animationDelay}
-              color={`url(#${isNegative ? NEGATIVE_GRADIENT_ID : barColor})`}
+              color={`url(#${getBarColor({
+                hasSingleBar,
+                isNegative,
+                color: barColor,
+              })})`}
               height={barHeight}
               index={groupIndex}
               isAnimated={isAnimated}
@@ -113,4 +118,20 @@ export function HorizontalBars({
       })}
     </g>
   );
+}
+
+function getBarColor({
+  hasSingleBar,
+  isNegative,
+  color,
+}: {
+  hasSingleBar: boolean;
+  isNegative: boolean;
+  color: string;
+}) {
+  if (isNegative && hasSingleBar) {
+    return NEGATIVE_GRADIENT_ID;
+  }
+
+  return color;
 }


### PR DESCRIPTION
## What does this implement/fix?
…

Based on feedback from @mirualves and @carysmills we are only showing the negative gradient for series that have single data points.

Any series with more than 1 data point will use the series colors for the current theme.

## Does this close any currently open issues?
…

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?
…

🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/138133350-cadca784-d5e4-4bde-82b0-43048b3d2620.png)|![image](https://user-images.githubusercontent.com/149873/138133405-4f632554-ddc0-4aa7-a7fe-ebd3e2bbe40a.png)|
 
## Storybook link
…

http://localhost:6006/?path=/story/charts-horizontalbarchart--multi-series-all-negative

http://localhost:6006/?path=/story/charts-horizontalbarchart--simple-negative


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
