### PR TITLE
Revert initial opacity value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - `<Sparkbar />` bar shape is now configurable by the theme bar.hasRoundedCorners property
+- Fixed bug where `showLabels=false` would cause `<SimpleBarChart >` to render with 0 opacity.
+
 
 ## [0.29.0] - 2022-01-20
 

--- a/src/hooks/useHorizontalTransitions.ts
+++ b/src/hooks/useHorizontalTransitions.ts
@@ -44,7 +44,7 @@ export function useHorizontalTransitions({
       return item.key ?? '';
     },
     initial: ({index}) => ({
-      opacity: 0,
+      opacity: 1,
       transform: getTransform(index),
     }),
     from: ({index}) => ({


### PR DESCRIPTION
## What does this implement/fix?

When adding the Legends, we introduced logic that resizes that chart height when legends are needed so we can keep everything within the container.

When a chart loads, the resize event is triggered and the chart is resized. This causes the `useHorizontalTransition` logic to make the load in animation start a little lower than it should. This results in a little "jump" in the animation.

https://user-images.githubusercontent.com/149873/154719914-16d8c289-b82f-416b-bc1b-b713b6b273e6.mov

When `showLegends` was `false`, the `update` event in the hook would not fire, resulting in `0` opacity charts.

After chatting with @krystalcampioni we decided that living with the jump is ok for now and we will revisit once we audit all the charts for data-changing animations.

## Does this close any currently open issues?

Resolves: https://github.com/Shopify/polaris-viz/issues/891

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
