### PR TITLE
Always reset bar state if index is -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,11 @@
 ### Removed
 
 - Removed legacy `<Legend >` component.
+
+### Fixed
+
 - Removed focus outline on `<StackedAreaChart />` and `<LineChart />`.
+- Fixed issue where color vision events wouldn't correctly update when first interaction was a keyboard event.
 
 ## [0.28.7] - 2022-01-20
 

--- a/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -65,7 +65,11 @@ export function BarGroup({
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
     onIndexChange: ({detail}) => {
-      if (activeBarGroup === -1 || activeBarGroup === barGroupIndex) {
+      if (
+        detail.index === -1 ||
+        activeBarGroup === -1 ||
+        activeBarGroup === barGroupIndex
+      ) {
         setActiveBarIndex(detail.index);
       }
     },

--- a/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
+++ b/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
@@ -52,7 +52,11 @@ export function Stack({
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
     onIndexChange: ({detail}) => {
-      if (activeBarGroup === -1 || activeBarGroup === groupIndex) {
+      if (
+        detail.index === -1 ||
+        activeBarGroup === -1 ||
+        activeBarGroup === groupIndex
+      ) {
         setActiveBarIndex(detail.index);
       }
     },


### PR DESCRIPTION
## What does this implement/fix?

We try to ignore updates when a user isn't actively hovering a group so we can highlight the individual bars. This was causing the other groups to ignore events.

Now, if the event is trying to reset the bar to an original state (index being -1), we'll allow the event to update the bar.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/883

## Storybook link

http://localhost:6006/?path=/story/default-charts-barchart--default

Repro steps are available in https://github.com/Shopify/polaris-viz/issues/883

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
