### PR TITLE
optional themes on providers

### DIFF
--- a/packages/polaris-viz-native/src/components/NativePolarisVizProvider/NativePolarisVizProvider.tsx
+++ b/packages/polaris-viz-native/src/components/NativePolarisVizProvider/NativePolarisVizProvider.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import {PolarisVizProvider as OriginalPolarisVizProvider} from '@shopify/polaris-viz-core';
 import {animated} from '@react-spring/native';
+import type {PartialTheme} from '@shopify/polaris-viz-core';
 
 import {DEFAULT_COMPONENTS as NativeComponents} from '../../constants';
 
-export const NativePolarisVizProvider = ({themes, children}) => {
+export const NativePolarisVizProvider = ({
+  themes,
+  children,
+}: {
+  children: React.ReactNode;
+  themes?: {[key: string]: PartialTheme};
+}) => {
   return (
     <OriginalPolarisVizProvider
       themes={themes}

--- a/packages/polaris-viz/src/components/WebPolarisVizProvider/WebPolarisVizProvider.tsx
+++ b/packages/polaris-viz/src/components/WebPolarisVizProvider/WebPolarisVizProvider.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import {PolarisVizProvider as OriginalPolarisVizProvider} from '@shopify/polaris-viz-core';
 import {animated} from '@react-spring/web';
+import type {PartialTheme} from '@shopify/polaris-viz-core';
 
-export const WebPolarisVizProvider = ({themes, children}) => {
+export const WebPolarisVizProvider = ({
+  themes,
+  children,
+}: {
+  children: React.ReactNode;
+  themes?: {[key: string]: PartialTheme};
+}) => {
   return (
     <OriginalPolarisVizProvider themes={themes} animated={animated}>
       {children}


### PR DESCRIPTION
## What does this implement/fix?
Themes should not be mandatory on the Providers, as we the default themes will always be there

## Does this close any currently open issues?
Needed to fix type errors on https://github.com/Shopify/web/pull/60062


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
