### PR TITLE
Remove outline on horizontal bars

### DIFF
--- a/src/components/shared/HorizontalBars/HorizontalBars.scss
+++ b/src/components/shared/HorizontalBars/HorizontalBars.scss
@@ -1,0 +1,5 @@
+@import '../../../styles/common';
+
+.Bar {
+  @include no-outline;
+}

--- a/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -21,6 +21,7 @@ import {Bar} from '../Bar';
 import {getGradientDefId} from '../GradientDefs';
 
 import {Label} from './components';
+import styles from './HorizontalBars.scss';
 
 export interface HorizontalBarsProps {
   activeGroupIndex: number;
@@ -132,6 +133,7 @@ export function HorizontalBars({
               />
             )}
             <rect
+              className={styles.Bar}
               x={0}
               y={y - HORIZONTAL_SPACE_BETWEEN_SINGLE / 2}
               width={width}


### PR DESCRIPTION
## What does this implement/fix?

When pressing on a horizontal bar, the focus outline was still visible. 

## What do the changes look like?

<img width="874" alt="image" src="https://user-images.githubusercontent.com/149873/155200038-aabae1ab-d78e-420c-b106-772a8e245f13.png">

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
