### PR TITLE
prevent tooltip from being placed outside chart vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Prevent tooltips from rendering outside `<ChartContainer/>`
+
 ### Changed
 
 - Changed loaded animation in `<StackedAreaChart />` from left to right to bottom up.

--- a/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -13,7 +13,6 @@ export function getAlteredHorizontalBarPosition(
   if (props.currentX < 0) {
     return getNegativeOffset(props);
   }
-
   return getPositiveOffset(props);
 }
 
@@ -23,8 +22,9 @@ function getNegativeOffset(props: AlteredPositionProps): AlteredPositionReturn {
   const flippedX = currentX * -1;
   const yOffset = (bandwidth - tooltipDimensions.height) / 2;
 
+  const y = currentY - tooltipDimensions.height;
   if (flippedX - tooltipDimensions.width < 0) {
-    return {x: flippedX, y: currentY - tooltipDimensions.height};
+    return {x: flippedX, y: y < 0 ? 0 : y};
   }
 
   return {
@@ -48,6 +48,20 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
     tooltipDimensions,
     chartDimensions,
   });
+
+  if (isOutside.top && isOutside.right) {
+    return {
+      x: chartDimensions.width - tooltipDimensions.width,
+      y: 0,
+    };
+  }
+
+  if (isOutside.top && !isOutside.right) {
+    return {
+      x: currentX + TOOLTIP_MARGIN,
+      y: 0,
+    };
+  }
 
   if (!isOutside.right && !isOutside.bottom) {
     const yOffset = (bandwidth - tooltipDimensions.height) / 2;
@@ -106,7 +120,9 @@ function isOutsideBounds({
   const bottom = y + tooltipDimensions.height;
 
   return {
+    left: x <= 0,
     right: right > chartDimensions.width,
     bottom: bottom > chartDimensions.height,
+    top: y <= 0,
   };
 }

--- a/src/components/TooltipWrapper/utilities.ts
+++ b/src/components/TooltipWrapper/utilities.ts
@@ -166,7 +166,11 @@ export function getVerticalCenterPosition(
   });
 
   if (wasOutsideBounds) {
-    y = props.currentY;
+    if (y <= 0) {
+      y = 0;
+    } else {
+      y = props.chartDimensions.height - props.tooltipDimensions.height;
+    }
   }
 
   return {value: y, wasOutsideBounds};


### PR DESCRIPTION
## What does this implement/fix?

Prevents tooltip from overflowing ChartContainer

|Before|After|
|-|-|
|<img width="433" alt="Screen Shot 2022-01-17 at 6 07 29 PM" src="https://user-images.githubusercontent.com/4037781/149846121-7dcd854f-3ac3-44ee-812a-6245e5105abf.png">|<img width="455" alt="Screen Shot 2022-01-17 at 6 07 17 PM" src="https://user-images.githubusercontent.com/4037781/149846140-9bf96450-039d-4277-b93b-c2e9cef6abc7.png">|
|<img width="705" alt="Screen Shot 2022-01-17 at 6 06 21 PM" src="https://user-images.githubusercontent.com/4037781/149846202-fa523dc5-5db4-4bd1-85ef-0e6deb8ee9fb.png">|<img width="698" alt="Screen Shot 2022-01-17 at 6 06 41 PM" src="https://user-images.githubusercontent.com/4037781/149846185-3880f6b9-47fa-4e8e-8970-b3502d2d0926.png">|


Not perfect, as in some edge cases the tooltip covers the bar group that is being highlighted, but better than what we currently have.

I noticed that we have tooltip positioning logic spread in a couple of places, maybe as a follow up we could refactor it and centralize the tooltip positioning logic somehow?



## Does this close any currently open issues?

solves https://github.com/Shopify/polaris-viz/issues/656

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
