### PR TITLE
Remove the xAxisHeight for simple charts

### DIFF
--- a/src/components/HorizontalBarChart/hooks/useBarSizes.ts
+++ b/src/components/HorizontalBarChart/hooks/useBarSizes.ts
@@ -64,7 +64,7 @@ export function useBarSizes({
     const simpleHeight = chartDimensions.height + SPACE_BETWEEN_SETS;
 
     const containerHeight = isSimple ? simpleHeight : chartDimensions.height;
-    const xAxisHeight = tallestXAxisLabel + spaceBetweenXAxis;
+    const xAxisHeight = isSimple ? 0 : tallestXAxisLabel + spaceBetweenXAxis;
     const chartHeight = containerHeight - xAxisHeight;
 
     const groupHeight = chartHeight / seriesLength;


### PR DESCRIPTION
## What does this implement/fix?
…

We weren't removing the xAxisHeight from the calculations when a bar was simple.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
