### PR TITLE
Use usePrintResizing inside HorizontalBarChart

### DIFF
--- a/src/components/HorizontalBarChart/Chart.scss
+++ b/src/components/HorizontalBarChart/Chart.scss
@@ -1,8 +1,10 @@
 .ChartContainer {
   position: relative;
   user-select: none;
+  max-width: 100%;
 }
 
 .SVG {
   overflow: visible;
+  max-width: 100%;
 }

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -181,9 +181,7 @@ export function Chart({
   }));
 
   const getTransform = (index: number) => {
-    return `translate(${longestLabel.negative + xScale(0)}px,${
-      groupHeight * index
-    }px)`;
+    return `translate(0px,${groupHeight * index}px)`;
   };
 
   const [isFirstRender, setIsFirstRender] = useState(true);
@@ -223,6 +221,8 @@ export function Chart({
     },
   });
 
+  const zeroPosition = longestLabel.negative + xScale(0);
+
   return (
     <div
       className={styles.ChartContainer}
@@ -233,10 +233,9 @@ export function Chart({
     >
       <svg
         className={styles.SVG}
-        height={chartDimensions.height}
         ref={setSvgRef}
         role="list"
-        width={chartDimensions.width}
+        viewBox={`0 0 ${chartDimensions.width} ${chartDimensions.height}`}
         xmlns={XMLNS}
       >
         {isSimple || xAxisOptions.hide === true ? null : (
@@ -293,6 +292,7 @@ export function Chart({
                 areAllNegative={areAllNegative}
                 label={name}
                 theme={theme}
+                zeroPosition={zeroPosition}
               />
 
               {isStacked && xScaleStacked ? (
@@ -301,6 +301,7 @@ export function Chart({
                   ariaLabel={ariaLabel}
                   barHeight={barHeight}
                   groupIndex={index}
+                  isAnimated={isAnimated}
                   name={name}
                   series={item.series.data}
                   theme={theme}
@@ -315,10 +316,11 @@ export function Chart({
                   isAnimated={isAnimated}
                   isSimple={isSimple}
                   labelFormatter={labelFormatter}
+                  name={name}
                   series={item.series.data}
                   theme={theme}
                   xScale={xScale}
-                  name={name}
+                  zeroPosition={zeroPosition}
                 />
               )}
             </animated.g>

--- a/src/components/HorizontalBarChart/components/Bar/Bar.tsx
+++ b/src/components/HorizontalBarChart/components/Bar/Bar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {animated, to, useSpring} from '@react-spring/web';
+import {animated, useSpring} from '@react-spring/web';
 
 import {DataType} from '../../../../types';
 import {
@@ -113,31 +113,30 @@ export const Bar = React.memo(function Bar({
     [needsMinWidth, roundedBorder],
   );
 
-  const spring = useSpring<{height: number; width: number}>({
-    from: {width: 0},
-    width,
-    height,
+  const spring = useSpring<{transform: string}>({
+    from: {transform: 'scaleX(0) translateZ(0)'},
+    to: {transform: 'scaleX(1) translateZ(0)'},
     delay: isAnimated ? animationDelay : 0,
     config: BARS_TRANSITION_CONFIG,
     default: {immediate: !isAnimated},
   });
 
   return (
-    <animated.path
-      d={to([spring.height, spring.width], (_height, _width) =>
-        getPath(_height, _width),
-      )}
-      data-id={`bar-${index}`}
-      data-index={index}
-      data-type={DataType.Bar}
-      fill={color}
-      aria-label={ariaLabel}
-      tabIndex={tabIndex}
-      role={role}
-      style={{
-        transform: `translate(${x}px, ${y}px) ${transform}`,
-      }}
-      className={styles.Bar}
-    />
+    <animated.g style={{transform: spring.transform}}>
+      <path
+        d={getPath(height, width)}
+        data-id={`bar-${index}`}
+        data-index={index}
+        data-type={DataType.Bar}
+        fill={color}
+        aria-label={ariaLabel}
+        tabIndex={tabIndex}
+        role={role}
+        style={{
+          transform: `translate(${x}px, ${y}px) ${transform}`,
+        }}
+        className={styles.Bar}
+      />
+    </animated.g>
   );
 });

--- a/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
+++ b/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
@@ -9,9 +9,15 @@ interface GroupLabelProps {
   areAllNegative: boolean;
   label: string;
   theme?: string;
+  zeroPosition: number;
 }
 
-export function GroupLabel({areAllNegative, label, theme}: GroupLabelProps) {
+export function GroupLabel({
+  areAllNegative,
+  label,
+  theme,
+  zeroPosition,
+}: GroupLabelProps) {
   const labelWidth = getTextWidth({text: label, fontSize: FONT_SIZE});
   const selectedTheme = useTheme(theme);
 
@@ -19,7 +25,7 @@ export function GroupLabel({areAllNegative, label, theme}: GroupLabelProps) {
     <foreignObject
       height={LABEL_HEIGHT}
       width="100%"
-      x={areAllNegative ? labelWidth * -1 : 0}
+      x={zeroPosition + (areAllNegative ? labelWidth * -1 : 0)}
       aria-hidden="true"
     >
       <div

--- a/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
@@ -26,6 +26,7 @@ interface HorizontalBarProps {
   name: string;
   series: Data[];
   xScale: ScaleLinear<number, number>;
+  zeroPosition: number;
   animationDelay?: number;
   theme?: string;
 }
@@ -42,12 +43,13 @@ export function HorizontalBars({
   series,
   theme,
   xScale,
+  zeroPosition,
 }: HorizontalBarProps) {
   const selectedTheme = useTheme(theme);
 
   return (
     <g
-      transform={`translate(0,${LABEL_HEIGHT})`}
+      transform={`translate(${zeroPosition},${LABEL_HEIGHT})`}
       aria-label={ariaLabel}
       role="listitem"
     >

--- a/src/components/HorizontalBarChart/components/Label/Label.tsx
+++ b/src/components/HorizontalBarChart/components/Label/Label.tsx
@@ -28,32 +28,38 @@ export function Label({
   const labelYOffset = (barHeight - BAR_LABEL_HEIGHT) / 2;
 
   const spring = useSpring({
-    from: {x: 0, opacity: 0},
-    to: {opacity: 1, x},
+    from: {transform: 'scaleX(0) translateZ(0)', opacity: 0},
+    to: {opacity: 1, transform: 'scaleX(1) translateZ(0)'},
     delay: isAnimated ? animationDelay : 0,
     config: BARS_TRANSITION_CONFIG,
     default: {immediate: !isAnimated},
   });
 
   return (
-    <animated.foreignObject
-      height={FONT_SIZE}
-      width={labelWidth}
-      x={spring.x}
-      y={y + labelYOffset}
-      aria-hidden="true"
-      opacity={spring.opacity}
+    <animated.g
+      style={{
+        opacity: spring.opacity,
+        transform: spring.transform,
+      }}
     >
-      <div
-        style={{
-          fontSize: `${FONT_SIZE}px`,
-          color,
-          lineHeight: `${BAR_LABEL_HEIGHT}px`,
-          height: BAR_LABEL_HEIGHT,
-        }}
+      <foreignObject
+        height={FONT_SIZE}
+        width={labelWidth}
+        aria-hidden="true"
+        y={y + labelYOffset}
+        x={x}
       >
-        {label}
-      </div>
-    </animated.foreignObject>
+        <div
+          style={{
+            fontSize: `${FONT_SIZE}px`,
+            color,
+            lineHeight: `${BAR_LABEL_HEIGHT}px`,
+            height: BAR_LABEL_HEIGHT,
+          }}
+        >
+          {label}
+        </div>
+      </foreignObject>
+    </animated.g>
   );
 }

--- a/src/components/HorizontalBarChart/components/StackedBar/StackedBar.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBar/StackedBar.tsx
@@ -7,6 +7,7 @@ interface StackedBarProps {
   color: string;
   groupIndex: number;
   height: number;
+  isAnimated: boolean;
   seriesIndex: number;
   width: number;
   x: number;
@@ -16,26 +17,30 @@ export function StackedBar({
   color,
   groupIndex,
   height,
+  isAnimated,
   seriesIndex,
   width,
   x,
 }: StackedBarProps) {
-  const spring = useSpring({
-    from: {width: width * 0.5, x: x * 0.5},
-    to: {width, x},
+  const {transform} = useSpring({
+    from: {transform: `scale(0.5, 1)`},
+    to: {transform: `scale(1, 1)`},
+    default: {immediate: !isAnimated},
   });
 
   return (
-    <animated.rect
-      data-index={groupIndex}
-      data-type={DataType.Bar}
-      fill={`url(#${color})`}
-      height={height}
-      key={seriesIndex}
-      style={{outline: 'none', transformOrigin: `${x}px 0px`}}
-      tabIndex={seriesIndex === 0 ? 0 : -1}
-      width={spring.width}
-      x={spring.x}
-    />
+    <animated.g style={{transform}}>
+      <rect
+        data-index={groupIndex}
+        data-type={DataType.Bar}
+        fill={`url(#${color})`}
+        height={height}
+        key={seriesIndex}
+        style={{outline: 'none', transformOrigin: `${x}px 0px`}}
+        tabIndex={seriesIndex === 0 ? 0 : -1}
+        width={width}
+        x={x}
+      />
+    </animated.g>
   );
 }

--- a/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
@@ -14,6 +14,7 @@ export interface StackedBarsProps {
   ariaLabel: string;
   barHeight: number;
   groupIndex: number;
+  isAnimated: boolean;
   name: string;
   series: Data[];
   xScale: ScaleLinear<number, number>;
@@ -25,6 +26,7 @@ export function StackedBars({
   ariaLabel,
   barHeight,
   groupIndex,
+  isAnimated,
   name,
   series,
   theme,
@@ -52,6 +54,7 @@ export function StackedBars({
     to: {transform: `scale(1, 1) translate(0, ${LABEL_HEIGHT}px`},
     config: BARS_TRANSITION_CONFIG,
     delay: animationDelay,
+    default: {immediate: !isAnimated},
   });
 
   return (
@@ -67,6 +70,7 @@ export function StackedBars({
             color={color ? id : getGradientDefId(theme, seriesIndex)}
             groupIndex={groupIndex}
             height={barHeight}
+            isAnimated={isAnimated}
             key={`${name}${sliceColor}`}
             seriesIndex={seriesIndex}
             width={xScale(rawValue)}


### PR DESCRIPTION
## What does this implement/fix?
…

We need to bring in the new print improvements (https://github.com/Shopify/polaris-viz/pull/653) into the Horizontal Bar Chart.

As part of this, we needed to move the animations from elements directly into a parent group container. The reason for this is the print resizing would always be a step behind because `react-spring` wouldn't update in time. 

This is also the way all the other charts animate their elements.

**All Negative Bars Issue**

When all the bars were negative, the print window was only showing the grid lines. I didn't dig much into why, but the preview window would not position the SVG elements correctly when they were positioned with negative `x` values.

To fix this, instead of using negative values to pull the bars from right to left back into the chart, we're pushing them from left to right using positive values.

![image](https://user-images.githubusercontent.com/149873/139729115-9617479b-1d82-4ab8-85d4-e682435bbd2a.png)

![image](https://user-images.githubusercontent.com/149873/139729130-1819426f-6b23-440f-a572-c80f1f0597e0.png)

![image](https://user-images.githubusercontent.com/149873/139879975-3db53280-77be-4132-b4c6-57d4cee778f0.png)

## Does this close any currently open issues?
…

Fixes https://github.com/Shopify/polaris-viz/issues/659
 
## Storybook link
…

- Tophat all the HorizontalBarChart stories to make sure all the animations still play and look ok-ish.
- Try printing a few charts, they should resize correctly in the print preview.


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
