### PR TITLE
Better calculations for simple width label offsets

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -68,9 +68,10 @@ export function Chart({
     selectedTheme,
   );
 
-  const {allNumbers, longestLabel, areAllAllNegative} = useDataForChart({
+  const {allNumbers, longestLabel, areAllNegative} = useDataForChart({
     series,
     isSimple,
+    isStacked,
     labelFormatter,
   });
 
@@ -79,13 +80,13 @@ export function Chart({
 
     series.forEach(({data}) => {
       const values = data.map(({rawValue}) => rawValue);
-      const max = areAllAllNegative ? Math.min(...values) : Math.max(...values);
+      const max = areAllNegative ? Math.min(...values) : Math.max(...values);
 
       maxes.push(max);
     });
 
     return maxes;
-  }, [series, areAllAllNegative]);
+  }, [series, areAllNegative]);
 
   const highestSumForStackedGroup = useMemo(() => {
     if (!isStacked) {
@@ -105,18 +106,10 @@ export function Chart({
     allNumbers,
     highestSumForStackedGroup,
     isStacked,
-    maxWidth: chartDimensions.width - longestLabel,
+    maxWidth:
+      chartDimensions.width - longestLabel.negative - longestLabel.positive,
     longestSeriesCount,
   });
-
-  const firstNonNegativeValue = useMemo(() => {
-    const value =
-      ticks.find((value) => {
-        return value >= 0;
-      }) ?? 0;
-
-    return xScale(value);
-  }, [xScale, ticks]);
 
   const {
     bandwidth,
@@ -188,7 +181,9 @@ export function Chart({
   }));
 
   const getTransform = (index: number) => {
-    return `translate(${firstNonNegativeValue}px,${groupHeight * index}px)`;
+    return `translate(${longestLabel.negative + xScale(0)}px,${
+      groupHeight * index
+    }px)`;
   };
 
   const [isFirstRender, setIsFirstRender] = useState(true);
@@ -294,7 +289,7 @@ export function Chart({
               }}
             >
               <GroupLabel
-                areAllAllNegative={areAllAllNegative}
+                areAllNegative={areAllNegative}
                 label={name}
                 theme={theme}
               />
@@ -305,17 +300,16 @@ export function Chart({
                   ariaLabel={ariaLabel}
                   barHeight={barHeight}
                   groupIndex={index}
-                  series={item.series.data}
-                  xScale={xScaleStacked}
                   name={name}
+                  series={item.series.data}
+                  theme={theme}
+                  xScale={xScaleStacked}
                 />
               ) : (
                 <HorizontalBars
                   animationDelay={animationDelay}
-                  areAllAllNegative={areAllAllNegative}
                   ariaLabel={ariaLabel}
                   barHeight={barHeight}
-                  firstNonNegativeValue={firstNonNegativeValue}
                   groupIndex={index}
                   isAnimated={isAnimated}
                   isSimple={isSimple}

--- a/src/components/HorizontalBarChart/components/GroupLabel.tsx
+++ b/src/components/HorizontalBarChart/components/GroupLabel.tsx
@@ -6,12 +6,12 @@ import {getTextWidth} from '../../../utilities';
 import {LABEL_HEIGHT} from '../constants';
 
 interface GroupLabelProps {
-  areAllAllNegative: boolean;
+  areAllNegative: boolean;
   label: string;
   theme?: string;
 }
 
-export function GroupLabel({areAllAllNegative, label, theme}: GroupLabelProps) {
+export function GroupLabel({areAllNegative, label, theme}: GroupLabelProps) {
   const labelWidth = getTextWidth({text: label, fontSize: FONT_SIZE});
   const selectedTheme = useTheme(theme);
 
@@ -19,7 +19,7 @@ export function GroupLabel({areAllAllNegative, label, theme}: GroupLabelProps) {
     <foreignObject
       height={LABEL_HEIGHT}
       width="100%"
-      x={areAllAllNegative ? -labelWidth : 0}
+      x={areAllNegative ? labelWidth * -1 : 0}
       aria-hidden="true"
     >
       <div

--- a/src/components/HorizontalBarChart/components/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars.tsx
@@ -18,35 +18,31 @@ import {Label} from './Label';
 import {getGradientDefId} from './GradientDefs';
 
 interface HorizontalBarProps {
-  areAllAllNegative: boolean;
   ariaLabel: string;
   barHeight: number;
-  firstNonNegativeValue: number;
   groupIndex: number;
   isAnimated: boolean;
-  labelFormatter: LabelFormatter;
-  series: Data[];
   isSimple: boolean;
+  labelFormatter: LabelFormatter;
+  name: string;
+  series: Data[];
   xScale: ScaleLinear<number, number>;
   animationDelay?: number;
   theme?: string;
-  name: string;
 }
 
 export function HorizontalBars({
-  areAllAllNegative,
+  animationDelay,
   ariaLabel,
   barHeight,
   groupIndex,
-  firstNonNegativeValue,
   isAnimated,
-  labelFormatter,
-  series,
   isSimple,
-  theme,
-  animationDelay,
-  xScale,
+  labelFormatter,
   name,
+  series,
+  theme,
+  xScale,
 }: HorizontalBarProps) {
   const selectedTheme = useTheme(theme);
 
@@ -71,14 +67,10 @@ export function HorizontalBars({
         });
 
         const leftLabelOffset = isSimple ? labelWidth + BAR_LABEL_OFFSET : 0;
-        const width = isNegative
-          ? Math.abs(xScale(rawValue) - firstNonNegativeValue + leftLabelOffset)
-          : Math.abs(xScale(rawValue) - firstNonNegativeValue);
+        const width = Math.abs(xScale(rawValue) - xScale(0));
 
         const y = barHeight * seriesIndex + SPACE_BETWEEN_SINGLE * seriesIndex;
-        const negativeX = areAllAllNegative
-          ? -(width + leftLabelOffset)
-          : -(width + leftLabelOffset);
+        const negativeX = (width + leftLabelOffset) * -1;
         const x = isNegative ? negativeX : width + BAR_LABEL_OFFSET;
         const ariaHidden = seriesIndex !== 0;
         const barColor = color ? id : getGradientDefId(theme, seriesIndex);

--- a/src/components/HorizontalBarChart/components/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars.tsx
@@ -8,15 +8,17 @@ import {GRADIENT_ID, LABEL_HEIGHT, STACKED_BAR_GAP} from '../constants';
 import {getBarId} from '../utilities';
 
 import {StackedBar} from './StackedBar';
+import {getGradientDefId} from './GradientDefs';
 
 export interface StackedBarsProps {
   animationDelay: number;
   ariaLabel: string;
   barHeight: number;
   groupIndex: number;
+  name: string;
   series: Data[];
   xScale: ScaleLinear<number, number>;
-  name: string;
+  theme?: string;
 }
 
 export function StackedBars({
@@ -24,9 +26,10 @@ export function StackedBars({
   ariaLabel,
   barHeight,
   groupIndex,
-  series,
-  xScale,
   name,
+  series,
+  theme,
+  xScale,
 }: StackedBarsProps) {
   const xOffsets = useMemo(() => {
     const offsets: number[] = [];
@@ -59,9 +62,10 @@ export function StackedBars({
         const id = getBarId(groupIndex, seriesIndex);
 
         const sliceColor = color ? id : `${GRADIENT_ID}${seriesIndex}`;
+
         return (
           <StackedBar
-            color={sliceColor}
+            color={color ? id : getGradientDefId(theme, seriesIndex)}
             groupIndex={groupIndex}
             height={barHeight}
             key={`${name}${sliceColor}`}

--- a/src/components/HorizontalBarChart/hooks/useDataForChart.ts
+++ b/src/components/HorizontalBarChart/hooks/useDataForChart.ts
@@ -6,12 +6,18 @@ import {BAR_LABEL_OFFSET, FONT_SIZE_PADDING} from '../constants';
 import type {LabelFormatter, Series} from '../types';
 
 interface Props {
-  series: Series[];
   isSimple: boolean;
+  isStacked: boolean;
   labelFormatter: LabelFormatter;
+  series: Series[];
 }
 
-export function useDataForChart({labelFormatter, series, isSimple}: Props) {
+export function useDataForChart({
+  labelFormatter,
+  series,
+  isSimple,
+  isStacked,
+}: Props) {
   const allNumbers = useMemo(() => {
     return series.reduce<number[]>((prev, cur) => {
       const numbers = cur.data.map(({rawValue}) => rawValue);
@@ -19,31 +25,47 @@ export function useDataForChart({labelFormatter, series, isSimple}: Props) {
     }, []);
   }, [series]);
 
+  const lowestNegative = useMemo(() => Math.min(...allNumbers), [allNumbers]);
+  const highestPositive = useMemo(() => Math.max(...allNumbers), [allNumbers]);
+
   const longestLabel = useMemo(() => {
-    if (!isSimple) {
-      return 0;
+    if (!isSimple || isStacked) {
+      return {positive: 0, negative: 0};
     }
 
-    return (
-      allNumbers.reduce((prev, cur) => {
-        if (`${cur}`.length > `${prev}`.length) {
-          return getTextWidth({
-            text: `${labelFormatter(cur)}`,
-            fontSize: FONT_SIZE + FONT_SIZE_PADDING,
-          });
-        }
+    const fontSize = FONT_SIZE + FONT_SIZE_PADDING;
 
-        return getTextWidth({
-          text: `${labelFormatter(prev)}`,
-          fontSize: FONT_SIZE + FONT_SIZE_PADDING,
-        });
-      }, 0) + BAR_LABEL_OFFSET
-    );
-  }, [allNumbers, labelFormatter, isSimple]);
+    const negativeTextSize =
+      lowestNegative >= 0
+        ? 0
+        : getTextWidth({
+            text: `${labelFormatter(lowestNegative)}`,
+            fontSize,
+          }) + BAR_LABEL_OFFSET;
 
-  const areAllAllNegative = useMemo(() => {
+    const positiveTextSize =
+      highestPositive < 0
+        ? 0
+        : getTextWidth({
+            text: `${labelFormatter(highestPositive)}`,
+            fontSize,
+          }) + BAR_LABEL_OFFSET;
+
+    return {
+      negative: negativeTextSize,
+      positive: positiveTextSize,
+    };
+  }, [labelFormatter, isSimple, isStacked, highestPositive, lowestNegative]);
+
+  const areAllNegative = useMemo(() => {
     return !allNumbers.some((num) => num >= 0);
   }, [allNumbers]);
 
-  return {allNumbers, longestLabel, areAllAllNegative};
+  return {
+    allNumbers,
+    areAllNegative,
+    highestPositive,
+    longestLabel,
+    lowestNegative,
+  };
 }


### PR DESCRIPTION
## What does this implement/fix?
…

Before this PR, we were doing some math to proportionally scale down all the bars to fit the labels within the container. We had issues around negative labels looking even worse because we were using the positive labels to scale them down.

This was complex. Enter @carysmills to the rescue.

Now we're going to shrink the chart down by each of the longest labels on the negative and positive sides. This allows us to rely on `xScale` to size all the bars automatically.

## What do the changes look like?
…

🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/138947933-0f77c268-1734-4545-8fb8-b0a58d50629f.png)|![image](https://user-images.githubusercontent.com/149873/138948028-fac22b2d-7ffe-4a77-b783-4407f2733e7b.png)|
 
## Storybook link
…

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
