### PR TITLE
Don't include comparison items in series color count

### DIFF
--- a/src/hooks/tests/useHorizontalSeriesColors.test.tsx
+++ b/src/hooks/tests/useHorizontalSeriesColors.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import type {DataSeries} from '../../types';
+import {useHorizontalSeriesColors} from '../useHorizontalSeriesColors';
+import {DEFAULT_THEME, LIGHT_THEME} from '../../constants';
+
+const DATA: DataSeries[] = [
+  {
+    name: 'Group 1',
+    data: [
+      {value: 5, key: 'Label 01'},
+      {value: -10, key: 'Label 02'},
+      {value: 12, key: 'Label 03'},
+    ],
+  },
+  {
+    name: 'Group 2',
+    data: [
+      {value: 1, key: 'Label 01'},
+      {value: -2, key: 'Label 02'},
+      {value: 3, key: 'Label 03'},
+    ],
+  },
+];
+
+const MOCK_PROPS = {
+  data: DATA,
+};
+
+describe('useHorizontalSeriesColors()', () => {
+  it('returns colors with no overrides', () => {
+    function TestComponent() {
+      const data = useHorizontalSeriesColors(MOCK_PROPS);
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data).toStrictEqual({
+      longestSeriesCount: 3,
+      seriesColors: [...DEFAULT_THEME.seriesColors.upToFour].splice(0, 2),
+    });
+  });
+
+  it('returns colors for theme', () => {
+    function TestComponent() {
+      const data = useHorizontalSeriesColors({...MOCK_PROPS, theme: 'Light'});
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data).toStrictEqual({
+      longestSeriesCount: 3,
+      seriesColors: LIGHT_THEME.seriesColors.upToFour.splice(0, 2),
+    });
+  });
+
+  it('returns colors with overrides', () => {
+    function TestComponent() {
+      const data = useHorizontalSeriesColors({
+        data: [
+          {
+            name: 'Group 1',
+            data: [
+              {value: 5, key: 'Label 01'},
+              {value: -10, key: 'Label 02'},
+            ],
+            color: 'red',
+          },
+          {
+            name: 'Group 2',
+            data: [
+              {value: 1, key: 'Label 01'},
+              {value: -2, key: 'Label 02'},
+            ],
+          },
+        ],
+      });
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data).toStrictEqual({
+      longestSeriesCount: 2,
+      seriesColors: ['red', DEFAULT_THEME.seriesColors.upToFour[0]],
+    });
+  });
+
+  it('returns comparison colors', () => {
+    function TestComponent() {
+      const data = useHorizontalSeriesColors({
+        data: [
+          {
+            name: 'Group 1',
+            data: [
+              {value: 5, key: 'Label 01'},
+              {value: -10, key: 'Label 02'},
+              {value: 12, key: 'Label 03'},
+            ],
+          },
+          {
+            name: 'Group 2',
+            isComparison: true,
+            data: [
+              {value: 1, key: 'Label 01'},
+              {value: -2, key: 'Label 02'},
+              {value: 3, key: 'Label 03'},
+            ],
+          },
+        ],
+      });
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data).toStrictEqual({
+      longestSeriesCount: 3,
+      seriesColors: [DEFAULT_THEME.seriesColors.single, 'colorDarkComparison'],
+    });
+  });
+});

--- a/src/hooks/useHorizontalSeriesColors.ts
+++ b/src/hooks/useHorizontalSeriesColors.ts
@@ -22,7 +22,14 @@ export function useHorizontalSeriesColors({data, theme}: Props) {
   }, [data]);
 
   const seriesColors = useMemo(() => {
-    const seriesColors = getSeriesColorsFromCount(data.length, selectedTheme);
+    const nonComparison = data.filter(
+      ({isComparison}) => isComparison !== true,
+    );
+
+    const seriesColors = getSeriesColorsFromCount(
+      nonComparison.length,
+      selectedTheme,
+    );
 
     data.forEach(({color, isComparison}, index) => {
       let newColor;
@@ -35,14 +42,10 @@ export function useHorizontalSeriesColors({data, theme}: Props) {
 
       if (newColor) {
         seriesColors.splice(index, 0, newColor);
-        // Remove the extra seriesColor from the
-        // end of the array so we're not rendering
-        // unused defs
-        seriesColors.pop();
       }
     });
 
-    return seriesColors;
+    return seriesColors.slice(0, data.length);
   }, [data, selectedTheme]);
 
   return {longestSeriesCount, seriesColors};


### PR DESCRIPTION
## What does this implement/fix?

Based on feedback from @mirualves in another PR: https://github.com/Shopify/polaris-viz/pull/733#issuecomment-983010953 - we realized that we were using the wrong colors when comparison data was available.

We weren't correctly removing comparison data when grabbing the series sets for single or multiple sets.

Now, if we have 2 sets of data, 1 being a comparison, we'll use the single series colors.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/144131487-cebcf80d-505c-4b78-bbd4-50d442966d49.png)|![image](https://user-images.githubusercontent.com/149873/144131091-e013c5ef-81f0-4051-86dd-2d4c398a94ba.png)|
 