### PR TITLE
Add padding theme value

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -125,7 +125,7 @@ export const decorators = [
               padding: '20px',
             },
             grid: {
-              horizontalMargin: 20,
+              horizontalMargin: context.parameters.horizontalMargin ?? 20,
               horizontalOverflow: true,
             },
           },

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -103,6 +103,6 @@ export type {
   SvgComponents,
   Theme,
   DataPoint,
-  Legend,
+  LegendTheme,
   Direction,
 } from './types';

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -102,7 +102,7 @@ export interface SeriesColors {
   fromFiveToSeven: Color[];
   all: Color[];
 }
-export interface Legend {
+export interface LegendTheme {
   labelColor: string;
   valueColor: string;
   trendIndicator: {positive: string; negative: string; neutral: string};
@@ -116,7 +116,7 @@ export interface PartialTheme {
   xAxis?: Partial<XAxisTheme>;
   yAxis?: Partial<YAxisTheme>;
   crossHair?: Partial<CrossHairTheme>;
-  legend?: Partial<Legend>;
+  legend?: Partial<LegendTheme>;
   seriesColors?: Partial<SeriesColors>;
   tooltip?: Partial<TooltipTheme>;
 }
@@ -129,7 +129,7 @@ export interface Theme {
   yAxis: YAxisTheme;
   line: LineTheme;
   crossHair: CrossHairTheme;
-  legend: Legend;
+  legend: LegendTheme;
   seriesColors: SeriesColors;
   tooltip: TooltipTheme;
 }

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- `<LegendContainer />` now uses `grid.horizontalMargin` to match consumer spacing inside the chart container.
 
 ## [1.0.4] - 2022-03-14
 

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -137,6 +137,7 @@ export default {
   title: 'polaris-viz/Default Charts/BarChart',
   component: BarChart,
   parameters: {
+    horizontalMargin: 0,
     docs: {
       description: {
         component:

--- a/packages/polaris-viz/src/components/ComparisonMetric/ComparisonMetric.tsx
+++ b/packages/polaris-viz/src/components/ComparisonMetric/ComparisonMetric.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {Legend} from '@shopify/polaris-viz-core';
+import type {LegendTheme} from '@shopify/polaris-viz-core';
 
 import styles from './ComparisonMetric.scss';
 import {UpChevron, DownChevron} from './components';
@@ -8,7 +8,7 @@ export interface ComparisonMetricProps {
   metric: string;
   trend: 'positive' | 'negative' | 'neutral';
   accessibilityLabel: string;
-  theme: Legend;
+  theme: LegendTheme;
   dataIndex?: number;
 }
 

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.scss
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.scss
@@ -1,7 +1,6 @@
 .Container {
   display: flex;
   gap: 10px;
-  width: 100%;
   justify-content: flex-end;
   flex-wrap: wrap;
 }

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import {useTheme} from '@shopify/polaris-viz-core';
 
 import {DEFAULT_LEGEND_HEIGHT, LEGENDS_TOP_MARGIN} from '../../constants';
 import {useResizeObserver, useWatchColorVisionEvents} from '../../hooks';
@@ -26,6 +27,7 @@ export function LegendContainer({
   onHeightChange,
   theme,
 }: LegendContainerProps) {
+  const selectedTheme = useTheme(theme);
   const {setRef, entry} = useResizeObserver();
   const previousHeight = useRef(DEFAULT_LEGEND_HEIGHT);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -65,7 +67,9 @@ export function LegendContainer({
       className={style.Container}
       ref={setRef}
       role="list"
-      style={{marginTop: LEGENDS_TOP_MARGIN}}
+      style={{
+        margin: `${LEGENDS_TOP_MARGIN}px ${selectedTheme.grid.horizontalMargin}px 0`,
+      }}
     >
       <Legend
         activeIndex={activeIndex}

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {isGradientType} from '@shopify/polaris-viz-core';
-import type {Color, Legend, Direction} from '@shopify/polaris-viz-core';
+import type {Color, LegendTheme, Direction} from '@shopify/polaris-viz-core';
 
 import {COLOR_VISION_SINGLE_ITEM} from '../../../../constants';
 import {
@@ -22,7 +22,7 @@ export interface Props {
   label: string;
   value: string;
   color: Color;
-  legendColors: Legend;
+  legendColors: LegendTheme;
   direction: Direction;
   labelPosition: LabelPosition;
   comparisonMetric?: Omit<ComparisonMetricProps, 'theme'> | null;


### PR DESCRIPTION
## What does this implement/fix?

Add padding value for legends in the theme to allow users to reposition legends.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/956

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="722" alt="image" src="https://user-images.githubusercontent.com/149873/158454255-40bf352c-6702-4146-aaae-6f7252ddf5d3.png">|<img width="677" alt="image" src="https://user-images.githubusercontent.com/149873/158454300-0cba242e-a541-460d-93c7-ef11779e1c53.png">|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
