### PR TITLE
apply position relative to the chart container

### DIFF
--- a/src/styles/shared/_chart-container.scss
+++ b/src/styles/shared/_chart-container.scss
@@ -1,4 +1,5 @@
 @mixin chart-container {
+  position: relative;
   width: 100%;
   height: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
## What does this implement/fix?

Apply `position: relative` to the chart container mixin, to avoid the breaking the tooltip position:

![image (12)](https://user-images.githubusercontent.com/4037781/144299819-f10bfe28-f006-4449-b54d-7220c1ad29d7.png)


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
