### PR TITLE
Disable events for single data points

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -67,7 +67,7 @@ export function Chart({
   type,
   xAxisOptions,
 }: ChartProps) {
-  useColorVisionEvents();
+  useColorVisionEvents(data.length > 1);
 
   const selectedTheme = useTheme(theme);
   const {labelFormatter} = xAxisOptions;

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -83,7 +83,7 @@ export function Chart({
   yAxisOptions,
   theme,
 }: ChartProps) {
-  useColorVisionEvents();
+  useColorVisionEvents(data.length > 1);
 
   const selectedTheme = useTheme(theme);
 

--- a/src/components/StackedAreaChart/Chart.tsx
+++ b/src/components/StackedAreaChart/Chart.tsx
@@ -78,7 +78,7 @@ export function Chart({
   showLegend,
   theme,
 }: Props) {
-  useColorVisionEvents();
+  useColorVisionEvents(data.length > 1);
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const selectedTheme = useTheme(theme);

--- a/src/components/VerticalBarChart/Chart.tsx
+++ b/src/components/VerticalBarChart/Chart.tsx
@@ -86,7 +86,7 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
 }: Props) {
-  useColorVisionEvents();
+  useColorVisionEvents(data.length > 1);
 
   const selectedTheme = useTheme(theme);
   const [activeBarGroup, setActiveBarGroup] = useState<number>(-1);

--- a/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
+++ b/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
@@ -5,10 +5,14 @@ import {ChartContext} from '../../components';
 import {COLOR_VISION_EVENT} from './constants';
 import {getDataSetItem, getEventName} from './utilities';
 
-export function useColorVisionEvents() {
+export function useColorVisionEvents(enabled = true) {
   const {id} = useContext(ChartContext);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const items = document.querySelectorAll(
       `#chart_${id} [${COLOR_VISION_EVENT.dataAttribute}-watch="true"]`,
     );
@@ -65,5 +69,5 @@ export function useColorVisionEvents() {
         item.removeEventListener('blur', onMouseLeave);
       });
     };
-  }, [id]);
+  }, [id, enabled]);
 }


### PR DESCRIPTION
## What does this implement/fix?

When rendering a single data point, the events don't make sense to enable.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/832
