### PR TITLE
Replace theme.line.dottedStrokeColor by theme.seriesColors.comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Replaced `theme.line.dottedStrokeColor` by `theme.seriesColors.comparison`
+
 ## [0.28.0] - 2021-12-07
 
 [0.28.0 Migration Guide](https://docs.google.com/document/d/1iO05cV5POYAjXI6HAiVXBHo7jWdMA7_ad3w08KQ52Dg)

--- a/src/components/Docs/stories/ThemeDefinition.stories.mdx
+++ b/src/components/Docs/stories/ThemeDefinition.stories.mdx
@@ -205,6 +205,11 @@ export interface GradientStop {
       </>
     }
   />
+  <PropertyTable.Row
+    property="seriesColors.comparison"
+    type={'string'}
+    description="CSS color string used when DataSeries.isComparison is true"
+  />
 </PropertyTable>
 
 <Title type="h4">Examples:</Title>
@@ -368,11 +373,42 @@ export interface GradientStop {
           },
         }}
       >
-        <SampleBarChart seriesLength={11}/>
+        <SampleBarChart seriesLength={11} />
       </PolarisVizProvider>
     </div>
   }
 />
+
+<ComponentContainer
+  codeSample={`
+    <PolarisVizProvider={{
+      Default: {
+        seriesColors: {
+          comparison: 'lime',
+        },
+      }
+    }}>
+    <SparkLineChart series={data} />
+  </PolarisVizProvider>
+    `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            seriesColors: {
+              comparison: 'lime',
+            },
+          },
+        }}
+      >
+        <SampleSparkLineChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
 </ExamplesGrid>
 <Divider noLine />
 
@@ -979,53 +1015,12 @@ export interface GradientStop {
     description="CSS color string used on the stroke around the point displayed when hovering the chart"
     chartsAffected={['LineChart', 'StackedAreaChart']}
   />
-  <PropertyTable.Row
-    property="line.dottedStrokeColor"
-    type={'string'}
-    description="CSS color string used on the stroke of dotted comparison lines"
-    chartsAffected={['SparkLineChart', 'SparkBarChart', 'LineChart']}
-  />
 </PropertyTable>
 
 <Title type="h4">Examples:</Title>
 
 <ExamplesGrid>
 
-<ComponentContainer
-  codeSample={`
-    <PolarisVizProvider={{
-      Default: {
-        line: {
-          sparkArea: 'rgba(250,50,250,0.2)',
-          hasSpline: true,
-          hasPoint: true,
-          dottedStrokeColor: 'lime'
-        }
-      }
-    }}>
-    <SparkLineChart series={data} />
-  </PolarisVizProvider>
-    `}
-  center
-  chart={
-    <div style={{width: '350px', height: '140px'}}>
-      <PolarisVizProvider
-        themes={{
-          Default: {
-            line: {
-              sparkArea: 'rgba(250,50,250,0.2)',
-              hasSpline: true,
-              hasPoint: true,
-              dottedStrokeColor: 'lime',
-            },
-          },
-        }}
-      >
-        <SampleSparkLineChart />
-      </PolarisVizProvider>
-    </div>
-  }
-/>
 <ComponentContainer
   codeSample={`
     <PolarisVizProvider={{

--- a/src/components/SparkBarChart/Chart.tsx
+++ b/src/components/SparkBarChart/Chart.tsx
@@ -222,7 +222,7 @@ export function Chart({
 
         {comparisonData == null ? null : (
           <path
-            stroke={selectedTheme.line.dottedStrokeColor}
+            stroke={selectedTheme.seriesColors.comparison}
             strokeWidth={STROKE_WIDTH}
             d={lineShape!}
             className={styles.ComparisonLine}

--- a/src/components/SparkLineChart/components/Series/Series.tsx
+++ b/src/components/SparkLineChart/components/Series/Series.tsx
@@ -131,7 +131,7 @@ export function Series({
         width={svgDimensions.width}
         height={svgDimensions.height}
         fill={
-          data.isComparison ? theme.line.dottedStrokeColor : `url(#line-${id})`
+          data.isComparison ? theme.seriesColors.comparison : `url(#line-${id})`
         }
         mask={`url(#mask-${`${id}`})`}
         className={classNames(styles.Line, !immediate && styles.AnimatedLine)}

--- a/src/components/SparkLineChart/components/Series/tests/Series.test.tsx
+++ b/src/components/SparkLineChart/components/Series/tests/Series.test.tsx
@@ -4,6 +4,7 @@ import {scaleLinear} from 'd3-scale';
 import {area} from 'd3-shape';
 
 import {Series} from '../Series';
+import {DEFAULT_THEME} from '../../../../../constants';
 import type {DataSeries} from '../../../../../types';
 
 jest.mock('d3-shape', () => ({
@@ -54,9 +55,7 @@ const mockProps = {
   isAnimated: false,
   svgDimensions: {height: 250, width: 250},
   hasSpline: false,
-  theme: {
-    line: {sparkArea: null, style: 'solid', color: 'red', hasPoint: true},
-  } as any,
+  theme: DEFAULT_THEME,
 };
 
 jest.mock('../../../../../utilities/unique-id', () => ({

--- a/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -102,7 +102,7 @@ export function HorizontalBars({
                 barHeight={barHeight}
                 color={
                   data[seriesIndex].isComparison
-                    ? selectedTheme.line.dottedStrokeColor
+                    ? selectedTheme.seriesColors.comparison
                     : selectedTheme.xAxis.labelColor
                 }
                 isAnimated={isAnimated}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,6 +79,7 @@ const NEUTRAL_SINGLE_GRADIENT = [
 
 export const DEFAULT_THEME: Theme = {
   seriesColors: {
+    comparison: variables.colorDarkComparison,
     single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
       createGradient(variables.colorIndigo70, variables.colorIndigo90),
@@ -132,7 +133,6 @@ export const DEFAULT_THEME: Theme = {
     hasPoint: true,
     width: 2,
     pointStroke: variables.colorGray160,
-    dottedStrokeColor: variables.colorDarkComparison,
   },
   bar: {
     hasRoundedCorners: true,
@@ -173,6 +173,7 @@ export const DEFAULT_THEME: Theme = {
 
 export const LIGHT_THEME: Theme = {
   seriesColors: {
+    comparison: variables.colorLightComparison,
     single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
       createGradient(variables.colorIndigo70, variables.colorIndigo90),
@@ -226,7 +227,6 @@ export const LIGHT_THEME: Theme = {
     hasPoint: true,
     width: 2,
     pointStroke: variables.colorGray00,
-    dottedStrokeColor: variables.colorLightComparison,
   },
   bar: {
     hasRoundedCorners: true,

--- a/src/hooks/use-theme-series-colors.ts
+++ b/src/hooks/use-theme-series-colors.ts
@@ -40,7 +40,7 @@ export function useThemeSeriesColors(
 
     return series.map(({color, lineStyle, isComparison}) => {
       if (isComparison === true || (lineStyle && lineStyle !== 'solid')) {
-        return selectedTheme.line.dottedStrokeColor;
+        return selectedTheme.seriesColors.comparison;
       }
 
       // If the series doesn't have a color property

--- a/src/hooks/useHorizontalSeriesColors.ts
+++ b/src/hooks/useHorizontalSeriesColors.ts
@@ -35,7 +35,7 @@ export function useHorizontalSeriesColors({data, theme}: Props) {
       let newColor;
 
       if (isComparison) {
-        newColor = selectedTheme.line.dottedStrokeColor;
+        newColor = selectedTheme.seriesColors.comparison;
       } else if (color != null) {
         newColor = color;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,6 @@ export interface LineTheme {
   hasPoint: boolean;
   width: number;
   pointStroke: string;
-  dottedStrokeColor: string;
 }
 
 export interface TooltipTheme {
@@ -145,6 +144,7 @@ export interface TooltipTheme {
   labelColor: string;
 }
 export interface SeriesColors {
+  comparison: string;
   single: Color;
   upToFour: Color[];
   fromFiveToSeven: Color[];


### PR DESCRIPTION
## What does this implement/fix?
Solves https://github.com/Shopify/polaris-viz/issues/743

- Replaces all instances of heme.line.dottedStrokeColor by theme.seriesColors.comparison
- Updates docs

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
