### PR TITLE
Fix wrong index used for bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 - `<Sparkbar />` bar shape is now configurable by the theme bar.hasRoundedCorners property
 - Fixed bug where `showLabels=false` would cause `<SimpleBarChart >` to render with 0 opacity.
-
+- Fix bug where vertical `<SimpleNormalizedChart />` would use the wrong index for color vision interactions.
 
 ## [0.29.0] - 2022-01-20
 

--- a/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/src/components/SimpleNormalizedChart/Chart.tsx
@@ -143,7 +143,7 @@ export function Chart({
           return (
             <BarSegment
               activeIndex={activeIndex}
-              index={index}
+              index={colorIndex}
               isAnimated={!prefersReducedMotion}
               direction={direction}
               size={size}


### PR DESCRIPTION
## What does this implement/fix?

The index being used for the interactions was only for horizontal versions. 

https://user-images.githubusercontent.com/149873/154721483-91b2a021-a2d6-4901-ac9c-5e1d41f9298a.mov

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/890
 
## Storybook link

http://localhost:6006/?path=/story/simple-charts-simplenormalizedchart--vertical-small

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
