### PR TITLE
Spike: Format data for SimpleBarChart & HorizontalBarChart

### DIFF
--- a/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -8,26 +8,37 @@ import {
 
 import type {RenderTooltipContentData} from '../types';
 import {getSingleColor, THEME_CONTROL_ARGS} from '../../../storybook';
-import type {DataSeries} from 'types';
+import type {DataPoint, DataSeries} from 'types';
 
 const LABELS = ['BCFM 2019', 'BCFM 2020', 'BCFM 2021'];
+const GROUPS = [
+  'Womens Leggings',
+  'Mens Bottoms',
+  'Mens Shorts',
+  'Socks',
+  'Hats',
+  'Ties',
+];
 
 function buildSeries(items: number[] | number[][]): DataSeries[] {
-  return [
-    'Womens Leggings',
-    'Mens Bottoms',
-    'Mens Shorts',
-    'Socks',
-    'Hats',
-    'Ties',
-  ].map((name, index) => {
-    const item = items[index];
-    const array = Array.isArray(item) ? item : [item];
+  return LABELS.map((name, index) => {
+    const data = GROUPS.map((name, groupIndex) => {
+      const item = items[groupIndex];
+      const array = Array.isArray(item) ? item : [item];
+
+      if (array[index] == null) {
+        return false;
+      }
+
+      return {
+        key: name,
+        value: array[index],
+      };
+    });
+
     return {
       name,
-      data: array.map((number, dataIndex) => {
-        return {value: number, key: LABELS[dataIndex]};
-      }),
+      data: data.filter(Boolean) as DataPoint[],
     };
   });
 }

--- a/src/components/SimpleBarChart/stories/SimpleBarChart.stories.tsx
+++ b/src/components/SimpleBarChart/stories/SimpleBarChart.stories.tsx
@@ -4,26 +4,37 @@ import type {Story, Meta} from '@storybook/react';
 import {SimpleBarChart, SimpleBarChartProps} from '../SimpleBarChart';
 
 import {THEME_CONTROL_ARGS} from '../../../storybook';
-import type {DataSeries} from '../../../types';
+import type {DataPoint, DataSeries} from '../../../types';
 
 const LABELS = ['BCFM 2019', 'BCFM 2020', 'BCFM 2021'];
+const GROUPS = [
+  'Womens Leggings',
+  'Mens Bottoms',
+  'Mens Shorts',
+  'Socks',
+  'Hats',
+  'Ties',
+];
 
 function buildSeries(items: number[] | number[][]): DataSeries[] {
-  return [
-    'Womens Leggings',
-    'Mens Bottoms',
-    'Mens Shorts',
-    'Socks',
-    'Hats',
-    'Ties',
-  ].map((name, index) => {
-    const item = items[index];
-    const array = Array.isArray(item) ? item : [item];
+  return LABELS.map((name, index) => {
+    const data = GROUPS.map((name, groupIndex) => {
+      const item = items[groupIndex];
+      const array = Array.isArray(item) ? item : [item];
+
+      if (array[index] == null) {
+        return false;
+      }
+
+      return {
+        key: name,
+        value: array[index],
+      };
+    });
+
     return {
       name,
-      data: array.map((number, dataIndex) => {
-        return {value: number, key: LABELS[dataIndex]};
-      }),
+      data: data.filter(Boolean) as DataPoint[],
     };
   });
 }
@@ -90,6 +101,41 @@ export const Default: Story<SimpleBarChartProps> = Template.bind({});
 
 Default.args = {
   series: SINGLE_SERIES,
+};
+
+export const MultipleSeries: Story<SimpleBarChartProps> = Template.bind({});
+
+MultipleSeries.args = {
+  series: SERIES,
+};
+
+export const ColorOverrides: Story<SimpleBarChartProps> = Template.bind({});
+
+ColorOverrides.args = {
+  series: [
+    {
+      name: 'Shirt',
+      data: [
+        {value: 4, key: 'Yesterday'},
+        {value: 7, key: 'Today'},
+      ],
+      color: 'red',
+    },
+    {
+      name: 'Pants',
+      data: [
+        {value: 5, key: 'Yesterday'},
+        {value: 6, key: 'Today'},
+      ],
+    },
+    {
+      name: 'Shoes',
+      data: [
+        {value: 15, key: 'Yesterday'},
+        {value: 12, key: 'Today'},
+      ],
+    },
+  ],
 };
 
 export const SimpleStacked: Story<SimpleBarChartProps> = Template.bind({});

--- a/src/components/shared/GradientDefs/GradientDefs.tsx
+++ b/src/components/shared/GradientDefs/GradientDefs.tsx
@@ -6,15 +6,15 @@ import {isGradientType} from '../../../utilities';
 import {LinearGradient} from '../../LinearGradient';
 
 interface GradientDefsProps {
-  colorOverrides: ColorOverrides[];
-  seriesColors: Color[];
+  colorOverrides?: ColorOverrides[];
+  seriesColors?: Color[];
   width: number;
   theme?: string;
 }
 
 export function GradientDefs({
-  colorOverrides,
-  seriesColors,
+  colorOverrides = [],
+  seriesColors = [],
   theme = 'Default',
   width,
 }: GradientDefsProps) {

--- a/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import {animated, SpringValue} from '@react-spring/web';
+import type {ScaleLinear} from 'd3-scale';
+
+import {DataSeries, DataType} from '../../../types';
+import {GroupLabel} from '../GroupLabel';
+import {HorizontalStackedBars} from '../HorizontalStackedBars';
+import {HorizontalBars} from '../HorizontalBars';
+
+interface HorizontalGroupProps {
+  animationDelay: number;
+  areAllNegative: boolean;
+  ariaLabel: string;
+  barHeight: number;
+  index: number;
+  isAnimated: boolean;
+  isSimple: boolean;
+  isStacked: boolean;
+  labelFormatter: any;
+  name: string;
+  opacity: SpringValue<number>;
+  series: DataSeries;
+  transform: SpringValue<string>;
+  xScale: ScaleLinear<number, number>;
+  xScaleStacked: ScaleLinear<number, number> | null;
+  zeroPosition: number;
+  theme?: string;
+}
+
+export function HorizontalGroup({
+  animationDelay,
+  areAllNegative,
+  ariaLabel,
+  barHeight,
+  index,
+  isAnimated,
+  isSimple,
+  isStacked,
+  labelFormatter,
+  name,
+  opacity,
+  series,
+  theme,
+  transform,
+  xScale,
+  xScaleStacked,
+  zeroPosition,
+}: HorizontalGroupProps) {
+  return (
+    <animated.g
+      key={`group-${name}`}
+      data-type={DataType.BarGroup}
+      data-id={`${DataType.BarGroup}-${index}`}
+      style={{
+        opacity,
+        transform,
+      }}
+    >
+      <GroupLabel
+        areAllNegative={areAllNegative}
+        label={name}
+        theme={theme}
+        zeroPosition={zeroPosition}
+      />
+
+      {isStacked && xScaleStacked ? (
+        <HorizontalStackedBars
+          animationDelay={animationDelay}
+          ariaLabel={ariaLabel}
+          barHeight={barHeight}
+          groupIndex={index}
+          isAnimated={isAnimated}
+          name={name}
+          series={series}
+          theme={theme}
+          xScale={xScaleStacked}
+        />
+      ) : (
+        <HorizontalBars
+          animationDelay={animationDelay}
+          ariaLabel={ariaLabel}
+          barHeight={barHeight}
+          groupIndex={index}
+          isAnimated={isAnimated}
+          isSimple={isSimple}
+          labelFormatter={labelFormatter}
+          name={name}
+          series={series}
+          theme={theme}
+          xScale={xScale}
+          zeroPosition={zeroPosition}
+        />
+      )}
+    </animated.g>
+  );
+}

--- a/src/components/shared/HorizontalGroup/index.ts
+++ b/src/components/shared/HorizontalGroup/index.ts
@@ -1,0 +1,1 @@
+export {HorizontalGroup} from './HorizontalGroup';

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -3,3 +3,4 @@ export {GroupLabel} from './GroupLabel';
 export {Bar} from './Bar';
 export {HorizontalBars} from './HorizontalBars';
 export {HorizontalStackedBars} from './HorizontalStackedBars';
+export {HorizontalGroup} from './HorizontalGroup';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,3 +16,5 @@ export {useHasTimeoutFinished} from './useHasTimeoutFinished';
 export {useDataForHorizontalChart} from './useDataForHorizontalChart';
 export {useHorizontalBarSizes} from './useHorizontalBarSizes';
 export {useHorizontalXScale} from './useHorizontalXScale';
+export {useHorizontalTransitions} from './useHorizontalTransitions';
+export {useHorizontalSeriesColors} from './useHorizontalSeriesColors';

--- a/src/hooks/useHorizontalSeriesColors.ts
+++ b/src/hooks/useHorizontalSeriesColors.ts
@@ -1,0 +1,49 @@
+import {useMemo} from 'react';
+
+import type {DataSeries} from '../types';
+
+import {getSeriesColorsFromCount} from './use-theme-series-colors';
+import {useTheme} from './useTheme';
+
+interface Props {
+  series: DataSeries[];
+  formattedSeries: DataSeries[];
+  theme?: string;
+}
+
+export function useHorizontalSeriesColors({
+  series,
+  formattedSeries,
+  theme,
+}: Props) {
+  const selectedTheme = useTheme(theme);
+
+  const longestSeriesCount = useMemo(() => {
+    return formattedSeries.reduce((prev, cur) => {
+      const count = cur.data.length;
+
+      return count > prev ? count : prev;
+    }, 0);
+  }, [formattedSeries]);
+
+  const seriesColors = useMemo(() => {
+    const seriesColors = getSeriesColorsFromCount(
+      longestSeriesCount,
+      selectedTheme,
+    );
+
+    series.forEach(({color}, index) => {
+      if (color != null) {
+        seriesColors.splice(index, 0, color);
+        // Remove the extra seriesColor from the
+        // end of the array so we're not rendering
+        // unused defs
+        seriesColors.pop();
+      }
+    });
+
+    return seriesColors;
+  }, [longestSeriesCount, series, selectedTheme]);
+
+  return {longestSeriesCount, seriesColors};
+}

--- a/src/hooks/useHorizontalTransitions.ts
+++ b/src/hooks/useHorizontalTransitions.ts
@@ -1,0 +1,69 @@
+import {useTransition} from '@react-spring/web';
+import {useMemo, useState} from 'react';
+
+import {BARS_SORT_TRANSITION_CONFIG} from '../constants';
+import type {DataSeries} from '../types';
+
+interface Props {
+  series: DataSeries[];
+  groupHeight: number;
+  isAnimated: boolean;
+}
+
+export function useHorizontalTransitions({
+  series,
+  groupHeight,
+  isAnimated,
+}: Props) {
+  const seriesWithIndex = useMemo(() => {
+    return series.map((series, index) => ({
+      series,
+      index,
+    }));
+  }, [series]);
+
+  const getTransform = (index: number) => {
+    return `translate(0px,${groupHeight * index}px)`;
+  };
+
+  const [isFirstRender, setIsFirstRender] = useState(true);
+
+  const handleOnTransitionRest = () => {
+    setIsFirstRender(false);
+  };
+
+  const animationTrail = isFirstRender ? 0 : 50;
+  const outOfChartPosition = getTransform(series.length + 1);
+
+  const transitions = useTransition(seriesWithIndex, {
+    keys: (item) => {
+      return item.series.name ?? '';
+    },
+    initial: ({index}) => ({
+      opacity: isFirstRender ? 1 : 0,
+      transform: isFirstRender ? getTransform(index) : outOfChartPosition,
+    }),
+    from: {
+      opacity: 0,
+      transform: outOfChartPosition,
+    },
+    leave: {
+      opacity: 0,
+      transform: outOfChartPosition,
+    },
+    enter: () => ({
+      opacity: 0,
+      transform: outOfChartPosition,
+    }),
+    update: ({index}) => ({opacity: 1, transform: getTransform(index)}),
+    expires: true,
+    config: BARS_SORT_TRANSITION_CONFIG,
+    trail: isAnimated ? animationTrail : 0,
+    default: {
+      immediate: !isAnimated,
+      onRest: handleOnTransitionRest,
+    },
+  });
+
+  return {transitions, isFirstRender};
+}

--- a/src/utilities/format-data-for-horizontal-bar-chart.ts
+++ b/src/utilities/format-data-for-horizontal-bar-chart.ts
@@ -1,0 +1,35 @@
+import type {DataSeries} from '../types';
+
+// The format between MultiSeriesBarChart and HorizontalBarChart
+// is a little bit different. Until we can take the time
+// to change how HorizontalBarChart renders the bars,
+// we're going to alter the format into what HorizontalBarChart
+// expects.
+export function formatDataForHorizontalBarChart(
+  series: DataSeries[],
+): DataSeries[] {
+  const roots: DataSeries[] = [];
+
+  series.forEach(({name, data}) => {
+    data.forEach(({key, value}, index) => {
+      if (!roots[index]) {
+        roots.push({
+          name: `${key}`,
+          data: [
+            {
+              key: `${name}`,
+              value,
+            },
+          ],
+        });
+      } else {
+        roots[index].data.push({
+          key: `${name}`,
+          value,
+        });
+      }
+    });
+  });
+
+  return roots;
+}

--- a/src/utilities/get-highest-sum-for-stacked.ts
+++ b/src/utilities/get-highest-sum-for-stacked.ts
@@ -1,0 +1,12 @@
+import type {DataSeries} from 'types';
+
+export function getHighestSumForStacked(series: DataSeries[]) {
+  const numbers: number[] = [];
+
+  series.forEach(({data}) => {
+    const sum = data.reduce((prev, {value}) => prev + value, 0);
+    numbers.push(sum);
+  });
+
+  return Math.max(...numbers);
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -26,3 +26,5 @@ export {
 } from './change-color-opacity';
 export {getRoundedRectPath} from './get-rounded-rect-path';
 export {getBarId} from './get-bar-id';
+export {formatDataForHorizontalBarChart} from './format-data-for-horizontal-bar-chart';
+export {getHighestSumForStacked} from './get-highest-sum-for-stacked';


### PR DESCRIPTION
## What does this implement/fix?

Currently the`<HorizontalBarChart />` & `<SimpleBarChart />` expect data that is different than what we want to provide with the `DataSeries` change. We want to use the same format as `<MultiSeriesBarChart />`.

Instead of rewriting how `<HorizontalBarChart />` works, we're going to format the data to what's expected and then refactor later once the rename work is done.

This PR also wraps up the work from https://github.com/Shopify/polaris-viz/pull/717 so both `<HorizontalBarChart />` and `<SimpleBarChart />` are all using the shared hooks and components.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
