### PR TITLE
Re-order storybook nav

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,6 +17,7 @@ const storiesOrder = {
   },
   Providers: null,
   Charts: null,
+  [`Spark Charts`]: null,
   Subcomponents: null,
   Playground: null,
 };


### PR DESCRIPTION
## What does this implement/fix?

This change explicitely sets the position of the `Spark Charts` folder in Storybook to be right after `Charts`, instead of as the last item


<img width="717" alt="Screen Shot 2021-11-16 at 1 29 35 PM" src="https://user-images.githubusercontent.com/4037781/142044362-45e36d27-07d1-47ef-b8f3-322f1dcaa0ee.png">

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
