### PR TITLE
Fix opacity not applying to area correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Prevent tooltips from rendering outside `<ChartContainer/>`
 - Fixed a bug that prevented Firefox from using `Print` theme on `<SimpleNormalizedChart/>`
+- Fixed opacity not applying to `<SparkLineChart />` area when animation is disabled.
 
 ### Changed
 

--- a/src/components/SparkLineChart/components/Area/Area.tsx
+++ b/src/components/SparkLineChart/components/Area/Area.tsx
@@ -47,7 +47,7 @@ export function Area({areaPath, color, immediate}: AreaProps) {
   return areaGradientColor == null ? null : (
     <React.Fragment>
       <defs>
-        <mask id={maskId} opacity="0.2">
+        <mask id={maskId}>
           <path
             fill={`url(#${maskId}-gradient)`}
             d={areaPath}
@@ -72,6 +72,7 @@ export function Area({areaPath, color, immediate}: AreaProps) {
         d={areaPath}
         fill={`url(#${gradientId})`}
         mask={`url(#${maskId})`}
+        opacity="0.2"
       />
     </React.Fragment>
   );


### PR DESCRIPTION
## What does this implement/fix?

When turning off animation for `<SparkLineChart />` the area would be at full opacity.

I'm not 100% sure why, but even setting `opacity: 1` in the style, the area would still render at 100% and not the `20%` based on the mask. I think there's some render oddity in the css animation and the mask, but I didn't dig too deep.

## Does this close any currently open issues?

Resolves: https://github.com/Shopify/polaris-viz/issues/787
 
## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/149990906-b6a38a6f-d385-4220-98df-f9bb079b3162.png)|![image](https://user-images.githubusercontent.com/149873/149990941-d1599507-f336-4be2-891f-b278bb07642e.png)|

## Storybook link

http://localhost:6006/?path=/story/spark-charts-sparklinechart--default&args=isAnimated:false

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
