### PR TITLE
Adds `shipit.beta-test.yml` to alloow shipping of beta releases

### DIFF
--- a/shipit.beta-test.yml
+++ b/shipit.beta-test.yml
@@ -1,0 +1,9 @@
+dependencies:
+  override:
+    - yarn install --frozen-lockfile --no-progress
+    - yarn lerna -- bootstrap
+deploy:
+  pre:
+    - yarn run build
+  override:
+    - yarn run lerna publish --dist-tag beta from-package --yes


### PR DESCRIPTION
## What does this implement/fix?

This will allow us to use [`beta-test` shipit stack](https://shipit.shopify.io/shopify/polaris-viz/beta-test) to create test releases to create test releases for whatever reason (test with different consumers before actually releasing etc).

## Does this close any currently open issues?

No issue, came out of a slack conversation.

## What do the changes look like?

I added [instructions to the vault](https://vault.shopify.io/pages/8693-Polaris-Viz#creating-releases-for-tophatting-changes)
 
## Storybook link


### Before merging

- [ ] Check your changes on a variety of browsers and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
