### PR TITLE
Remove tooltip when no child elements have focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Filter down ticks on horizontal `<BarChart />` based on chart size.
+- Fixed issue where tooltip would still be visible when chart lost focus.
 
 ## [0.28.2] - 2021-12-13
 

--- a/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -48,7 +48,9 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
 
   const activeIndexRef = useRef<number | null>(null);
   const focusElements = useMemo<NodeListOf<SVGPathElement> | undefined>(() => {
-    return parentRef?.querySelectorAll(`[data-type="${focusElementDataType}"]`);
+    return parentRef?.querySelectorAll(
+      `[data-type="${focusElementDataType}"][aria-hidden="false"]`,
+    );
   }, [focusElementDataType, parentRef]);
 
   useEffect(() => {
@@ -96,6 +98,12 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     [getPosition, onIndexChange],
   );
 
+  const onFocusIn = useCallback(() => {
+    if (!parentRef?.contains(document.activeElement)) {
+      onMouseLeave();
+    }
+  }, [parentRef, onMouseLeave]);
+
   const setFocusListeners = useCallback(
     (attach: boolean) => {
       if (!focusElements) {
@@ -134,6 +142,14 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
       setFocusListeners(false);
     };
   }, [parentRef, onMouseMove, onMouseLeave, onFocus, setFocusListeners]);
+
+  useEffect(() => {
+    document.addEventListener('focusin', onFocusIn);
+
+    return () => {
+      document.removeEventListener('focusin', onFocusIn);
+    };
+  }, [parentRef, onFocusIn]);
 
   if (position.activeIndex == null || position.activeIndex < 0) {
     return null;


### PR DESCRIPTION
## What does this implement/fix?

When tabbing through chart elements, once you reach the last element and tab outside of the chart, the tooltip would stay visible.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/32353

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
