### PR TITLE
Truncate group labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Correctly truncate long group labels in `<HorizontalBarChart />`.
+
 ## [0.25.1] - 2021-11-16
 
 ### Added

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -298,6 +298,7 @@ export function Chart({
             >
               <GroupLabel
                 areAllNegative={areAllNegative}
+                containerWidth={width}
                 label={name}
                 theme={theme}
                 zeroPosition={zeroPosition}

--- a/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.scss
+++ b/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.scss
@@ -1,0 +1,5 @@
+@import '../../../../styles/common';
+
+.Label {
+  @include ellipsis-overflow;
+}

--- a/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
+++ b/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
@@ -5,21 +5,29 @@ import {FONT_SIZE} from '../../../../constants';
 import {getTextWidth} from '../../../../utilities';
 import {LABEL_HEIGHT} from '../../constants';
 
+import styles from './GroupLabel.scss';
+
 interface GroupLabelProps {
   areAllNegative: boolean;
+  containerWidth: number;
   label: string;
-  theme?: string;
   zeroPosition: number;
+  theme?: string;
 }
 
 export function GroupLabel({
   areAllNegative,
+  containerWidth,
   label,
   theme,
   zeroPosition,
 }: GroupLabelProps) {
   const labelWidth = getTextWidth({text: label, fontSize: FONT_SIZE});
   const selectedTheme = useTheme(theme);
+
+  const maxWidth = areAllNegative
+    ? labelWidth + LABEL_HEIGHT
+    : containerWidth - zeroPosition;
 
   return (
     <foreignObject
@@ -29,12 +37,13 @@ export function GroupLabel({
       aria-hidden="true"
     >
       <div
+        className={styles.Label}
         style={{
           background: selectedTheme.chartContainer.backgroundColor,
           fontSize: `${FONT_SIZE}px`,
           color: selectedTheme.yAxis.labelColor,
           height: LABEL_HEIGHT,
-          width: labelWidth + LABEL_HEIGHT,
+          maxWidth,
         }}
       >
         {label}


### PR DESCRIPTION
## What does this implement/fix?

Long group labels were not being truncated correctly.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/31517

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/142929480-2f36bb1d-d743-400d-b477-07b72e82a24b.png)|![image](https://user-images.githubusercontent.com/149873/142929439-25728fd4-71ba-4562-9d43-db65010ebe63.png)|
|![image](https://user-images.githubusercontent.com/149873/142932618-bf3790f7-c052-4f63-845c-00b88c73ffb4.png)|![image](https://user-images.githubusercontent.com/149873/142932383-6cd6157e-e7dd-4699-9a43-3ec13fa014a5.png)|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
