### PR TITLE
Document DataSeries and DataPoint

### DIFF
--- a/documentation/utilities/index.ts
+++ b/documentation/utilities/index.ts
@@ -113,3 +113,48 @@ export function copyTextToClipboard(text: string) {
 
   document.body.removeChild(textArea);
 }
+
+export const SHARK_SPECIES_GROWTH = [
+  {
+    name: 'Carcharhinus obscurus',
+    data: [
+      {
+        key: '0',
+        value: 80,
+      },
+      {
+        key: '5',
+        value: 170,
+      },
+      {
+        key: '10',
+        value: 210,
+      },
+      {
+        key: '15',
+        value: 240,
+      },
+    ],
+  },
+  {
+    name: 'Carcharhinus brevipinna',
+    data: [
+      {
+        key: '0',
+        value: 80,
+      },
+      {
+        key: '5',
+        value: 180,
+      },
+      {
+        key: '10',
+        value: 250,
+      },
+      {
+        key: '15',
+        value: 300,
+      },
+    ],
+  },
+];

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -48,11 +48,17 @@ export function BarChart({
   const hideSkipLink =
     skipLinkText == null || skipLinkText.length === 0 || emptyState;
 
-  const xAxisOptionsForChart: XAxisOptions = {
+  const xAxisOptionsForChart: Required<XAxisOptions> = {
     labelFormatter: (value: string) => value,
     hide: false,
     wrapLabels: false,
     ...xAxisOptions,
+  };
+
+  const yAxisOptionsForChart: Required<YAxisOptions> = {
+    labelFormatter: (value: number) => value.toString(),
+    integersOnly: false,
+    ...yAxisOptions,
   };
 
   function renderTooltip({data}: RenderTooltipContentData) {
@@ -63,7 +69,7 @@ export function BarChart({
     const tooltipData = data.map(({value, label, color, type}) => {
       return {
         label,
-        value: xAxisOptionsForChart.labelFormatter!(value),
+        value: yAxisOptionsForChart.labelFormatter(value),
         color,
         type,
       };
@@ -84,7 +90,7 @@ export function BarChart({
           annotationsLookupTable={annotationsLookupTable}
           data={data}
           xAxisOptions={xAxisOptionsForChart}
-          yAxisOptions={yAxisOptions}
+          yAxisOptions={yAxisOptionsForChart}
           theme={theme}
           type={type}
           emptyStateText={emptyStateText}

--- a/src/components/BarChart/types.ts
+++ b/src/components/BarChart/types.ts
@@ -14,8 +14,8 @@ export interface XAxisOptions {
 }
 
 export interface YAxisOptions {
-  labelFormatter: LabelFormatter;
-  integersOnly: boolean;
+  labelFormatter?: LabelFormatter;
+  integersOnly?: boolean;
 }
 
 export interface Annotation {

--- a/src/components/Docs/stories/Data.stories.mdx
+++ b/src/components/Docs/stories/Data.stories.mdx
@@ -1,0 +1,353 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks';
+
+import {SHARK_SPECIES_GROWTH} from '../../../../documentation/utilities';
+import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {BarChart, LineChart} from '../../';
+import {
+  Divider,
+  ComponentContainer,
+  Title,
+  ExamplesGrid,
+  SampleSparkbar,
+  SampleSparkLineChart,
+  SampleBarChart,
+  PropertyTable,
+  SampleLineChart,
+  SampleStackedAreaChart,
+  SampleSimpleNormalizedChart,
+} from './components';
+
+<Meta
+  title="Docs/Data Structure"
+  parameters={{
+    viewMode: 'docs',
+    docsOnly: true,
+  }}
+/>
+
+<PolarisVizProvider>
+
+<div style={{ margin: '0 auto', maxWidth: '800px', color: 'white'}}>
+<Title>🧪 Data Structure</Title>
+
+<p>
+  All Polaris Viz charts have a <code>data</code> prop that accepts an array of{' '}
+  <code>DataSeries</code>:
+</p>
+
+```tsx
+interface DataSeries {
+  data: DataPoint[];
+  color?: Color;
+  isComparison?: boolean;
+  name?: string;
+}
+```
+
+<Divider />
+<Title type="h2">Properties</Title>
+
+<Title type="h3">
+  <code>DataSeries.data</code>
+</Title>
+
+Accepts an array of `DataPoint`, where `DataPoint` is:
+
+```tsx
+interface DataPoint {
+  key: number | string;
+  value: number | null;
+}
+```
+
+<Title type="h4">Examples:</Title>
+For this sample data set, that compares the size of different shark species as they
+grow:
+
+- <code>DataSeries.name</code> is the shark species scientific name;
+- <code>DataPoint.key</code> is the shark's age in years
+- <code>DataPoint.value</code> is the shark's size in cm, in the given age
+
+```tsx
+export const SHARK_SPECIES_GROWTH = [
+  {
+    name: 'Carcharhinus obscurus',
+    data: [
+      {
+        key: '0',
+        value: 80,
+      },
+      {
+        key: '5',
+        value: 170,
+      },
+      {
+        key: '10',
+        value: 210,
+      },
+      {
+        key: '15',
+        value: 240,
+      },
+    ],
+  },
+  {
+    name: 'Carcharhinus brevipinna',
+    data: [
+      {
+        key: '0',
+        value: 80,
+      },
+      {
+        key: '5',
+        value: 180,
+      },
+      {
+        key: '10',
+        value: 250,
+      },
+      {
+        key: '15',
+        value: 350,
+      },
+    ],
+  },
+];
+```
+
+We can use the same data set to visualize the data in different ways:
+
+<ExamplesGrid cols={2}>
+
+<ComponentContainer
+  codeSample={`
+  <BarChart
+    xAxisOptions={{
+      labelFormatter: (x) => {
+        return \`\${x} years old\`
+      }
+    }}
+    yAxisOptions={{
+      labelFormatter: (y) => {
+        return \`\${y} cm\`
+      }
+    }}
+    data={SHARK_SPECIES_GROWTH}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <BarChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={SHARK_SPECIES_GROWTH}
+      />
+    </div>
+  }
+/>
+<ComponentContainer
+  codeSample={`
+  <LineChart
+    xAxisOptions={{
+      labelFormatter: (x) => {
+        return \`\${x} years old\`
+      }
+    }}
+    yAxisOptions={{
+      labelFormatter: (y) => {
+        return \`\${y} cm\`
+      }
+    }}
+    data={SHARK_SPECIES_GROWTH}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <LineChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={SHARK_SPECIES_GROWTH}
+      />
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+
+<Title type="h3">
+  <code>DataSeries.color</code>
+</Title>
+
+Can be used to overwrite the <a href='/docs/docs-themes-theme-definition--page&viewMode=docs#titleAnchor-1913'>theme's series color</a>.
+
+<Title type="h4">Examples:</Title>
+
+If we use the same data set used above, but set `color: 'lime'` to the first series:
+
+<ExamplesGrid cols={2}>
+
+<ComponentContainer
+  codeSample={`
+  <BarChart
+     //...
+     data={[
+        {
+          ...SHARK_SPECIES_GROWTH[0],
+          color: 'lime',
+        },
+        SHARK_SPECIES_GROWTH[1],
+      ]}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <BarChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={[
+          {
+            ...SHARK_SPECIES_GROWTH[0],
+            color: 'lime',
+          },
+          SHARK_SPECIES_GROWTH[1],
+        ]}
+      />
+    </div>
+  }
+/>
+<ComponentContainer
+  codeSample={`
+  <LineChart
+    //...
+     data={[
+      {
+        ...SHARK_SPECIES_GROWTH[0],
+        color: 'lime',
+      },
+      SHARK_SPECIES_GROWTH[1],
+    ]}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <LineChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={[
+          {
+            ...SHARK_SPECIES_GROWTH[0],
+            color: 'lime',
+          },
+          SHARK_SPECIES_GROWTH[1],
+        ]}
+      />
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+
+<Title type="h3">
+  <code>DataSeries.isComparison</code>
+</Title>
+
+If set to `true` will use the default styles of comparison series - gray bars and gray dashed lines.
+
+<Title type="h4">Examples:</Title>
+
+If we use the same data set used above, but set `isComparison: true` to the first series:
+
+<ExamplesGrid cols={2}>
+
+<ComponentContainer
+  codeSample={`
+  <BarChart
+     //...
+     data={[
+        {
+          ...SHARK_SPECIES_GROWTH[0],
+          isComparison: true,
+        },
+        SHARK_SPECIES_GROWTH[1],
+      ]}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <BarChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={[
+          {
+            ...SHARK_SPECIES_GROWTH[0],
+            isComparison: true,
+          },
+          SHARK_SPECIES_GROWTH[1],
+        ]}
+      />
+    </div>
+  }
+/>
+<ComponentContainer
+  codeSample={`
+  <LineChart
+    //...
+     data={[
+      {
+        ...SHARK_SPECIES_GROWTH[0],
+        isComparison: true,
+      },
+      SHARK_SPECIES_GROWTH[1],
+    ]}
+  />
+`}
+  center
+  chart={
+    <div style={{width: '350px', height: '200px'}}>
+      <LineChart
+        yAxisOptions={{
+          labelFormatter: (a) => `${a} cm`,
+        }}
+        xAxisOptions={{
+          labelFormatter: (a) => `${a} years old`,
+        }}
+        data={[
+          {
+            ...SHARK_SPECIES_GROWTH[0],
+            isComparison: true,
+          },
+          SHARK_SPECIES_GROWTH[1],
+        ]}
+      />
+    </div>
+  }
+/>
+
+</ExamplesGrid>
+</div>
+</PolarisVizProvider>

--- a/src/components/Docs/stories/components/ExamplesGrid/ExamplesGrid.tsx
+++ b/src/components/Docs/stories/components/ExamplesGrid/ExamplesGrid.tsx
@@ -1,12 +1,18 @@
 import React, {ReactChildren} from 'react';
 
-export function ExamplesGrid({children}: {children: ReactChildren}) {
+export function ExamplesGrid({
+  children,
+  cols = 2,
+}: {
+  children: ReactChildren;
+  cols: number;
+}) {
   return (
     <div
       style={{
         display: 'grid',
         gridGap: '20px',
-        gridTemplateColumns: 'repeat(2, minmax(250px, 1fr))',
+        gridTemplateColumns: `repeat(${cols}, minmax(250px, 1fr))`,
         gridTemplateRows: '1fr',
       }}
     >

--- a/src/components/VerticalBarChart/Chart.tsx
+++ b/src/components/VerticalBarChart/Chart.tsx
@@ -51,8 +51,8 @@ export interface Props {
   dimensions?: Dimensions;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   type: ChartType;
-  xAxisOptions: XAxisOptions;
-  yAxisOptions: YAxisOptions;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
   emptyStateText?: string;
   isAnimated?: boolean;

--- a/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -15,13 +15,13 @@ import {Chart} from './Chart';
 export interface VerticalBarChartProps {
   data: DataSeries[];
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
-  xAxisOptions: XAxisOptions;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
   barOptions?: {isStacked: boolean};
   emptyStateText?: string;
   isAnimated?: boolean;
   theme?: string;
-  yAxisOptions?: Partial<YAxisOptions>;
   type?: ChartType;
 }
 
@@ -39,12 +39,6 @@ export function VerticalBarChart({
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(data, selectedTheme);
 
-  const yAxisOptionsWithDefaults: Required<YAxisOptions> = {
-    labelFormatter: (value: number) => value.toString(),
-    integersOnly: false,
-    ...yAxisOptions,
-  };
-
   const seriesWithDefaults = data.map((series, index) => ({
     color: seriesColors[index],
     ...series,
@@ -57,7 +51,7 @@ export function VerticalBarChart({
           annotationsLookupTable={annotationsLookupTable}
           data={seriesWithDefaults}
           xAxisOptions={xAxisOptions}
-          yAxisOptions={yAxisOptionsWithDefaults}
+          yAxisOptions={yAxisOptions}
           isAnimated={isAnimated}
           renderTooltipContent={renderTooltipContent}
           emptyStateText={emptyStateText}

--- a/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -66,6 +66,7 @@ describe('Chart />', () => {
     xAxisOptions: {
       labelFormatter: jest.fn((value: string) => value.toString()),
       hide: false,
+      wrapLabels: false,
     },
     yAxisOptions: {
       labelFormatter: (value: number) => value.toString(),
@@ -105,6 +106,7 @@ describe('Chart />', () => {
       <Chart
         {...mockProps}
         xAxisOptions={{
+          ...mockProps.xAxisOptions,
           labelFormatter: (value: string) => `${value} pickles`,
         }}
       />,

--- a/src/components/VerticalBarChart/tests/VerticalBarChart.test.tsx
+++ b/src/components/VerticalBarChart/tests/VerticalBarChart.test.tsx
@@ -18,7 +18,15 @@ describe('<VerticalBarChart />', () => {
       },
     ],
     renderTooltipContent: (value) => `${value}`,
-    xAxisOptions: {},
+    xAxisOptions: {
+      labelFormatter: (value) => `${value}`,
+      hide: false,
+      wrapLabels: false,
+    },
+    yAxisOptions: {
+      labelFormatter: (value) => `${value}`,
+      integersOnly: false,
+    },
   };
 
   it('renders a <Chart />', () => {


### PR DESCRIPTION
## What does this implement/fix?

Creates a new `Data Structure` story, that documents `DataSeries` and `DataPoint`:

## Does this close any currently open issues?

Closes https://github.com/Shopify/polaris-viz/issues/706


## What do the changes look like?


<img width="1110" alt="Screen Shot 2021-12-09 at 4 17 35 PM" src="https://user-images.githubusercontent.com/4037781/145477179-01864cd7-61bc-46de-ad7a-7a6131665793.png">

 
## Storybook link

http://localhost:6006/?path=/docs/docs-data-structure--page

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
