### PR TITLE
Fix tooltip position for bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 
 - Filter down ticks on horizontal `<BarChart />` based on chart size.
+
+### Fixed
+
+- Fixed tooltip position when first bar has largest value in series in `<BarChart />`.
+- Fixed tooltip position when all values are 0 in horizontal `<BarChart />`.
 - Fixed issue where tooltip would still be visible when chart lost focus.
 
 ## [0.28.2] - 2021-12-13

--- a/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -10,7 +10,7 @@ import {
 export function getAlteredHorizontalBarPosition(
   props: AlteredPositionProps,
 ): AlteredPositionReturn {
-  if (props.currentX <= 0) {
+  if (props.currentX < 0) {
     return getNegativeOffset(props);
   }
 

--- a/src/components/TooltipWrapper/utilities.ts
+++ b/src/components/TooltipWrapper/utilities.ts
@@ -79,10 +79,11 @@ export function getAlteredVerticalBarPosition(
 
   if (newPosition.horizontal === TooltipHorizontalOffset.Left) {
     const left = getLeftPosition(x, props);
-    x = left.value;
 
     if (left.wasOutsideBounds) {
       newPosition.horizontal = TooltipHorizontalOffset.Right;
+    } else {
+      x = left.value;
     }
   }
 

--- a/src/hooks/tests/useDataForHorizontalChart.test.tsx
+++ b/src/hooks/tests/useDataForHorizontalChart.test.tsx
@@ -127,4 +127,56 @@ describe('useDataForHorizontalChart()', () => {
       expect(data.longestLabel).toStrictEqual({negative: 0, positive: 0});
     });
   });
+
+  it('allNumbers will not filter out values of 0', () => {
+    function TestComponent() {
+      const data = useDataForHorizontalChart({
+        ...MOCK_PROPS,
+        data: [
+          {
+            name: 'Group 1',
+            data: [
+              {value: 0, key: 'Label 01'},
+              {value: 0, key: 'Label 02'},
+              {value: 0, key: 'Label 03'},
+            ],
+          },
+        ],
+      });
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data.allNumbers).toStrictEqual([0, 0, 0]);
+  });
+
+  it('areAllNegative returns false when all numbers are 0', () => {
+    function TestComponent() {
+      const data = useDataForHorizontalChart({
+        ...MOCK_PROPS,
+        data: [
+          {
+            name: 'Group 1',
+            data: [
+              {value: 0, key: 'Label 01'},
+              {value: 0, key: 'Label 02'},
+              {value: 0, key: 'Label 03'},
+            ],
+          },
+        ],
+      });
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+    expect(data.areAllNegative).toStrictEqual(false);
+  });
 });

--- a/src/hooks/useDataForHorizontalChart.ts
+++ b/src/hooks/useDataForHorizontalChart.ts
@@ -25,7 +25,7 @@ export function useDataForHorizontalChart({
     return data.reduce<number[]>((prev, cur) => {
       const numbers = cur.data
         .map(({value}) => value)
-        .filter(Boolean) as number[];
+        .filter((value) => value !== null) as number[];
       return prev.concat(...numbers);
     }, []);
   }, [data]);
@@ -63,7 +63,9 @@ export function useDataForHorizontalChart({
   }, [labelFormatter, isSimple, isStacked, highestPositive, lowestNegative]);
 
   const areAllNegative = useMemo(() => {
-    return !allNumbers.some((num) => num >= 0);
+    return !allNumbers.some((num) => {
+      return num >= 0;
+    });
   }, [allNumbers]);
 
   return {


### PR DESCRIPTION
## What does this implement/fix?

Products in Context found 2 cases where the Tooltip positioning for `BarChart` components was wrong.

### Case 1: First bar has highest value

When a BarChart's first bar was the largest value in the set, the logic was pushing the tooltip to the left and then to the right. This was adding the width of the bar twice, pushing the tooltip too far away from the active bar.

### Case 2: All 0 values for HorizontalBarChart

When all values in a HorizontalBarChart were `0`, there were two bugs. First, the `areAllNegative` check was coming back as true because we were filtering on `Boolean`. 

This was making the tooltip position itself as if the value was negative.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/32367

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
