### PR TITLE
Add new data structure to types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Renamed `<Sparkbar />` to `<SparkBarChart />`.
+- Renamed `DataSeries` to `LegacyDataSeries`.
 
 ## [0.24.1] - 2021-11-02
 

--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import {useTheme} from '../../hooks';
 import type {
-  DataSeries,
+  LegacyDataSeries,
   Data,
   NullableData,
   LineStyle,
@@ -14,7 +14,7 @@ import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './Legend.scss';
 
-type LegendData = DataSeries<Data | NullableData, Color>;
+type LegendData = LegacyDataSeries<Data | NullableData, Color>;
 
 interface LegendSeries extends Omit<LegendData, 'data'> {
   lineStyle?: LineStyle;

--- a/src/components/LineChart/types.ts
+++ b/src/components/LineChart/types.ts
@@ -1,5 +1,5 @@
 import type {
-  DataSeries,
+  LegacyDataSeries,
   Data,
   LineStyle,
   StringLabelFormatter,
@@ -7,12 +7,12 @@ import type {
   Color,
 } from '../../types';
 
-export interface Series extends DataSeries<Data, Color> {
+export interface Series extends LegacyDataSeries<Data, Color> {
   areaColor?: string | null;
   lineStyle?: LineStyle;
 }
 
-export type SeriesWithDefaults = Required<DataSeries<Data, Color>> & {
+export type SeriesWithDefaults = Required<LegacyDataSeries<Data, Color>> & {
   lineStyle: LineStyle;
   areaColor?: string | null;
 };

--- a/src/components/MultiSeriesBarChart/types.ts
+++ b/src/components/MultiSeriesBarChart/types.ts
@@ -3,12 +3,12 @@ import type {Series as ShapeSeries} from 'd3-shape';
 import type {
   StringLabelFormatter,
   NumberLabelFormatter,
-  DataSeries,
+  LegacyDataSeries,
   Data,
   Color,
 } from '../../types';
 
-export type Series = DataSeries<Data, Color>;
+export type Series = LegacyDataSeries<Data, Color>;
 
 export type StackSeries = ShapeSeries<
   {

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -46,7 +46,7 @@ import {
   StringLabelFormatter,
   NumberLabelFormatter,
   Dimensions,
-  DataSeries,
+  LegacyDataSeries,
   Data,
   DataType,
 } from '../../types';
@@ -74,7 +74,7 @@ interface Props {
   theme?: string;
 }
 
-type SeriesForAnimation = Required<Partial<DataSeries<Data, null>>>;
+type SeriesForAnimation = Required<Partial<LegacyDataSeries<Data, null>>>;
 
 export function Chart({
   hideXAxis,

--- a/src/components/StackedAreaChart/types.ts
+++ b/src/components/StackedAreaChart/types.ts
@@ -1,6 +1,6 @@
-import type {Color, Data, DataSeries} from '../../types';
+import type {Color, Data, LegacyDataSeries} from '../../types';
 
-export type Series = DataSeries<Data, Color>;
+export type Series = LegacyDataSeries<Data, Color>;
 
 export interface RenderTooltipContentData {
   title: string;

--- a/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
+++ b/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type {
   NumberLabelFormatter,
-  DataSeries,
+  LegacyDataSeries,
   NullableData,
   Data,
   Color,
@@ -11,7 +11,7 @@ import type {
 import styles from './VisuallyHiddenRows.scss';
 
 interface Props {
-  series: DataSeries<Data | NullableData, Color>[];
+  series: LegacyDataSeries<Data | NullableData, Color>[];
   xAxisLabels: string[];
   formatYAxisLabel: NumberLabelFormatter;
 }

--- a/src/hooks/tests/use-linear-chart-animations.test.tsx
+++ b/src/hooks/tests/use-linear-chart-animations.test.tsx
@@ -3,10 +3,10 @@ import {mount} from '@shopify/react-testing';
 import {line} from 'd3-shape';
 
 import {useLinearChartAnimations} from '../use-linear-chart-animations';
-import type {Color, Data, DataSeries} from '../../types';
+import type {Color, Data, LegacyDataSeries} from '../../types';
 import {getPointAtLength} from '../../utilities';
 
-type SeriesWithDefaults = Required<DataSeries<Data, Color>>;
+type SeriesWithDefaults = Required<LegacyDataSeries<Data, Color>>;
 
 jest.mock('../../utilities', () => {
   return {

--- a/src/hooks/use-linear-chart-animations.tsx
+++ b/src/hooks/use-linear-chart-animations.tsx
@@ -3,7 +3,7 @@ import type {Line} from 'd3-shape';
 import {useSprings} from '@react-spring/web';
 
 import {getPathLength, getPointAtLength} from '../utilities';
-import type {Data, DataSeries} from '../types';
+import type {Data, LegacyDataSeries} from '../types';
 
 export const SPRING_CONFIG = {
   friction: 5,
@@ -12,7 +12,7 @@ export const SPRING_CONFIG = {
   tension: 190,
 };
 
-type SeriesWithData = Required<DataSeries<Data, any>>;
+type SeriesWithData = Required<LegacyDataSeries<Data, any>>;
 
 export function useLinearChartAnimations<T extends SeriesWithData>({
   activeIndex,

--- a/src/hooks/use-theme-series-colors.ts
+++ b/src/hooks/use-theme-series-colors.ts
@@ -1,11 +1,11 @@
 import {useMemo} from 'react';
 
-import type {Theme, Color, LineStyle, DataSeries} from '../types';
+import type {Theme, Color, LineStyle, LegacyDataSeries} from '../types';
 
 // We don't use the data property anywhere, so it's
-// safe to use "any" here as the type passed to DataSeries.
+// safe to use "any" here as the type passed to LegacyDataSeries.
 // We really only care about color and lineStyle
-interface ValidData extends DataSeries<any, Color> {
+interface ValidData extends LegacyDataSeries<any, Color> {
   lineStyle?: LineStyle;
 }
 

--- a/src/hooks/useLinearXAxisDetails.ts
+++ b/src/hooks/useLinearXAxisDetails.ts
@@ -22,7 +22,7 @@ import type {
   StringLabelFormatter,
   NullableData,
   Data,
-  DataSeries,
+  LegacyDataSeries,
   Color,
   YAxisTick,
 } from '../types';
@@ -37,7 +37,7 @@ function getDatumSpace(width: number, numberOfTicks: number) {
 }
 
 export interface ChartDetails {
-  series: DataSeries<Data | NullableData, Color>[];
+  series: LegacyDataSeries<Data | NullableData, Color>[];
   fontSize: number;
   width: number;
   formatXAxisLabel: StringLabelFormatter;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,17 @@
 import type {InterpolatorFn} from '@react-spring/web';
 
+export interface DataPoint {
+  key: number | string;
+  value: number;
+}
+
+export interface DataSeries {
+  data: DataPoint[];
+  color?: Color;
+  isComparison?: boolean;
+  name?: string;
+}
+
 export interface Data {
   label: string;
   rawValue: number;
@@ -12,7 +24,7 @@ export interface NullableData {
 
 export type LineStyle = 'dashed' | 'solid' | 'dotted';
 
-export interface DataSeries<T, C> {
+export interface LegacyDataSeries<T, C> {
   name: string;
   data: T[];
   color?: C;


### PR DESCRIPTION
## What does this implement/fix?
…

Add new `DataPoint` and `DataSeries` to the repo. Rename old `DataSeries` to `LegacyDataSeries` so we can remove it later on.

Run `dev type-check` to make sure all the types are still valid.


## Does this close any currently open issues?
…

Resolves https://github.com/Shopify/polaris-viz/issues/681

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
