### PR TITLE
Prevents error when series are removed on `HorizontalBarChart` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolves issue where removal of series in a `<HorizontalBarChart />` can lead to throwing of a TypeError.
+
 ## [0.25.4] - 2021-11-25
 
 ### Changed

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -276,13 +276,12 @@ export function Chart({
         />
 
         {transitions(({opacity, transform}, item, _transition, index) => {
-          const {name} = item.series;
-          const ariaLabel = getAriaLabel(name, item.index);
-
           if (series[index] == null) {
             return null;
           }
 
+          const {name} = item.series;
+          const ariaLabel = getAriaLabel(name, item.index);
           const animationDelay =
             isFirstRender && isAnimated
               ? (HORIZONTAL_BAR_GROUP_DELAY * index) / series.length


### PR DESCRIPTION
## What does this implement/fix?

Load `HorizontalBarChart` in storybook. Remove the most bottom series from the options below. You might have to do this a couple of times, but you should eventually get a Type error because `series[index]` resolves to `undefined`.

The reason this is happening is that `transitions` iterates over what it knows to be the current series which doesn't update in time with the actual series prop. As a result certain indexes might already be removed when the callback of `transitions` is trying to access them using `series[index]`. 

This came to our attention because we're getting a lot of these errors in `Live View` where any series in a `HorizontalBarChart` could appear/disappear at any time (as data refreshes).

It would be great to get this merged, cut a new release and update `shopify/web` so we don't get thousands of these in bugsnag every day.

## Does this close any currently open issues?

🔗 https://github.com/Shopify/core-issues/issues/31684

## What do the changes look like?

| Before  | After  |
|---|---|
| https://user-images.githubusercontent.com/4960217/143622561-f9eb8c59-d5e9-47f4-916f-8fb3720f021e.mp4  | https://user-images.githubusercontent.com/4960217/143622679-609e8e52-5e2f-47d5-9cc1-1fb999328744.mp4 |

## Storybook link

http://localhost:6006/?path=/story/charts-horizontalbarchart--simple (Sorry I couldn't find the hosted storybook anywhere)

### Before merging

- [x] Check your changes on a variety of browsers and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.

cc: @GoodForOneFare 