### PR TITLE
Round corners for Stacked bar types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 - "Reduce Motion" was not respected in `<BarChart />` and `<Sparkbar />`.
 
+### Added
+
+- Added rounded corners to `stacked` versions of `<HorizontalBarChart />` & `<MultiSeriesBarChart />`.
+
 ## [0.24.1] - 2021-11-02
 
 ### Fixed

--- a/src/components/HorizontalBarChart/components/Bar/Bar.tsx
+++ b/src/components/HorizontalBarChart/components/Bar/Bar.tsx
@@ -1,33 +1,11 @@
 import React, {useCallback} from 'react';
 import {animated, useSpring} from '@react-spring/web';
 
-import {DataType} from '../../../../types';
-import {
-  BARS_TRANSITION_CONFIG,
-  DEFAULT_BORDER_RADIUS,
-  MIN_WIDTH_BORDER_RADIUS,
-} from '../../../../constants';
-import {clamp} from '../../../../utilities';
+import {getRoundedRectPath} from '../../../../utilities';
+import {DataType, RoundedBorder} from '../../../../types';
+import {BARS_TRANSITION_CONFIG} from '../../../../constants';
 
 import styles from './Bar.scss';
-
-export enum RoundedBorder {
-  None,
-  Top,
-  Right,
-  Bottom,
-  Left,
-}
-
-type RoundedCorners = [number, number, number, number];
-
-interface Borders {
-  [RoundedBorder.None]: RoundedCorners;
-  [RoundedBorder.Top]: RoundedCorners;
-  [RoundedBorder.Right]: RoundedCorners;
-  [RoundedBorder.Bottom]: RoundedCorners;
-  [RoundedBorder.Left]: RoundedCorners;
-}
 
 interface BarProps {
   color: string;
@@ -44,25 +22,6 @@ interface BarProps {
   role?: string;
   roundedBorder?: RoundedBorder;
   transform?: string;
-}
-
-function keepValuePositive(amount: number): number {
-  return clamp({amount, min: 0, max: Infinity});
-}
-
-function getBorderRadius(
-  roundedCorner: RoundedBorder,
-  radius: number,
-): RoundedCorners {
-  const borders: Borders = {
-    [RoundedBorder.None]: [0, 0, 0, 0],
-    [RoundedBorder.Top]: [radius, radius, 0, 0],
-    [RoundedBorder.Right]: [0, radius, radius, 0],
-    [RoundedBorder.Bottom]: [0, 0, radius, radius],
-    [RoundedBorder.Left]: [radius, 0, 0, radius],
-  };
-
-  return borders[roundedCorner];
 }
 
 export const Bar = React.memo(function Bar({
@@ -83,32 +42,7 @@ export const Bar = React.memo(function Bar({
 }: BarProps) {
   const getPath = useCallback(
     (height: number, width: number) => {
-      if (height == null || width == null) {
-        return '';
-      }
-
-      const [topLeft, topRight, bottomRight, bottomLeft] = getBorderRadius(
-        roundedBorder,
-        needsMinWidth ? MIN_WIDTH_BORDER_RADIUS : DEFAULT_BORDER_RADIUS,
-      );
-
-      const top = topLeft + topRight;
-      const right = topRight + bottomRight;
-      const bottom = bottomRight + bottomLeft;
-      const left = bottomLeft + topLeft;
-
-      return `
-      M${topLeft},0
-      h${keepValuePositive(width - top)}
-      a${topRight},${topRight} 0 0 1 ${topRight},${topRight}
-      v${keepValuePositive(height - right)}
-      a${bottomRight},${bottomRight} 0 0 1 -${bottomRight},${bottomRight}
-      h-${keepValuePositive(width - bottom)}
-      a${bottomLeft},${bottomLeft} 0 0 1 -${bottomLeft},-${bottomLeft}
-      v-${keepValuePositive(height - left)}
-      a${topLeft},${topLeft} 0 0 1 ${topLeft},-${topLeft}
-      Z
-    `;
+      return getRoundedRectPath({height, width, needsMinWidth, roundedBorder});
     },
     [needsMinWidth, roundedBorder],
   );

--- a/src/components/HorizontalBarChart/components/Bar/index.ts
+++ b/src/components/HorizontalBarChart/components/Bar/index.ts
@@ -1,1 +1,1 @@
-export {Bar, RoundedBorder} from './Bar';
+export {Bar} from './Bar';

--- a/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type {ScaleLinear} from 'd3-scale';
 
-import {FONT_SIZE, MIN_BAR_HEIGHT} from '../../../../constants';
+import {RoundedBorder} from '../../../../types';
+import {FONT_SIZE} from '../../../../constants';
 import type {Data, LabelFormatter} from '../../types';
 import {getTextWidth} from '../../../../utilities';
 import {
@@ -12,7 +13,7 @@ import {
 } from '../../constants';
 import {useTheme} from '../../../../hooks';
 import {getBarId} from '../../utilities';
-import {Bar, RoundedBorder} from '../Bar';
+import {Bar} from '../Bar';
 import {Label} from '../Label';
 import {getGradientDefId} from '../GradientDefs';
 
@@ -54,10 +55,6 @@ export function HorizontalBars({
       role="listitem"
     >
       {series.map(({rawValue, color}, seriesIndex) => {
-        const needsMinWidth = selectedTheme.bar.zeroAsMinHeight
-          ? rawValue < MIN_BAR_HEIGHT
-          : rawValue < MIN_BAR_HEIGHT && rawValue !== 0;
-
         const isNegative = rawValue < 0;
         const label = labelFormatter(rawValue);
         const id = getBarId(groupIndex, seriesIndex);
@@ -84,7 +81,7 @@ export function HorizontalBars({
               height={barHeight}
               index={groupIndex}
               isAnimated={isAnimated}
-              needsMinWidth={needsMinWidth}
+              needsMinWidth
               role="img"
               roundedBorder={RoundedBorder.Right}
               tabIndex={ariaHidden ? -1 : 0}

--- a/src/components/HorizontalBarChart/components/StackedBar/StackedBar.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBar/StackedBar.tsx
@@ -1,7 +1,8 @@
 import {animated, useSpring} from '@react-spring/web';
 import React from 'react';
 
-import {DataType} from '../../../../types';
+import {getRoundedRectPath} from '../../../../utilities';
+import {DataType, RoundedBorder} from '../../../../types';
 
 interface StackedBarProps {
   color: string;
@@ -9,6 +10,7 @@ interface StackedBarProps {
   height: number;
   isAnimated: boolean;
   seriesIndex: number;
+  roundedBorder: RoundedBorder;
   width: number;
   x: number;
 }
@@ -18,6 +20,7 @@ export function StackedBar({
   groupIndex,
   height,
   isAnimated,
+  roundedBorder,
   seriesIndex,
   width,
   x,
@@ -28,9 +31,17 @@ export function StackedBar({
     default: {immediate: !isAnimated},
   });
 
+  const pathD = getRoundedRectPath({
+    height,
+    width,
+    needsMinWidth: false,
+    roundedBorder,
+  });
+
   return (
     <animated.g style={{transform}}>
-      <rect
+      <path
+        d={pathD}
         data-index={groupIndex}
         data-type={DataType.Bar}
         fill={`url(#${color})`}
@@ -39,7 +50,7 @@ export function StackedBar({
         style={{outline: 'none', transformOrigin: `${x}px 0px`}}
         tabIndex={seriesIndex === 0 ? 0 : -1}
         width={width}
-        x={x}
+        transform={`translate(${x},0)`}
       />
     </animated.g>
   );

--- a/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
@@ -8,6 +8,7 @@ import {GRADIENT_ID, LABEL_HEIGHT, STACKED_BAR_GAP} from '../../constants';
 import {getBarId} from '../../utilities';
 import {StackedBar} from '../StackedBar';
 import {getGradientDefId} from '../GradientDefs';
+import {RoundedBorder} from '../../../../types';
 
 export interface StackedBarsProps {
   animationDelay: number;
@@ -62,6 +63,7 @@ export function StackedBars({
       {series.map(({rawValue, color}, seriesIndex) => {
         const x = xOffsets[seriesIndex] + STACKED_BAR_GAP * seriesIndex;
         const id = getBarId(groupIndex, seriesIndex);
+        const isLast = seriesIndex === series.length - 1;
 
         const sliceColor = color ? id : `${GRADIENT_ID}${seriesIndex}`;
 
@@ -75,6 +77,7 @@ export function StackedBars({
             seriesIndex={seriesIndex}
             width={xScale(rawValue)}
             x={x}
+            roundedBorder={isLast ? RoundedBorder.Right : RoundedBorder.None}
           />
         );
       })}

--- a/src/components/MultiSeriesBarChart/components/StackedBarGroup/components/Stack/Stack.tsx
+++ b/src/components/MultiSeriesBarChart/components/StackedBarGroup/components/Stack/Stack.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
+import {getRoundedRectPath} from '../../../../../../utilities';
 import {DataType} from '../../../../../../types';
-import {formatAriaLabel} from '../../../../utilities';
+import {
+  formatAriaLabel,
+  getRoundedBorderForStackedValues,
+} from '../../../../utilities';
 import {BAR_SPACING} from '../../../../constants';
 import type {StackedBarGroupProps} from '../../types';
 
@@ -21,13 +25,23 @@ export function Stack({
   const barWidth = xScale.bandwidth() - BAR_SPACING;
   return (
     <React.Fragment>
-      {data.map(([start, end], barIndex) => {
+      {data.map((data, barIndex) => {
+        const [start, end] = data;
         const xPosition = xScale(barIndex.toString());
 
         const ariaLabel = formatAriaLabel(accessibilityData[barIndex]);
         const height = Math.abs(yScale(end) - yScale(start));
         const ariaEnabledBar = groupIndex === 0 && !ariaHidden;
         const isActive = activeBarGroup != null && barIndex === activeBarGroup;
+
+        const values = data.data ? Object.values(data.data) : [];
+
+        const pathD = getRoundedRectPath({
+          height,
+          width: barWidth,
+          needsMinWidth: false,
+          roundedBorder: getRoundedBorderForStackedValues(values, groupIndex),
+        });
 
         return (
           <g
@@ -39,13 +53,11 @@ export function Stack({
             tabIndex={ariaEnabledBar ? 0 : -1}
             aria-label={ariaEnabledBar ? ariaLabel : undefined}
           >
-            <rect
+            <path
+              d={pathD}
               id={isActive ? activeBarId : ''}
               key={barIndex}
-              x={xPosition}
-              y={yScale(end)}
-              height={height}
-              width={barWidth}
+              transform={`translate(${xPosition},${yScale(end)})`}
             />
           </g>
         );

--- a/src/components/MultiSeriesBarChart/utilities/get-rounded-border-for-stacked-values.ts
+++ b/src/components/MultiSeriesBarChart/utilities/get-rounded-border-for-stacked-values.ts
@@ -1,0 +1,35 @@
+import {RoundedBorder} from '../../../types';
+
+export function getRoundedBorderForStackedValues(
+  values: number[],
+  groupIndex: number,
+): RoundedBorder {
+  const highestIndex = getIndex(values, (value) => value > 0);
+  const lowestIndex = getIndex(values, (value) => value < 0);
+
+  if (groupIndex === highestIndex) {
+    return RoundedBorder.Top;
+  }
+
+  if (groupIndex === lowestIndex) {
+    return RoundedBorder.Bottom;
+  }
+
+  return RoundedBorder.None;
+}
+
+function getIndex(values: number[], checkFn: (value: number) => boolean) {
+  let prevIndex = -1;
+
+  const value = values.reduce((prev, cur, curIndex) => {
+    if (curIndex > prevIndex && checkFn(cur)) {
+      prevIndex = curIndex;
+      return cur;
+    }
+
+    prevIndex = curIndex;
+    return prev;
+  }, -1);
+
+  return values.lastIndexOf(value);
+}

--- a/src/components/MultiSeriesBarChart/utilities/index.ts
+++ b/src/components/MultiSeriesBarChart/utilities/index.ts
@@ -1,3 +1,4 @@
 export {getStackedValues} from './get-stacked-values';
 export {getMinMax} from './get-min-max';
 export {formatAriaLabel} from './format-aria-label';
+export {getRoundedBorderForStackedValues} from './get-rounded-border-for-stacked-values';

--- a/src/components/MultiSeriesBarChart/utilities/tests/get-rounded-border.test.ts
+++ b/src/components/MultiSeriesBarChart/utilities/tests/get-rounded-border.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable jest/expect-expect */
+
+import {RoundedBorder} from '../../../../types';
+import {getRoundedBorderForStackedValues} from '../get-rounded-border-for-stacked-values';
+
+describe('getRoundedBorderForStackedValues()', () => {
+  function runAssertion(stackedValues: number[], cases: RoundedBorder[]) {
+    cases.forEach((expected, index) => {
+      const roundedBorder = getRoundedBorderForStackedValues(
+        stackedValues,
+        index,
+      );
+
+      expect(roundedBorder).toStrictEqual(expected);
+    });
+  }
+
+  it('returns borders for all positive values', () => {
+    runAssertion(
+      [5, 10, 15],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Top],
+    );
+  });
+
+  it('returns borders for all negative values', () => {
+    runAssertion(
+      [-5, -10, -15],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Bottom],
+    );
+  });
+
+  it('returns borders for non-sequential mixed values', () => {
+    runAssertion(
+      [10, -15, -5, 5],
+      [
+        RoundedBorder.None,
+        RoundedBorder.None,
+        RoundedBorder.Bottom,
+        RoundedBorder.Top,
+      ],
+    );
+  });
+
+  it('returns borders for matching positive values', () => {
+    runAssertion(
+      [50, 8, 50],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Top],
+    );
+  });
+
+  it('returns borders for matching negative values', () => {
+    runAssertion(
+      [-50, -8, -50],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Bottom],
+    );
+  });
+
+  it('returns borders for mixed positive & negative values', () => {
+    runAssertion(
+      [-5, 10, 15],
+      [RoundedBorder.Bottom, RoundedBorder.None, RoundedBorder.Top],
+    );
+
+    runAssertion(
+      [-5, -10, 15],
+      [RoundedBorder.None, RoundedBorder.Bottom, RoundedBorder.Top],
+    );
+
+    runAssertion(
+      [5, -10, 15],
+      [RoundedBorder.None, RoundedBorder.Bottom, RoundedBorder.Top],
+    );
+
+    runAssertion(
+      [5, -10, -15],
+      [RoundedBorder.Top, RoundedBorder.None, RoundedBorder.Bottom],
+    );
+
+    runAssertion(
+      [-5, 10, -15],
+      [RoundedBorder.None, RoundedBorder.Top, RoundedBorder.Bottom],
+    );
+  });
+
+  it('returns borders for positive, mostly 0 values', () => {
+    runAssertion(
+      [7, 0, 0],
+      [RoundedBorder.Top, RoundedBorder.None, RoundedBorder.None],
+    );
+
+    runAssertion(
+      [0, 7, 0],
+      [RoundedBorder.None, RoundedBorder.Top, RoundedBorder.None],
+    );
+
+    runAssertion(
+      [0, 0, 7],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Top],
+    );
+  });
+
+  it('returns borders for negative, mostly 0 values', () => {
+    runAssertion(
+      [-7, 0, 0],
+      [RoundedBorder.Bottom, RoundedBorder.None, RoundedBorder.None],
+    );
+
+    runAssertion(
+      [0, -7, 0],
+      [RoundedBorder.None, RoundedBorder.Bottom, RoundedBorder.None],
+    );
+
+    runAssertion(
+      [0, 0, -7],
+      [RoundedBorder.None, RoundedBorder.None, RoundedBorder.Bottom],
+    );
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,3 +185,11 @@ export enum DataType {
   BarGroup = 'BarGroup',
   Bar = 'Bar',
 }
+
+export enum RoundedBorder {
+  None,
+  Top,
+  Right,
+  Bottom,
+  Left,
+}

--- a/src/utilities/get-rounded-rect-path.ts
+++ b/src/utilities/get-rounded-rect-path.ts
@@ -1,0 +1,84 @@
+import {
+  DEFAULT_BORDER_RADIUS,
+  MIN_BAR_HEIGHT,
+  MIN_WIDTH_BORDER_RADIUS,
+} from '../constants';
+import {RoundedBorder} from '../types';
+
+import {clamp} from './clamp';
+
+type RoundedCorners = [number, number, number, number];
+
+interface Borders {
+  [RoundedBorder.None]: RoundedCorners;
+  [RoundedBorder.Top]: RoundedCorners;
+  [RoundedBorder.Right]: RoundedCorners;
+  [RoundedBorder.Bottom]: RoundedCorners;
+  [RoundedBorder.Left]: RoundedCorners;
+}
+
+function keepValuePositive(amount: number): number {
+  return clamp({amount, min: 0, max: Infinity});
+}
+
+function getBorderRadius(
+  roundedCorner: RoundedBorder,
+  radius: number,
+): RoundedCorners {
+  const borders: Borders = {
+    [RoundedBorder.None]: [0, 0, 0, 0],
+    [RoundedBorder.Top]: [radius, radius, 0, 0],
+    [RoundedBorder.Right]: [0, radius, radius, 0],
+    [RoundedBorder.Bottom]: [0, 0, radius, radius],
+    [RoundedBorder.Left]: [radius, 0, 0, radius],
+  };
+
+  return borders[roundedCorner];
+}
+
+interface Props {
+  height: number;
+  width: number;
+  roundedBorder: RoundedBorder;
+  needsMinWidth: boolean;
+}
+
+export function getRoundedRectPath({
+  height,
+  width,
+  roundedBorder,
+  needsMinWidth,
+}: Props) {
+  if (height == null || width == null) {
+    return '';
+  }
+
+  // Return a basic rect if the rounded arcs
+  // would make the rect bigger than the min size.
+  if (!needsMinWidth && (height < MIN_BAR_HEIGHT || width < MIN_BAR_HEIGHT)) {
+    return `m 0 0 h ${width} v ${height} h -${width} z`;
+  }
+
+  const [topLeft, topRight, bottomRight, bottomLeft] = getBorderRadius(
+    roundedBorder,
+    needsMinWidth ? MIN_WIDTH_BORDER_RADIUS : DEFAULT_BORDER_RADIUS,
+  );
+
+  const top = topLeft + topRight;
+  const right = topRight + bottomRight;
+  const bottom = bottomRight + bottomLeft;
+  const left = bottomLeft + topLeft;
+
+  return `
+  M${topLeft},0
+  h${keepValuePositive(width - top)}
+  a${topRight},${topRight} 0 0 1 ${topRight},${topRight}
+  v${keepValuePositive(height - right)}
+  a${bottomRight},${bottomRight} 0 0 1 -${bottomRight},${bottomRight}
+  h-${keepValuePositive(width - bottom)}
+  a${bottomLeft},${bottomLeft} 0 0 1 -${bottomLeft},-${bottomLeft}
+  v-${keepValuePositive(height - left)}
+  a${topLeft},${topLeft} 0 0 1 ${topLeft},-${topLeft}
+  Z
+`;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -24,3 +24,4 @@ export {
   changeColorOpacity,
   changeGradientOpacity,
 } from './change-color-opacity';
+export {getRoundedRectPath} from './get-rounded-rect-path';


### PR DESCRIPTION
## What does this implement/fix?
…

We were missing the rounded corners for Stacked versions of `<MultiSeriesBarChart />` and `<HorizontalBarChart />`.

For `<HorizontalBarChart />` it's always the right most bar because we don't currently support negative values in the stacked bars.

For `<MultiSeriesBarChart />` the rounded bar will be the last one in both the positive and negative values because the chart will display both.

Example: 
![image](https://user-images.githubusercontent.com/149873/140985158-3a9684f7-820e-4e9c-a353-68afadf58df8.png)

## Does this close any currently open issues?
…

Fixes https://github.com/Shopify/polaris-viz/issues/507


## What do the changes look like?
…

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/140984691-ebf49e0e-2b2f-477a-97ad-c13dc69b15b2.png)|![image](https://user-images.githubusercontent.com/149873/140984658-4cc96524-2b0b-4276-8209-7c85667e179c.png)|
|---|---|
|![image](https://user-images.githubusercontent.com/149873/140984773-9e6205c7-c5f1-41fb-a1e7-652db294b667.png)|![image](https://user-images.githubusercontent.com/149873/140984805-41c3f91e-329a-40c0-b1b6-695fa8635892.png)|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
