### PR TITLE
Highlight active group labels

### DIFF
--- a/src/components/BarChartXAxis/BarChartXAxis.tsx
+++ b/src/components/BarChartXAxis/BarChartXAxis.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {ScaleBand} from 'd3-scale';
 
-import {useTheme} from '../../hooks';
+import {
+  getOpacityStylesForActive,
+  useTheme,
+  useWatchColorVisionEvents,
+} from '../../hooks';
 import {
   TICK_SIZE,
   BELOW_X_AXIS_MARGIN,
@@ -10,6 +14,7 @@ import {
   LINE_HEIGHT,
   DEFAULT_LABEL_RATIO,
   SPACING_BASE_TIGHT,
+  COLOR_VISION_GROUP_ITEM,
 } from '../../constants';
 import {RightAngleTriangle} from '../../utilities';
 
@@ -87,6 +92,13 @@ export const BarChartXAxis = React.memo(function BarChartXAxis({
   theme,
 }: BarChartXAxisProps) {
   const selectedTheme = useTheme(theme);
+
+  const [activeGroupIndex, setActiveGroupIndex] = useState(-1);
+
+  useWatchColorVisionEvents({
+    type: COLOR_VISION_GROUP_ITEM,
+    onIndexChange: ({detail}) => setActiveGroupIndex(detail.index),
+  });
 
   const {
     maxXLabelHeight,
@@ -176,6 +188,10 @@ export const BarChartXAxis = React.memo(function BarChartXAxis({
                   ? textTransform
                   : ''
               }
+              style={getOpacityStylesForActive({
+                activeIndex: activeGroupIndex,
+                index,
+              })}
             >
               <div
                 className={textContainerClassName}

--- a/src/components/VerticalBarChart/Chart.tsx
+++ b/src/components/VerticalBarChart/Chart.tsx
@@ -6,6 +6,7 @@ import {GradientDefs} from '../shared';
 import {
   BarChartMargin as Margin,
   COLOR_VISION_SINGLE_ITEM,
+  COLOR_VISION_GROUP_ITEM,
   XMLNS,
 } from '../../constants';
 import {
@@ -93,7 +94,7 @@ export function Chart({
   const id = useMemo(() => uniqueId('VerticalBarChart'), []);
 
   useWatchColorVisionEvents({
-    type: 'group',
+    type: COLOR_VISION_GROUP_ITEM,
     onIndexChange: ({detail}) => {
       setActiveBarGroup(detail.index);
     },

--- a/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -18,6 +18,7 @@ import {
   LOAD_ANIMATION_DURATION,
   MASK_HIGHLIGHT_COLOR,
   BAR_ANIMATION_HEIGHT_BUFFER,
+  COLOR_VISION_GROUP_ITEM,
   COLOR_VISION_SINGLE_ITEM,
 } from '../../../../constants';
 import {clamp, uniqueId} from '../../../../utilities';
@@ -158,7 +159,7 @@ export function BarGroup({
       </g>
       <g
         {...getColorVisionEventAttrs({
-          type: 'group',
+          type: COLOR_VISION_GROUP_ITEM,
           index: barGroupIndex,
         })}
         className={styles.BarGroup}

--- a/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
+++ b/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import type {ScaleBand, ScaleLinear} from 'd3-scale';
 
+import {COLOR_VISION_GROUP_ITEM} from '../../../../constants';
 import {formatAriaLabel} from '../../../VerticalBarChart/utilities';
 import {
   getOpacityStylesForActive,
@@ -63,7 +64,7 @@ export function StackedBarGroups({
           <g
             key={groupIndex}
             {...getColorVisionEventAttrs({
-              type: 'group',
+              type: COLOR_VISION_GROUP_ITEM,
               index: groupIndex,
             })}
             className={styles.Group}

--- a/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -3,6 +3,7 @@ import {animated, SpringValue} from '@react-spring/web';
 import type {ScaleLinear} from 'd3-scale';
 
 import {
+  COLOR_VISION_GROUP_ITEM,
   HORIZONTAL_GROUP_LABEL_HEIGHT,
   HORIZONTAL_SPACE_BETWEEN_SINGLE,
 } from '../../../constants';
@@ -69,7 +70,7 @@ export function HorizontalGroup({
   const [activeGroupIndex, setActiveGroupIndex] = useState(-1);
 
   useWatchColorVisionEvents({
-    type: 'group',
+    type: COLOR_VISION_GROUP_ITEM,
     onIndexChange: ({detail}) => {
       setActiveGroupIndex(detail.index);
     },
@@ -103,7 +104,7 @@ export function HorizontalGroup({
           index,
         })}
         {...getColorVisionEventAttrs({
-          type: 'group',
+          type: COLOR_VISION_GROUP_ITEM,
           index,
         })}
         data-type={DataType.BarGroup}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -330,3 +330,4 @@ export const DEFAULT_LEGEND_HEIGHT = 29;
 export const COLOR_VISION_SINGLE_LINE = 'singleLine';
 export const COLOR_VISION_SINGLE_ITEM = 'singleItem';
 export const LEGENDS_TOP_MARGIN = 16;
+export const COLOR_VISION_GROUP_ITEM = 'group';


### PR DESCRIPTION
## What does this implement/fix?

When hovering over groups, the label should also be highlighted. 

## What do the changes look like?

Example: When hovering `Monday`, the labels for `Thursday` & `Monday` be faded out.

https://user-images.githubusercontent.com/149873/152866685-a07bf273-f60b-42cc-b2f6-dff608c95428.mov
 