### PR TITLE
Add unique id to stop chart colors from clashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add unique id to series colors used in `<HorizontalBarChart />`.
+
 ## [0.25.2] - 2021-11-22
 
 ### Changed

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -8,7 +8,7 @@ import {
   HORIZONTAL_BAR_GROUP_DELAY,
   BARS_SORT_TRANSITION_CONFIG,
 } from '../../constants';
-import {eventPointNative} from '../../utilities';
+import {eventPointNative, uniqueId} from '../../utilities';
 import {DataType, Dimensions} from '../../types';
 import {
   TOOLTIP_POSITION_DEFAULT_RETURN,
@@ -59,6 +59,7 @@ export function Chart({
 }: ChartProps) {
   const selectedTheme = useTheme(theme);
   const {labelFormatter} = xAxisOptions;
+  const id = uniqueId('HorizontalBarChart');
 
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
 
@@ -176,13 +177,14 @@ export function Chart({
     series.forEach(({data}, groupIndex) => {
       data.forEach(({color}, seriesIndex) => {
         if (color != null) {
-          colors.push({id: getBarId(groupIndex, seriesIndex), color});
+          colors.push({id: getBarId(id, groupIndex, seriesIndex), color});
         }
       });
     });
 
     return colors;
-  }, [series]);
+  }, [series, id]);
+
   const seriesWithIndex = series.map((series, index) => ({
     series,
     index,
@@ -310,6 +312,7 @@ export function Chart({
                   ariaLabel={ariaLabel}
                   barHeight={barHeight}
                   groupIndex={index}
+                  id={id}
                   isAnimated={isAnimated}
                   name={name}
                   series={item.series.data}
@@ -322,6 +325,7 @@ export function Chart({
                   ariaLabel={ariaLabel}
                   barHeight={barHeight}
                   groupIndex={index}
+                  id={id}
                   isAnimated={isAnimated}
                   isSimple={isSimple}
                   labelFormatter={labelFormatter}

--- a/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
+++ b/src/components/HorizontalBarChart/components/GroupLabel/GroupLabel.tsx
@@ -43,6 +43,7 @@ export function GroupLabel({
           fontSize: `${FONT_SIZE}px`,
           color: selectedTheme.yAxis.labelColor,
           height: LABEL_HEIGHT,
+          width: labelWidth + LABEL_HEIGHT,
           maxWidth,
         }}
       >

--- a/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/HorizontalBarChart/components/HorizontalBars/HorizontalBars.tsx
@@ -21,6 +21,7 @@ interface HorizontalBarProps {
   ariaLabel: string;
   barHeight: number;
   groupIndex: number;
+  id: string;
   isAnimated: boolean;
   isSimple: boolean;
   labelFormatter: LabelFormatter;
@@ -37,6 +38,7 @@ export function HorizontalBars({
   ariaLabel,
   barHeight,
   groupIndex,
+  id,
   isAnimated,
   isSimple,
   labelFormatter,
@@ -57,7 +59,7 @@ export function HorizontalBars({
       {series.map(({rawValue, color}, seriesIndex) => {
         const isNegative = rawValue < 0;
         const label = labelFormatter(rawValue);
-        const id = getBarId(groupIndex, seriesIndex);
+        const barId = getBarId(id, groupIndex, seriesIndex);
 
         const labelWidth = getTextWidth({
           text: `${label}`,
@@ -71,7 +73,7 @@ export function HorizontalBars({
         const negativeX = (width + leftLabelOffset) * -1;
         const x = isNegative ? negativeX : width + BAR_LABEL_OFFSET;
         const ariaHidden = seriesIndex !== 0;
-        const barColor = color ? id : getGradientDefId(theme, seriesIndex);
+        const barColor = color ? barId : getGradientDefId(theme, seriesIndex);
 
         return (
           <React.Fragment key={`series-${barColor}-${name}`}>

--- a/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
+++ b/src/components/HorizontalBarChart/components/StackedBars/StackedBars.tsx
@@ -15,6 +15,7 @@ export interface StackedBarsProps {
   ariaLabel: string;
   barHeight: number;
   groupIndex: number;
+  id: string;
   isAnimated: boolean;
   name: string;
   series: Data[];
@@ -27,6 +28,7 @@ export function StackedBars({
   ariaLabel,
   barHeight,
   groupIndex,
+  id,
   isAnimated,
   name,
   series,
@@ -62,14 +64,14 @@ export function StackedBars({
     <animated.g aria-label={ariaLabel} role="listitem" style={{transform}}>
       {series.map(({rawValue, color}, seriesIndex) => {
         const x = xOffsets[seriesIndex] + STACKED_BAR_GAP * seriesIndex;
-        const id = getBarId(groupIndex, seriesIndex);
+        const barId = getBarId(id, groupIndex, seriesIndex);
         const isLast = seriesIndex === series.length - 1;
 
-        const sliceColor = color ? id : `${GRADIENT_ID}${seriesIndex}`;
+        const sliceColor = color ? barId : `${GRADIENT_ID}${seriesIndex}`;
 
         return (
           <StackedBar
-            color={color ? id : getGradientDefId(theme, seriesIndex)}
+            color={color ? barId : getGradientDefId(theme, seriesIndex)}
             groupIndex={groupIndex}
             height={barHeight}
             isAnimated={isAnimated}

--- a/src/components/HorizontalBarChart/utilities/getBarId.ts
+++ b/src/components/HorizontalBarChart/utilities/getBarId.ts
@@ -1,3 +1,3 @@
-export function getBarId(groupIndex: number, seriesIndex: number) {
-  return `series-${groupIndex}-${seriesIndex}`;
+export function getBarId(id: string, groupIndex: number, seriesIndex: number) {
+  return `${id}-series-${groupIndex}-${seriesIndex}`;
 }


### PR DESCRIPTION
## What does this implement/fix?

When building the defs for the gradients used for coloring the bars, the ids generated were scoped to the indexes. This causes issues if more than one `<HorizontalBarChart />` is used on a page.

The sizing for the rest of the charts will use the first chart rendered on the page. 

This change scopes the defs to each individual component, not just the series indexes.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/31521 and https://github.com/Shopify/core-issues/issues/31524

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/142941697-4e92e7ce-f2d1-49db-aacb-46a2e7c8bbbf.png)|![image](https://user-images.githubusercontent.com/149873/142941455-da0cf13f-366a-4e09-ac7f-8898b5705780.png)|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
