### PR TITLE
Allow data with only comparison to render

### DIFF
--- a/src/components/SparkBarChart/stories/SparkBarChart.stories.tsx
+++ b/src/components/SparkBarChart/stories/SparkBarChart.stories.tsx
@@ -171,26 +171,3 @@ OverwrittenSeriesColors.args = {
     },
   ],
 };
-
-export const ComparisonOnly: Story<SparkBarChartProps> = Template.bind({});
-ComparisonOnly.args = {
-  ...defaultProps,
-  data: [
-    {
-      isComparison: true,
-      data: [
-        {key: 0, value: 200},
-        {key: 1, value: 200},
-        {key: 2, value: 200},
-        {key: 3, value: 200},
-        {key: 4, value: 200},
-        {key: 5, value: 200},
-        {key: 6, value: 200},
-        {key: 7, value: 200},
-        {key: 8, value: 200},
-        {key: 9, value: 200},
-        {key: 10, value: 200},
-      ],
-    },
-  ],
-};

--- a/src/components/SparkBarChart/tests/Chart.test.tsx
+++ b/src/components/SparkBarChart/tests/Chart.test.tsx
@@ -4,6 +4,7 @@ import {scaleBand} from 'd3-scale';
 
 import type {DataSeries} from '../../../types';
 import {Chart} from '../Chart';
+import {Bar} from '../components';
 
 const sampleData: DataSeries = {
   data: [
@@ -64,5 +65,59 @@ describe('<Chart/>', () => {
       offsetLeft,
       mockWidth - offsetRight,
     ]);
+  });
+
+  describe('data', () => {
+    it('renders a single non-comparison chart', () => {
+      const chart = mount(<Chart data={[sampleData]} />);
+
+      expect(chart).toContainReactComponentTimes(Bar, 4);
+    });
+
+    it('renders a single comparison chart', () => {
+      const chart = mount(
+        <Chart
+          data={[
+            {
+              data: [
+                {key: 1, value: 200},
+                {key: 2, value: 200},
+                {key: 3, value: 200},
+                {key: 4, value: 200},
+              ],
+              isComparison: true,
+            },
+          ]}
+        />,
+      );
+
+      const line = chart.find('path');
+
+      expect(line).not.toBeNull();
+    });
+
+    it('renders a chart with 2 data sets', () => {
+      const chart = mount(
+        <Chart
+          data={[
+            sampleData,
+            {
+              data: [
+                {key: 1, value: 200},
+                {key: 2, value: 200},
+                {key: 3, value: 200},
+                {key: 4, value: 200},
+              ],
+              isComparison: true,
+            },
+          ]}
+        />,
+      );
+
+      const line = chart.find('path');
+
+      expect(line).not.toBeNull();
+      expect(chart).toContainReactComponentTimes(Bar, 4);
+    });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

The way we were sorting data for the `SparkBarChart` meant that data sets with only comparison data would crash the chart. This allows sets with only comparison to also render.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/760

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

http://localhost:6006/?path=/story/spark-charts-sparkbarchart--comparison-only

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
