### PR TITLE
Use average gradient color intead of first color in the gradient ( Areas on LineChart ) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Use average color between gradient stops for `<LineChart />` area color.
+
 ## [0.25.3] - 2021-11-22
 
 - Add unique id to series colors used in `<HorizontalBarChart />`.

--- a/src/utilities/get-average-color.ts
+++ b/src/utilities/get-average-color.ts
@@ -1,0 +1,21 @@
+import {color} from 'd3-color';
+
+export const getAverageColor = (firstColor: string, lastColor: string) => {
+  if (firstColor === lastColor) {
+    return firstColor;
+  }
+
+  const first = color(firstColor);
+  const last = color(lastColor);
+
+  if (!first || !last) {
+    return first?.toString() ?? last?.toString() ?? '';
+  }
+
+  const {r: r1, g: g1, b: b1} = first.rgb();
+  const {r: r2, g: g2, b: b2} = last.rgb();
+
+  return `rgb(${Math.round((r1 + r2) / 2)},${Math.round(
+    (g1 + g2) / 2,
+  )},${Math.round((b1 + b2) / 2)})`;
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -25,3 +25,4 @@ export {
   changeGradientOpacity,
 } from './change-color-opacity';
 export {getRoundedRectPath} from './get-rounded-rect-path';
+export {getAverageColor} from './get-average-color';

--- a/src/utilities/tests/get-average-color.test.ts
+++ b/src/utilities/tests/get-average-color.test.ts
@@ -1,0 +1,33 @@
+import {getAverageColor} from '../';
+
+describe('getAverageColor', () => {
+  it('returns average color from 2 different colors', () => {
+    const result = getAverageColor('red', 'green');
+    expect(result).toStrictEqual('rgb(128,64,0)');
+  });
+
+  it('returns first color if both are the same', () => {
+    const result = getAverageColor('red', 'red');
+    expect(result).toStrictEqual('red');
+  });
+
+  it('returns last color if first value is empty', () => {
+    const result = getAverageColor('', 'red');
+    expect(result).toStrictEqual('rgb(255, 0, 0)');
+  });
+
+  it('returns first color if last value is empty', () => {
+    const result = getAverageColor('red', '');
+    expect(result).toStrictEqual('rgb(255, 0, 0)');
+  });
+
+  it('returns empty string if both values are empty', () => {
+    const result = getAverageColor('', '');
+    expect(result).toStrictEqual('');
+  });
+
+  it('returns empty string is both values are not valid colors', () => {
+    const result = getAverageColor('trees', 'cars');
+    expect(result).toStrictEqual('');
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

Instead of using the first color of a gradient stop to determine the color of the area of a line chart, we're going to calculate the average color between the start and end stops.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/143039218-a04db664-e059-476b-af15-13d9451a27ac.png)|![image](https://user-images.githubusercontent.com/149873/143038975-39ae0fa9-1dda-4098-801f-a544f9b5da5a.png)|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
