### PR TITLE
Changes all references from `master` to `main`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -239,4 +239,4 @@ Pull requests are welcome. See the <a href="/CONTRIBUTING.md">contribution guide
   <h3>Licenses</h3>
 </a>
 
-- Source code is under a [custom license](https://github.com/Shopify/polaris-viz/blob/master/LICENSE.md) based on MIT. The license restricts Polaris Viz usage to applications that integrate or interoperate with Shopify software or services, with additional restrictions for external, stand-alone applications.
+- Source code is under a [custom license](https://github.com/Shopify/polaris-viz/blob/main/LICENSE.md) based on MIT. The license restricts Polaris Viz usage to applications that integrate or interoperate with Shopify software or services, with additional restrictions for external, stand-alone applications.

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -1,4 +1,4 @@
-// Inspired by: https://github.com/Shopify/web/blob/master/.storybook/theme.ts
+// Inspired by: https://github.com/Shopify/web/blob/main/.storybook/theme.ts
 import {create} from '@storybook/theming';
 
 import logo from './polaris-viz-logo.svg';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -843,11 +843,11 @@ It is not advised to use this version -- stick to `0.16.1` or wait for `0.17.1` 
 
 ### Changed
 
-- Removed the accessibilityLabel from [`<StackedAreaChart/>`](https://github.com/Shopify/polaris-viz/blob/master/src/)
+- Removed the accessibilityLabel from [`<StackedAreaChart/>`](https://github.com/Shopify/polaris-viz/blob/main/src/)
 
 ### Added
 
-- `skipLinkText` prop to [`<StackedAreaChart/>`](https://github.com/Shopify/polaris-viz/blob/master/src/)
+- `skipLinkText` prop to [`<StackedAreaChart/>`](https://github.com/Shopify/polaris-viz/blob/main/src/)
 
 ### Fixed
 

--- a/src/components/Docs/stories/GettingStarted.stories.mdx
+++ b/src/components/Docs/stories/GettingStarted.stories.mdx
@@ -69,4 +69,4 @@ Pull requests are welcome. See the <a href="/CONTRIBUTING.md">contribution guide
 <br />
 <Title type="h3">Licenses</Title>
 
-- Source code is under a [custom license](https://github.com/Shopify/polaris-viz/blob/master/LICENSE.md) based on MIT. The license restricts Polaris Viz usage to applications that integrate or interoperate with Shopify software or services, with additional restrictions for external, stand-alone applications.
+- Source code is under a [custom license](https://github.com/Shopify/polaris-viz/blob/main/LICENSE.md) based on MIT. The license restricts Polaris Viz usage to applications that integrate or interoperate with Shopify software or services, with additional restrictions for external, stand-alone applications.

--- a/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
+++ b/src/components/LineChart/components/TooltipContent/stories/LineChartTooltipContent.stories.tsx
@@ -24,7 +24,7 @@ export default {
   argTypes: {
     data: {
       description:
-        'The data to display in the tooltip. [TooltipData type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/LineChart/types.ts#L20)',
+        'The data to display in the tooltip. [TooltipData type definition.](https://github.com/Shopify/polaris-viz/blob/main/src/components/LineChart/types.ts#L20)',
     },
   },
 } as Meta;

--- a/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -57,7 +57,7 @@ export default {
     },
     yAxisOptions: {
       description:
-        'An object containing the `formatYAxisLabel` function, which formats the values displayed on the yAxis and in the tooltip. [NumberLabelFormatter type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/types.ts#L114)',
+        'An object containing the `formatYAxisLabel` function, which formats the values displayed on the yAxis and in the tooltip. [NumberLabelFormatter type definition.](https://github.com/Shopify/polaris-viz/blob/main/src/types.ts#L114)',
     },
     renderTooltipContent: {
       options: Object.keys(TOOLTIP_CONTENT),
@@ -105,9 +105,8 @@ HideXAxisLabels.args = {
   xAxisOptions: {...defaultProps.xAxisOptions, hide: true},
 };
 
-export const OverwrittenSeriesColors: Story<StackedAreaChartProps> = Template.bind(
-  {},
-);
+export const OverwrittenSeriesColors: Story<StackedAreaChartProps> =
+  Template.bind({});
 OverwrittenSeriesColors.args = {
   ...defaultProps,
   xAxisOptions: {

--- a/src/components/TooltipContent/stories/TooltipContent.stories.tsx
+++ b/src/components/TooltipContent/stories/TooltipContent.stories.tsx
@@ -25,7 +25,7 @@ export default {
   argTypes: {
     data: {
       description:
-        'The data and corresponding color displayed in the tooltip. [TooltipData type definition.](https://github.com/Shopify/polaris-viz/blob/master/src/components/TooltipContent/TooltipContent.tsx#L8)',
+        'The data and corresponding color displayed in the tooltip. [TooltipData type definition.](https://github.com/Shopify/polaris-viz/blob/main/src/components/TooltipContent/TooltipContent.tsx#L8)',
     },
     title: {description: 'An optional title to display on the tooltip.'},
     total: {description: 'An optional total to display on the tooltip.'},


### PR DESCRIPTION
## What does this implement/fix?

I renamed the `master` branch to `main`. We have references to the `master` branch in some places of our docs but also in the `storybook.yml`. This PR updates these to point to `main` instead.

## Does this close any currently open issues?

Closes: https://github.com/Shopify/polaris-viz/issues/427

## What do the changes look like?
 
## Storybook link


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
