### PR TITLE
Move SkipLink and renderTooltipContent to main BarChart component

### DIFF
--- a/src/components/BarChart/tests/BarChart.test.tsx
+++ b/src/components/BarChart/tests/BarChart.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {SkipLink} from '../../../components/SkipLink';
+import {BarChart, BarChartProps} from '../BarChart';
+import {VerticalBarChart} from '../../VerticalBarChart';
+import {HorizontalBarChart} from '../../HorizontalBarChart';
+
+describe('<BarChart />', () => {
+  const mockProps: BarChartProps = {
+    data: [
+      {
+        data: [
+          {key: 'Something', value: 10},
+          {key: 'Another', value: 20},
+          {key: 'Thing', value: 30},
+        ],
+        color: 'black',
+        name: 'LABEL1',
+      },
+    ],
+    xAxisOptions: {},
+    skipLinkText: 'Skip Chart Content',
+  };
+
+  it('passes down renderTooltipContent() when not provided to parent props', () => {
+    const chart = mount(<BarChart {...mockProps} />);
+    const barChart = chart.find(VerticalBarChart);
+
+    expect(barChart?.props.renderTooltipContent).toBeDefined();
+  });
+
+  it('sets defaults for xAxisOptions', () => {
+    const chart = mount(<BarChart {...mockProps} />);
+    const barChart = chart.find(VerticalBarChart);
+
+    expect(barChart?.props.xAxisOptions.labelFormatter).toBeDefined();
+    expect(barChart?.props.xAxisOptions.hide).toStrictEqual(false);
+    expect(barChart?.props.xAxisOptions.wrapLabels).toStrictEqual(false);
+  });
+
+  describe('direction', () => {
+    it('renders a <VerticalBarChart /> when vertical', () => {
+      const chart = mount(<BarChart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(VerticalBarChart);
+    });
+
+    it('renders a <HorizontalBarChart /> when horizontal', () => {
+      const chart = mount(<BarChart {...mockProps} direction="horizontal" />);
+
+      expect(chart).toContainReactComponent(HorizontalBarChart);
+    });
+  });
+
+  describe('skipLinkText', () => {
+    it('renders a <SkipLink />', () => {
+      const chart = mount(<BarChart {...mockProps} />);
+
+      expect(chart).toContainReactComponent(SkipLink);
+    });
+
+    it('does not render a <SkipLink /> when data is empty', () => {
+      const chart = mount(<BarChart {...mockProps} data={[]} />);
+
+      expect(chart).not.toContainReactComponent(SkipLink);
+    });
+  });
+});

--- a/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,7 +1,6 @@
 import React, {ReactNode} from 'react';
 
 import type {ChartType, DataSeries} from '../../types';
-import {TooltipContent} from '../TooltipContent';
 import {ChartContainer} from '../../components/ChartContainer';
 import {usePrefersReducedMotion} from '../../hooks';
 import type {RenderTooltipContentData, XAxisOptions} from '../BarChart';
@@ -10,11 +9,11 @@ import {Chart} from './Chart';
 
 export interface HorizontalBarChartProps {
   data: DataSeries[];
+  renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  xAxisOptions: XAxisOptions;
   isAnimated?: boolean;
-  renderTooltipContent?: (data: RenderTooltipContentData) => ReactNode;
   theme?: string;
   type?: ChartType;
-  xAxisOptions?: XAxisOptions;
 }
 
 export function HorizontalBarChart({
@@ -34,28 +33,12 @@ export function HorizontalBarChart({
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
 
-  function renderTooltip({data}: RenderTooltipContentData) {
-    if (renderTooltipContent != null) {
-      return renderTooltipContent({data});
-    }
-
-    const tooltipData = data.map(({value, label, color}) => {
-      return {
-        label,
-        value: xAxisOptionsForChart.labelFormatter!(value),
-        color,
-      };
-    });
-
-    return <TooltipContent data={tooltipData} theme={theme} />;
-  }
-
   return (
     <ChartContainer theme={theme}>
       <Chart
         data={data}
         isAnimated={isAnimated && !prefersReducedMotion}
-        renderTooltipContent={renderTooltip}
+        renderTooltipContent={renderTooltipContent}
         type={type}
         xAxisOptions={xAxisOptionsForChart}
       />

--- a/src/components/HorizontalBarChart/tests/HorizontalBarChart.test.tsx
+++ b/src/components/HorizontalBarChart/tests/HorizontalBarChart.test.tsx
@@ -10,6 +10,8 @@ import {Chart} from '../Chart';
 
 const mockProps: HorizontalBarChartProps = {
   data: [{name: 'Test', data: [{value: 10, key: 'data'}]}],
+  xAxisOptions: {},
+  renderTooltipContent: (value) => `${value}`,
 };
 
 describe('<HorizontalBarChart />', () => {

--- a/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -1,9 +1,6 @@
-import React, {useRef} from 'react';
+import React from 'react';
 
 import {ChartContainer} from '../../components/ChartContainer';
-import {SkipLink} from '../SkipLink';
-import {TooltipContent} from '../TooltipContent';
-import {uniqueId} from '../../utilities';
 import {useTheme, useThemeSeriesColors} from '../../hooks';
 import type {ChartType, DataSeries} from '../../types';
 import type {
@@ -16,14 +13,12 @@ import {Chart} from './Chart';
 
 export interface VerticalBarChartProps {
   data: DataSeries[];
-  renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
-
+  renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
+  xAxisOptions: XAxisOptions;
   barOptions?: {isStacked: boolean};
   emptyStateText?: string;
   isAnimated?: boolean;
-  skipLinkText?: string;
   theme?: string;
-  xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
   type?: ChartType;
 }
@@ -31,7 +26,6 @@ export interface VerticalBarChartProps {
 export function VerticalBarChart({
   data,
   renderTooltipContent,
-  skipLinkText,
   isAnimated = false,
   xAxisOptions,
   yAxisOptions,
@@ -42,31 +36,11 @@ export function VerticalBarChart({
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(data, selectedTheme);
 
-  const skipLinkAnchorId = useRef(uniqueId('VerticalBarChart'));
-
-  const emptyState = data.length === 0;
-
-  const xAxisOptionsWithDefaults: XAxisOptions = {
-    labelFormatter: (value: string) => value,
-    wrapLabels: true,
-    ...xAxisOptions,
-  };
-
   const yAxisOptionsWithDefaults: Required<YAxisOptions> = {
     labelFormatter: (value: number) => value.toString(),
     integersOnly: false,
     ...yAxisOptions,
   };
-
-  function renderDefaultTooltipContent({data}: RenderTooltipContentData) {
-    const formattedData = data.map(({label, value, color}) => ({
-      color,
-      label,
-      value: yAxisOptionsWithDefaults.labelFormatter(value),
-    }));
-
-    return <TooltipContent theme={theme} data={formattedData} />;
-  }
 
   const seriesWithDefaults = data.map((series, index) => ({
     color: seriesColors[index],
@@ -75,32 +49,17 @@ export function VerticalBarChart({
 
   return (
     <React.Fragment>
-      {skipLinkText == null ||
-      skipLinkText.length === 0 ||
-      emptyState ? null : (
-        <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
-      )}
       <ChartContainer theme={theme}>
         <Chart
           data={seriesWithDefaults}
-          xAxisOptions={xAxisOptionsWithDefaults}
+          xAxisOptions={xAxisOptions}
           yAxisOptions={yAxisOptionsWithDefaults}
           isAnimated={isAnimated}
-          renderTooltipContent={
-            renderTooltipContent != null
-              ? renderTooltipContent
-              : renderDefaultTooltipContent
-          }
+          renderTooltipContent={renderTooltipContent}
           emptyStateText={emptyStateText}
           type={type}
         />
       </ChartContainer>
-
-      {skipLinkText == null ||
-      skipLinkText.length === 0 ||
-      emptyState ? null : (
-        <SkipLink.Anchor id={skipLinkAnchorId.current} />
-      )}
     </React.Fragment>
   );
 }

--- a/src/components/VerticalBarChart/tests/VerticalBarChart.test.tsx
+++ b/src/components/VerticalBarChart/tests/VerticalBarChart.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
-import {SkipLink} from '../../../components/SkipLink';
 import {VerticalBarChart, VerticalBarChartProps} from '../VerticalBarChart';
 import {Chart} from '../Chart';
 
@@ -18,29 +17,13 @@ describe('<VerticalBarChart />', () => {
         name: 'LABEL1',
       },
     ],
+    renderTooltipContent: (value) => `${value}`,
     xAxisOptions: {},
-    skipLinkText: 'Skip Chart Content',
   };
 
   it('renders a <Chart />', () => {
     const verticalBarChart = mount(<VerticalBarChart {...mockProps} />);
 
     expect(verticalBarChart).toContainReactComponent(Chart);
-  });
-
-  describe('skipLinkText', () => {
-    it('renders a <SkipLink />', () => {
-      const verticalBarChart = mount(<VerticalBarChart {...mockProps} />);
-
-      expect(verticalBarChart).toContainReactComponent(SkipLink);
-    });
-
-    it('does not render a <SkipLink /> when series is empty', () => {
-      const verticalBarChart = mount(
-        <VerticalBarChart {...mockProps} data={[]} />,
-      );
-
-      expect(verticalBarChart).not.toContainReactComponent(SkipLink);
-    });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

Now that vertical and horizontal bar charts are sharing almost the same data, we can move some functionality from `<VerticalBarChart />` into `<BarChart />` so both charts get it for "free".

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/748
