### PR TITLE
Use ChartContainer in SparkLineChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Added
 
-- Horizontal overflow style to `<StackedAreaChart />`, which were unintentionally removed
+- Horizontal overflow style to `<StackedAreaChart />`, which were unintentionally removed.
+- Use `<ChartContainer />` in `<SparkLineChart />`.
+
 
 ### Changed
 

--- a/src/components/SparkLineChart/Chart.tsx
+++ b/src/components/SparkLineChart/Chart.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {scaleLinear} from 'd3-scale';
+
+import type {Dimensions} from '../../types';
+import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
+import {useTheme} from '../../hooks';
+import {XMLNS} from '../../constants';
+
+import styles from './SparkLineChart.scss';
+import {Series} from './components';
+import type {SparkLineChartProps} from './SparkLineChart';
+
+const SVG_MARGIN = 2;
+
+interface Props extends SparkLineChartProps {
+  dimensions?: Dimensions;
+}
+
+export function Chart({
+  data,
+  dimensions,
+  accessibilityLabel,
+  isAnimated = false,
+  offsetLeft = 0,
+  offsetRight = 0,
+  theme,
+}: Props) {
+  const selectedTheme = useTheme(theme);
+  const seriesColors = useThemeSeriesColors(data, selectedTheme);
+
+  const {width, height} = dimensions ?? {height: 0, width: 0};
+
+  const xValues = Array.prototype.concat.apply(
+    [],
+    data.map(({data}) => data.map(({key}) => key)),
+  );
+
+  const minXValues = Math.min(...xValues);
+  const maxXValues = Math.max(...xValues);
+
+  const yValues = Array.prototype.concat.apply(
+    [],
+    data.map(({data}) => data.map(({value}) => value)),
+  );
+
+  const yScale = scaleLinear()
+    .range([height - SVG_MARGIN, SVG_MARGIN])
+    .domain([Math.min(...yValues), Math.max(...yValues)]);
+
+  return (
+    <React.Fragment>
+      {accessibilityLabel ? (
+        <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
+      ) : null}
+
+      <svg xmlns={XMLNS} aria-hidden width={width} height={height}>
+        {data.map((series, index) => {
+          const singleOffsetLeft = series.isComparison ? 0 : offsetLeft;
+          const singleOffsetRight = series.isComparison ? 0 : offsetRight;
+
+          const xScale = scaleLinear()
+            .range([
+              singleOffsetLeft + SVG_MARGIN,
+              width - singleOffsetRight - SVG_MARGIN,
+            ])
+            .domain([minXValues, maxXValues]);
+
+          const seriesWithColor = {
+            color: seriesColors[index],
+            ...series,
+          };
+
+          return (
+            <g key={index}>
+              <Series
+                xScale={xScale}
+                yScale={yScale}
+                data={seriesWithColor}
+                isAnimated={isAnimated}
+                svgDimensions={{height, width}}
+                theme={selectedTheme}
+              />
+            </g>
+          );
+        })}
+      </svg>
+    </React.Fragment>
+  );
+}

--- a/src/components/SparkLineChart/SparkLineChart.scss
+++ b/src/components/SparkLineChart/SparkLineChart.scss
@@ -13,7 +13,3 @@
   border: 0 !important;
   // stylelint-enable declaration-no-important
 }
-
-.Container {
-  @include chart-container;
-}

--- a/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/src/components/SparkLineChart/SparkLineChart.tsx
@@ -1,16 +1,9 @@
-import React, {useState, useLayoutEffect, useCallback} from 'react';
-import {useDebouncedCallback} from 'use-debounce';
-import {scaleLinear} from 'd3-scale';
+import React from 'react';
 
 import type {DataSeries} from '../../types';
-import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
-import {useResizeObserver, useTheme} from '../../hooks';
-import {XMLNS} from '../../constants';
+import {ChartContainer} from '../ChartContainer';
 
-import styles from './SparkLineChart.scss';
-import {Series} from './components';
-
-const SVG_MARGIN = 2;
+import {Chart} from './Chart';
 
 export interface Coordinates {
   x: number;
@@ -34,140 +27,16 @@ export function SparkLineChart({
   offsetRight = 0,
   theme,
 }: SparkLineChartProps) {
-  const {
-    ref: containerRef,
-    setRef: setContainerRef,
-    entry,
-  } = useResizeObserver();
-  const [svgDimensions, setSvgDimensions] = useState({width: 0, height: 0});
-  const selectedTheme = useTheme(theme);
-  const seriesColors = useThemeSeriesColors(data, selectedTheme);
-
-  const [updateMeasurements] = useDebouncedCallback(() => {
-    if (entry == null) return;
-
-    setSvgDimensions({
-      height: entry.contentRect.height,
-      width: entry.contentRect.width,
-    });
-  }, 10);
-
-  const handlePrintMediaQueryChange = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches && entry != null) {
-        setSvgDimensions({
-          height: entry.contentRect.width,
-          width: entry.contentRect.height,
-        });
-      }
-    },
-    [entry],
-  );
-
-  useLayoutEffect(() => {
-    if (entry == null) return;
-
-    if (containerRef == null) return;
-
-    updateMeasurements();
-
-    const isServer = typeof window === 'undefined';
-
-    if (!isServer) {
-      window.addEventListener('resize', () => updateMeasurements());
-
-      if (typeof window.matchMedia('print').addEventListener === 'function') {
-        window
-          .matchMedia('print')
-          .addEventListener('change', handlePrintMediaQueryChange);
-      } else if (typeof window.matchMedia('print').addListener === 'function') {
-        window.matchMedia('print').addListener(handlePrintMediaQueryChange);
-      }
-    }
-
-    return () => {
-      if (!isServer) {
-        window.removeEventListener('resize', () => updateMeasurements());
-
-        if (typeof window.matchMedia('print').addEventListener === 'function') {
-          window
-            .matchMedia('print')
-            .removeEventListener('change', handlePrintMediaQueryChange);
-        } else if (
-          typeof window.matchMedia('print').addListener === 'function'
-        ) {
-          window
-            .matchMedia('print')
-            .removeListener(handlePrintMediaQueryChange);
-        }
-      }
-    };
-  }, [entry, containerRef, updateMeasurements, handlePrintMediaQueryChange]);
-
-  const {width, height} = svgDimensions;
-
-  const xValues = Array.prototype.concat.apply(
-    [],
-    data.map(({data}) => data.map(({key}) => key)),
-  );
-
-  const minXValues = Math.min(...xValues);
-  const maxXValues = Math.max(...xValues);
-
-  const yValues = Array.prototype.concat.apply(
-    [],
-    data.map(({data}) => data.map(({value}) => value)),
-  );
-
-  const yScale = scaleLinear()
-    .range([height - SVG_MARGIN, SVG_MARGIN])
-    .domain([Math.min(...yValues), Math.max(...yValues)]);
-
   return (
-    <div
-      ref={setContainerRef}
-      className={styles.Container}
-      style={{
-        background: selectedTheme.chartContainer.backgroundColor,
-        padding: selectedTheme.chartContainer.padding,
-        borderRadius: selectedTheme.chartContainer.borderRadius,
-      }}
-    >
-      {accessibilityLabel ? (
-        <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
-      ) : null}
-
-      <svg xmlns={XMLNS} aria-hidden width={width} height={height}>
-        {data.map((series, index) => {
-          const singleOffsetLeft = series.isComparison ? 0 : offsetLeft;
-          const singleOffsetRight = series.isComparison ? 0 : offsetRight;
-
-          const xScale = scaleLinear()
-            .range([
-              singleOffsetLeft + SVG_MARGIN,
-              width - singleOffsetRight - SVG_MARGIN,
-            ])
-            .domain([minXValues, maxXValues]);
-
-          const seriesWithColor = {
-            color: seriesColors[index],
-            ...series,
-          };
-
-          return (
-            <g key={index}>
-              <Series
-                xScale={xScale}
-                yScale={yScale}
-                data={seriesWithColor}
-                isAnimated={isAnimated}
-                svgDimensions={svgDimensions}
-                theme={selectedTheme}
-              />
-            </g>
-          );
-        })}
-      </svg>
-    </div>
+    <ChartContainer theme={theme}>
+      <Chart
+        data={data}
+        accessibilityLabel={accessibilityLabel}
+        isAnimated={isAnimated}
+        offsetLeft={offsetLeft}
+        offsetRight={offsetRight}
+        theme={theme}
+      />
+    </ChartContainer>
   );
 }

--- a/src/components/SparkLineChart/tests/Chart.test.tsx
+++ b/src/components/SparkLineChart/tests/Chart.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import {scaleLinear} from 'd3-scale';
+
+import {Chart} from '../Chart';
+
+jest.mock('d3-scale', () => ({
+  scaleLinear: jest.fn(() => {
+    const scale = (value: any) => value;
+    scale.range = (range: any) => (range ? scale : range);
+    scale.domain = (domain: any) => (domain ? scale : domain);
+    return scale;
+  }),
+}));
+
+describe('<Chart />', () => {
+  it('reduces the series width according to the offset and margin', () => {
+    let rangeSpy = jest.fn();
+    (scaleLinear as jest.Mock).mockImplementation(() => {
+      const scale = (value: any) => value;
+      rangeSpy = jest.fn((range: any) => (range ? scale : range));
+      scale.range = rangeSpy;
+      scale.domain = (domain: any) => (domain ? scale : domain);
+      return scale;
+    });
+
+    const offsetLeft = 100;
+    const offsetRight = 50;
+    const margin = 2;
+    const mockWidth = 0;
+
+    mount(
+      <Chart
+        data={[
+          {
+            data: [{key: 0, value: 100}],
+          },
+        ]}
+        offsetLeft={offsetLeft}
+        offsetRight={offsetRight}
+      />,
+    );
+
+    expect(rangeSpy).toHaveBeenCalledWith([
+      offsetLeft + margin,
+      mockWidth - offsetRight - margin,
+    ]);
+  });
+});

--- a/src/components/SparkLineChart/tests/SparkLineChart.test.tsx
+++ b/src/components/SparkLineChart/tests/SparkLineChart.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {scaleLinear} from 'd3-scale';
 
 import {SparkLineChart} from '../SparkLineChart';
 import {Series} from '../components';
@@ -83,44 +82,11 @@ describe('<SparkLineChart />', () => {
     });
   });
 
-  describe('Series', () => {
+  describe('<Series />', () => {
     it('renders a Series for each series provided', () => {
       const sparkLineChart = mount(<SparkLineChart data={mockData} />);
 
       expect(sparkLineChart.findAll(Series)).toHaveLength(mockData.length);
-    });
-
-    it('reduces the series width according to the offset and margin', () => {
-      let rangeSpy = jest.fn();
-      (scaleLinear as jest.Mock).mockImplementation(() => {
-        const scale = (value: any) => value;
-        rangeSpy = jest.fn((range: any) => (range ? scale : range));
-        scale.range = rangeSpy;
-        scale.domain = (domain: any) => (domain ? scale : domain);
-        return scale;
-      });
-
-      const offsetLeft = 100;
-      const offsetRight = 50;
-      const margin = 2;
-      const mockWidth = 0;
-
-      mount(
-        <SparkLineChart
-          data={[
-            {
-              data: [{key: 0, value: 100}],
-            },
-          ]}
-          offsetLeft={offsetLeft}
-          offsetRight={offsetRight}
-        />,
-      );
-
-      expect(rangeSpy).toHaveBeenCalledWith([
-        offsetLeft + margin,
-        mockWidth - offsetRight - margin,
-      ]);
     });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

As a followup to https://github.com/Shopify/polaris-viz/pull/691 we want to use `<ChartContainer />` in the SparkCharts.

The PR looks hairy, but most of the changes are moving code to `<Chart />` so we can correctly accept the `dimension` prop that passed from `<ChartContainer />`.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/693

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/142237873-38272275-f998-4a81-95aa-6ed84036456c.png)|![image](https://user-images.githubusercontent.com/149873/142237938-0becec07-4ebd-4555-a576-587d2223ac66.png)|
 
## Storybook link

- Open http://localhost:6006/?path=/story/spark-charts-sparklinechart--default
- Try and print the page.
  - Chart should be correctly sized with light theme.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
