### PR TITLE
Evenly space out tooltip items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Filter down ticks on horizontal `<BarChart />` based on chart size.
+- Added `10px` of space between `<TooltipContent />` elements.
 
 ### Fixed
 

--- a/src/components/TooltipContent/TooltipContent.scss
+++ b/src/components/TooltipContent/TooltipContent.scss
@@ -12,6 +12,7 @@
   align-items: center;
   width: 100%;
   margin: 0 0 9px;
+  column-gap: 10px;
 }
 
 .Row:last-child {
@@ -21,10 +22,6 @@
 .Title {
   text-align: center;
   margin-bottom: 12px;
-}
-
-.Label {
-  margin: 0 0 0 10px;
 }
 
 .AnnotationLabel {

--- a/src/components/TooltipContent/components/DefaultRow.tsx
+++ b/src/components/TooltipContent/components/DefaultRow.tsx
@@ -16,7 +16,7 @@ export function DefaultRow({
   return (
     <div className={styles.Row}>
       <SquareColorPreview color={color} />
-      <span className={styles.Label}>{label}</span>
+      <span>{label}</span>
       <span className={styles.Value}>{value}</span>
     </div>
   );


### PR DESCRIPTION
## What does this implement/fix?

When 🎩 'ing https://github.com/Shopify/web/pull/54497 we noticed that the tooltips could push into the values if the data was long. 

Now we're going to space items 10px from each other so top data from running into each other.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/148109638-91b49fab-9959-41a6-a7dd-35d1eb1cdfa3.png)|![image](https://user-images.githubusercontent.com/149873/148109328-5f2a43d0-c31b-4f15-94ba-b635830537ec.png)|

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
