### PR TITLE
Add vertical lines to Bar charts

### DIFF
--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -315,6 +315,7 @@ export function Chart({
             aria-hidden="true"
           >
             <BarChartXAxis
+              drawableHeight={drawableHeight}
               labels={xAxisLabels}
               xScale={xScale}
               fontSize={fontSize}

--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -67,6 +67,7 @@ function getMiniminalLabelPosition({
 }
 
 interface BarChartXAxisProps {
+  drawableHeight: number;
   xScale: ScaleBand<string>;
   labels: {value: string; xOffset: number}[];
   fontSize: number;
@@ -77,6 +78,7 @@ interface BarChartXAxisProps {
 }
 
 export const BarChartXAxis = React.memo(function BarChartXAxis({
+  drawableHeight,
   labels,
   xScale,
   fontSize,
@@ -157,6 +159,14 @@ export const BarChartXAxis = React.memo(function BarChartXAxis({
           <g key={index} transform={groupTransform}>
             {minimalLabelIndexes == null && selectedTheme.xAxis.showTicks ? (
               <line y2={TICK_SIZE} stroke={selectedTheme.grid.color} />
+            ) : null}
+            {selectedTheme.grid.showVerticalLines ? (
+              <line
+                y1="0"
+                y2={drawableHeight * -1}
+                stroke={selectedTheme.grid.color}
+                strokeDasharray="3 2"
+              />
             ) : null}
             <foreignObject
               width={angleAwareWidth}

--- a/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
+++ b/src/components/BarChartXAxis/tests/BarChartXAxis.test.tsx
@@ -35,6 +35,7 @@ describe('<BarChartXAxis/>', () => {
       maxDiagonalLabelLength: 100,
       maxWidth: 100,
     },
+    drawableHeight: 100,
   };
 
   it('renders a line for each label value', () => {
@@ -162,5 +163,19 @@ describe('<BarChartXAxis/>', () => {
     expect(axis).toContainReactComponent('g', {
       transform: 'translate(5, 24)',
     });
+  });
+
+  it('renders vertical lines when enabled by the theme', () => {
+    const chart = mountWithProvider(
+      <svg>
+        <BarChartXAxis {...mockProps} />,
+      </svg>,
+      mockDefaultTheme({grid: {showVerticalLines: true}}),
+    );
+
+    const lines = chart.findAll('line');
+
+    expect(chart).toContainReactComponentTimes('line', 2);
+    expect(lines[0].props.y2).toStrictEqual(-100);
   });
 });

--- a/src/components/LinearXAxis/LinearXAxis.tsx
+++ b/src/components/LinearXAxis/LinearXAxis.tsx
@@ -133,7 +133,7 @@ function Axis({
             {selectedTheme.grid.showVerticalLines ? (
               <line
                 y1="0"
-                y2={-drawableHeight}
+                y2={drawableHeight * -1}
                 stroke={selectedTheme.grid.color}
                 strokeDasharray="3 2"
               />

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -235,6 +235,7 @@ export function Chart({
             aria-hidden="true"
           >
             <BarChartXAxis
+              drawableHeight={drawableHeight}
               labels={xAxisLabels}
               xScale={xScale}
               xAxisDetails={xAxisDetails}


### PR DESCRIPTION
## What does this implement/fix?
…

Vertical grid lines were missing for `<Bar />` and `<MultiSeriesBarChart />`. This PR adds them to those charts.


## Does this close any currently open issues?
…

Fixes https://github.com/Shopify/polaris-viz/issues/607

## What do the changes look like?
…

🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/138727372-0b71b633-a9de-421e-b4ad-1a6bc1424a53.png)|![image](https://user-images.githubusercontent.com/149873/138727538-e8e51c74-70c6-4706-af12-ee926dfcc667.png)|
|![image](https://user-images.githubusercontent.com/149873/138727429-d7ed3c9a-33f2-49bb-bf2b-89eb3b714a35.png)|![image](https://user-images.githubusercontent.com/149873/138727482-96938bf8-0106-4c40-a9c1-e3daac16e494.png)|

## Storybook link
…

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
