### PR TITLE
Use light mode for print, using context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Charts use the Light theme when printed to ensure enough contrast
+
 ## [0.24.1] - 2021-11-02
 
 ### Fixed

--- a/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React, {useMemo, useState} from 'react';
 
 import type {PartialTheme} from '../../types';
 import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../../constants';
@@ -14,15 +14,19 @@ export function PolarisVizProvider({
   children,
   themes,
 }: PolarisVizProviderProps) {
+  const [isPrinting, setPrinting] = useState(false);
+
   const value = useMemo(() => {
     return {
+      setPrinting,
+      isPrinting,
       themes: createThemes({
         Default,
         Light,
         ...themes,
       }),
     };
-  }, [themes]);
+  }, [themes, isPrinting]);
 
   return (
     <PolarisVizContext.Provider value={value}>

--- a/src/hooks/use-print-resizing.ts
+++ b/src/hooks/use-print-resizing.ts
@@ -1,5 +1,6 @@
-import {useLayoutEffect} from 'react';
+import {useLayoutEffect, useContext} from 'react';
 
+import {PolarisVizContext} from '../utilities';
 import type {Dimensions} from '../types';
 
 export function usePrintResizing({
@@ -9,6 +10,8 @@ export function usePrintResizing({
   ref: HTMLElement | null;
   setChartDimensions: (value: React.SetStateAction<Dimensions | null>) => void;
 }) {
+  const {setPrinting} = useContext(PolarisVizContext);
+
   useLayoutEffect(() => {
     const isServer = typeof window === 'undefined';
 
@@ -28,6 +31,9 @@ export function usePrintResizing({
           ref.clientHeight -
           parseInt(paddingTop, 10) -
           parseInt(paddingBottom, 10);
+
+        setPrinting((isPrinting) => !isPrinting);
+
         setChartDimensions({width, height});
       }
     }
@@ -77,5 +83,5 @@ export function usePrintResizing({
         }
       }
     };
-  }, [setChartDimensions, ref]);
+  }, [setChartDimensions, ref, setPrinting]);
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -4,7 +4,11 @@ import type {Theme} from '../types';
 import {PolarisVizContext} from '../utilities/';
 
 export function useTheme(themeName = 'Default'): Theme {
-  const {themes} = useContext(PolarisVizContext);
+  const {themes, isPrinting} = useContext(PolarisVizContext);
+
+  if (isPrinting) {
+    return themes.Light;
+  }
 
   if (Object.prototype.hasOwnProperty.call(themes, themeName)) {
     return themes[themeName];

--- a/src/utilities/polaris-viz-context.ts
+++ b/src/utilities/polaris-viz-context.ts
@@ -5,7 +5,11 @@ import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../constants';
 
 export const PolarisVizContext = createContext<{
   themes: {[key: string]: Theme};
+  isPrinting: boolean;
+  setPrinting: React.Dispatch<React.SetStateAction<boolean>>;
 }>({
+  isPrinting: false,
+  setPrinting: () => false,
   themes: {
     Default,
     Light,


### PR DESCRIPTION
## What does this implement/fix?
Makes our charts use light mode for printing so that we can guarantee good contrast ✨ 

Originally I implemented the changes throughout the components, which required duplication and the use of state within the print hook. This approach means that new charts will not need to add extra handling for print colors and instead will just need to use the print hook, as they already would have needed to. 

## Does this close any currently open issues?
Resolves https://github.com/Shopify/polaris-viz/issues/660

As noted on the issue, this won't work for Firefox, but we're okay with that

## What do the changes look like?

Note: the colors we use in the Report Viewer will make the improvement starker 

| Before  | After  |
|---|---|
| <img width="621" alt="before" src="https://user-images.githubusercontent.com/12213371/140826164-f4beb8ac-267d-4d0d-850d-8d73721d8eb1.png">  | <img width="618" alt="after" src="https://user-images.githubusercontent.com/12213371/140826165-dddafaa1-d460-40eb-b389-b2bf70d7b9c1.png">  |

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
