### PR TITLE
Switch issue action to approved GH action

### DIFF
--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -3,21 +3,15 @@ name: Auto Assign to Project(s)
 on:
   issues:
     types: [opened]
-  # pull_request:
-  #   types: [opened, labeled]
-  issue_comment:
-    types: [created]
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  assign_one_project:
+  add-issues-to-board:
     runs-on: ubuntu-latest
-    name: Assign to One Project
     steps:
-    - name: Assign NEW issues to General Backlog
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/Shopify/polaris-viz/projects/1'
-        column_name: 'Backlog ( Unprioritized )'
+      - name: Add to Board
+        uses: monry/actions-add-issue-to-project@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project-owner: "shopify"
+          project-number: 1
+          issue-id: ${{ github.event.issue.node_id }}


### PR DESCRIPTION
## What does this implement/fix?
Use a [Github Action that is approved in Kepler ](https://kepler.shopifycloud.com/services/github-action-add-issue-to-project) instead of the one we had that isn't approved. Hopefully 🤞 it works the same way and adds the issues to the backlog column, however there is no way to specify the column with this action.

## Does this close any currently open issues?
Part of closing https://github.com/Shopify/polaris-viz/pull/793

## What do the changes look like?
We shall see upon merging.


### Before merging

~- [ ] Check your changes on a variety of browsers and devices.~

~- [ ] Update the Changelog's Unreleased section with your changes.~

~- [ ] Update relevant documentation, tests, and Storybook.~
