### PR TITLE
Take into account word wrapping when measuring height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed issue where the element to measure in `getTextHeight()` was not wrapped.
+
 ## [0.24.0] - 2021-11-01
 
 ### Changed

--- a/src/utilities/get-text-dimensions.ts
+++ b/src/utilities/get-text-dimensions.ts
@@ -33,7 +33,8 @@ export function getTextHeight({
   display: inline-block;
   font-feature-settings: 'tnum';
   visibility: hidden;
-  width: ${containerWidth}px`;
+  width: ${containerWidth}px;
+  word-wrap: break-word;`;
 
   document.body.appendChild(paragraph);
   paragraph.innerText = text;


### PR DESCRIPTION
## What does this implement/fix?
…

When measuring the height of the text object, we weren't taking into account if the word was wrapped.

## What do the changes look like?
…

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/139871715-b1ff9f71-0184-4337-92de-7ff27a49b565.png)|![image](https://user-images.githubusercontent.com/149873/139871651-33e26c6d-f184-42a8-afec-bd402c6f15ae.png)|
 
## Storybook link
…

Add a label formatter to one of the stories: 

```
  xAxisOptions: {
    labelFormatter: (value) => `CA$${value}K`,
  },
```

Load the story and shrink the browser until the last label would break. It should break correctly.


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
