### PR TITLE
[Monorepo] Fix path to types in `polaris-viz` package

### DIFF
--- a/packages/polaris-viz/package.json
+++ b/packages/polaris-viz/package.json
@@ -15,7 +15,7 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.esnext",
-  "types": "build/ts/src/index.d.ts",
+  "types": "build/ts/index.d.ts",
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },


### PR DESCRIPTION
## What does this implement/fix?

The path was old and needed updating. This solves the issue where `shopify/web` is not able to correctly identify the types form the package.

## Does this close any currently open issues?

https://docs.google.com/spreadsheets/d/1_bWEKD2ZdzJ7coUiJWchylFVCjYr-z2Y41l3UMTu_G4/edit#gid=0

## What do the changes look like?

No visual changes
 
## Storybook link


### Before merging

- [ ] Check your changes on a variety of browsers and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
