### PR TITLE
Made nonSafari code more resilient in `usePrintResizing`

### DIFF
--- a/src/hooks/use-print-resizing.ts
+++ b/src/hooks/use-print-resizing.ts
@@ -53,7 +53,11 @@ export function usePrintResizing({
     const safariNotServer = isSafari && !isServer;
 
     if (notSafariOrServer) {
-      window.matchMedia('print').addEventListener('change', handlePrint);
+      if (addEventListener) {
+        window.matchMedia('print').addEventListener('change', handlePrint);
+      } else if (addListener) {
+        window.matchMedia('print').addListener(printSafari);
+      }
     }
 
     if (safariNotServer) {


### PR DESCRIPTION
## What does this implement/fix?

We assume nonSafari browsers support `addEventListener` on `window.matchMedia`. Unfortunately on WebViews our `isSafari` value from the current implementation misses these cases leading to [lots of errors in Bugsnag](https://app.bugsnag.com/shopify/shopify-web-client/errors/6192b1ee84be97000721b485?filters[event.since]=7d&filters[error.status]=open&filters[request.url]=%2Fadmin%2Fdashboards%2Flive&pivot_tab=event).

I'm able to load things fine on my iPhone but it's likely we have merchants who are [not able to access LiveView](https://shopify.slack.com/archives/C023SNQU0CE/p1637946322091600)

## Does this close any currently open issues?

https://github.com/Shopify/polaris-viz/issues/725

## What do the changes look like?
 
## Storybook link

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
