### PR TITLE
allow custom print themes, export print theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Added
+- Added `Print` theme. This theme gets automatically applied when printing charts. Can be overwritten through the [PolarisVizProvider](https://polaris-viz.shopify.io/?path=/docs/docs-themes-customizing--page)
 ## [0.28.4] - 2022-01-06
 
 ### Added

--- a/src/components/ChartContainer/ChartContainer.tsx
+++ b/src/components/ChartContainer/ChartContainer.tsx
@@ -25,7 +25,7 @@ export const ChartContainer = (props: Props) => {
   const {ref, setRef, entry} = useResizeObserver();
 
   const {isPrinting} = usePrintResizing({ref, setChartDimensions});
-  const printFriendlyTheme = isPrinting ? 'Light' : props.theme;
+  const printFriendlyTheme = isPrinting ? 'Print' : props.theme;
   const {chartContainer} = useTheme(printFriendlyTheme);
 
   const updateDimensions = useCallback(() => {

--- a/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,7 +1,11 @@
 import React, {useMemo} from 'react';
 
 import type {PartialTheme} from '../../types';
-import {DEFAULT_THEME as Default, LIGHT_THEME as Light} from '../../constants';
+import {
+  DEFAULT_THEME as Default,
+  LIGHT_THEME as Light,
+  PRINT_THEME as Print,
+} from '../../constants';
 import {PolarisVizContext} from '../../utilities/polaris-viz-context';
 import {createThemes} from '../../utilities';
 
@@ -19,6 +23,7 @@ export function PolarisVizProvider({
       themes: createThemes({
         Default,
         Light,
+        Print,
         ...themes,
       }),
     };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -265,6 +265,45 @@ export const LIGHT_THEME: Theme = {
   },
 };
 
+export const PRINT_THEME = {
+  ...LIGHT_THEME,
+  seriesColors: {
+    comparison: variables.colorLightComparison,
+    single: variables.colorIndigo90,
+    upToFour: [
+      variables.colorIndigo90,
+      variables.colorBlue90,
+      variables.colorMagenta90,
+      variables.colorTeal90,
+    ],
+    fromFiveToSeven: [
+      variables.colorTeal90,
+      variables.colorBlue90,
+      variables.colorIndigo90,
+      variables.colorPurple90,
+      variables.colorMagenta90,
+      variables.colorOrange90,
+      variables.colorYellow90,
+    ],
+    all: [
+      variables.colorTeal90,
+      variables.colorBlue70,
+      variables.colorIndigo90,
+      variables.colorPurple70,
+      variables.colorMagenta90,
+      variables.colorOrange80,
+      variables.colorYellow50,
+      variables.colorTeal70,
+      variables.colorBlue80,
+      variables.colorIndigo70,
+      variables.colorPurple90,
+      variables.colorMagenta70,
+      variables.colorOrange110,
+      variables.colorYellow70,
+    ],
+  },
+};
+
 export const BASE_ANIMATION_DURATION = 200;
 export const XMLNS = 'http://www.w3.org/2000/svg';
 

--- a/src/hooks/tests/usePolarisVizContext.test.tsx
+++ b/src/hooks/tests/usePolarisVizContext.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {mountWithProvider} from '../../test-utilities';
-import {DEFAULT_THEME, LIGHT_THEME} from '../../constants';
+import {DEFAULT_THEME, LIGHT_THEME, PRINT_THEME} from '../../constants';
 import {usePolarisVizContext} from '../usePolarisVizContext';
 
 describe('usePolarisVizContext', () => {
@@ -43,6 +43,7 @@ describe('usePolarisVizContext', () => {
           },
         },
         Light: LIGHT_THEME,
+        Print: PRINT_THEME,
       }),
     );
   });
@@ -62,6 +63,7 @@ describe('usePolarisVizContext', () => {
       JSON.stringify({
         Default: DEFAULT_THEME,
         Light: LIGHT_THEME,
+        Print: PRINT_THEME,
         SomeOtherTheme: {
           ...DEFAULT_THEME,
           chartContainer: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ export type {
 
 export {
   DEFAULT_THEME as PolarisVizDefaultTheme,
-  LIGHT_THEME as PolarisVizLightheme,
+  LIGHT_THEME as PolarisVizLightTheme,
+  PRINT_THEME as PolarisVizPrintTheme,
 } from './constants';
 
 export {createTheme} from './utilities/create-themes';

--- a/src/utilities/create-themes.ts
+++ b/src/utilities/create-themes.ts
@@ -1,9 +1,10 @@
 import type {Theme, PartialTheme} from '../types';
-import {DEFAULT_THEME, LIGHT_THEME} from '../constants';
+import {DEFAULT_THEME, LIGHT_THEME, PRINT_THEME} from '../constants';
 
 const BASE_THEMES: {[key: string]: Theme} = {
   Default: DEFAULT_THEME,
   Light: LIGHT_THEME,
+  Print: PRINT_THEME,
 };
 
 export const createTheme = (


### PR DESCRIPTION
## What does this implement/fix?
Introduces a customizable `Print` theme, that uses `Light` as a base, but removes gradients 

## Does this close any currently open issues?

closes https://github.com/Shopify/polaris-viz/issues/770


## What do the changes look like?


| component  | screenshot  |
|---|---|
|   BarChart |  <img width="451" alt="Screen Shot 2022-01-10 at 3 43 55 PM" src="https://user-images.githubusercontent.com/4037781/148840477-d6ffdfdc-85f3-4b76-982a-79d90e7f4f63.png">|
| LineChart | <img width="437" alt="Screen Shot 2022-01-10 at 2 00 16 PM" src="https://user-images.githubusercontent.com/4037781/148840536-e6488f60-745c-45ca-87cb-492d65d66ebe.png">|
|SparkLineChart|<img width="309" alt="Screen Shot 2022-01-10 at 2 00 23 PM" src="https://user-images.githubusercontent.com/4037781/148840561-c2c22f34-e551-4048-81ea-c8e550ddcf0e.png">|
|SparkBarChart| <img width="317" alt="Screen Shot 2022-01-10 at 2 00 20 PM" src="https://user-images.githubusercontent.com/4037781/148840653-5ae2bbef-4564-4c01-8881-0f51e93534c4.png">|
|SimpleBarChart|<img width="468" alt="Screen Shot 2022-01-10 at 2 00 40 PM" src="https://user-images.githubusercontent.com/4037781/148840696-d36d9673-d225-4e28-8187-45575654f326.png">|
|SimpleNormalizedChart|<img width="446" alt="Screen Shot 2022-01-10 at 2 00 36 PM" src="https://user-images.githubusercontent.com/4037781/148840766-1fde5cec-9572-4e5b-a989-81a9aa5364de.png">|




### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
