### PR TITLE
Respect grid.showHorizontalLines theme setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added `grid.showHorizontalLines` theme option to `<StackedAreaChart />`.
+
 ## [0.22.0] - 2021-10-22
 
 ### Changed

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -300,15 +300,17 @@ export function Chart({
           />
         </g>
 
-        <HorizontalGridLines
-          ticks={ticks}
-          transform={{
-            x: dataStartPosition,
-            y: Margin.Top,
-          }}
-          width={drawableWidth}
-          theme={theme}
-        />
+        {selectedTheme.grid.showHorizontalLines && (
+          <HorizontalGridLines
+            ticks={ticks}
+            transform={{
+              x: dataStartPosition,
+              y: Margin.Top,
+            }}
+            width={drawableWidth}
+            theme={theme}
+          />
+        )}
 
         <VisuallyHiddenRows
           formatYAxisLabel={formatYAxisLabel}

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
+import {mockDefaultTheme} from '../../../test-utilities/mount-with-provider';
 import {LinearXAxis} from '../../../components/LinearXAxis';
 import {YAxis} from '../../../components/YAxis';
 import {HorizontalGridLines} from '../../../components/HorizontalGridLines';
@@ -11,7 +12,7 @@ import {
   TooltipWrapper,
   TooltipAnimatedContainer,
 } from '../../../components/TooltipWrapper';
-import {triggerSVGMouseMove} from '../../../test-utilities';
+import {mountWithProvider, triggerSVGMouseMove} from '../../../test-utilities';
 import {StackedAreas} from '../components';
 import {Chart} from '../Chart';
 
@@ -225,5 +226,14 @@ describe('<Chart />', () => {
     const chart = mount(<Chart {...updatedProps} />);
 
     expect(chart).toContainReactComponent(HorizontalGridLines);
+  });
+
+  it("doesn't render <HorizontalGridLines /> when theme disables them", () => {
+    const chart = mountWithProvider(
+      <Chart {...mockProps} />,
+      mockDefaultTheme({grid: {showHorizontalLines: false}}),
+    );
+
+    expect(chart).not.toContainReactComponent(HorizontalGridLines);
   });
 });


### PR DESCRIPTION
## What does this implement/fix?
…

The `grid.showHorizontalLines` theme setting was not being applied to `<StackedAreaChart />`.

## Does this close any currently open issues?
…

Fixes https://github.com/Shopify/polaris-viz/issues/606

## What do the changes look like?
…

![image](https://user-images.githubusercontent.com/149873/138744495-e8a34bb2-6c4b-44d6-a93c-71e8ea714f4b.png)
 
## Storybook link
…

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
