### PR TITLE
Remove debounced groups. Resize hit areas

### DIFF
--- a/src/components/HorizontalBarChart/Chart.tsx
+++ b/src/components/HorizontalBarChart/Chart.tsx
@@ -237,6 +237,7 @@ export function Chart({
               barHeight={barHeight}
               containerWidth={width}
               data={data}
+              groupHeight={groupHeight}
               id={id}
               index={index}
               isAnimated={isAnimated}

--- a/src/components/SimpleBarChart/Chart.tsx
+++ b/src/components/SimpleBarChart/Chart.tsx
@@ -136,6 +136,7 @@ export function Chart({
               barHeight={barHeight}
               containerWidth={width}
               data={data}
+              groupHeight={groupHeight}
               id={id}
               index={index}
               isAnimated={isAnimated}

--- a/src/components/VerticalBarChart/Chart.tsx
+++ b/src/components/VerticalBarChart/Chart.tsx
@@ -204,7 +204,7 @@ export function Chart({
       .some((num) => num > 0);
   }, [sortedData]);
 
-  const {xScale, xAxisLabels} = useXScale({
+  const {xScale, xAxisLabels, gapWidth} = useXScale({
     drawableWidth,
     data: sortedData,
     innerMargin: BarMargin[selectedTheme.bar.innerMargin],
@@ -319,6 +319,7 @@ export function Chart({
               activeBarGroup={activeBarGroup}
               colors={barColors}
               drawableHeight={drawableHeight}
+              gapWidth={gapWidth}
               id={id}
               labels={labels}
               stackedValues={stackedValues}
@@ -332,6 +333,7 @@ export function Chart({
               return (
                 <BarGroup
                   isAnimated={isAnimated}
+                  gapWidth={gapWidth}
                   key={index}
                   x={xPosition == null ? 0 : xPosition}
                   yScale={yScale}

--- a/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -35,6 +35,7 @@ interface Props {
   accessibilityData: AccessibilitySeries[];
   activeBarGroup: number;
   zeroAsMinHeight: boolean;
+  gapWidth: number;
   isAnimated?: boolean;
   rotateZeroBars?: boolean;
 }
@@ -53,6 +54,7 @@ export function BarGroup({
   rotateZeroBars = false,
   accessibilityData,
   activeBarGroup,
+  gapWidth,
 }: Props) {
   const groupAriaLabel = formatAriaLabel(accessibilityData[barGroupIndex]);
 
@@ -169,8 +171,8 @@ export function BarGroup({
         role="list"
       >
         <rect
-          width={barWidth * dataLength}
-          x={x}
+          width={barWidth * dataLength + gapWidth}
+          x={x - gapWidth / 2}
           height={height}
           fill="transparent"
           aria-hidden="true"

--- a/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -52,6 +52,7 @@ describe('<BarGroup/>', () => {
     isSubdued: false,
     zeroAsMinHeight: false,
     isAnimated: false,
+    gapWidth: 10,
   };
 
   it('renders a <Bar /> for each data item', () => {

--- a/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
+++ b/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
@@ -19,6 +19,7 @@ interface StackedBarGroupsProps {
   activeBarGroup: number;
   colors: Color[];
   drawableHeight: number;
+  gapWidth: number;
   id: string;
   labels: string[];
   stackedValues: StackedSeries[];
@@ -31,6 +32,7 @@ export function StackedBarGroups({
   accessibilityData,
   activeBarGroup,
   drawableHeight,
+  gapWidth,
   id,
   labels,
   stackedValues,
@@ -79,9 +81,9 @@ export function StackedBarGroups({
           >
             <rect
               height={drawableHeight}
-              x={x}
-              width={xScale.bandwidth()}
               fill="transparent"
+              x={x - gapWidth / 2}
+              width={xScale.bandwidth() + gapWidth}
               aria-hidden="true"
             />
             <Stack

--- a/src/components/VerticalBarChart/hooks/tests/use-x-scale.test.tsx
+++ b/src/components/VerticalBarChart/hooks/tests/use-x-scale.test.tsx
@@ -36,6 +36,7 @@ describe('useXScale', () => {
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       scale.paddingOuter = () => scale;
+      scale.step = () => 10;
       return scale;
     });
 
@@ -59,6 +60,7 @@ describe('useXScale', () => {
       scale.bandwidth = () => 10;
       scale.paddingInner = () => scale;
       scale.paddingOuter = () => scale;
+      scale.step = () => 10;
       domainSpy = jest.fn(() => scale);
       scale.domain = domainSpy;
       return scale;
@@ -83,6 +85,7 @@ describe('useXScale', () => {
       scale.paddingInner = () => scale;
       scale.paddingOuter = () => scale;
       scale.domain = () => scale;
+      scale.step = () => 10;
       return scale;
     });
 
@@ -111,6 +114,7 @@ describe('useXScale', () => {
         scale.range = () => scale;
         scale.bandwidth = () => 10;
         scale.paddingOuter = () => scale;
+        scale.step = () => 10;
 
         paddingInnerSpy = jest.fn(() => scale);
         scale.paddingInner = paddingInnerSpy;
@@ -143,6 +147,7 @@ describe('useXScale', () => {
         scale.range = () => scale;
         scale.bandwidth = () => 10;
         scale.paddingInner = () => scale;
+        scale.step = () => 10;
 
         paddingOuterSpy = jest.fn(() => scale);
         scale.paddingOuter = paddingOuterSpy;

--- a/src/components/VerticalBarChart/hooks/use-x-scale.ts
+++ b/src/components/VerticalBarChart/hooks/use-x-scale.ts
@@ -35,5 +35,9 @@ export function useXScale({
     });
   }, [labels, xScale, barWidthOffset]);
 
-  return {xScale, xAxisLabels};
+  const gapWidth = useMemo(() => {
+    return xScale.step() - xScale.bandwidth();
+  }, [xScale]);
+
+  return {xScale, xAxisLabels, gapWidth};
 }

--- a/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -30,6 +30,7 @@ export interface HorizontalGroupProps {
   barHeight: number;
   containerWidth: number;
   data: DataSeries[];
+  groupHeight: number;
   id: string;
   index: number;
   isAnimated: boolean;
@@ -52,6 +53,7 @@ export function HorizontalGroup({
   barHeight,
   containerWidth,
   data,
+  groupHeight,
   id,
   index,
   isAnimated,
@@ -79,7 +81,7 @@ export function HorizontalGroup({
     return data.map(({name}) => name ?? '');
   }, [data]);
 
-  const hitAreaHeight = useMemo(() => {
+  const rowHeight = useMemo(() => {
     const barPlusSpaceHeight = barHeight + HORIZONTAL_SPACE_BETWEEN_SINGLE;
 
     if (isStacked) {
@@ -115,8 +117,9 @@ export function HorizontalGroup({
       >
         <rect
           fill="transparent"
-          height={hitAreaHeight}
+          height={groupHeight}
           width={containerWidth}
+          y={-(groupHeight - rowHeight) / 2}
         />
         <GroupLabel
           areAllNegative={areAllNegative}

--- a/src/components/shared/HorizontalGroup/tests/HorizontalGroup.test.tsx
+++ b/src/components/shared/HorizontalGroup/tests/HorizontalGroup.test.tsx
@@ -71,6 +71,7 @@ const MOCK_PROPS: HorizontalGroupProps = {
   barHeight: 12,
   containerWidth: 200,
   data: DATA,
+  groupHeight: 20,
   id: 'id',
   index: 1,
   isAnimated: false,

--- a/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
+++ b/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
@@ -1,26 +1,12 @@
 import {useContext, useEffect} from 'react';
-import {useDebouncedCallback} from 'use-debounce/lib';
 
 import {ChartContext} from '../../components';
 
 import {COLOR_VISION_EVENT} from './constants';
 import {getDataSetItem, getEventName} from './utilities';
 
-type ColorBlindEvent = CustomEvent<{
-  index: number;
-}>;
-
-const DEBOUNCE_TIME = 100;
-
 export function useColorVisionEvents() {
   const {id} = useContext(ChartContext);
-
-  const [debounced, cancel] = useDebouncedCallback(function (
-    custom: ColorBlindEvent,
-  ) {
-    window.dispatchEvent(custom);
-  },
-  DEBOUNCE_TIME);
 
   useEffect(() => {
     const items = document.querySelectorAll(
@@ -36,8 +22,6 @@ export function useColorVisionEvents() {
       if (id == null || type == null) {
         return;
       }
-
-      cancel();
 
       const custom = new CustomEvent(getEventName(id, type), {
         detail: {
@@ -63,7 +47,7 @@ export function useColorVisionEvents() {
         },
       });
 
-      debounced(custom);
+      window.dispatchEvent(custom);
     }
 
     items.forEach((item) => {
@@ -81,5 +65,5 @@ export function useColorVisionEvents() {
         item.removeEventListener('blur', onMouseLeave);
       });
     };
-  }, [id, debounced, cancel]);
+  }, [id]);
 }


### PR DESCRIPTION
## What does this implement/fix?

As part of https://github.com/Shopify/polaris-viz/pull/842 we started debouncing events so that all the groups stopped flashing when slowly moving between them.

This ended up being the wrong solution because debouncing introduced a few issues around events not correctly firing in situations where they didn't need to be debounced.

Instead of debouncing events, we're going to expand the hit areas of groups so that each area is touching each other. This achieves the same effect without having to debounce events.

The new hit areas outlined in red.

<img width="2092" alt="image" src="https://user-images.githubusercontent.com/149873/153057400-c658a25e-2b23-4384-9f02-01b968774109.png">

and the old hit areas in blue

<img width="2102" alt="image" src="https://user-images.githubusercontent.com/149873/153057547-d428bad4-6eb4-4124-bf95-cd4fde9e1873.png">

