### PR TITLE
Add ChartContainer to SimpleNormalizedChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fixed tooltip position when all values are 0 in horizontal `<BarChart />`.
 - Fixed issue where tooltip would still be visible when chart lost focus.
 
+### Added
+
+- Add `<ChartContainer />` to `<SimpleNormalizedChart />` so it inherits the print styles.
+
 ## [0.28.2] - 2021-12-13
 
 - Replaced `theme.line.dottedStrokeColor` by `theme.seriesColors.comparison`

--- a/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/src/components/SimpleNormalizedChart/Chart.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import {sum} from 'd3-array';
+import {scaleLinear} from 'd3-scale';
+
+import type {ComparisonMetricProps} from '../ComparisonMetric';
+import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
+import {usePrefersReducedMotion, useTheme} from '../../hooks';
+import {classNames} from '../../utilities';
+import type {DataPoint, Direction, LabelFormatter} from '../../types';
+
+import {BarSegment, BarLabel} from './components';
+import type {Size, LabelPosition} from './types';
+import styles from './SimpleNormalizedChart.scss';
+
+export interface ChartProps {
+  data: DataPoint[];
+  comparisonMetrics?: Omit<ComparisonMetricProps, 'theme'>[];
+  labelFormatter?: LabelFormatter;
+  labelPosition?: LabelPosition;
+  direction?: Direction;
+  size?: Size;
+  theme?: string;
+}
+
+export function Chart({
+  comparisonMetrics = [],
+  data,
+  labelFormatter = (value) => `${value}`,
+  labelPosition = 'top-left',
+  direction = 'horizontal',
+  size = 'small',
+  theme,
+}: ChartProps) {
+  const selectedTheme = useTheme(theme);
+  const colors = getSeriesColorsFromCount(data.length, selectedTheme);
+  const containsNegatives = data.some(({value}) => value !== null && value < 0);
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  const {prefersReducedMotion} = usePrefersReducedMotion();
+
+  if (isDevelopment && containsNegatives) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This component is not built to handle negatives. Consider using a different component.',
+    );
+  }
+
+  if (isDevelopment && data.length > 4) {
+    throw new Error(
+      'This component displays a max of 4 data items. Please modify your data before passing it into this component.',
+    );
+  }
+
+  const slicedData = data.slice(0, 4);
+  const totalValue = sum(slicedData, ({value}) => value);
+
+  const xScale = scaleLinear().range([0, 100]).domain([0, totalValue]);
+
+  const isVertical = direction === 'vertical';
+  const bars = isVertical ? slicedData.reverse() : slicedData;
+
+  const isRightLabel = labelPosition.includes('right');
+  const isBottomLabel = labelPosition.includes('bottom');
+  const isVerticalAndRightLabel = isVertical && isRightLabel;
+  const isVerticalAndBottomLabel = isVertical && isBottomLabel;
+  const isHorizontalAndRightLabel = !isVertical && isRightLabel;
+  const isHorizontalAndBottomLabel = !isVertical && isBottomLabel;
+
+  return (
+    <div
+      className={classNames(
+        styles.Container,
+        isVertical ? styles.VerticalContainer : styles.HorizontalContainer,
+        isVerticalAndRightLabel && styles.VerticalContainerRightLabel,
+        isHorizontalAndBottomLabel && styles.HorizontalContainerBottomLabel,
+      )}
+    >
+      <ul
+        className={classNames(
+          isVertical
+            ? styles.VerticalLabelContainer
+            : styles.HorizontalLabelContainer,
+          (isVerticalAndBottomLabel || isHorizontalAndRightLabel) &&
+            styles.LabelContainerEndJustify,
+        )}
+      >
+        {slicedData.map(({key, value}, index) => {
+          if (value == null) {
+            return null;
+          }
+
+          const comparisonMetric = comparisonMetrics.find(
+            ({dataIndex}) => index === dataIndex,
+          );
+
+          const formattedValue = labelFormatter(value);
+          return (
+            <BarLabel
+              key={`${key}-${formattedValue}`}
+              label={`${key}`}
+              value={formattedValue}
+              color={colors[index]}
+              comparisonMetric={comparisonMetric}
+              legendColors={selectedTheme.legend}
+              direction={direction}
+              labelPosition={labelPosition}
+            />
+          );
+        })}
+      </ul>
+
+      <div
+        className={classNames(
+          styles.BarContainer,
+          isVertical
+            ? styles.VerticalBarContainer
+            : styles.HorizontalBarContainer,
+        )}
+      >
+        {bars.map(({value, key}, index) => {
+          if (value == null || value === 0) {
+            return null;
+          }
+
+          const colorIndex = isVertical ? bars.length - 1 - index : index;
+
+          return (
+            <BarSegment
+              index={index}
+              isAnimated={!prefersReducedMotion}
+              direction={direction}
+              size={size}
+              scale={xScale(value)}
+              key={`${key}`}
+              color={colors[colorIndex]}
+              roundedCorners={selectedTheme.bar.hasRoundedCorners}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import {sum} from 'd3-array';
-import {scaleLinear} from 'd3-scale';
-import type {ComparisonMetricProps} from 'components/ComparisonMetric';
 
-import {getSeriesColorsFromCount} from '../../hooks/use-theme-series-colors';
-import {usePrefersReducedMotion, useTheme} from '../../hooks';
-import {classNames} from '../../utilities';
+import type {ComparisonMetricProps} from '../ComparisonMetric';
+import {ChartContainer} from '../ChartContainer';
 import type {DataPoint, Direction, LabelFormatter} from '../../types';
 
-import {BarSegment, BarLabel} from './components';
+import {Chart} from './Chart';
 import type {Size, LabelPosition} from './types';
-import styles from './SimpleNormalizedChart.scss';
 
 export interface SimpleNormalizedChartProps {
   data: DataPoint[];
@@ -31,117 +26,16 @@ export function SimpleNormalizedChart({
   size = 'small',
   theme,
 }: SimpleNormalizedChartProps) {
-  const selectedTheme = useTheme(theme);
-  const colors = getSeriesColorsFromCount(data.length, selectedTheme);
-  const containsNegatives = data.some(({value}) => value !== null && value < 0);
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  const {prefersReducedMotion} = usePrefersReducedMotion();
-
-  if (isDevelopment && containsNegatives) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This component is not built to handle negatives. Consider using a different component.',
-    );
-  }
-
-  if (isDevelopment && data.length > 4) {
-    throw new Error(
-      'This component displays a max of 4 data items. Please modify your data before passing it into this component.',
-    );
-  }
-
-  const slicedData = data.slice(0, 4);
-  const totalValue = sum(slicedData, ({value}) => value);
-
-  const xScale = scaleLinear().range([0, 100]).domain([0, totalValue]);
-
-  const isVertical = direction === 'vertical';
-  const bars = isVertical ? slicedData.reverse() : slicedData;
-
-  const isRightLabel = labelPosition.includes('right');
-  const isBottomLabel = labelPosition.includes('bottom');
-  const isVerticalAndRightLabel = isVertical && isRightLabel;
-  const isVerticalAndBottomLabel = isVertical && isBottomLabel;
-  const isHorizontalAndRightLabel = !isVertical && isRightLabel;
-  const isHorizontalAndBottomLabel = !isVertical && isBottomLabel;
-
   return (
-    <div
-      className={classNames(
-        styles.Container,
-        isVertical ? styles.VerticalContainer : styles.HorizontalContainer,
-        isVerticalAndRightLabel && styles.VerticalContainerRightLabel,
-        isHorizontalAndBottomLabel && styles.HorizontalContainerBottomLabel,
-      )}
-      style={{
-        background: selectedTheme.chartContainer.backgroundColor,
-        padding: selectedTheme.chartContainer.padding,
-        borderRadius: selectedTheme.chartContainer.borderRadius,
-      }}
-    >
-      <ul
-        className={classNames(
-          isVertical
-            ? styles.VerticalLabelContainer
-            : styles.HorizontalLabelContainer,
-          (isVerticalAndBottomLabel || isHorizontalAndRightLabel) &&
-            styles.LabelContainerEndJustify,
-        )}
-      >
-        {slicedData.map(({key, value}, index) => {
-          if (value == null) {
-            return null;
-          }
-
-          const comparisonMetric = comparisonMetrics.find(
-            ({dataIndex}) => index === dataIndex,
-          );
-
-          const formattedValue = labelFormatter(value);
-          return (
-            <BarLabel
-              key={`${key}-${formattedValue}`}
-              label={`${key}`}
-              value={formattedValue}
-              color={colors[index]}
-              comparisonMetric={comparisonMetric}
-              legendColors={selectedTheme.legend}
-              direction={direction}
-              labelPosition={labelPosition}
-            />
-          );
-        })}
-      </ul>
-
-      <div
-        className={classNames(
-          styles.BarContainer,
-          isVertical
-            ? styles.VerticalBarContainer
-            : styles.HorizontalBarContainer,
-        )}
-      >
-        {bars.map(({value, key}, index) => {
-          if (value == null || value === 0) {
-            return null;
-          }
-
-          const colorIndex = isVertical ? bars.length - 1 - index : index;
-
-          return (
-            <BarSegment
-              index={index}
-              isAnimated={!prefersReducedMotion}
-              direction={direction}
-              size={size}
-              scale={xScale(value)}
-              key={`${key}`}
-              color={colors[colorIndex]}
-              roundedCorners={selectedTheme.bar.hasRoundedCorners}
-            />
-          );
-        })}
-      </div>
-    </div>
+    <ChartContainer theme={theme}>
+      <Chart
+        comparisonMetrics={comparisonMetrics}
+        data={data}
+        labelFormatter={labelFormatter}
+        labelPosition={labelPosition}
+        direction={direction}
+        size={size}
+      />
+    </ChartContainer>
   );
 }

--- a/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
+++ b/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {SimpleNormalizedChart} from '../../../components/SimpleNormalizedChart';
+import {mountWithProvider} from '../../../test-utilities';
+import {BarSegment, BarLabel} from '../components';
+import type {SimpleNormalizedChartProps} from '../SimpleNormalizedChart';
+
+describe('<Chart />', () => {
+  const mockProps: SimpleNormalizedChartProps = {
+    data: [
+      {key: 'label0', value: 993.9266809283133},
+      {key: 'label1', value: 666.4681407384194},
+      {key: 'label2', value: 500},
+      {key: 'label3', value: 200},
+    ],
+    labelFormatter: (value) => `$${Number(value).toFixed(2)}`,
+  };
+
+  describe('Bars', () => {
+    it('renders 4 bars when given 4 data items', () => {
+      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(4);
+    });
+
+    it('renders 4 bars when given more than 4 data items', () => {
+      const highEdgeProps = {
+        data: [
+          {
+            key: 'DuckDuckGo',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'Google',
+            value: 666.4681407384194,
+          },
+          {key: 'Yahoo', value: 500},
+          {key: 'Bing', value: 200},
+          {
+            key: 'DuckDuck',
+            value: 993.9266809283133,
+          },
+          {key: 'Goog', value: 666.4681407384194},
+          {key: 'Yah', value: 500},
+          {key: 'Bin', value: 200},
+        ],
+      };
+      const barChart = mount(<SimpleNormalizedChart {...highEdgeProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(4);
+    });
+
+    it('renders 0 bars when given 0', () => {
+      const lowEdgeProps = {
+        data: [],
+      };
+
+      const barChart = mount(<SimpleNormalizedChart {...lowEdgeProps} />);
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(0);
+    });
+
+    it('does not render a bar for 0 values', () => {
+      const barChart = mount(
+        <SimpleNormalizedChart
+          data={[
+            {key: 'Bin', value: 200},
+            {key: 'Stuff', value: 0},
+          ]}
+        />,
+      );
+
+      expect(barChart.findAll(BarSegment)).toHaveLength(1);
+    });
+  });
+
+  describe('Labels', () => {
+    it('renders 4 Labels when more than 4 data items are provided', () => {
+      const highEdgeProps = {
+        data: [
+          {
+            key: 'DuckDuckGo',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo1',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo2',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo3',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo4',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo5',
+            value: 993.9266809283133,
+          },
+        ],
+      };
+
+      const barChart = mount(<SimpleNormalizedChart {...highEdgeProps} />);
+
+      expect(barChart.findAll(BarLabel)).toHaveLength(4);
+    });
+
+    it('renders 2 BarLabels given 2 data items are provided', () => {
+      const lowEdgeProps = {
+        data: [
+          {
+            key: 'DuckDuckGo',
+            value: 993.9266809283133,
+          },
+          {
+            key: 'DuckDuckGo1',
+            value: 993.9266809283133,
+          },
+        ],
+      };
+
+      const barChart = mount(<SimpleNormalizedChart {...lowEdgeProps} />);
+
+      expect(barChart.findAll(BarLabel)).toHaveLength(2);
+    });
+  });
+
+  describe('Colors', () => {
+    it('inherits colors from the theme', () => {
+      const barChart = mountWithProvider(
+        <SimpleNormalizedChart {...mockProps} />,
+        {
+          themes: {
+            Default: {
+              seriesColors: {
+                upToFour: ['#00A', '#00B', '#00C', '#00D'],
+              },
+            },
+          },
+        },
+      );
+
+      expect(barChart.find(BarSegment)!.props.color).toStrictEqual('#00A');
+    });
+  });
+
+  describe('direction', () => {
+    it('defaults to horizontal direction and passes it to BarSegment', () => {
+      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
+
+      expect(barChart.find(BarSegment)!.props.direction).toBe('horizontal');
+    });
+
+    it('accepts vertical direction and passes it to BarSegment', () => {
+      const barChart = mount(
+        <SimpleNormalizedChart {...mockProps} direction="vertical" />,
+      );
+
+      expect(barChart.find(BarSegment)!.props.direction).toBe('vertical');
+    });
+  });
+
+  describe('Label Position', () => {
+    it('defaults to top-left label position and passes it to BarLabel', () => {
+      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
+
+      expect(barChart.find(BarLabel)!.props.labelPosition).toBe('top-left');
+    });
+
+    it('accepts bottom-right label position and passes it to BarLabel', () => {
+      const barChart = mount(
+        <SimpleNormalizedChart {...mockProps} labelPosition="bottom-right" />,
+      );
+
+      expect(barChart.find(BarLabel)!.props.labelPosition).toBe('bottom-right');
+    });
+  });
+});

--- a/src/components/SimpleNormalizedChart/tests/SimpleNormalizedChart.test.tsx
+++ b/src/components/SimpleNormalizedChart/tests/SimpleNormalizedChart.test.tsx
@@ -1,184 +1,33 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
-import {SimpleNormalizedChart} from '../../../components/SimpleNormalizedChart';
-import {mountWithProvider} from '../../../test-utilities';
-import {BarSegment, BarLabel} from '../components';
-import type {SimpleNormalizedChartProps} from '../SimpleNormalizedChart';
+import {ChartContainer} from '../../ChartContainer';
+import {
+  SimpleNormalizedChart,
+  SimpleNormalizedChartProps,
+} from '../SimpleNormalizedChart';
+import {Chart} from '../Chart';
+
+const mockProps: SimpleNormalizedChartProps = {
+  data: [
+    {key: 'label0', value: 993.9266809283133},
+    {key: 'label1', value: 666.4681407384194},
+    {key: 'label2', value: 500},
+    {key: 'label3', value: 200},
+  ],
+  labelFormatter: (value) => `$${Number(value).toFixed(2)}`,
+};
 
 describe('<SimpleNormalizedChart />', () => {
-  const mockProps: SimpleNormalizedChartProps = {
-    data: [
-      {key: 'label0', value: 993.9266809283133},
-      {key: 'label1', value: 666.4681407384194},
-      {key: 'label2', value: 500},
-      {key: 'label3', value: 200},
-    ],
-    labelFormatter: (value) => `$${Number(value).toFixed(2)}`,
-  };
+  it('renders <ChartContainer />', () => {
+    const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
 
-  describe('Bars', () => {
-    it('renders 4 bars when given 4 data items', () => {
-      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
-
-      expect(barChart.findAll(BarSegment)).toHaveLength(4);
-    });
-
-    it('renders 4 bars when given more than 4 data items', () => {
-      const highEdgeProps = {
-        data: [
-          {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'Google',
-            value: 666.4681407384194,
-          },
-          {key: 'Yahoo', value: 500},
-          {key: 'Bing', value: 200},
-          {
-            key: 'DuckDuck',
-            value: 993.9266809283133,
-          },
-          {key: 'Goog', value: 666.4681407384194},
-          {key: 'Yah', value: 500},
-          {key: 'Bin', value: 200},
-        ],
-      };
-      const barChart = mount(<SimpleNormalizedChart {...highEdgeProps} />);
-
-      expect(barChart.findAll(BarSegment)).toHaveLength(4);
-    });
-
-    it('renders 0 bars when given 0', () => {
-      const lowEdgeProps = {
-        data: [],
-      };
-
-      const barChart = mount(<SimpleNormalizedChart {...lowEdgeProps} />);
-
-      expect(barChart.findAll(BarSegment)).toHaveLength(0);
-    });
-
-    it('does not render a bar for 0 values', () => {
-      const barChart = mount(
-        <SimpleNormalizedChart
-          data={[
-            {key: 'Bin', value: 200},
-            {key: 'Stuff', value: 0},
-          ]}
-        />,
-      );
-
-      expect(barChart.findAll(BarSegment)).toHaveLength(1);
-    });
+    expect(barChart).toContainReactComponent(ChartContainer);
   });
 
-  describe('Labels', () => {
-    it('renders 4 Labels when more than 4 data items are provided', () => {
-      const highEdgeProps = {
-        data: [
-          {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo1',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo2',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo3',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo4',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo5',
-            value: 993.9266809283133,
-          },
-        ],
-      };
+  it('renders <Chart />', () => {
+    const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
 
-      const barChart = mount(<SimpleNormalizedChart {...highEdgeProps} />);
-
-      expect(barChart.findAll(BarLabel)).toHaveLength(4);
-    });
-
-    it('renders 2 BarLabels given 2 data items are provided', () => {
-      const lowEdgeProps = {
-        data: [
-          {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
-          },
-          {
-            key: 'DuckDuckGo1',
-            value: 993.9266809283133,
-          },
-        ],
-      };
-
-      const barChart = mount(<SimpleNormalizedChart {...lowEdgeProps} />);
-
-      expect(barChart.findAll(BarLabel)).toHaveLength(2);
-    });
-  });
-
-  describe('Colors', () => {
-    it('inherits colors from the theme', () => {
-      const barChart = mountWithProvider(
-        <SimpleNormalizedChart {...mockProps} />,
-        {
-          themes: {
-            Default: {
-              seriesColors: {
-                upToFour: ['#00A', '#00B', '#00C', '#00D'],
-              },
-            },
-          },
-        },
-      );
-
-      expect(barChart.find(BarSegment)!.props.color).toStrictEqual('#00A');
-    });
-  });
-
-  describe('direction', () => {
-    it('defaults to horizontal direction and passes it to BarSegment', () => {
-      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
-
-      expect(barChart.find(BarSegment)!.props.direction).toBe('horizontal');
-    });
-
-    it('accepts vertical direction and passes it to BarSegment', () => {
-      const barChart = mount(
-        <SimpleNormalizedChart {...mockProps} direction="vertical" />,
-      );
-
-      expect(barChart.find(BarSegment)!.props.direction).toBe('vertical');
-    });
-  });
-
-  describe('Label Position', () => {
-    it('defaults to top-left label position and passes it to BarLabel', () => {
-      const barChart = mount(<SimpleNormalizedChart {...mockProps} />);
-
-      expect(barChart.find(BarLabel)!.props.labelPosition).toBe('top-left');
-    });
-
-    it('accepts bottom-right label position and passes it to BarLabel', () => {
-      const barChart = mount(
-        <SimpleNormalizedChart {...mockProps} labelPosition="bottom-right" />,
-      );
-
-      expect(barChart.find(BarLabel)!.props.labelPosition).toBe('bottom-right');
-    });
+    expect(barChart).toContainReactComponent(Chart);
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

`SimpleNormalizedChart` wasn't using `ChartContainer` so it wasn't getting the print styles.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/32352

## What do the changes look like?

![image](https://user-images.githubusercontent.com/149873/146255775-51374884-614c-47e5-bd4c-13f3b9c61ab6.png)
 
### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
