### PR TITLE
Remove LegacyDataSeries

### DIFF
--- a/src/components/Legend/Legend.tsx
+++ b/src/components/Legend/Legend.tsx
@@ -2,23 +2,16 @@ import React from 'react';
 
 import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import {useTheme} from '../../hooks';
-import type {
-  LegacyDataSeries,
-  Data,
-  NullableData,
-  LineStyle,
-  Color,
-} from '../../types';
+import type {LineStyle, Color} from '../../types';
 import {LinePreview} from '../LinePreview';
 import {SquareColorPreview} from '../SquareColorPreview';
 
 import styles from './Legend.scss';
 
-type LegendData = LegacyDataSeries<Data | NullableData, Color>;
-
-interface LegendSeries extends Omit<LegendData, 'data'> {
+interface LegendSeries {
   lineStyle?: LineStyle;
-  data?: (Data | NullableData)[];
+  name?: string;
+  color?: Color;
 }
 
 export interface Props {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,12 +24,6 @@ export interface NullableData {
 
 export type LineStyle = 'dashed' | 'solid' | 'dotted';
 
-export interface LegacyDataSeries<T, C> {
-  name: string;
-  data: T[];
-  color?: C;
-}
-
 export interface GradientStop {
   offset: number;
   color: string;


### PR DESCRIPTION
## What does this implement/fix?

We had a bandaid `LegacyDataSeries` type that was being used as a band-aid while we worked through the milestones.

Now that we're at the end, we can remove it.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/724
