### PR TITLE
Add print theme overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Chart components resizing and printing behaviour is now centralized in ChartContainer.
+- Most charts are printed using the light theme, however any prop color overrides will still apply when printed. Charts that do not have this treatment yet are `<Sparkline />`, `<Sparkbar />` and `<NormalizedStackedBarChart />`.
 
 ## [0.24.1] - 2021-11-02
 

--- a/src/components/ChartContainer/ChartContainer.tsx
+++ b/src/components/ChartContainer/ChartContainer.tsx
@@ -18,15 +18,15 @@ interface Props {
 }
 
 export const ChartContainer = (props: Props) => {
-  const {chartContainer} = useTheme(props.theme);
-
   const [chartDimensions, setChartDimensions] = useState<Dimensions | null>(
     null,
   );
 
   const {ref, setRef, entry} = useResizeObserver();
 
-  usePrintResizing({ref, setChartDimensions});
+  const {isPrinting} = usePrintResizing({ref, setChartDimensions});
+  const printFriendlyTheme = isPrinting ? 'Light' : props.theme;
+  const {chartContainer} = useTheme(printFriendlyTheme);
 
   const updateDimensions = useCallback(() => {
     if (entry != null) {
@@ -80,7 +80,7 @@ export const ChartContainer = (props: Props) => {
         : cloneElement<{theme: string; dimensions: Dimensions}>(
             props.children,
             {
-              theme: props.theme,
+              theme: printFriendlyTheme,
               dimensions: chartDimensions,
             },
           )}

--- a/src/components/HorizontalBarChart/components/Bar/Bar.scss
+++ b/src/components/HorizontalBarChart/components/Bar/Bar.scss
@@ -4,3 +4,11 @@
   @include no-outline;
   transition: fill $duration-slow ease;
 }
+
+.Group {
+  @media print {
+    // stylelint-disable declaration-no-important
+    transform: none !important;
+    // stylelint-enable declaration-no-important
+  }
+}

--- a/src/components/HorizontalBarChart/components/Bar/Bar.tsx
+++ b/src/components/HorizontalBarChart/components/Bar/Bar.tsx
@@ -122,7 +122,7 @@ export const Bar = React.memo(function Bar({
   });
 
   return (
-    <animated.g style={{transform: spring.transform}}>
+    <animated.g className={styles.Group} style={{transform: spring.transform}}>
       <path
         d={getPath(height, width)}
         data-id={`bar-${index}`}

--- a/src/hooks/use-print-resizing.ts
+++ b/src/hooks/use-print-resizing.ts
@@ -1,4 +1,4 @@
-import {useLayoutEffect} from 'react';
+import {useLayoutEffect, useState} from 'react';
 
 import type {Dimensions} from '../types';
 
@@ -9,10 +9,12 @@ export function usePrintResizing({
   ref: HTMLElement | null;
   setChartDimensions: (value: React.SetStateAction<Dimensions | null>) => void;
 }) {
+  const [isPrinting, setIsPrinting] = useState(false);
+
   useLayoutEffect(() => {
     const isServer = typeof window === 'undefined';
 
-    function setDimensionsForPrint() {
+    function handlePrint() {
       if (ref != null) {
         const {
           paddingRight,
@@ -29,12 +31,14 @@ export function usePrintResizing({
           parseInt(paddingTop, 10) -
           parseInt(paddingBottom, 10);
         setChartDimensions({width, height});
+
+        setIsPrinting((isPrinting) => !isPrinting);
       }
     }
 
     const printSafari = () => {
       setTimeout(() => {
-        setDimensionsForPrint();
+        handlePrint();
       });
     };
 
@@ -49,9 +53,7 @@ export function usePrintResizing({
     const safariNotServer = isSafari && !isServer;
 
     if (notSafariOrServer) {
-      window
-        .matchMedia('print')
-        .addEventListener('change', setDimensionsForPrint);
+      window.matchMedia('print').addEventListener('change', handlePrint);
     }
 
     if (safariNotServer) {
@@ -64,9 +66,7 @@ export function usePrintResizing({
 
     return () => {
       if (notSafariOrServer) {
-        window
-          .matchMedia('print')
-          .removeEventListener('change', setDimensionsForPrint);
+        window.matchMedia('print').removeEventListener('change', handlePrint);
       }
 
       if (safariNotServer) {
@@ -78,4 +78,6 @@ export function usePrintResizing({
       }
     };
   }, [setChartDimensions, ref]);
+
+  return {isPrinting};
 }


### PR DESCRIPTION
## What does this implement/fix?

Overwrites the theme in the ChartContainer when the chart is being printed

We need to detect printing in our printing hook and then use that to update the theme appropriately 

## Does this close any currently open issues?
Resolves https://github.com/Shopify/polaris-viz/issues/660


## What do the changes look like?

| Before  | After  |
|---|---|
| <img width="632" alt="Screen Shot 2021-11-10 at 12 15 22 PM" src="https://user-images.githubusercontent.com/12213371/141160871-dbb8b684-29e5-4fcf-a8b1-62bf4d00d249.png">  | <img width="643" alt="Screen Shot 2021-11-10 at 12 14 54 PM" src="https://user-images.githubusercontent.com/12213371/141160874-16f80a5d-5a0f-4eab-8708-dd196a5662d9.png"> |
 
## Storybook link
All of our interactive charts


### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
