### PR TITLE
Filter down ticks based on chart size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Filter down ticks on horizontal `<BarChart />` based on chart size.
+
 ## [0.28.2] - 2021-12-13
 
 - Replaced `theme.line.dottedStrokeColor` by `theme.seriesColors.comparison`

--- a/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
+++ b/src/components/HorizontalBarChart/components/XAxisLabels/XAxisLabels.tsx
@@ -58,7 +58,7 @@ export const XAxisLabels = ({
         return (
           <foreignObject
             transform={`translate(${
-              isFirstItem ? 0 : xScale(value) - textOffset
+              isFirstItem ? xScale(value) : xScale(value) - textOffset
             },0)`}
             height={tallestXAxisLabel}
             width={width}

--- a/src/hooks/useHorizontalXScale.ts
+++ b/src/hooks/useHorizontalXScale.ts
@@ -2,6 +2,12 @@ import {extent} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 import {useMemo} from 'react';
 
+import {clamp} from '../utilities';
+
+const MIN_Y_LABEL_SPACE = 80;
+const MAX_TICKS = 12;
+const MIN_TICKS = 3;
+
 export function useHorizontalXScale({
   allNumbers,
   highestSumForStackedGroup,
@@ -23,8 +29,14 @@ export function useHorizontalXScale({
   }, [maxWidth, allNumbers]);
 
   const ticks = useMemo(() => {
-    return xScale.ticks();
-  }, [xScale]);
+    const maxTicks = clamp({
+      amount: Math.max(1, Math.floor(maxWidth / MIN_Y_LABEL_SPACE)),
+      min: MIN_TICKS,
+      max: MAX_TICKS,
+    });
+
+    return xScale.ticks(maxTicks);
+  }, [xScale, maxWidth]);
 
   const xScaleStacked = useMemo(() => {
     if (!isStacked) {


### PR DESCRIPTION
## What does this implement/fix?

The horizontal version of `<BarChart />` doesn't use diagonal labels, the labels are broken onto 3 lines and then truncated. This causes issues for small screens, so we're going to remove ticks based on the width of the chart.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/32349

## What do the changes look like?

https://user-images.githubusercontent.com/149873/146264139-ca4de5c2-46a0-41e2-80e3-2d0b74849fc4.mp4

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
