### PR TITLE
Chart container deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Chart components resizing and printing behaviour is now centralized in ChartContainer.
+
 ## [0.24.1] - 2021-11-02
 
 ### Fixed

--- a/src/components/BarChart/Chart.tsx
+++ b/src/components/BarChart/Chart.tsx
@@ -60,19 +60,19 @@ type RequiredXAxis = Pick<
 interface Props {
   data: BarChartData[];
   annotationsLookupTable: AnnotationLookupTable;
-  chartDimensions: Dimensions;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   xAxisOptions: RequiredXAxis;
   yAxisOptions: Required<YAxisOptions>;
   emptyStateText?: string;
   isAnimated?: boolean;
+  dimensions?: Dimensions;
   theme?: string;
 }
 
 export function Chart({
   data,
   annotationsLookupTable,
-  chartDimensions,
+  dimensions,
   renderTooltipContent,
   emptyStateText,
   isAnimated = false,
@@ -92,14 +92,14 @@ export function Chart({
     dataLength: data.length,
   });
 
-  const fontSize =
-    chartDimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
+  const {width, height} = dimensions ?? {width: 0, height: 0};
+
+  const fontSize = width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
   const emptyState = data.length === 0;
 
   const {ticks: initialTicks} = useYScale({
-    drawableHeight:
-      chartDimensions.height - Margin.Top - Margin.Bottom - LINE_HEIGHT,
+    drawableHeight: height - Margin.Top - Margin.Bottom - LINE_HEIGHT,
     data,
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
@@ -129,7 +129,7 @@ export function Chart({
           : data.map(({label}, index) =>
               xAxisOptions.labelFormatter(label, index, xLabels),
             ),
-        width: chartDimensions.width - selectedTheme.grid.horizontalMargin * 2,
+        width: width - selectedTheme.grid.horizontalMargin * 2,
         innerMargin: BarMargin[selectedTheme.bar.innerMargin],
         outerMargin: BarMargin[selectedTheme.bar.outerMargin],
         minimalLabelIndexes,
@@ -140,7 +140,7 @@ export function Chart({
       approxYAxisLabelWidth,
       fontSize,
       data,
-      chartDimensions.width,
+      width,
       selectedTheme.grid.horizontalMargin,
       selectedTheme.bar.innerMargin,
       selectedTheme.bar.outerMargin,
@@ -151,10 +151,7 @@ export function Chart({
   );
 
   const drawableHeight =
-    chartDimensions.height -
-    Margin.Top -
-    Margin.Bottom -
-    xAxisDetails.maxXLabelHeight;
+    height - Margin.Top - Margin.Bottom - xAxisDetails.maxXLabelHeight;
 
   const {yScale, ticks} = useYScale({
     drawableHeight,
@@ -178,10 +175,7 @@ export function Chart({
   const axisMargin = SPACING + yAxisLabelWidth;
   const chartStartPosition = axisMargin + selectedTheme.grid.horizontalMargin;
   const drawableWidth =
-    chartDimensions.width -
-    Margin.Right -
-    axisMargin -
-    selectedTheme.grid.horizontalMargin * 2;
+    width - Margin.Right - axisMargin - selectedTheme.grid.horizontalMargin * 2;
 
   const {xScale, xAxisLabels} = useXScale({
     drawableWidth,
@@ -227,8 +221,6 @@ export function Chart({
   );
 
   const shouldAnimate = !prefersReducedMotion && isAnimated;
-
-  const {width, height} = chartDimensions;
 
   const gradientId = useMemo(() => uniqueId('gradient'), []);
   const clipId = useMemo(() => uniqueId('clip'), []);
@@ -309,9 +301,7 @@ export function Chart({
         {hideXAxis ? null : (
           <g
             transform={`translate(${chartStartPosition},${
-              chartDimensions.height -
-              Margin.Bottom -
-              xAxisDetails.maxXLabelHeight
+              height - Margin.Bottom - xAxisDetails.maxXLabelHeight
             })`}
             aria-hidden="true"
           >
@@ -336,9 +326,7 @@ export function Chart({
               y: Margin.Top,
             }}
             width={
-              selectedTheme.grid.horizontalOverflow
-                ? chartDimensions.width
-                : drawableWidth
+              selectedTheme.grid.horizontalOverflow ? width : drawableWidth
             }
           />
         ) : null}
@@ -406,7 +394,7 @@ export function Chart({
 
       <TooltipWrapper
         bandwidth={xScale.bandwidth()}
-        chartDimensions={chartDimensions}
+        chartDimensions={{width, height}}
         focusElementDataType={DataType.Bar}
         getMarkup={tooltipMarkup}
         getPosition={getTooltipPosition}

--- a/src/components/BarChart/tests/Chart.test.tsx
+++ b/src/components/BarChart/tests/Chart.test.tsx
@@ -34,7 +34,7 @@ describe('Chart />', () => {
       {rawValue: 10, label: 'data'},
       {rawValue: 20, label: 'data 2'},
     ],
-    chartDimensions: {width: 500, height: 250},
+    dimensions: {width: 500, height: 250},
     annotationsLookupTable: {
       1: {
         dataIndex: 1,

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -32,7 +32,7 @@ import {useBarSizes, useDataForChart, useXScale} from './hooks';
 import styles from './Chart.scss';
 
 interface ChartProps {
-  chartDimensions: Dimensions;
+  dimensions?: Dimensions;
   isAnimated: boolean;
   isSimple: boolean;
   isStacked: boolean;
@@ -42,7 +42,7 @@ interface ChartProps {
 }
 
 export function Chart({
-  chartDimensions,
+  dimensions,
   isAnimated,
   isSimple,
   isStacked,
@@ -54,6 +54,8 @@ export function Chart({
   const {labelFormatter} = xAxisOptions;
 
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
+
+  const {width, height} = dimensions ?? {width: 0, height: 0};
 
   const longestSeriesCount = useMemo(() => {
     return series.reduce((prev, cur) => {
@@ -106,8 +108,7 @@ export function Chart({
     allNumbers,
     highestSumForStackedGroup,
     isStacked,
-    maxWidth:
-      chartDimensions.width - longestLabel.negative - longestLabel.positive,
+    maxWidth: width - longestLabel.negative - longestLabel.positive,
     longestSeriesCount,
   });
 
@@ -119,7 +120,7 @@ export function Chart({
     groupHeight,
     tallestXAxisLabel,
   } = useBarSizes({
-    chartDimensions,
+    chartDimensions: {width, height},
     isSimple: isSimple || xAxisOptions.hide,
     isStacked,
     labelFormatter,
@@ -227,15 +228,15 @@ export function Chart({
     <div
       className={styles.ChartContainer}
       style={{
-        width: chartDimensions.width,
-        height: chartDimensions.height,
+        width,
+        height,
       }}
     >
       <svg
         className={styles.SVG}
         ref={setSvgRef}
         role="list"
-        viewBox={`0 0 ${chartDimensions.width} ${chartDimensions.height}`}
+        viewBox={`0 0 ${width} ${height}`}
         xmlns={XMLNS}
       >
         {isSimple || xAxisOptions.hide === true ? null : (
@@ -262,7 +263,7 @@ export function Chart({
           colorOverrides={seriesWithColorOverride}
           seriesColors={seriesColors}
           theme={theme}
-          width={chartDimensions.width}
+          width={width}
         />
 
         {transitions(({opacity, transform}, item, _transition, index) => {
@@ -329,7 +330,7 @@ export function Chart({
       </svg>
       <TooltipWrapper
         bandwidth={groupBarsAreaHeight}
-        chartDimensions={chartDimensions}
+        chartDimensions={{width, height}}
         focusElementDataType={DataType.Bar}
         getAlteredPosition={getAlteredHorizontalBarPosition}
         getMarkup={getTooltipMarkup}

--- a/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,13 +1,7 @@
-import React, {useCallback, useLayoutEffect, useState} from 'react';
-import {useDebouncedCallback} from 'use-debounce/lib';
+import React from 'react';
 
 import {ChartContainer} from '../../components/ChartContainer';
-import {
-  useResizeObserver,
-  usePrefersReducedMotion,
-  usePrintResizing,
-} from '../../hooks';
-import type {Dimensions} from '../../types';
+import {usePrefersReducedMotion} from '../../hooks';
 
 import {Chart} from './Chart';
 import type {Series, XAxisOptions} from './types';
@@ -35,65 +29,17 @@ export function HorizontalBarChart({
     ...xAxisOptions,
   };
 
-  const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
-    null,
-  );
-  const {ref, setRef, entry} = useResizeObserver();
-
-  usePrintResizing({ref, setChartDimensions});
-
-  const updateDimensions = useCallback(() => {
-    if (entry != null) {
-      const {width, height} = entry.contentRect;
-      setChartDimensions((prevDimensions) => {
-        if (
-          prevDimensions != null &&
-          width === prevDimensions.width &&
-          height === prevDimensions.height
-        ) {
-          return prevDimensions;
-        } else {
-          return {width, height};
-        }
-      });
-    }
-  }, [entry]);
-
-  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
-    updateDimensions();
-  }, 100);
-
-  useLayoutEffect(() => {
-    updateDimensions();
-
-    const isServer = typeof window === 'undefined';
-
-    if (!isServer) {
-      window.addEventListener('resize', debouncedUpdateDimensions);
-    }
-
-    return () => {
-      if (!isServer) {
-        window.removeEventListener('resize', debouncedUpdateDimensions);
-      }
-    };
-  }, [entry, debouncedUpdateDimensions, updateDimensions]);
-
   const {prefersReducedMotion} = usePrefersReducedMotion();
 
   return (
-    <ChartContainer theme={theme} ref={setRef}>
-      {chartDimensions !== null && (
-        <Chart
-          chartDimensions={chartDimensions}
-          isAnimated={isAnimated && !prefersReducedMotion}
-          isSimple={isSimple}
-          isStacked={isStacked}
-          series={series}
-          theme={theme}
-          xAxisOptions={xAxisOptionsForChart}
-        />
-      )}
+    <ChartContainer theme={theme}>
+      <Chart
+        isAnimated={isAnimated && !prefersReducedMotion}
+        isSimple={isSimple}
+        isStacked={isStacked}
+        series={series}
+        xAxisOptions={xAxisOptionsForChart}
+      />
     </ChartContainer>
   );
 }

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -55,7 +55,6 @@ import {Line, GradientArea} from './components';
 import styles from './Chart.scss';
 
 interface Props {
-  dimensions: Dimensions;
   isAnimated: boolean;
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   series: SeriesWithDefaults[];
@@ -63,6 +62,7 @@ interface Props {
   yAxisOptions: Required<YAxisOptions>;
   emptyStateText?: string;
   theme?: string;
+  dimensions?: Dimensions;
 }
 
 const TOOLTIP_POSITION = {
@@ -88,14 +88,15 @@ export function Chart({
   const gradientId = useRef(uniqueId('lineChartGradient'));
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
 
-  const fontSize =
-    dimensions.width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
+  const {width, height} = dimensions ?? {width: 0, height: 0};
+
+  const fontSize = width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
   const emptyState = series.length === 0;
 
   const {ticks: initialTicks} = useYScale({
     fontSize,
-    drawableHeight: dimensions.height - Margin.Top,
+    drawableHeight: height - Margin.Top,
     series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
@@ -106,7 +107,7 @@ export function Chart({
   const xAxisDetails = useLinearXAxisDetails({
     series,
     fontSize,
-    width: dimensions.width - selectedTheme.grid.horizontalMargin * 2,
+    width: width - selectedTheme.grid.horizontalMargin * 2,
     formatXAxisLabel: xAxisOptions.labelFormatter,
     initialTicks,
     xAxisLabels: hideXAxis ? [] : xAxisOptions.xAxisLabels,
@@ -118,7 +119,7 @@ export function Chart({
     ? SPACING_TIGHT
     : Number(Margin.Bottom) + xAxisDetails.maxXLabelHeight;
 
-  const drawableHeight = dimensions.height - Margin.Top - marginBottom;
+  const drawableHeight = height - Margin.Top - marginBottom;
 
   const formattedLabels = useMemo(
     () => xAxisOptions.xAxisLabels.map(xAxisOptions.labelFormatter),
@@ -175,7 +176,7 @@ export function Chart({
   const drawableWidth =
     axisMargin == null
       ? null
-      : dimensions.width -
+      : width -
         Margin.Right -
         axisMargin -
         selectedTheme.grid.horizontalMargin * 2 -
@@ -286,19 +287,19 @@ export function Chart({
   return (
     <div className={styles.Container}>
       <svg
-        viewBox={`0 0 ${dimensions.width} ${dimensions.height}`}
+        viewBox={`0 0 ${width} ${height}`}
         className={styles.Chart}
         role={emptyState ? 'img' : 'table'}
         xmlns={XMLNS}
-        width={dimensions.width}
-        height={dimensions.height}
+        width={width}
+        height={height}
         ref={setSvgRef}
         aria-label={emptyState ? emptyStateText : undefined}
       >
         {xAxisOptions.hide ? null : (
           <g
             transform={`translate(${dataStartPosition},${
-              dimensions.height - marginBottom
+              height - marginBottom
             })`}
           >
             <LinearXAxis
@@ -323,9 +324,7 @@ export function Chart({
               y: Margin.Top,
             }}
             width={
-              selectedTheme.grid.horizontalOverflow
-                ? dimensions.width
-                : drawableWidth
+              selectedTheme.grid.horizontalOverflow ? width : drawableWidth
             }
           />
         ) : null}
@@ -476,7 +475,7 @@ export function Chart({
 
       <TooltipWrapper
         alwaysUpdatePosition
-        chartDimensions={dimensions}
+        chartDimensions={{width, height}}
         focusElementDataType={DataType.Point}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}

--- a/src/components/MultiSeriesBarChart/Chart.tsx
+++ b/src/components/MultiSeriesBarChart/Chart.tsx
@@ -35,7 +35,7 @@ import styles from './Chart.scss';
 
 interface Props {
   series: Required<Series>[];
-  chartDimensions: Dimensions;
+  dimensions?: Dimensions;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   xAxisOptions: XAxisOptions;
   yAxisOptions: YAxisOptions;
@@ -47,7 +47,7 @@ interface Props {
 
 export function Chart({
   series,
-  chartDimensions,
+  dimensions,
   renderTooltipContent,
   xAxisOptions,
   yAxisOptions,
@@ -60,8 +60,9 @@ export function Chart({
   const [activeBarGroup, setActiveBarGroup] = useState<number | null>(null);
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
 
-  const fontSize =
-    chartDimensions.width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
+  const {width, height} = dimensions ?? {width: 0, height: 0};
+
+  const fontSize = width < SMALL_WIDTH ? SMALL_FONT_SIZE : FONT_SIZE;
 
   const emptyState = series.length === 0;
 
@@ -70,7 +71,7 @@ export function Chart({
     : null;
 
   const {ticks: initialTicks} = useYScale({
-    drawableHeight: chartDimensions.height - Margin.Top - Margin.Bottom,
+    drawableHeight: height - Margin.Top - Margin.Bottom,
     data: series,
     formatYAxisLabel: yAxisOptions.labelFormatter,
     stackedValues,
@@ -93,10 +94,7 @@ export function Chart({
   const axisMargin = SPACING + yAxisLabelWidth;
   const chartStartPosition = axisMargin + selectedTheme.grid.horizontalMargin;
   const drawableWidth =
-    chartDimensions.width -
-    Margin.Right -
-    axisMargin -
-    selectedTheme.grid.horizontalMargin * 2;
+    width - Margin.Right - axisMargin - selectedTheme.grid.horizontalMargin * 2;
 
   const formattedXAxisLabels = useMemo(
     () => xAxisOptions.labels.map(xAxisOptions.labelFormatter),
@@ -118,7 +116,7 @@ export function Chart({
         yAxisLabelWidth,
         xLabels: hideXAxis ? [] : formattedXAxisLabels,
         fontSize,
-        width: chartDimensions.width - selectedTheme.grid.horizontalMargin * 2,
+        width: width - selectedTheme.grid.horizontalMargin * 2,
         innerMargin: BarMargin[selectedTheme.bar.innerMargin],
         outerMargin: BarMargin[selectedTheme.bar.outerMargin],
         wrapLabels: xAxisOptions.wrapLabels ?? true,
@@ -128,7 +126,7 @@ export function Chart({
       yAxisLabelWidth,
       formattedXAxisLabels,
       fontSize,
-      chartDimensions.width,
+      width,
       selectedTheme.grid.horizontalMargin,
       selectedTheme.bar.innerMargin,
       selectedTheme.bar.outerMargin,
@@ -159,10 +157,7 @@ export function Chart({
   const {maxXLabelHeight} = xAxisDetails;
 
   const drawableHeight =
-    chartDimensions.height -
-    Margin.Top -
-    Margin.Bottom -
-    xAxisDetails.maxXLabelHeight;
+    height - Margin.Top - Margin.Bottom - xAxisDetails.maxXLabelHeight;
 
   const {yScale, ticks} = useYScale({
     drawableHeight,
@@ -214,15 +209,15 @@ export function Chart({
     <div
       className={styles.ChartContainer}
       style={{
-        height: chartDimensions.height,
-        width: chartDimensions.width,
+        height,
+        width,
       }}
     >
       <svg
-        viewBox={`0 0 ${chartDimensions.width} ${chartDimensions.height}`}
+        viewBox={`0 0 ${width} ${height}`}
         xmlns={XMLNS}
-        width={chartDimensions.width}
-        height={chartDimensions.height}
+        width={width}
+        height={height}
         className={styles.Svg}
         role={emptyState ? 'img' : 'list'}
         aria-label={emptyState ? emptyStateText : undefined}
@@ -231,7 +226,7 @@ export function Chart({
         {hideXAxis ? null : (
           <g
             transform={`translate(${chartStartPosition},${
-              chartDimensions.height - Margin.Bottom - maxXLabelHeight
+              height - Margin.Bottom - maxXLabelHeight
             })`}
             aria-hidden="true"
           >
@@ -254,9 +249,7 @@ export function Chart({
               y: Margin.Top,
             }}
             width={
-              selectedTheme.grid.horizontalOverflow
-                ? chartDimensions.width
-                : drawableWidth
+              selectedTheme.grid.horizontalOverflow ? width : drawableWidth
             }
             theme={theme}
           />
@@ -317,7 +310,7 @@ export function Chart({
 
       <TooltipWrapper
         bandwidth={xScale.bandwidth()}
-        chartDimensions={chartDimensions}
+        chartDimensions={{width, height}}
         focusElementDataType={DataType.BarGroup}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}

--- a/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
+++ b/src/components/MultiSeriesBarChart/tests/Chart.test.tsx
@@ -63,7 +63,7 @@ describe('Chart />', () => {
         name: 'LABEL2',
       },
     ],
-    chartDimensions: {width: 500, height: 250},
+    dimensions: {width: 500, height: 250},
     renderTooltipContent,
     isStacked: false,
     xAxisOptions: {

--- a/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -66,7 +66,6 @@ describe('<Chart />', () => {
       },
     ],
     xAxisOptions: {labels: ['Day 1', 'Day 2']},
-    hideXAxis: false,
     dimensions: {width: 500, height: 250},
     isAnimated: true,
     formatXAxisLabel: (val: string) => val,
@@ -98,7 +97,10 @@ describe('<Chart />', () => {
   });
 
   it('does not render LinearAxis labels if the axis is hidden', () => {
-    const chart = mount(<Chart {...mockProps} hideXAxis />);
+    const chart = mountWithProvider(
+      <Chart {...mockProps} />,
+      mockDefaultTheme({xAxis: {hide: true}}),
+    );
     expect(chart).not.toContainReactComponent(LinearXAxis);
   });
 


### PR DESCRIPTION
## What does this implement/fix?
As suggested in [this PR](https://github.com/Shopify/polaris-viz/pull/678), another way to approach overriding the theme without making the ThemeProvider mandatory involves overwriting the theme in the ChartContainer. This PR does not overwrite the theme based on printing, but gets us almost all the way there, by removing a lot of duplication in the Chart components by moving print, ref and resizing handling to the ChartContainer component.

Since this is a large diff, which would be challenging to separate, I have tried to keep the commits atomic.

Some changes of note:
- StackedAreaChart was not using the container at all, but now it is. As a result, there are some additional changes in that component.
- the change in ChartContainer from using a forwardRef to cloning the component is so that we will be able to pass down the changed theme in a followup PR to this one
- as part of the change mentioned above, there is some weirdness with the props that are passed to the cloned component. My approach was to make those props optional and then deal with the fact they could be undefined, even though for the chart dimensions, they should never be undefined once we render the cloned child component. I am open to suggestions.
- the SkipLinks were inconsistently rendered within or outside the chart container. I have moved them all outside.

## Does this close any currently open issues?
On the way to https://github.com/Shopify/polaris-viz/issues/660

## What do the changes look like?
There should be no visual changes 🤞 
 
## Storybook link
Throughout storybook, check the:
- line chart
- area chart
- bar chart
- multiseries bar chart
- horizontal bar chart

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
