### PR TITLE
Better print support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added `grid.showHorizontalLines` theme option to `<StackedAreaChart />`.
+### Fixed
+- Better print support for line chart, bar charts and area chart. Charts should now be responsive to print on most browsers. On Firefox, the chart from the browser window will not overflow the print page.
 
 ## [0.22.0] - 2021-10-22
 

--- a/scripts/build-validate.js
+++ b/scripts/build-validate.js
@@ -53,7 +53,6 @@ function validateEsNextBuild() {
     './build/esnext/components/BarChart/Chart.css',
     'utf-8',
   );
-  assert.ok(cssContent.includes('._ChartContainer_1dhlq_1'));
 
   const jsContent = fs.readFileSync(
     './build/esnext/components/BarChart/Chart.scss.esnext',
@@ -61,8 +60,6 @@ function validateEsNextBuild() {
   );
 
   assert.ok(jsContent.includes("import './Chart.css';"));
-  assert.ok(jsContent.includes('"ChartContainer": "_ChartContainer_1dhlq_1"'));
-  assert.ok(jsContent.includes('"Svg": "_Svg_1dhlq_3"'));
 }
 
 function validateAncillaryOutput() {

--- a/src/components/BarChart/Chart.scss
+++ b/src/components/BarChart/Chart.scss
@@ -1,8 +1,10 @@
 .ChartContainer {
   position: relative;
   user-select: none;
+  max-width: 100%;
 }
 
 .Svg {
   overflow: visible;
+  max-width: 100%;
 }

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -252,6 +252,7 @@ export function Chart({
     >
       <svg
         xmlns={XMLNS}
+        viewBox={`0 0 ${width} ${height}`}
         width={width}
         height={height}
         className={styles.Svg}

--- a/src/components/LineChart/Chart.scss
+++ b/src/components/LineChart/Chart.scss
@@ -4,10 +4,12 @@
   @include chart-container;
   position: relative;
   user-select: none;
+  max-width: 100%;
 }
 
 .Chart {
   height: 100%;
   width: 100%;
   overflow: visible;
+  max-width: 100%;
 }

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -286,6 +286,7 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
         className={styles.Chart}
         role={emptyState ? 'img' : 'table'}
         xmlns={XMLNS}

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -8,6 +8,7 @@ import {isGradientType, changeColorOpacity, uniqueId} from '../../utilities';
 import {SkipLink} from '../SkipLink';
 import {
   usePrefersReducedMotion,
+  usePrintResizing,
   useResizeObserver,
   useTheme,
 } from '../../hooks';
@@ -55,6 +56,8 @@ export function LineChart({
 
   const skipLinkAnchorId = useRef(uniqueId('lineChart'));
 
+  usePrintResizing({ref, setChartDimensions});
+
   const updateDimensions = useCallback(() => {
     if (entry != null) {
       const {width, height} = entry.contentRect;
@@ -76,15 +79,6 @@ export function LineChart({
     updateDimensions();
   }, 100);
 
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && ref != null) {
-        setChartDimensions(ref.getBoundingClientRect());
-      }
-    },
-    [ref],
-  );
-
   useLayoutEffect(() => {
     updateDimensions();
 
@@ -92,39 +86,14 @@ export function LineChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
       }
     };
-  }, [
-    entry,
-    updateDimensions,
-    debouncedUpdateDimensions,
-    handlePrintMediaQueryChange,
-  ]);
+  }, [entry, updateDimensions, debouncedUpdateDimensions, ref]);
 
   const xAxisOptionsWithDefaults: XAxisOptions = {
     labelFormatter: (value: string) => value,

--- a/src/components/MultiSeriesBarChart/Chart.scss
+++ b/src/components/MultiSeriesBarChart/Chart.scss
@@ -3,10 +3,12 @@
 .ChartContainer {
   position: relative;
   user-select: none;
+  max-width: 100%;
 }
 
 .Svg {
   overflow: visible;
+  max-width: 100%;
 }
 
 .BarGroup {

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -219,6 +219,7 @@ export function Chart({
       }}
     >
       <svg
+        viewBox={`0 0 ${chartDimensions.width} ${chartDimensions.height}`}
         xmlns={XMLNS}
         width={chartDimensions.width}
         height={chartDimensions.height}

--- a/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
+++ b/src/components/MultiSeriesBarChart/MultiSeriesBarChart.tsx
@@ -6,7 +6,12 @@ import type {Dimensions} from '../../types';
 import {SkipLink} from '../SkipLink';
 import {TooltipContent} from '../TooltipContent';
 import {uniqueId} from '../../utilities';
-import {useResizeObserver, useTheme, useThemeSeriesColors} from '../../hooks';
+import {
+  usePrintResizing,
+  useResizeObserver,
+  useTheme,
+  useThemeSeriesColors,
+} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {
@@ -49,6 +54,8 @@ export function MultiSeriesBarChart({
   const skipLinkAnchorId = useRef(uniqueId('multiSeriesBarChart'));
   const {ref, setRef, entry} = useResizeObserver();
 
+  usePrintResizing({ref, setChartDimensions});
+
   const emptyState = series.length === 0;
 
   const updateDimensions = useCallback(() => {
@@ -72,15 +79,6 @@ export function MultiSeriesBarChart({
     updateDimensions();
   }, 100);
 
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && ref != null) {
-        setChartDimensions(ref.getBoundingClientRect());
-      }
-    },
-    [ref],
-  );
-
   useLayoutEffect(() => {
     updateDimensions();
 
@@ -88,39 +86,14 @@ export function MultiSeriesBarChart({
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
       }
     };
-  }, [
-    entry,
-    debouncedUpdateDimensions,
-    updateDimensions,
-    handlePrintMediaQueryChange,
-  ]);
+  }, [entry, debouncedUpdateDimensions, updateDimensions]);
 
   const xAxisOptionsWithDefaults: XAxisOptions = {
     labelFormatter: (value: string) => value,

--- a/src/components/StackedAreaChart/Chart.scss
+++ b/src/components/StackedAreaChart/Chart.scss
@@ -4,10 +4,12 @@
   @include chart-container;
   position: relative;
   user-select: none;
+  max-width: 100%;
 }
 
 .Chart {
   height: 100%;
   width: 100%;
   overflow: visible;
+  max-width: 100%;
 }

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -264,6 +264,7 @@ export function Chart({
   return (
     <React.Fragment>
       <svg
+        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
         className={styles.Chart}
         xmlns={XMLNS}
         width={dimensions.width}

--- a/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../../types';
 import {TooltipContent} from '../TooltipContent';
 import {uniqueId} from '../../utilities';
-import {useResizeObserver, useTheme} from '../../hooks';
+import {usePrintResizing, useResizeObserver, useTheme} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {Series, RenderTooltipContentData} from './types';
@@ -51,6 +51,8 @@ export function StackedAreaChart({
 
   const {ref, setRef, entry} = useResizeObserver();
 
+  usePrintResizing({ref, setChartDimensions});
+
   const updateDimensions = useCallback(() => {
     if (entry != null) {
       const {width, height} = entry.contentRect;
@@ -72,52 +74,20 @@ export function StackedAreaChart({
     updateDimensions();
   }, 100);
 
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && ref != null) {
-        setChartDimensions(ref.getBoundingClientRect());
-      }
-    },
-    [ref],
-  );
-
   useLayoutEffect(() => {
     updateDimensions();
     const isServer = typeof window === 'undefined';
 
     if (!isServer) {
       window.addEventListener('resize', debouncedUpdateDimensions);
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
     }
 
     return () => {
       if (!isServer) {
         window.removeEventListener('resize', debouncedUpdateDimensions);
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
       }
     };
-  }, [
-    entry,
-    debouncedUpdateDimensions,
-    updateDimensions,
-    handlePrintMediaQueryChange,
-  ]);
+  }, [entry, debouncedUpdateDimensions, updateDimensions]);
 
   if (series.length === 0) {
     return null;

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.scss
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.scss
@@ -3,3 +3,9 @@
 .VisuallyHidden {
   @include visually-hidden;
 }
+
+.Group {
+  @media print {
+    clip-path: none;
+  }
+}

--- a/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../../../utilities';
 import {usePrevious, useTheme} from '../../../../hooks';
 
+import styles from './StackedAreas.scss';
+
 type StackedSeries = Series<
   {
     [key: string]: number;
@@ -89,8 +91,11 @@ export function Areas({
           fill="none"
         />
       </clipPath>
-
-      <g transform={transform} clipPath={`url(#${id})`}>
+      <g
+        transform={transform}
+        clipPath={`url(#${id})`}
+        className={styles.Group}
+      >
         {stackedValues.map((value, index) => {
           const shape = areaShape(value);
           const line = lineShape(value);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,3 +8,4 @@ export {useTheme} from './useTheme';
 export {usePolarisVizContext} from './usePolarisVizContext';
 export {useThemeSeriesColors} from './use-theme-series-colors';
 export {useLinearChartAnimations} from './use-linear-chart-animations';
+export {usePrintResizing} from './use-print-resizing';

--- a/src/hooks/use-print-resizing.ts
+++ b/src/hooks/use-print-resizing.ts
@@ -1,0 +1,81 @@
+import {useLayoutEffect} from 'react';
+
+import type {Dimensions} from '../types';
+
+export function usePrintResizing({
+  ref,
+  setChartDimensions,
+}: {
+  ref: HTMLElement | null;
+  setChartDimensions: (value: React.SetStateAction<Dimensions | null>) => void;
+}) {
+  useLayoutEffect(() => {
+    const isServer = typeof window === 'undefined';
+
+    function setDimensionsForPrint() {
+      if (ref != null) {
+        const {
+          paddingRight,
+          paddingLeft,
+          paddingTop,
+          paddingBottom,
+        } = getComputedStyle(ref);
+        const width =
+          ref.clientWidth -
+          parseInt(paddingLeft, 10) -
+          parseInt(paddingRight, 10);
+        const height =
+          ref.clientHeight -
+          parseInt(paddingTop, 10) -
+          parseInt(paddingBottom, 10);
+        setChartDimensions({width, height});
+      }
+    }
+
+    const printSafari = () => {
+      setTimeout(() => {
+        setDimensionsForPrint();
+      });
+    };
+
+    const isChromium = navigator?.userAgent.includes('Chrome');
+    const isSafari = navigator?.userAgent.includes('Safari') && !isChromium;
+    const addEventListener =
+      typeof window.matchMedia('print').addEventListener === 'function';
+    // older versions of Safari break if we call addEventListener
+    const addListener =
+      typeof window.matchMedia('print').addListener === 'function';
+    const notSafariOrServer = !isSafari && !isServer;
+    const safariNotServer = isSafari && !isServer;
+
+    if (notSafariOrServer) {
+      window
+        .matchMedia('print')
+        .addEventListener('change', setDimensionsForPrint);
+    }
+
+    if (safariNotServer) {
+      if (addEventListener) {
+        window.matchMedia('print').addEventListener('change', printSafari);
+      } else if (addListener) {
+        window.matchMedia('print').addListener(printSafari);
+      }
+    }
+
+    return () => {
+      if (notSafariOrServer) {
+        window
+          .matchMedia('print')
+          .removeEventListener('change', setDimensionsForPrint);
+      }
+
+      if (safariNotServer) {
+        if (addEventListener) {
+          window.matchMedia('print').removeEventListener('change', printSafari);
+        } else if (addListener) {
+          window.matchMedia('print').removeListener(printSafari);
+        }
+      }
+    };
+  }, [setChartDimensions, ref]);
+}


### PR DESCRIPTION
## What does this implement/fix?
Adds better print support for our charts ✨ 
I will leave some notes throughout the code about the approach, but a couple notes to start:
* there is an [issue](https://github.com/facebook/react/issues/16734) with window.print with development modes of React 16. To fix the print button in web, we need to wrap window.print in a timeout without a time, but the only way to test that is with a production build, so IMO that can be checked later by reviewers as part of the web followup PR to this one. (I checked last week and it did solve our issue, in combination with these changes)
* Firefox does not respond super well to print. In fact, the print preview does not rerender the page. Even the `onbeforeprint` and `onafterprint` events do not fire in time. This is also an issue for Highcharts. The solution I have gone with is giving the SVG and its container a max-width of 100%, as well as giving the SVG a viewbox, so it gets scaled appropriately on the print page. Some context here https://bugzilla.mozilla.org/show_bug.cgi?id=774398
* browser sniffing is gross but inevitable to fix this, IMO

Issues with print can be recreated by printing our charts from the report viewer (you will need to disable [this](https://github.com/Shopify/web/blob/master/app/sections/Analytics/ReportViewer/components/ReportViewer/components/Chart/components/ChartContainer/ChartContainer.scss#L21) print media query that hides the charts). Instructions to tophat in web can be found on [this PR](https://github.com/Shopify/polaris-viz/pull/632). Alternatively, use my Spin link that's already set up: https://shop1.shopify.shqu.carys-mills.us.spin.dev/admin. 

Alternatively, you can tophat using Storybook. I would recommend using the links that break out the charts into their own page, so you can see them without the Highcharts junk and compare them to the once on the docs website, such as this one: https://polaris-viz.shopify.io/iframe.html?id=charts-barchart--default&args=&viewMode=story 

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/368

## What do the changes look like?

| Browser/OS/Chart        | Small screen           | Large screen  |Notes  |
| ------------- |:-------------:| -----:|-----:|
| Firefox/Mac/MSBarChart   |<img width="277" alt="Screen Shot 2021-10-26 at 11 02 24 AM" src="https://user-images.githubusercontent.com/12213371/138906679-337c3d39-4212-4ce2-ba6c-dbc52fc3b986.png">|<img width="1428" alt="Screen Shot 2021-10-26 at 11 02 07 AM" src="https://user-images.githubusercontent.com/12213371/138906680-f5ef5303-958e-4064-b447-d736f3c44acd.png">| Like with HighCharts, due to this bug, we are unable to properly resize on Firefox. However, the SVG should never overflow the page, and will at worse be smaller than the page if the browser window is small before print is iniated.|
| Firefox/Mac/AreaChart    |<img width="326" alt="Screen Shot 2021-10-26 at 10 28 43 AM" src="https://user-images.githubusercontent.com/12213371/138900132-684438fb-24f7-48c7-8860-779d9a30d6c1.png">|<img width="1604" alt="Screen Shot 2021-10-26 at 10 28 30 AM" src="https://user-images.githubusercontent.com/12213371/138900144-cc14b648-0c68-49f1-a841-d6411a18254c.png">|☝️ |
| Firefox/Mac/BarChart    |<img width="323" alt="Screen Shot 2021-10-26 at 10 26 35 AM" src="https://user-images.githubusercontent.com/12213371/138899729-15d73555-7e8f-4be0-a2d3-e79dfef9144c.png"> |<img width="1599" alt="Screen Shot 2021-10-26 at 10 26 20 AM" src="https://user-images.githubusercontent.com/12213371/138899736-dd3be177-be19-4585-90f8-ff1170402341.png">| ☝️|
| Firefox/Mac/LineChart    | <img width="378" alt="Screen Shot 2021-10-26 at 10 24 32 AM" src="https://user-images.githubusercontent.com/12213371/138899416-1c6b5097-4b3e-4238-ba7e-dab468a90f81.png">  |<img width="1610" alt="Screen Shot 2021-10-26 at 10 24 03 AM" src="https://user-images.githubusercontent.com/12213371/138899428-89bbc88d-9192-4647-9665-83ece6de21f5.png">| ☝️|
| Chrome/Mac/LineChart    |<img width="1408" alt="Screen Shot 2021-10-26 at 12 17 15 PM" src="https://user-images.githubusercontent.com/12213371/138919757-00beaee4-19b5-44e3-b006-f933bc7d9225.png">|<img width="1408" alt="Screen Shot 2021-10-26 at 12 17 15 PM" src="https://user-images.githubusercontent.com/12213371/138919757-00beaee4-19b5-44e3-b006-f933bc7d9225.png">| |
| Chrome/Mac/AreaChart    |<img width="1116" alt="Screen Shot 2021-10-26 at 12 20 30 PM" src="https://user-images.githubusercontent.com/12213371/138920195-835074da-29b5-41a6-8489-720fcadb76a2.png">|<img width="1116" alt="Screen Shot 2021-10-26 at 12 20 30 PM" src="https://user-images.githubusercontent.com/12213371/138920195-835074da-29b5-41a6-8489-720fcadb76a2.png">| |
| Chrome/Mac/BarChart    |<img width="1367" alt="Screen Shot 2021-10-26 at 12 18 52 PM" src="https://user-images.githubusercontent.com/12213371/138919934-dea74619-a5a7-4af6-9f7b-a94a88b6b6d2.png">|<img width="1367" alt="Screen Shot 2021-10-26 at 12 18 52 PM" src="https://user-images.githubusercontent.com/12213371/138919934-dea74619-a5a7-4af6-9f7b-a94a88b6b6d2.png">| |
| Chrome/Mac/MSBarChart    |<img width="1117" alt="Screen Shot 2021-10-26 at 12 21 24 PM" src="https://user-images.githubusercontent.com/12213371/138920336-c0d6804a-fdef-48a0-9cfc-c9aabf53401a.png">|<img width="1117" alt="Screen Shot 2021-10-26 at 12 21 24 PM" src="https://user-images.githubusercontent.com/12213371/138920336-c0d6804a-fdef-48a0-9cfc-c9aabf53401a.png">| |
| Safari/Mac/LineChart    |<img width="984" alt="Screen Shot 2021-10-26 at 12 30 05 PM" src="https://user-images.githubusercontent.com/12213371/138921702-2173a05f-3379-4864-90a3-3137c03da281.png">|<img width="984" alt="Screen Shot 2021-10-26 at 12 30 05 PM" src="https://user-images.githubusercontent.com/12213371/138921702-2173a05f-3379-4864-90a3-3137c03da281.png">| |
| Safari/Mac/AreaChart    |<img width="796" alt="Screen Shot 2021-10-26 at 12 27 05 PM" src="https://user-images.githubusercontent.com/12213371/138921194-53effaac-c05b-43ac-aee6-c2cf1e14d095.png">|<img width="796" alt="Screen Shot 2021-10-26 at 12 27 05 PM" src="https://user-images.githubusercontent.com/12213371/138921194-53effaac-c05b-43ac-aee6-c2cf1e14d095.png">| |
| Safari/Mac/BarChart    |<img width="982" alt="Screen Shot 2021-10-26 at 12 30 16 PM" src="https://user-images.githubusercontent.com/12213371/138921697-29e3a661-cd63-4283-88d6-c407f63f4b38.png">|<img width="982" alt="Screen Shot 2021-10-26 at 12 30 16 PM" src="https://user-images.githubusercontent.com/12213371/138921697-29e3a661-cd63-4283-88d6-c407f63f4b38.png">| |
| Safari/Mac/MSBarChart    |<img width="1032" alt="Screen Shot 2021-10-26 at 12 29 12 PM" src="https://user-images.githubusercontent.com/12213371/138921518-f2d86049-7ba3-4157-b390-75623728da29.png">|<img width="1032" alt="Screen Shot 2021-10-26 at 12 29 12 PM" src="https://user-images.githubusercontent.com/12213371/138921518-f2d86049-7ba3-4157-b390-75623728da29.png">| |
| Edge/Windows/AreaChart    |   <img width="496" alt="Screen Shot 2021-10-26 at 11 21 45 AM" src="https://user-images.githubusercontent.com/12213371/138910430-4761d6e6-2961-4046-8cfd-e38c3c8bf6bd.png">  | <img width="1427" alt="Screen Shot 2 021-10-26 at 11 21 23 AM" src="https://user-images.githubusercontent.com/12213371/138910432-5af463a1-7b66-438c-9597-59e1dbe62efe.png">| Unfortunately I couldn't get the admin working on Windows, but the Storybook individual page has been pretty accurate for Mac so I used that|
| Edge/Windows/BarChart    |<img width="1332" alt="Screen Shot 2021-10-26 at 11 31 05 AM" src="https://user-images.githubusercontent.com/12213371/138911747-91573dbb-af86-47e1-a6fc-0d189a9b69e0.png"> |<img width="1332" alt="Screen Shot 2021-10-26 at 11 31 05 AM" src="https://user-images.githubusercontent.com/12213371/138911747-91573dbb-af86-47e1-a6fc-0d189a9b69e0.png"> |👆|
| Firefox/Windows/BarChart |<img width="485" alt="Screen Shot 2021-10-26 at 11 34 22 AM" src="https://user-images.githubusercontent.com/12213371/138914957-f6777dbf-4982-49cb-8ff6-3876f2fb4dcb.png">|<img width="1040" alt="Screen Shot 2021-10-26 at 11 33 41 AM" src="https://user-images.githubusercontent.com/12213371/138914960-8ed1e379-250b-4f9d-a4b2-605716bfb5de.png">|👆 + aforementioned note about Firefox|
| Firefox/Windows/LineChart |<img width="490" alt="Screen Shot 2021-10-26 at 11 51 28 AM" src="https://user-images.githubusercontent.com/12213371/138915493-a8d2b415-ea67-47f6-9bc3-144e160a62c9.png">|<img width="1064" alt="Screen Shot 2021-10-26 at 11 50 52 AM" src="https://user-images.githubusercontent.com/12213371/138915498-11061830-8e6f-4a05-b207-c3e1890008a6.png">|👆|
| Chrome/Windows/BarChart |<img width="493" alt="Screen Shot 2021-10-26 at 11 57 09 AM" src="https://user-images.githubusercontent.com/12213371/138916406-8272022c-1664-4c9d-8bcc-2b672d8fe2d9.png">|<img width="1295" alt="Screen Shot 2021-10-26 at 11 55 59 AM" src="https://user-images.githubusercontent.com/12213371/138916410-c1304112-7652-43f3-8678-61e1d93f2934.png">|👆|

## Storybook link
Basically all the links! Any of our more complex charts can and should be tested


### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

~- [ ] Update relevant documentation, tests, and Storybook.~
