### PR TITLE
Debounce events to reduce flashing

### DIFF
--- a/src/components/LegendContainer/components/LegendItem/LegendItem.tsx
+++ b/src/components/LegendContainer/components/LegendItem/LegendItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type {LegendData} from '../../types';
 import {
   getColorBlindEventAttrs,
-  getOpacityForActive,
+  getOpacityStylesForActive,
   useTheme,
 } from '../../../../hooks';
 import {LinePreview, SquareColorPreview} from '../../..';
@@ -52,7 +52,7 @@ export function LegendItem({
       {...colorBlindAttrs}
       style={{
         background: selectedTheme.tooltip.backgroundColor,
-        opacity: getOpacityForActive({
+        ...getOpacityStylesForActive({
           activeIndex,
           index,
         }),

--- a/src/components/LineChart/components/Line/Line.tsx
+++ b/src/components/LineChart/components/Line/Line.tsx
@@ -5,7 +5,7 @@ import {useSpring, animated} from '@react-spring/web';
 import type {DataPoint, DataSeries, LineStyle} from '../../../../types';
 import {
   getColorBlindEventAttrs,
-  getOpacityForActive,
+  getOpacityStylesForActive,
   useTheme,
 } from '../../../../hooks';
 import {ANIMATION_DELAY} from '../../constants';
@@ -71,12 +71,10 @@ export const Line = React.memo(function Shape({
         strokeLinejoin="round"
         strokeLinecap="round"
         strokeDasharray={StrokeDasharray[lineStyle]}
-        style={{
-          opacity: getOpacityForActive({
-            activeIndex: activeLineIndex,
-            index,
-          }),
-        }}
+        style={getOpacityStylesForActive({
+          activeIndex: activeLineIndex,
+          index,
+        })}
       />
       {children}
       <path

--- a/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
+++ b/src/components/LineChart/components/TooltipContent/TooltipContent.tsx
@@ -4,7 +4,7 @@ import type {LineStyle, Color} from 'types';
 import {COLOR_BLIND_SINGLE_LINE} from '../../../../constants';
 import {getSeriesColorsFromCount} from '../../../../hooks/use-theme-series-colors';
 import {
-  getOpacityForActive,
+  getOpacityStylesForActive,
   useTheme,
   useWatchColorBlindEvents,
 } from '../../../../hooks';
@@ -52,12 +52,10 @@ export function TooltipContent({data, theme}: TooltipContentProps) {
           <div
             className={styles.Row}
             key={`${name}-${index}`}
-            style={{
-              opacity: getOpacityForActive({
-                activeIndex: activeLineIndex,
-                index,
-              }),
-            }}
+            style={getOpacityStylesForActive({
+              activeIndex: activeLineIndex,
+              index,
+            })}
           >
             <LinePreview
               color={color ?? seriesColor[index]}

--- a/src/components/StackedAreaChart/components/Area/Area.tsx
+++ b/src/components/StackedAreaChart/components/Area/Area.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import {animated, useSpring} from '@react-spring/web';
 import type {Area as D3Area, Line} from 'd3-shape';
 
-import {getColorBlindEventAttrs, getOpacityForActive} from '../../../../hooks';
+import {
+  getColorBlindEventAttrs,
+  getOpacityStylesForActive,
+} from '../../../../hooks';
 import type {
   Color,
   GradientStop,
@@ -101,9 +104,7 @@ export function Area({
         />
       </defs>
       <g
-        style={{
-          opacity: getOpacityForActive({activeIndex: activeLineIndex, index}),
-        }}
+        style={getOpacityStylesForActive({activeIndex: activeLineIndex, index})}
         aria-hidden="true"
         tabIndex={-1}
       >

--- a/src/components/StackedAreaChart/components/Points/Points.tsx
+++ b/src/components/StackedAreaChart/components/Points/Points.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../utilities';
 import {DataType} from '../../../../types';
 import {
-  getOpacityForActive,
+  getOpacityStylesForActive,
   usePrefersReducedMotion,
   useTheme,
   useWatchColorBlindEvents,
@@ -96,13 +96,11 @@ export function Points({
         return (
           <g
             key={stackIndex}
-            style={{
-              opacity: getOpacityForActive({
-                activeIndex: activeLineIndex,
-                index: stackIndex,
-                fadedOpacity: 0,
-              }),
-            }}
+            style={getOpacityStylesForActive({
+              activeIndex: activeLineIndex,
+              index: stackIndex,
+              fadedOpacity: 0,
+            })}
           >
             {isGradientType(color) && (
               <defs>

--- a/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -4,7 +4,7 @@ import type {ScaleLinear} from 'd3-scale';
 import type {AccessibilitySeries} from '../../../VerticalBarChart/types';
 import {formatAriaLabel} from '../../utilities';
 import {
-  getOpacityForActive,
+  getOpacityStylesForActive,
   getColorBlindEventAttrs,
   usePrefersReducedMotion,
   useWatchColorBlindEvents,
@@ -109,12 +109,10 @@ export function BarGroup({
               data-type={DataType.BarGroup}
               data-index={barGroupIndex}
               key={`${barGroupIndex}${index}`}
-              style={{
-                opacity: getOpacityForActive({
-                  activeIndex: activeBarGroup,
-                  index: barGroupIndex,
-                }),
-              }}
+              style={getOpacityStylesForActive({
+                activeIndex: activeBarGroup,
+                index: barGroupIndex,
+              })}
             >
               <Bar
                 height={getBarHeight(rawValue)}
@@ -149,7 +147,7 @@ export function BarGroup({
                 width={barWidth - BAR_SPACING}
                 height={height + BAR_ANIMATION_HEIGHT_BUFFER * 2}
                 fill={`url(#${gradientId}${index})`}
-                opacity={getOpacityForActive({
+                style={getOpacityStylesForActive({
                   activeIndex: activeBarIndex,
                   index,
                 })}
@@ -173,7 +171,6 @@ export function BarGroup({
         <rect
           width={barWidth * dataLength}
           x={x}
-          y={BAR_ANIMATION_HEIGHT_BUFFER * -1}
           height={height}
           fill="transparent"
           aria-hidden="true"

--- a/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
+++ b/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react';
 import type {ScaleBand, ScaleLinear} from 'd3-scale';
 
 import {formatAriaLabel} from '../../../VerticalBarChart/utilities';
-import {getOpacityForActive} from '../../../../hooks/ColorBlindA11y';
+import {getOpacityStylesForActive} from '../../../../hooks/ColorBlindA11y';
 import {BAR_SPACING} from '../../../VerticalBarChart/constants';
 import {getColorBlindEventAttrs} from '../../../../hooks';
 import type {AccessibilitySeries} from '../../../VerticalBarChart/types';
@@ -65,12 +65,10 @@ export function StackedBarGroups({
               index: groupIndex,
             })}
             className={styles.Group}
-            style={{
-              opacity: getOpacityForActive({
-                activeIndex: activeBarGroup,
-                index: groupIndex,
-              }),
-            }}
+            style={getOpacityStylesForActive({
+              activeIndex: activeBarGroup,
+              index: groupIndex,
+            })}
             aria-label={groupAriaLabel}
             role="list"
             data-type={DataType.BarGroup}

--- a/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
+++ b/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
@@ -13,7 +13,7 @@ import {
 import {getGradientDefId} from '../../../../../../components/shared';
 import {
   getColorBlindEventAttrs,
-  getOpacityForActive,
+  getOpacityStylesForActive,
   useWatchColorBlindEvents,
 } from '../../../../../../hooks';
 import {
@@ -89,12 +89,10 @@ export function Stack({
               d={pathD}
               key={index}
               transform={`translate(${x},${y})`}
-              style={{
-                opacity: getOpacityForActive({
-                  activeIndex: activeBarIndex,
-                  index,
-                }),
-              }}
+              style={getOpacityStylesForActive({
+                activeIndex: activeBarIndex,
+                index,
+              })}
               aria-hidden="true"
             />
             <rect

--- a/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../constants';
 import {
   getColorBlindEventAttrs,
-  getOpacityForActive,
+  getOpacityStylesForActive,
   useWatchColorBlindEvents,
 } from '../../../hooks';
 import {
@@ -98,9 +98,10 @@ export function HorizontalGroup({
       }}
     >
       <g
-        style={{
-          opacity: getOpacityForActive({activeIndex: activeGroupIndex, index}),
-        }}
+        style={getOpacityStylesForActive({
+          activeIndex: activeGroupIndex,
+          index,
+        })}
         {...getColorBlindEventAttrs({
           type: 'group',
           index,

--- a/src/components/shared/HorizontalStackedBars/components/StackedBar/StackedBar.tsx
+++ b/src/components/shared/HorizontalStackedBars/components/StackedBar/StackedBar.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../../constants';
 import {
   getColorBlindEventAttrs,
-  getOpacityForActive,
+  getOpacityStylesForActive,
 } from '../../../../../hooks';
 import {getRoundedRectPath} from '../../../../../utilities';
 import type {RoundedBorder} from '../../../../../types';
@@ -59,7 +59,7 @@ export function StackedBar({
         style={{
           outline: 'none',
           transformOrigin: `${x}px 0px`,
-          opacity: getOpacityForActive({
+          ...getOpacityStylesForActive({
             activeIndex: activeBarIndex,
             index: seriesIndex,
           }),

--- a/src/hooks/ColorBlindA11y/index.ts
+++ b/src/hooks/ColorBlindA11y/index.ts
@@ -2,4 +2,4 @@ export {getColorBlindEventAttrs} from './getColorBlindEventAttrs';
 export {useColorBlindEvents} from './useColorBlindEvents';
 export {useWatchColorBlindEvents} from './useWatchColorBlindEvents';
 export {COLOR_BLIND_EVENT} from './constants';
-export {getOpacityForActive} from './utilities';
+export {getOpacityStylesForActive} from './utilities';

--- a/src/hooks/ColorBlindA11y/tests/utilities.test.ts
+++ b/src/hooks/ColorBlindA11y/tests/utilities.test.ts
@@ -2,7 +2,7 @@ import {
   capitalize,
   getDataSetItem,
   getEventName,
-  getOpacityForActive,
+  getOpacityStylesForActive,
 } from '../utilities';
 
 describe('utilities', () => {
@@ -30,25 +30,39 @@ describe('utilities', () => {
     });
   });
 
-  describe('getOpacityForActive()', () => {
+  describe('getOpacityStylesForActive()', () => {
     it('returns full opacity when activeIndex is -1', () => {
-      expect(getOpacityForActive({activeIndex: -1, index: 0})).toStrictEqual(1);
+      expect(
+        getOpacityStylesForActive({activeIndex: -1, index: 0}).opacity,
+      ).toStrictEqual(1);
     });
 
     it('returns full opacity when activeIndex and index match', () => {
-      expect(getOpacityForActive({activeIndex: 1, index: 1})).toStrictEqual(1);
+      expect(
+        getOpacityStylesForActive({activeIndex: 1, index: 1}).opacity,
+      ).toStrictEqual(1);
+    });
+
+    it('returns transition style', () => {
+      expect(
+        getOpacityStylesForActive({activeIndex: -1, index: 0}),
+      ).toStrictEqual({opacity: 1, transition: 'opacity 100ms ease'});
     });
 
     describe('fadedOpacity', () => {
       it('returns default when no match', () => {
-        expect(getOpacityForActive({activeIndex: 0, index: 1})).toStrictEqual(
-          0.3,
-        );
+        expect(
+          getOpacityStylesForActive({activeIndex: 0, index: 1}).opacity,
+        ).toStrictEqual(0.3);
       });
 
       it('returns fadedOpacity when provided and no match', () => {
         expect(
-          getOpacityForActive({activeIndex: 0, index: 1, fadedOpacity: 0}),
+          getOpacityStylesForActive({
+            activeIndex: 0,
+            index: 1,
+            fadedOpacity: 0,
+          }).opacity,
         ).toStrictEqual(0);
       });
     });

--- a/src/hooks/ColorBlindA11y/utilities.ts
+++ b/src/hooks/ColorBlindA11y/utilities.ts
@@ -17,7 +17,7 @@ export function getEventName(id: string, type: string) {
   return `${id}:${COLOR_BLIND_EVENT.name}:${type}`;
 }
 
-export function getOpacityForActive({
+export function getOpacityStylesForActive({
   activeIndex,
   index,
   fadedOpacity = COLOR_BLIND_FADED_OPACITY,
@@ -29,5 +29,8 @@ export function getOpacityForActive({
   const activeOpacity =
     activeIndex === index ? COLOR_BLIND_ACTIVE_OPACITY : fadedOpacity;
 
-  return activeIndex === -1 ? COLOR_BLIND_ACTIVE_OPACITY : activeOpacity;
+  return {
+    opacity: activeIndex === -1 ? COLOR_BLIND_ACTIVE_OPACITY : activeOpacity,
+    transition: 'opacity 100ms ease',
+  };
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -25,6 +25,6 @@ export {
   useColorBlindEvents,
   getColorBlindEventAttrs,
   useWatchColorBlindEvents,
-  getOpacityForActive,
+  getOpacityStylesForActive,
 } from './ColorBlindA11y';
 export {useCallbackRef} from './useCallbackRef';


### PR DESCRIPTION
## What does this implement/fix?

When moving between groups the events would fire instantly which would cause the opacity to quickly jump between faded and 100%.

By adding a 100ms debounce and 100ms css transition, we can make the transition between groups look a lot nicer.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/834

## What do the changes look like?

https://user-images.githubusercontent.com/149873/152833939-eefc9439-5535-4619-a267-19231290c754.mov
 