### PR TITLE
Adds conditionals to fix `HorizontalBars` crashing when a data item gets removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Added extra conditionals in `HorizontalBarChart` to prevent crashing of the component when `data` prop changes.
+
 ### Added
 - Added `Print` theme. This theme gets automatically applied when printing charts. Can be overwritten through the [PolarisVizProvider](https://polaris-viz.shopify.io/?path=/docs/docs-themes-customizing--page)
 ## [0.28.4] - 2022-01-06

--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -135,6 +135,10 @@ export function Chart({
 
   const getAriaLabel = useCallback(
     (seriesIndex: number) => {
+      if (data[seriesIndex] == null) {
+        return '';
+      }
+
       const ariaSeries = data
         .map(({name, data}) => {
           return `${name} ${labelFormatter(data[seriesIndex].value)}`;

--- a/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -57,6 +57,9 @@ export function HorizontalBars({
       role="listitem"
     >
       {data.map((_, seriesIndex) => {
+        if (data[seriesIndex].data[groupIndex] == null) {
+          return;
+        }
         const {value} = data[seriesIndex].data[groupIndex];
 
         const isNegative = value && value < 0;


### PR DESCRIPTION
## What does this implement/fix?

Currently, when removing a bar by removing a `data[0].data` array item, the component crashes and is unrecoverable. This PR tries to catch those through the introduction of new conditionals.

To re-create simply load `polaris-viz` in storybook (I recommend using the `localhost` URL since that one will include sourcemaps), navigate to the SimpleBarChart and remove one of the data entries through the bottom add-on bar. The page should reload and stats should be re-drawn.

Are there other cases we're missing?

This is currently causing a Bug in LiveView where occasionally Bars get removed when user behaviour changes significantly. For context, we currently have over 30k errors with this on LiveView, so this would be important to be solved.

https://app.bugsnag.com/shopify/shopify-web-client/errors/61d865cca47f2c0008ff2ebd?filters[event.since]=7d&filters[request.url]=%2Fadmin%2Fdashboards%2Flive&pivot_tab=event

## Does this close any currently open issues?

Closes:  https://github.com/Shopify/core-issues/issues/32965

## What do the changes look like?

Before
<img width="1478" alt="Screen Shot 2022-01-13 at 10 00 19 PM" src="https://user-images.githubusercontent.com/4960217/149444171-e48339ec-a38b-4700-9a85-76dcb830ee32.png">

After
Everything works as expected.
 
## Storybook link

Soryr don't have storybook running in spin.


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
