### PR TITLE
Fix bug where chart re-animates on every data change

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -64,7 +64,7 @@ export function Chart({
 }: ChartProps) {
   const selectedTheme = useTheme(theme);
   const {labelFormatter} = xAxisOptions;
-  const id = uniqueId('HorizontalBarChart');
+  const id = useMemo(() => uniqueId('HorizontalBarChart'), []);
 
   const isStacked = type === 'stacked';
 

--- a/src/components/SimpleBarChart/Chart.tsx
+++ b/src/components/SimpleBarChart/Chart.tsx
@@ -33,7 +33,7 @@ export function Chart({
   type,
   xAxisOptions,
 }: ChartProps) {
-  const id = uniqueId('SimpleBarChart');
+  const id = useMemo(() => uniqueId('SimpleBarChart'), []);
 
   const {labelFormatter} = xAxisOptions;
   const isStacked = type === 'stacked';

--- a/src/components/shared/Bar/Bar.tsx
+++ b/src/components/shared/Bar/Bar.tsx
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react';
 import {animated, useSpring} from '@react-spring/web';
 
 import {getRoundedRectPath} from '../../../utilities';
-import {DataType, RoundedBorder} from '../../../types';
+import {DataType, Direction, RoundedBorder} from '../../../types';
 import {BARS_TRANSITION_CONFIG} from '../../../constants';
 
 import styles from './Bar.scss';
@@ -14,6 +14,7 @@ export interface BarProps {
   width: number;
   x: number;
   y: number;
+  animationDirection?: Direction;
   animationDelay?: number;
   ariaLabel?: string;
   index?: number;
@@ -25,6 +26,7 @@ export interface BarProps {
 }
 
 export const Bar = React.memo(function Bar({
+  animationDirection = 'horizontal',
   animationDelay = 0,
   ariaLabel,
   color,
@@ -41,24 +43,27 @@ export const Bar = React.memo(function Bar({
   y,
 }: BarProps) {
   const getPath = useCallback(
-    (height: number, width: number) => {
+    (height = 0, width = 0) => {
       return getRoundedRectPath({height, width, needsMinWidth, roundedBorder});
     },
     [needsMinWidth, roundedBorder],
   );
 
-  const spring = useSpring<{transform: string}>({
-    from: {transform: 'scaleX(0) translateZ(0)'},
-    to: {transform: 'scaleX(1) translateZ(0)'},
+  const initialHeight = animationDirection === 'horizontal' ? height : 0;
+  const initialWidth = animationDirection === 'horizontal' ? 0 : width;
+
+  const spring = useSpring<{pathD: string}>({
+    from: {pathD: getPath(initialHeight, initialWidth)},
+    to: {pathD: getPath(height, width)},
     delay: isAnimated ? animationDelay : 0,
     config: BARS_TRANSITION_CONFIG,
     default: {immediate: !isAnimated},
   });
 
   return (
-    <animated.g className={styles.Group} style={{transform: spring.transform}}>
-      <path
-        d={getPath(height, width)}
+    <g className={styles.Group}>
+      <animated.path
+        d={spring.pathD}
         data-id={`bar-${index}`}
         data-index={index}
         data-type={DataType.Bar}
@@ -71,6 +76,6 @@ export const Bar = React.memo(function Bar({
         }}
         className={styles.Bar}
       />
-    </animated.g>
+    </g>
   );
 });

--- a/src/components/shared/Bar/tests/Bar.test.tsx
+++ b/src/components/shared/Bar/tests/Bar.test.tsx
@@ -33,7 +33,7 @@ describe('<Bar />', () => {
     const path = bar.find('path');
 
     expect(path?.props?.style?.transform).toStrictEqual(
-      'translate(5px, 10px) scaleX(-10)',
+      ' translate(5px, 10px) scaleX(-10)',
     );
   });
 });

--- a/src/components/shared/HorizontalBars/components/Label/Label.tsx
+++ b/src/components/shared/HorizontalBars/components/Label/Label.tsx
@@ -31,38 +31,34 @@ export function Label({
   const labelYOffset = (barHeight - HORIZONTAL_BAR_LABEL_HEIGHT) / 2;
 
   const spring = useSpring({
-    from: {transform: 'scaleX(0) translateZ(0)', opacity: 0},
-    to: {opacity: 1, transform: 'scaleX(1) translateZ(0)'},
+    from: {transform: 'translateX(0px)', opacity: 0},
+    to: {opacity: 1, transform: `translateX(${x}px)`},
     delay: isAnimated ? animationDelay : 0,
     config: BARS_TRANSITION_CONFIG,
     default: {immediate: !isAnimated},
   });
 
   return (
-    <animated.g
+    <animated.foreignObject
+      height={FONT_SIZE}
+      width={labelWidth}
+      aria-hidden="true"
+      y={y + labelYOffset}
       style={{
         opacity: spring.opacity,
         transform: spring.transform,
       }}
     >
-      <foreignObject
-        height={FONT_SIZE}
-        width={labelWidth}
-        aria-hidden="true"
-        y={y + labelYOffset}
-        x={x}
+      <div
+        style={{
+          fontSize: `${FONT_SIZE}px`,
+          color,
+          lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
+          height: HORIZONTAL_BAR_LABEL_HEIGHT,
+        }}
       >
-        <div
-          style={{
-            fontSize: `${FONT_SIZE}px`,
-            color,
-            lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-            height: HORIZONTAL_BAR_LABEL_HEIGHT,
-          }}
-        >
-          {label}
-        </div>
-      </foreignObject>
-    </animated.g>
+        {label}
+      </div>
+    </animated.foreignObject>
   );
 }

--- a/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
+++ b/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
@@ -45,7 +45,6 @@ describe('<Label />', () => {
 
     const object = label.find('foreignObject');
 
-    expect(object?.props.x).toStrictEqual(10);
     expect(object?.props.y).toStrictEqual(21.5);
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

This was the culprit: https://github.com/Shopify/polaris-viz/pull/790/files#diff-56a83ccaa9e7509066ffb2570840dd6fd2f8590a6dfbd4253cd11684b12b0ce5R36

The ID used in the keys was being regenerated on every data change. This meant that keys were always different, causing the animation to re-run.

Along the way, we also changed the bar structure so that we couldn't animate the bar width when new data came in.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/32969
 
## Storybook link

http://localhost:6006/?path=/story/simple-charts-simplebarchart--sorting

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
