### PR TITLE
Fix empty data line chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Fixed
 - `<Sparkbar />` bar shape is now configurable by the theme bar.hasRoundedCorners property
-- Fixed bug where `showLabels=false` would cause `<SimpleBarChart >` to render with 0 opacity.
-- Fix bug where vertical `<SimpleNormalizedChart />` would use the wrong index for color vision interactions.
+- Bug where `showLabels=false` would cause `<SimpleBarChart >` to render with 0 opacity.
+- Bug where vertical `<SimpleNormalizedChart />` would use the wrong index for color vision interactions.
+- Bug causing the animated `<LineChart />` to break when hovered over if empty data was provided
 
 ## [0.29.0] - 2022-01-20
 

--- a/src/components/LineChart/Chart.tsx
+++ b/src/components/LineChart/Chart.tsx
@@ -108,7 +108,8 @@ export function Chart({
 
   const fontSize = width < SMALL_SCREEN ? SMALL_FONT_SIZE : FONT_SIZE;
 
-  const emptyState = data.length === 0;
+  const emptyState =
+    data.length === 0 || data.every((series) => series.data.length === 0);
 
   const {ticks: initialTicks} = useYScale({
     fontSize,
@@ -268,7 +269,11 @@ export function Chart({
     if (eventType === 'mouse') {
       const point = eventPointNative(event!);
 
-      if (point == null || xScale == null) {
+      if (
+        point == null ||
+        xScale == null ||
+        reversedSeries[longestSeriesIndex] == null
+      ) {
         return TOOLTIP_POSITION_DEFAULT_RETURN;
       }
 
@@ -419,7 +424,7 @@ export function Chart({
           })}
 
           <Points
-            activeIndex={activeIndex}
+            activeIndex={emptyState ? null : activeIndex}
             animatedCoordinates={animatedCoordinates}
             animatePoints={animatePoints}
             data={reversedSeries}

--- a/src/hooks/tests/use-linear-chart-animations.test.tsx
+++ b/src/hooks/tests/use-linear-chart-animations.test.tsx
@@ -4,7 +4,6 @@ import {line} from 'd3-shape';
 import type {DataWithDefaults} from 'components/LineChart/types';
 
 import {useLinearChartAnimations} from '../use-linear-chart-animations';
-import {getPointAtLength} from '../../utilities';
 
 jest.mock('../../utilities', () => {
   return {
@@ -158,30 +157,5 @@ describe('useLinearChartAnimations', () => {
     mount(<TestComponent />);
 
     expect(lineGeneratorMock).not.toHaveBeenCalled();
-  });
-
-  it('calls getPointAtLength with a length of 0 if there is only one point in the series', () => {
-    let animatedCoordinates: any[] | null;
-
-    function TestComponent() {
-      animatedCoordinates = useLinearChartAnimations({
-        ...mockProps,
-        data: [
-          {
-            ...data[0],
-            data: [{key: 'Jan 1', value: 1500}],
-          },
-        ],
-        isAnimated: true,
-      }).animatedCoordinates;
-
-      return null;
-    }
-
-    mount(<TestComponent />);
-
-    animatedCoordinates![0].get();
-
-    expect(getPointAtLength).toHaveBeenCalledWith(expect.any(SVGElement), 0);
   });
 });

--- a/src/hooks/use-linear-chart-animations.tsx
+++ b/src/hooks/use-linear-chart-animations.tsx
@@ -94,7 +94,7 @@ export function useLinearChartAnimations({
   // Using the percentage, get the length to calculate the coordinates at the current index
   const getCoordinatesFromPercentage = useCallback(
     (percent: number, path: SVGPathElement, totalLength: number) => {
-      if (path == null || totalLength == null) {
+      if (path == null || totalLength == null || totalLength === 0) {
         return {x: 0, y: 0};
       }
 


### PR DESCRIPTION
## What does this implement/fix?
Fixes bug where an animated line chart with an empty array of data, which broke when hovering on the chart.

Left comments in the code about the details of the fixes


## Does this close any currently open issues?
Resolves https://github.com/Shopify/polaris-viz/issues/913
 
## Storybook link
You can tophat by using a line chart story, ensuring the chart is animated and updating the data to something like this


```
[
    {
        "data": [],
        "color": "blue",
        "name": "Last 14 days"
    }
]
```


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
