### PR TITLE
Use new DataSeries type in theme series colors hooks

### DIFF
--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -28,7 +28,7 @@ export interface Props {
 
 export function Legend({series, theme}: Props) {
   const selectedTheme = useTheme(theme);
-  const seriesColors = useThemeSeriesColors(series, selectedTheme);
+  const seriesColors = useThemeSeriesColors(series as any, selectedTheme);
   const {labelColor} = selectedTheme.legend;
   return (
     <div className={styles.Container} aria-hidden>

--- a/src/components/Sparkline/Sparkline.tsx
+++ b/src/components/Sparkline/Sparkline.tsx
@@ -47,7 +47,7 @@ export function Sparkline({
   } = useResizeObserver();
   const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
   const selectedTheme = useTheme(theme);
-  const seriesColors = useThemeSeriesColors(series, selectedTheme);
+  const seriesColors = useThemeSeriesColors(series as any, selectedTheme);
 
   const [updateMeasurements] = useDebouncedCallback(() => {
     if (entry == null) return;

--- a/src/hooks/use-theme-series-colors.ts
+++ b/src/hooks/use-theme-series-colors.ts
@@ -1,11 +1,15 @@
 import {useMemo} from 'react';
 
-import type {Theme, Color, LineStyle, LegacyDataSeries} from '../types';
+import type {Theme, Color, LineStyle, DataPoint, Data} from '../types';
 
-// We don't use the data property anywhere, so it's
-// safe to use "any" here as the type passed to LegacyDataSeries.
-// We really only care about color and lineStyle
-interface ValidData extends LegacyDataSeries<any, Color> {
+// Note: This is a bandaid until all component are using
+// the new DataSeries type.
+interface ValidData {
+  data: (DataPoint | Data)[];
+  color?: Color;
+  isComparison?: boolean;
+  name?: string;
+
   lineStyle?: LineStyle;
 }
 
@@ -14,7 +18,7 @@ function getFilteredSeriesCount(series: Partial<ValidData>[]): number {
   // count when grabbing the series color.
   return (
     series.filter((item) => {
-      if (!item.lineStyle) {
+      if (item.isComparison !== true && !item.lineStyle) {
         return true;
       }
       return item.lineStyle === 'solid';


### PR DESCRIPTION
## What does this implement/fix?

As we slowly move components over to use `DataSeries` we're going to have to bandaid fix a few of the non-converted components while we release in smaller milestones.

The `any` in `src/components/Sparkline/Sparkline.tsx` will be fixed in another PR as part of milestone one.


## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/697

## What do the changes look like?

Everything should look the same and nothing should blow up.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
