### PR TITLE
Make gradients full width of the chart

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -263,6 +263,7 @@ export function Chart({
           colorOverrides={seriesWithColorOverride}
           seriesColors={seriesColors}
           theme={theme}
+          width={chartDimensions.width}
         />
 
         {transitions(({opacity, transform}, item, _transition, index) => {

--- a/src/components/HorizontalBarChart/components/GradientDefs.tsx
+++ b/src/components/HorizontalBarChart/components/GradientDefs.tsx
@@ -9,6 +9,7 @@ import type {ColorOverrides} from '../types';
 interface GradientDefsProps {
   colorOverrides: ColorOverrides[];
   seriesColors: Color[];
+  width: number;
   theme?: string;
 }
 
@@ -16,21 +17,30 @@ export function GradientDefs({
   colorOverrides,
   seriesColors,
   theme = 'Default',
+  width,
 }: GradientDefsProps) {
   return (
     <defs>
       {colorOverrides.map(({id, color}) => {
-        return <Gradient key={id} id={id} color={color} />;
+        return <Gradient key={id} id={id} color={color} width={width} />;
       })}
       {seriesColors.map((color, index) => {
         const id = getGradientDefId(theme, index);
-        return <Gradient key={id} id={id} color={color} />;
+        return <Gradient key={id} id={id} color={color} width={width} />;
       })}
     </defs>
   );
 }
 
-function Gradient({id, color}: {id: string; color: Color}) {
+function Gradient({
+  id,
+  color,
+  width,
+}: {
+  id: string;
+  color: Color;
+  width: number;
+}) {
   const gradient: GradientStop[] = isGradientType(color)
     ? color
     : [
@@ -39,7 +49,15 @@ function Gradient({id, color}: {id: string; color: Color}) {
           offset: 0,
         },
       ];
-  return <LinearGradient gradient={gradient} id={id} x2="100%" y1="0%" />;
+  return (
+    <LinearGradient
+      gradient={gradient}
+      gradientUnits="userSpaceOnUse"
+      id={id}
+      x2={`${width}px`}
+      y1="0"
+    />
+  );
 }
 
 export function getGradientDefId(theme = 'Default', index: number) {


### PR DESCRIPTION
## What does this implement/fix?
…

The gradient for the bars was using the individual bar widths to size the gradient, but the gradient should use the entire size of the chart to make the gradient visibly mean something.

## What do the changes look like?
…

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/139283164-38d53aeb-48dd-415b-9712-762fe0490c3e.png)|![image](https://user-images.githubusercontent.com/149873/139282728-5d81bb5e-776d-4b88-8d3b-c7a3fcd3e6d3.png)|

 
## Storybook link
…

http://localhost:6006/?path=/story/charts-horizontalbarchart--simple-long-labels

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
