### PR TITLE
Changes `build-consumer` script to always copy `polaris-viz-core`

### DIFF
--- a/scripts/build-consumer.js
+++ b/scripts/build-consumer.js
@@ -8,14 +8,19 @@ const {config, cp, mkdir, rm} = require('shelljs');
 const root = resolve(__dirname, '..');
 const packageName = process.argv[2];
 const projectDir = process.argv[3];
+const packageNames = ['polaris-viz-core'];
 
 config.fatal = true;
 
 if (!packageName) {
   console.log(
-    'Please define which package you want to copy to the consumer. `yarn build-consumer PACKAGE_NAME PROJECT_DIRECTORY`',
+    'Please define which package you want to copy to the consumer. `yarn build-consumer PACKAGE_NAME PROJECT_DIRECTORY`. Options: `polaris-viz`, `polaris-viz-native`',
   );
   process.exit(1);
+} else if (packageName === 'polaris-viz') {
+  packageNames.push('polaris-viz');
+} else if (packageName === 'polaris-viz-native') {
+  packageNames.push('polaris-viz-native');
 }
 
 if (!projectDir) {
@@ -26,7 +31,7 @@ if (!projectDir) {
 }
 
 const packageJSON = require(`../packages/${packageName}/package.json`);
-const projectPolarisDir = resolve(
+const projectPolarisVizDir = resolve(
   root,
   `../${projectDir}/node_modules/@shopify/${packageName}`,
 );
@@ -42,13 +47,13 @@ const filesWithPath = files.map((file) =>
 );
 
 console.log('Cleaning up old build...');
-rm('-rf', projectPolarisDir);
+rm('-rf', projectPolarisVizDir);
 
 console.log('Creating new build directory...');
-mkdir(projectPolarisDir);
+mkdir(projectPolarisVizDir);
 
 console.log('Copying build to node_modules...');
-cp('-R', filesWithPath, projectPolarisDir);
+cp('-R', filesWithPath, projectPolarisVizDir);
 
 console.log(
   'Build copied to consuming project. You can now run the consuming app and it will include your changes from Polaris Viz.',


### PR DESCRIPTION
## What does this implement/fix?

Alters the `build-consumer` script to always include `polaris-viz-core`. When running the command you now just need to specify if you want `polaris-viz` or `polaris-viz-native` to be copied.

## Does this close any currently open issues?

No issue for this, was just a quick feedback from @envex.

## What do the changes look like?

No visual changes
 
## Storybook link

1. Create spin instance (e.g. `spin up web --name=polaris-viz-build-consumer`)
2. Checkout `polaris-viz`
3. Run `yarn build-consumer polaris-viz web` to build and copy over the packages to your spin checkout of `shopify/web`.

### Before merging

Didn't do changelog updates since this doesn't really present any changes in the package itself.

- [ ] Check your changes on a variety of browsers and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
