### PR TITLE
Add renderTooltipContent prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added `renderTooltipContent` prop to `<HorizontalBarChart />`.
+
 ### Changed
 
 - Chart components resizing and printing behaviour is now centralized in ChartContainer.

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -1,8 +1,7 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {ReactNode, useCallback, useMemo, useState} from 'react';
 import {useTransition, animated} from '@react-spring/web';
 
 import {getSeriesColorsFromCount, useTheme} from '../../hooks';
-import {TooltipContent} from '../TooltipContent';
 import {
   XMLNS,
   BarChartMargin as Margin,
@@ -17,6 +16,7 @@ import {
   TooltipPositionParams,
   TooltipWrapper,
 } from '../TooltipWrapper';
+import type {TooltipData} from '../TooltipContent';
 
 import {getAlteredHorizontalBarPosition, getBarId} from './utilities';
 import {
@@ -27,7 +27,12 @@ import {
   VerticalGridLines,
   XAxisLabels,
 } from './components';
-import type {ColorOverrides, Series, XAxisOptions} from './types';
+import type {
+  ColorOverrides,
+  RenderTooltipContentData,
+  Series,
+  XAxisOptions,
+} from './types';
 import {useBarSizes, useDataForChart, useXScale} from './hooks';
 import styles from './Chart.scss';
 
@@ -36,6 +41,7 @@ interface ChartProps {
   isAnimated: boolean;
   isSimple: boolean;
   isStacked: boolean;
+  renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
   series: Series[];
   xAxisOptions: Required<XAxisOptions>;
   theme?: string;
@@ -46,6 +52,7 @@ export function Chart({
   isAnimated,
   isSimple,
   isStacked,
+  renderTooltipContent,
   series,
   theme,
   xAxisOptions,
@@ -148,19 +155,19 @@ export function Chart({
         return null;
       }
 
-      const data = series[activeIndex].data.map(
+      const data: TooltipData[] = series[activeIndex].data.map(
         ({rawValue, label, color}, index) => {
           return {
             label,
-            value: labelFormatter(rawValue),
+            value: `${rawValue}`,
             color: color ?? seriesColors[index],
           };
         },
       );
 
-      return <TooltipContent data={data} theme={theme} />;
+      return renderTooltipContent({data});
     },
-    [series, seriesColors, labelFormatter, theme],
+    [series, seriesColors, renderTooltipContent],
   );
 
   const seriesWithColorOverride = useMemo(() => {

--- a/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 
+import {TooltipContent} from '../TooltipContent';
 import {ChartContainer} from '../../components/ChartContainer';
 import {usePrefersReducedMotion} from '../../hooks';
 
 import {Chart} from './Chart';
-import type {Series, XAxisOptions} from './types';
+import type {RenderTooltipContentData, Series, XAxisOptions} from './types';
 
 export interface HorizontalBarChartProps {
   series: Series[];
   isAnimated?: boolean;
   isSimple?: boolean;
   isStacked?: boolean;
+  renderTooltipContent?: (data: RenderTooltipContentData) => ReactNode;
   theme?: string;
   xAxisOptions?: XAxisOptions;
 }
@@ -19,6 +21,7 @@ export function HorizontalBarChart({
   isAnimated = true,
   isSimple = false,
   isStacked = false,
+  renderTooltipContent,
   series,
   theme,
   xAxisOptions,
@@ -31,12 +34,29 @@ export function HorizontalBarChart({
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
 
+  function renderTooltip({data}: RenderTooltipContentData) {
+    if (renderTooltipContent != null) {
+      return renderTooltipContent({data});
+    }
+
+    const tooltipData = data.map(({value, label, color}) => {
+      return {
+        label,
+        value: xAxisOptionsForChart.labelFormatter(value),
+        color,
+      };
+    });
+
+    return <TooltipContent data={tooltipData} theme={theme} />;
+  }
+
   return (
     <ChartContainer theme={theme}>
       <Chart
         isAnimated={isAnimated && !prefersReducedMotion}
         isSimple={isSimple}
         isStacked={isStacked}
+        renderTooltipContent={renderTooltip}
         series={series}
         xAxisOptions={xAxisOptionsForChart}
       />

--- a/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -6,8 +6,8 @@ import {
   HorizontalBarChartProps,
 } from '../HorizontalBarChart';
 
-import type {Series} from '../types';
-import {THEME_CONTROL_ARGS} from '../../../storybook';
+import type {RenderTooltipContentData, Series} from '../types';
+import {getSingleColor, THEME_CONTROL_ARGS} from '../../../storybook';
 
 const LABELS = ['BCFM 2019', 'BCFM 2020', 'BCFM 2021'];
 
@@ -44,6 +44,25 @@ const CONTAINER_HEIGHT = 500;
 
 const SINGLE_SERIES = buildSeries([3, 7, 4, 8, 4, 1, 4, 6]);
 
+const TOOLTIP_CONTENT = {
+  empty: undefined,
+  Custom: ({data}: RenderTooltipContentData) => {
+    return data.map(({value, label, color}) => {
+      return (
+        <div
+          style={{
+            color: getSingleColor(color),
+            padding: '10px',
+          }}
+          key={label}
+        >
+          {`${label}: ${value} pickles`}
+        </div>
+      );
+    });
+  },
+};
+
 export default {
   title: 'Charts/HorizontalBarChart',
   component: HorizontalBarChart,
@@ -79,6 +98,19 @@ export default {
     isStacked: {
       description:
         'Changes the grouping of the bars. If `true` the bar groups will stack vertically, otherwise they will render individual bars for each data point in each group.',
+    },
+    renderTooltipContent: {
+      description:
+        'Accepts a function that renders the tooltip content. By default it calls `xAxisOptions.labelFormatter` to format the the tooltip values and passes them to `<TooltipContent />`.',
+      options: Object.keys(TOOLTIP_CONTENT),
+      mapping: TOOLTIP_CONTENT,
+      control: {
+        type: 'select',
+        labels: {
+          empty: 'Default',
+          Annotation: 'Custom',
+        },
+      },
     },
     theme: THEME_CONTROL_ARGS,
     xAxisOptions: {

--- a/src/components/HorizontalBarChart/types.ts
+++ b/src/components/HorizontalBarChart/types.ts
@@ -1,3 +1,5 @@
+import type {TooltipData} from 'components/TooltipContent';
+
 import type {Color} from '../../types';
 
 export type LabelFormatter = (value: string | number) => string;
@@ -21,4 +23,8 @@ export interface Series {
 export interface ColorOverrides {
   id: string;
   color: Color;
+}
+
+export interface RenderTooltipContentData {
+  data: TooltipData[];
 }

--- a/src/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/TooltipContent/TooltipContent.tsx
@@ -6,7 +6,7 @@ import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './TooltipContent.scss';
 
-interface TooltipData {
+export interface TooltipData {
   color: Color;
   label: string;
   value: string;

--- a/src/components/TooltipContent/index.ts
+++ b/src/components/TooltipContent/index.ts
@@ -1,2 +1,2 @@
 export {TooltipContent} from './TooltipContent';
-export type {TooltipContentProps} from './TooltipContent';
+export type {TooltipContentProps, TooltipData} from './TooltipContent';

--- a/src/storybook/index.ts
+++ b/src/storybook/index.ts
@@ -1,3 +1,6 @@
+import type {Color} from '../types';
+import {isGradientType} from '../utilities';
+
 export const getDataPoint = (limit = 1000) => {
   return Math.random() * limit;
 };
@@ -5,4 +8,12 @@ export const getDataPoint = (limit = 1000) => {
 export const THEME_CONTROL_ARGS = {
   description: 'The theme that the chart will inherit its styles from',
   control: {type: 'select', options: ['Default', 'Light']},
+};
+
+export const getSingleColor = (color: Color): string => {
+  if (isGradientType(color)) {
+    return color[0].color;
+  }
+
+  return color;
 };


### PR DESCRIPTION
## What does this implement/fix?
…

HorizontalBarChart was missing the functionality to render custom tooltip content.

## Does this close any currently open issues?
…

Resolves https://github.com/Shopify/polaris-viz/issues/695


## What do the changes look like?
…

![image](https://user-images.githubusercontent.com/149873/141196235-cbf704d9-e2de-41ee-8656-c7a6c524b68d.png)

## Storybook link
…

- Open any of the Horizontal Bar Chart stories and use the `renderTooltipContent` control to switch to `Custom`.
- Mouse over the bars and the custom tooltip should render.

![image](https://user-images.githubusercontent.com/149873/141196368-c0c8a755-2eff-463d-b16d-cd4fc008a496.png)



### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.
