### PR TITLE
Jsonschema powered component example

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.7",
     "fast-deep-equal": "^3.1.3",
+    "jsonschema": "^1.4.0",
     "lodash.throttle": "^4.1.1",
     "use-debounce": "^3.3.0"
   },

--- a/src/components/ChartConfig/ChartConfig.tsx
+++ b/src/components/ChartConfig/ChartConfig.tsx
@@ -1,0 +1,174 @@
+/* eslint-disable no-case-declarations */
+import React from 'react';
+import {validate} from 'jsonschema';
+
+import {BarChart, LineChart} from '../../';
+import type {DataSeries, Direction} from '../../types';
+
+import schemaJson from './schema.json';
+
+const schema = {
+  $ref: '#/definitions/ChartTopLevelConfig',
+  definitions: {
+    ChartTopLevelConfig: {
+      type: 'object',
+      anyOf: [
+        {
+          $ref: '#/definitions/BarChartConfig',
+        },
+        {
+          $ref: '#/definitions/LineChartConfig',
+        },
+      ],
+    },
+    ChartType: {
+      description: 'Chart types',
+      enum: ['bar', 'line'],
+      type: 'string',
+    },
+    BarChartConfig: {
+      additionalProperties: false,
+      type: 'object',
+      properties: {
+        type: {
+          $ref: '#/definitions/BarChartTypeDef',
+        },
+        data: {
+          description: 'Bar chart data',
+          items: {
+            $ref: '#/definitions/DataSeries',
+          },
+          type: 'array',
+        },
+        direction: {
+          $ref: '#/definitions/Direction',
+        },
+      },
+    },
+    BarChartTypeDef: {
+      description: 'Bar chart type',
+      enum: ['bar'],
+      type: 'string',
+    },
+    Direction: {
+      description: 'chart direction',
+      enum: ['horizontal', 'vertical'],
+      type: 'string',
+    },
+    DataSeries: {
+      additionalProperties: false,
+      type: 'object',
+      properties: {
+        data: {
+          items: {
+            $ref: '#/definitions/DataPoint',
+          },
+          type: 'array',
+        },
+        color: {
+          anyOf: [
+            {
+              type: ['string', 'null'],
+            },
+            {
+              items: {
+                $ref: '#/definitions/GradientStop',
+              },
+              type: 'array',
+            },
+          ],
+        },
+        isComparison: {
+          type: ['boolean', 'null'],
+        },
+        name: {
+          type: ['string', 'null'],
+        },
+      },
+    },
+    DataPoint: {
+      additionalProperties: false,
+      type: 'object',
+      properties: {
+        key: {
+          type: ['number', 'string'],
+        },
+        value: {
+          type: ['number', 'null'],
+        },
+      },
+    },
+    GradientStop: {
+      additionalProperties: false,
+      properties: {
+        offset: {
+          type: 'number',
+        },
+        color: {
+          type: 'string',
+        },
+        stopOpacity: {
+          type: ['number', 'null'],
+        },
+      },
+    },
+    LineChartConfig: {
+      additionalProperties: false,
+      type: 'object',
+      properties: {
+        type: {
+          $ref: '#/definitions/LineChartTypeDef',
+        },
+        data: {
+          description: 'Bar chart data',
+          items: {
+            $ref: '#/definitions/DataSeries',
+          },
+          type: 'array',
+        },
+      },
+    },
+    LineChartTypeDef: {
+      description: 'Line chart type',
+      enum: ['line'],
+      type: 'string',
+    },
+  },
+};
+
+export type ChartConfigProps = BarChartConfigProps | LineChartConfigProps;
+
+interface LineChartConfigProps {
+  type: string;
+  data: DataSeries[];
+}
+interface BarChartConfigProps {
+  type: string;
+  data: DataSeries[];
+  direction?: Direction;
+}
+
+export function ChartConfig(props: any) {
+  const result = validate(props, schema);
+  function chartType() {
+    if (result.errors.length > 0) {
+      return <p>{result.toString()}</p>;
+    }
+    switch (props.type) {
+      case 'bar':
+        const barChartProps = props as BarChartConfigProps;
+        return (
+          <BarChart
+            data={barChartProps.data}
+            direction={barChartProps.direction}
+          />
+        );
+      case 'line':
+        const lineChartProps = props as LineChartConfigProps;
+        return <LineChart data={lineChartProps.data} />;
+      default:
+        return null;
+    }
+  }
+  return <React.Fragment>{chartType()}</React.Fragment>;
+}

--- a/src/components/ChartConfig/index.ts
+++ b/src/components/ChartConfig/index.ts
@@ -1,0 +1,1 @@
+export {ChartConfig} from './ChartConfig';

--- a/src/components/ChartConfig/schema.json
+++ b/src/components/ChartConfig/schema.json
@@ -1,0 +1,129 @@
+{
+  "$ref": "#/definitions/ChartTopLevelConfig",
+  "definitions": {
+    "ChartTopLevelConfig": {
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BarChartConfig"
+        },
+        {
+          "$ref": "#/definitions/LineChartConfig"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "ChartType": {
+      "description": "Chart types",
+      "enum": ["bar", "line"],
+      "type": "string"
+    },
+    "BarChartConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/BarChartTypeDef"
+        },
+        "data": {
+          "description": "Bar chart data",
+          "items": {
+            "$ref": "#/definitions/DataSeries"
+          },
+          "type": "array"
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction"
+        }
+      }
+    },
+    "BarChartTypeDef": {
+      "description": "Bar chart type",
+      "enum": ["bar"],
+      "type": "string"
+    },
+    "Direction": {
+      "description": "chart direction",
+      "enum": ["horizontal", "vertical"],
+      "type": "string"
+    },
+    "DataSeries": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/DataPoint"
+          },
+          "type": "array"
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": ["string", "null"]
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/GradientStop"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "isComparison": {
+          "type": ["boolean", "null"]
+        },
+        "name": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "DataPoint": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": ["number", "string"]
+        },
+        "value": {
+          "type": ["number", "null"]
+        }
+      }
+    },
+    "GradientStop": {
+      "additionalProperties": false,
+      "properties": {
+        "offset": {
+          "type": "number"
+        },
+        "color": {
+          "type": "string"
+        },
+        "stopOpacity": {
+          "type": ["number", "null"]
+        }
+      }
+    },
+    "LineChartConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/LineChartTypeDef"
+        },
+        "data": {
+          "description": "Bar chart data",
+          "items": {
+            "$ref": "#/definitions/DataSeries"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "LineChartTypeDef": {
+      "description": "Line chart type",
+      "enum": ["line"],
+      "type": "string"
+    }
+  }
+}

--- a/src/components/ChartConfig/stories/ChartConfig.stories.tsx
+++ b/src/components/ChartConfig/stories/ChartConfig.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type {Story, Meta} from '@storybook/react';
+
+import {ChartConfig} from '../..';
+
+import type {DataSeries} from '../../../types';
+
+const DATA: DataSeries[] = [
+  {
+    name: 'Breakfast',
+    data: [
+      {key: 'Monday', value: 3},
+      {key: 'Tuesday', value: -7},
+      {key: 'Wednesday', value: -7},
+      {key: 'Thursday', value: -8},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 0},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Lunch',
+    data: [
+      {key: 'Monday', value: 4},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -10},
+      {key: 'Thursday', value: 15},
+      {key: 'Friday', value: 8},
+      {key: 'Saturday', value: 50},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Dinner',
+    data: [
+      {key: 'Monday', value: 7},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -15},
+      {key: 'Thursday', value: -12},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 5},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+];
+
+export default {
+  title: 'ChartConfig',
+  component: ChartConfig,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Used when you need a single set of props to determine which chart to use',
+      },
+    },
+  },
+  argTypes: {
+    data: {
+      description:
+        'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
+    },
+    type: {
+      control: {
+        type: 'select',
+      },
+      description: 'Which type of chart to render',
+      options: ['bar', 'line'],
+    },
+    direction: {
+      control: {
+        type: 'select',
+      },
+      description: 'Which direction to render a chart',
+      options: ['horizontal', 'vertical'],
+    },
+  },
+} as Meta;
+
+const Template: Story<any> = (args: any) => {
+  return <ChartConfig {...args} />;
+};
+
+export const BarChart: Story<any> = Template.bind({});
+BarChart.parameters = {controls: {include: ['data', 'type', 'direction']}};
+BarChart.args = {
+  data: DATA,
+  type: 'bar',
+};
+
+export const LineChart: Story<any> = Template.bind({});
+LineChart.parameters = {
+  controls: {include: ['data', 'type']},
+};
+LineChart.args = {
+  data: DATA,
+  type: 'line',
+};
+
+export const ErrorChart: Story<any> = Template.bind({});
+ErrorChart.parameters = {controls: {include: ['data', 'type']}};
+
+ErrorChart.args = {
+  data: DATA,
+  test: 1,
+  type: 'line',
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,3 +32,4 @@ export type {SimpleBarChartProps} from './SimpleBarChart';
 export {ChartContext} from './ChartContainer';
 export {Legend} from './LegendContainer';
 export type {LegendProps} from './LegendContainer';
+export {ChartConfig} from './ChartConfig';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10239,6 +10239,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonschema@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
+  integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"


### PR DESCRIPTION
## What does this implement/fix?

There are 2 approaches for creating a single component to render charts from some sort of serialized form, this explores the approach that vega takes to render charts from a json-schema.

Try out the storybook for the example <ChartConfig> component I created  http://localhost:6006/?path=/story/chartconfig--bar-chart

Still TBD which repo this should go in, we'll need to re-use the types from polaris-viz to properly map config to components.


 
## Storybook link

[<!-- 🎩 Include links to help tophatting -->](http://localhost:6006/?path=/story/chartconfig--bar-chart)


### Before merging