### PR TITLE
Remove xAxisLabels and inherit from DataSeries

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -113,4 +113,7 @@ export type {
   DataPoint,
   LegendTheme,
   Direction,
+  XAxisOptions,
+  YAxisOptions,
+  LabelFormatter,
 } from './types';

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -1,9 +1,7 @@
 import type {Series, SeriesPoint} from 'd3-shape';
 import type {SVGProps} from 'react';
-import type {
-  StringLabelFormatter,
-  NumberLabelFormatter,
-} from '@shopify/polaris-viz/src/types';
+
+export type LabelFormatter = (value: string | number | null) => string;
 
 export interface DataPoint {
   key: number | string;
@@ -39,11 +37,11 @@ export interface Dimensions {
 export type Color = string | GradientStop[];
 
 export interface XAxisOptions {
-  labelFormatter?: StringLabelFormatter;
+  labelFormatter?: LabelFormatter;
   hide?: boolean;
 }
 export interface YAxisOptions {
-  labelFormatter?: NumberLabelFormatter;
+  labelFormatter?: LabelFormatter;
   integersOnly?: boolean;
 }
 

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- All components now use the core `XAxisOptions` & `YAxisOptions` types.
+- All label formatters now use the core `LabelFormatter` type.
+
+### Removed
+
+- Removed `xAxisLabels` from `LinearXAxisOptions.xAxisOptions`.
+- Removed `StringLabelFormatter` & `NumberLabelFormatter` types.
 
 ## [1.1.0] - 2022-03-28
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -1,17 +1,17 @@
 import React, {useRef} from 'react';
 import {uniqueId, ChartType, DataSeries} from '@shopify/polaris-viz-core';
-import type {Direction} from '@shopify/polaris-viz-core';
+import type {
+  Direction,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import {TooltipContent} from '../TooltipContent';
 import {SkipLink} from '../SkipLink';
 import {normalizeData} from '../../utilities';
 import {HorizontalBarChart} from '../HorizontalBarChart';
 import {VerticalBarChart} from '../VerticalBarChart';
-import type {
-  RenderTooltipContentData,
-  XAxisOptions,
-  YAxisOptions,
-} from '../BarChart';
+import type {RenderTooltipContentData} from '../BarChart';
 
 import type {Annotation} from './types';
 

--- a/packages/polaris-viz/src/components/BarChart/index.ts
+++ b/packages/polaris-viz/src/components/BarChart/index.ts
@@ -1,9 +1,4 @@
 export {BarChart} from './BarChart';
 export type {BarChartProps} from './BarChart';
-export type {
-  AnnotationLookupTable,
-  RenderTooltipContentData,
-  XAxisOptions,
-  YAxisOptions,
-} from './types';
+export type {AnnotationLookupTable, RenderTooltipContentData} from './types';
 export {AnnotationLine} from './components/AnnotationLine';

--- a/packages/polaris-viz/src/components/BarChart/types.ts
+++ b/packages/polaris-viz/src/components/BarChart/types.ts
@@ -1,20 +1,9 @@
 import type {TooltipData} from 'components/TooltipContent';
-import type {LabelFormatter} from 'types';
 
 export interface RenderTooltipContentData {
   data: TooltipData[];
   title?: string;
   annotation?: Annotation;
-}
-
-export interface XAxisOptions {
-  labelFormatter?: LabelFormatter;
-  hide?: boolean;
-}
-
-export interface YAxisOptions {
-  labelFormatter?: LabelFormatter;
-  integersOnly?: boolean;
 }
 
 export interface Annotation {

--- a/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
@@ -10,7 +10,7 @@ import {
   StackedAreaChart,
   SimpleNormalizedChart,
 } from '../../../../components';
-import {generateLabels, generateMultipleSeries} from '../../../Docs/utilities';
+import {generateMultipleSeries} from '../../../Docs/utilities';
 
 import {SimpleContainer} from './SimpleContainer';
 
@@ -74,9 +74,6 @@ export const SampleLineChart = (
           ],
         },
       ]}
-      xAxisOptions={{
-        xAxisLabels: ['Jan. 1', 'Jan. 2', 'Jan. 3', 'Jan. 4', 'Jan. 5'],
-      }}
       showLegend={showLegend}
     />
   );
@@ -100,9 +97,6 @@ export const SampleStackedAreaChart = (
   return (
     <StackedAreaChart
       data={generateMultipleSeries(seriesLength, 3)}
-      xAxisOptions={{
-        xAxisLabels: generateLabels(3),
-      }}
       showLegend={showLegend}
       theme={theme}
     />

--- a/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
@@ -90,9 +90,6 @@ export function WebComponents() {
                   ],
                 },
               ]}
-              xAxisOptions={{
-                xAxisLabels: ['Jan. 1', 'Jan. 2', 'Jan. 3', 'Jan. 4', 'Jan. 5'],
-              }}
             />
           }
         />
@@ -103,17 +100,6 @@ export function WebComponents() {
           chart={
             <StackedAreaChart
               isAnimated
-              xAxisOptions={{
-                xAxisLabels: [
-                  'January',
-                  'February',
-                  'March',
-                  'April',
-                  'May',
-                  'June',
-                  'July',
-                ],
-              }}
               data={[
                 {
                   name: 'First-time',

--- a/packages/polaris-viz/src/components/Docs/utilities/index.ts
+++ b/packages/polaris-viz/src/components/Docs/utilities/index.ts
@@ -21,14 +21,6 @@ export function randomNumber(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-export const generateLabels = (dataLength: number) => {
-  return Array(dataLength)
-    .fill(null)
-    .map(() => {
-      return PRODUCT_NAMES[Math.floor(Math.random() * PRODUCT_NAMES.length)];
-    });
-};
-
 export const generateDataSet = (dataLength: number) => {
   return Array(dataLength)
     .fill(null)

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -4,6 +4,7 @@ import type {
   DataSeries,
   ChartType,
   Dimensions,
+  XAxisOptions,
 } from '@shopify/polaris-viz-core';
 
 import {HorizontalBarChartXAxisLabels} from '../HorizontalBarChartXAxisLabels';
@@ -38,7 +39,6 @@ import {
 import type {
   AnnotationLookupTable,
   RenderTooltipContentData,
-  XAxisOptions,
 } from '../BarChart';
 import {AnnotationLine} from '../BarChart';
 
@@ -332,7 +332,7 @@ export function Chart({
     }
 
     const highestValue = highestValueForSeries[index];
-    const x = xScale(highestValue);
+    const x = chartStartPosition + xScale(highestValue);
 
     return {
       x: highestValue < 0 ? -x : x,

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,10 +1,13 @@
 import React, {ReactNode} from 'react';
-import type {DataSeries, ChartType} from '@shopify/polaris-viz-core';
+import type {
+  DataSeries,
+  ChartType,
+  XAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import type {
   AnnotationLookupTable,
   RenderTooltipContentData,
-  XAxisOptions,
 } from '../BarChart';
 import {ChartContainer} from '../../components/ChartContainer';
 import {usePrefersReducedMotion} from '../../hooks';

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -7,8 +7,14 @@ import {
   isGradientType,
   DataType,
 } from '@shopify/polaris-viz-core';
-import type {DataPoint, Dimensions} from '@shopify/polaris-viz-core';
+import type {
+  DataPoint,
+  Dimensions,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 
+import {useXAxisLabels} from '../../hooks/useXAxisLabels';
 import {LinearXAxisLabels} from '../LinearXAxisLabels';
 import {useLegend, LegendContainer} from '../LegendContainer';
 import {
@@ -36,7 +42,6 @@ import {
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
 import {YAxis} from '../YAxis';
 import {Crosshair} from '../Crosshair';
-import type {LinearXAxisOptions, LinearYAxisOptions} from '../../types';
 import {HorizontalGridLines} from '../HorizontalGridLines';
 
 import {Points, Line, GradientArea} from './components';
@@ -54,8 +59,8 @@ export interface ChartProps {
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
   data: DataWithDefaults[];
   showLegend: boolean;
-  xAxisOptions: Required<LinearXAxisOptions>;
-  yAxisOptions: Required<LinearYAxisOptions>;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
   emptyStateText?: string;
   theme?: string;
   dimensions?: Dimensions;
@@ -97,6 +102,8 @@ export function Chart({
     onIndexChange: ({detail}) => setActiveLineIndex(detail.index),
   });
 
+  const formattedLabels = useXAxisLabels({data: [data[0]], xAxisOptions});
+
   const tooltipId = useRef(uniqueId('lineChart'));
   const gradientId = useRef(uniqueId('lineChartGradient'));
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
@@ -106,11 +113,6 @@ export function Chart({
 
   const drawableHeight =
     height - labelHeight - LABEL_AREA_TOP_SPACING - Margin.Top;
-
-  const formattedLabels = useMemo(
-    () => xAxisOptions.xAxisLabels.map(xAxisOptions.labelFormatter),
-    [xAxisOptions.labelFormatter, xAxisOptions.xAxisLabels],
-  );
 
   const {yAxisLabelWidth, ticks, yScale} = useYScale({
     drawableHeight,

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -1,8 +1,11 @@
 import React, {useRef} from 'react';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  DataSeries,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 import {isGradientType, uniqueId} from '@shopify/polaris-viz-core';
 
-import type {LinearXAxisOptions, LinearYAxisOptions} from '../../types';
 import {ChartContainer} from '../../components/ChartContainer';
 import {useThemeSeriesColors} from '../../hooks/use-theme-series-colors';
 import {changeColorOpacity, getAverageColor} from '../../utilities';
@@ -22,8 +25,8 @@ export interface LineChartProps {
   showLegend?: boolean;
   skipLinkText?: string;
   theme?: string;
-  xAxisOptions?: Partial<LinearXAxisOptions>;
-  yAxisOptions?: Partial<LinearYAxisOptions>;
+  xAxisOptions?: Partial<XAxisOptions>;
+  yAxisOptions?: Partial<YAxisOptions>;
 }
 
 export function LineChart({
@@ -43,14 +46,13 @@ export function LineChart({
 
   const skipLinkAnchorId = useRef(uniqueId('lineChart'));
 
-  const xAxisOptionsWithDefaults: Required<LinearXAxisOptions> = {
+  const xAxisOptionsWithDefaults: Required<XAxisOptions> = {
     labelFormatter: (value: string) => value,
-    xAxisLabels: [],
     hide: false,
     ...xAxisOptions,
   };
 
-  const yAxisOptionsWithDefaults: Required<LinearYAxisOptions> = {
+  const yAxisOptionsWithDefaults: Required<YAxisOptions> = {
     labelFormatter: (value: number) => value.toString(),
     integersOnly: false,
     ...yAxisOptions,

--- a/packages/polaris-viz/src/components/LineChart/hooks/use-y-scale.ts
+++ b/packages/polaris-viz/src/components/LineChart/hooks/use-y-scale.ts
@@ -1,12 +1,11 @@
 import {useContext, useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
 import {maxIndex} from 'd3-array';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {estimateStringWidth, shouldRoundScaleUp} from '../../../utilities';
 import {yAxisMinMax} from '../utilities';
 import {MIN_Y_LABEL_SPACE} from '../constants';
-import type {NumberLabelFormatter} from '../../../types';
 import {ChartContext} from '../../ChartContainer';
 
 export function useYScale({
@@ -17,7 +16,7 @@ export function useYScale({
 }: {
   drawableHeight: number;
   data: DataSeries[];
-  formatYAxisLabel: NumberLabelFormatter;
+  formatYAxisLabel: LabelFormatter;
   integersOnly: boolean;
 }) {
   const {characterWidths} = useContext(ChartContext);

--- a/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
@@ -5,14 +5,13 @@ import {LineChart, LineChartProps} from '../LineChart';
 import styles from './LineChart.stories.scss';
 import {
   data,
-  xAxisLabels,
   formatXAxisLabel,
   formatYAxisLabel,
   renderTooltipContent,
 } from './utils.stories';
 import {LEGEND_CONTROL_ARGS, THEME_CONTROL_ARGS} from '../../../storybook';
 
-import {generateMultipleSeries, generateLabels} from '../../Docs/utilities';
+import {generateMultipleSeries} from '../../Docs/utilities';
 
 const TOOLTIP_CONTENT = {
   empty: undefined,
@@ -107,7 +106,6 @@ export const Default: Story<LineChartProps> = Template.bind({});
 Default.args = {
   data,
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
   },
   yAxisOptions: {labelFormatter: formatYAxisLabel},
@@ -118,7 +116,6 @@ export const HideXAxisLabels: Story<LineChartProps> = Template.bind({});
 HideXAxisLabels.args = {
   data,
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
     hide: true,
   },
@@ -131,7 +128,6 @@ NoOverflowStyle.args = {
   theme: 'NoOverflow',
   data,
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
   },
   yAxisOptions: {labelFormatter: formatYAxisLabel},
@@ -155,7 +151,6 @@ IntegersOnly.args = {
     },
   ],
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
   },
   yAxisOptions: {integersOnly: true},
@@ -179,7 +174,6 @@ NoArea.args = {
     },
   ],
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
   },
   renderTooltipContent,
@@ -203,7 +197,6 @@ OverwrittenSeriesColors.args = {
     },
   ],
   xAxisOptions: {
-    xAxisLabels,
     labelFormatter: formatXAxisLabel,
   },
   renderTooltipContent,
@@ -213,9 +206,6 @@ export const SeriesColorsUpToFour: Story<LineChartProps> = Template.bind({});
 
 SeriesColorsUpToFour.args = {
   data: generateMultipleSeries(4),
-  xAxisOptions: {
-    xAxisLabels: generateLabels(10),
-  },
   renderTooltipContent,
   isAnimated: true,
 };
@@ -226,9 +216,6 @@ export const SeriesColorsFromFiveToSeven: Story<LineChartProps> = Template.bind(
 
 SeriesColorsFromFiveToSeven.args = {
   data: generateMultipleSeries(7),
-  xAxisOptions: {
-    xAxisLabels: generateLabels(10),
-  },
   renderTooltipContent,
 };
 
@@ -238,8 +225,5 @@ export const SeriesColorsUpToFourteen: Story<LineChartProps> = Template.bind(
 
 SeriesColorsUpToFourteen.args = {
   data: generateMultipleSeries(14),
-  xAxisOptions: {
-    xAxisLabels: generateLabels(10),
-  },
   renderTooltipContent,
 };

--- a/packages/polaris-viz/src/components/LineChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/Playground.stories.tsx
@@ -24,7 +24,6 @@ export const LargeDataSet: Story<LineChartProps> = Template.bind({});
 LargeDataSet.args = {
   data: HOURLY_DATA,
   xAxisOptions: {
-    xAxisLabels: HOURLY_DATA[0].data.map(({key}) => key),
     labelFormatter: formatHourlyLabel,
   },
 };

--- a/packages/polaris-viz/src/components/LineChart/stories/utils.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/utils.stories.tsx
@@ -228,8 +228,6 @@ export const seriesUsingSeriesColors = [
   },
 ];
 
-export const xAxisLabels = data[0].data.map(({key}) => `${key}`);
-
 export function formatXAxisLabel(value: string) {
   return new Date(value).toLocaleDateString('en-CA', {
     day: 'numeric',

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {line} from 'd3-shape';
-import {LinearGradientWithStops} from '@shopify/polaris-viz-core';
+import {
+  LinearGradientWithStops,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import {LegendContainer} from '../../LegendContainer';
 import {Crosshair} from '../../../components/Crosshair';
@@ -16,7 +20,7 @@ import {Line, GradientArea} from '../components';
 import {YAxis} from '../../YAxis';
 import type {DataWithDefaults} from '../types';
 
-const primaryData: Required<DataWithDefaults> = {
+const MOCK_DATA: Required<DataWithDefaults> = {
   name: 'Primary',
   color: 'red',
   lineStyle: 'solid',
@@ -30,24 +34,18 @@ const primaryData: Required<DataWithDefaults> = {
   ],
 };
 
-const xAxisOptions = {
-  xAxisLabels: ['Jan 1'],
-  labelFormatter: jest.fn((value) => value),
-  hideXAxisLabels: false,
-  showTicks: true,
-  labelColor: 'red',
+const xAxisOptions: Required<XAxisOptions> = {
+  labelFormatter: jest.fn(),
   hide: false,
 };
 
-const yAxisOptions = {
-  labelFormatter: jest.fn((value) => value),
-  labelColor: 'red',
-  backgroundColor: 'transparent',
+const yAxisOptions: Required<YAxisOptions> = {
+  labelFormatter: jest.fn(),
   integersOnly: false,
 };
 
-const mockProps: ChartProps = {
-  data: [primaryData],
+const MOCK_PROPS: ChartProps = {
+  data: [MOCK_DATA],
   dimensions: {width: 500, height: 250},
   xAxisOptions,
   yAxisOptions,
@@ -59,6 +57,7 @@ const mockProps: ChartProps = {
 jest.mock('../../../utilities', () => {
   return {
     ...jest.requireActual('../../../utilities'),
+    estimateStringWidth: () => 100,
     getPathLength: () => 0,
     getPointAtLength: () => ({x: 0, y: 0}),
     eventPointNative: () => {
@@ -88,13 +87,13 @@ describe('<Chart />', () => {
   });
 
   it('renders an svg element', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).toContainReactComponent('svg');
   });
 
   it('sets an active point and tooltip position on svg mouse or touch interaction', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -102,13 +101,13 @@ describe('<Chart />', () => {
   });
 
   it('renders a <YAxis />', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).toContainReactComponent(YAxis);
   });
 
   it('renders a <Crosshair /> at full opacity if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -116,7 +115,7 @@ describe('<Chart />', () => {
   });
 
   it('renders a <Crosshair /> at 0 opacity if there is no active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart.find(Crosshair)).toHaveReactProps({opacity: 0});
   });
@@ -124,8 +123,8 @@ describe('<Chart />', () => {
   it('renders a <Line /> for each data-point', () => {
     const chart = mount(
       <Chart
-        {...mockProps}
-        data={[primaryData, {...primaryData, name: 'A second data-point'}]}
+        {...MOCK_PROPS}
+        data={[MOCK_DATA, {...MOCK_DATA, name: 'A second data-point'}]}
       />,
     );
 
@@ -144,8 +143,8 @@ describe('<Chart />', () => {
 
     mount(
       <Chart
-        {...mockProps}
-        data={[primaryData, {...primaryData, name: 'A second data-point'}]}
+        {...MOCK_PROPS}
+        data={[MOCK_DATA, {...MOCK_DATA, name: 'A second data-point'}]}
       />,
     );
 
@@ -153,15 +152,15 @@ describe('<Chart />', () => {
   });
 
   it('renders a <Point /> for each data item in each data-point', () => {
-    const data = [primaryData, {...primaryData, name: 'A second data-point'}];
-    const chart = mount(<Chart {...mockProps} data={data} />);
+    const data = [MOCK_DATA, {...MOCK_DATA, name: 'A second data-point'}];
+    const chart = mount(<Chart {...MOCK_PROPS} data={data} />);
 
     expect(chart).toContainReactComponentTimes(Point, 8);
   });
 
   it('renders an additional <Point /> for each data-point if isAnimated is true', () => {
-    const data = [primaryData, {...primaryData, name: 'A second data-point'}];
-    const chart = mount(<Chart {...mockProps} data={data} isAnimated />);
+    const data = [MOCK_DATA, {...MOCK_DATA, name: 'A second data-point'}];
+    const chart = mount(<Chart {...MOCK_PROPS} data={data} isAnimated />);
 
     expect(chart).toContainReactComponentTimes(Point, 8 + data.length);
   });
@@ -169,8 +168,8 @@ describe('<Chart />', () => {
   it('passes props to <Point />', () => {
     const chart = mount(
       <Chart
-        {...mockProps}
-        data={[primaryData, {...primaryData, name: 'A second data-point'}]}
+        {...MOCK_PROPS}
+        data={[MOCK_DATA, {...MOCK_DATA, name: 'A second data-point'}]}
       />,
     );
 
@@ -185,7 +184,7 @@ describe('<Chart />', () => {
   });
 
   it('renders tooltip content inside a <TooltipContainer /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     // No tooltip if there is no active point
     expect(chart).not.toContainReactText('Mock Tooltip');
@@ -199,30 +198,30 @@ describe('<Chart />', () => {
   });
 
   it('renders <VisuallyHiddenRows />', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).toContainReactComponent(VisuallyHiddenRows, {
-      data: mockProps.data,
-      xAxisLabels: mockProps.xAxisOptions.xAxisLabels,
+      data: MOCK_PROPS.data,
+      xAxisLabels: MOCK_DATA.data.map(({key}) => key),
     });
   });
 
   describe('empty state', () => {
     it('does not render tooltip for empty state', () => {
-      const chart = mount(<Chart {...mockProps} data={[]} />);
+      const chart = mount(<Chart {...MOCK_PROPS} data={[]} />);
 
       expect(chart).not.toContainReactText('Mock Tooltip');
       expect(chart).not.toContainReactComponent(TooltipAnimatedContainer);
     });
 
     it('does not render crosshair for empty state', () => {
-      const chart = mount(<Chart {...mockProps} data={[]} />);
+      const chart = mount(<Chart {...MOCK_PROPS} data={[]} />);
 
       expect(chart).not.toContainReactComponent(Crosshair);
     });
 
     it('does not render Visually Hidden Rows for empty state', () => {
-      const chart = mount(<Chart {...mockProps} data={[]} />);
+      const chart = mount(<Chart {...MOCK_PROPS} data={[]} />);
 
       expect(chart).not.toContainReactComponent(VisuallyHiddenRows);
     });
@@ -233,10 +232,10 @@ describe('<Chart />', () => {
       it('removes transparency for <Point />', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: 'rgba(255, 255, 255, 0.5)',
               },
             ]}
@@ -251,10 +250,10 @@ describe('<Chart />', () => {
       it('does not remove transparency for <Line />', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: 'rgb(255, 255, 255)',
               },
             ]}
@@ -271,10 +270,10 @@ describe('<Chart />', () => {
       it('renders a LinearGradientWithStops if data-point color is a gradient', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: [
                   {
                     offset: 1,
@@ -292,10 +291,10 @@ describe('<Chart />', () => {
       it('passes gradient url as color prop to <Line />', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: [
                   {
                     offset: 1,
@@ -315,10 +314,10 @@ describe('<Chart />', () => {
       it('passes point gradient url as color prop to <Point />', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: [
                   {
                     offset: 1,
@@ -338,10 +337,10 @@ describe('<Chart />', () => {
       it('removes transparency from the gradient', () => {
         const chart = mount(
           <Chart
-            {...mockProps}
+            {...MOCK_PROPS}
             data={[
               {
-                ...primaryData,
+                ...MOCK_DATA,
                 color: [
                   {
                     offset: 1,
@@ -368,7 +367,7 @@ describe('<Chart />', () => {
   describe('areaColor', () => {
     it('renders a <GradientArea /> for a data-point if areaColor is specified', () => {
       const chart = mount(
-        <Chart {...mockProps} data={[{...primaryData, areaColor: 'red'}]} />,
+        <Chart {...MOCK_PROPS} data={[{...MOCK_DATA, areaColor: 'red'}]} />,
       );
 
       expect(chart).toContainReactComponentTimes(GradientArea, 1);
@@ -378,7 +377,7 @@ describe('<Chart />', () => {
   describe('gridOptions.showHorizontalLines', () => {
     it('does not render HorizontalGridLines when false', () => {
       const chart = mountWithProvider(
-        <Chart {...mockProps} />,
+        <Chart {...MOCK_PROPS} />,
         mockDefaultTheme({grid: {showHorizontalLines: false}}),
       );
 
@@ -386,7 +385,7 @@ describe('<Chart />', () => {
     });
 
     it('renders HorizontalGridLines when true', () => {
-      const chart = mountWithProvider(<Chart {...mockProps} />);
+      const chart = mountWithProvider(<Chart {...MOCK_PROPS} />);
 
       expect(chart).toContainReactComponent(HorizontalGridLines);
     });
@@ -394,7 +393,7 @@ describe('<Chart />', () => {
 
   describe('showLegend', () => {
     it('does not render <LegendContainer /> when false', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
       const svg = chart.find('svg');
 
       expect(chart).not.toContainReactComponent(LegendContainer);
@@ -403,7 +402,7 @@ describe('<Chart />', () => {
     });
 
     it('renders <LegendContainer /> when true', () => {
-      const chart = mount(<Chart {...mockProps} showLegend />);
+      const chart = mount(<Chart {...MOCK_PROPS} showLegend />);
 
       expect(chart).toContainReactComponent(LegendContainer);
     });

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -4,6 +4,7 @@ import type {
   ChartType,
   DataSeries,
   Dimensions,
+  XAxisOptions,
 } from '@shopify/polaris-viz-core';
 
 import {LegendContainer, useLegend} from '../../components/LegendContainer';
@@ -24,7 +25,6 @@ import {
   COLOR_VISION_SINGLE_ITEM,
 } from '../../constants';
 
-import type {XAxisOptions} from './types';
 import styles from './Chart.scss';
 
 export interface ChartProps {

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import type {ChartType, DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  ChartType,
+  DataSeries,
+  XAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import {ChartContainer} from '../../components/ChartContainer';
 import {usePrefersReducedMotion} from '../../hooks';
 
 import {Chart} from './Chart';
-import type {XAxisOptions} from './types';
 
 export interface SimpleBarChartProps {
   data: DataSeries[];
@@ -26,6 +29,7 @@ export function SimpleBarChart({
 }: SimpleBarChartProps) {
   const xAxisOptionsForChart: Required<XAxisOptions> = {
     labelFormatter: (value: string) => value,
+    hide: false,
     ...xAxisOptions,
   };
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/types.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/types.ts
@@ -1,5 +1,0 @@
-import type {LabelFormatter} from '../../types';
-
-export interface XAxisOptions {
-  labelFormatter?: LabelFormatter;
-}

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -1,7 +1,11 @@
 import React, {useState} from 'react';
 import {sum} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
-import type {DataPoint, Direction} from '@shopify/polaris-viz-core';
+import type {
+  DataPoint,
+  Direction,
+  LabelFormatter,
+} from '@shopify/polaris-viz-core';
 
 import {COLOR_VISION_SINGLE_ITEM} from '../../constants';
 import type {ComparisonMetricProps} from '../ComparisonMetric';
@@ -13,7 +17,6 @@ import {
   useWatchColorVisionEvents,
 } from '../../hooks';
 import {classNames} from '../../utilities';
-import type {LabelFormatter} from '../../types';
 
 import {BarSegment, BarLabel} from './components';
 import type {Size, LabelPosition} from './types';

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import type {DataPoint, Direction} from '@shopify/polaris-viz-core';
+import type {
+  DataPoint,
+  Direction,
+  LabelFormatter,
+} from '@shopify/polaris-viz-core';
 
 import type {ComparisonMetricProps} from '../ComparisonMetric';
 import {ChartContainer} from '../ChartContainer';
-import type {LabelFormatter} from '../../types';
 
 import {Chart} from './Chart';
 import type {Size, LabelPosition} from './types';

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -1,6 +1,11 @@
 import React, {useState, useMemo, useRef, useCallback} from 'react';
 import {line} from 'd3-shape';
-import type {DataSeries, DataPoint} from '@shopify/polaris-viz-core';
+import type {
+  DataSeries,
+  DataPoint,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 import {
   uniqueId,
   curveStepRounded,
@@ -38,7 +43,6 @@ import {YAxis} from '../YAxis';
 import {Crosshair} from '../Crosshair';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
 import {HorizontalGridLines} from '../HorizontalGridLines';
-import type {LinearXAxisOptions, LinearYAxisOptions} from '../../types';
 
 import {useYScale, useStackedData} from './hooks';
 import {StackedAreas, Points} from './components';
@@ -55,8 +59,8 @@ export interface Props {
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   showLegend: boolean;
   isAnimated: boolean;
-  xAxisOptions: Required<LinearXAxisOptions>;
-  yAxisOptions: Required<LinearYAxisOptions>;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
   dimensions?: Dimensions;
   theme?: string;
 }
@@ -143,10 +147,10 @@ export function Chart({
 
       return renderTooltipContent({
         data: content,
-        title: xAxisOptions.xAxisLabels[index],
+        title: labels[index],
       });
     },
-    [data, xAxisOptions, renderTooltipContent, seriesColors],
+    [data, labels, renderTooltipContent, seriesColors],
   );
 
   const lineGenerator = useMemo(() => {

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -1,10 +1,13 @@
 import React, {useRef} from 'react';
 import {uniqueId} from '@shopify/polaris-viz-core';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  DataSeries,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import {ChartContainer} from '../ChartContainer';
 import {SkipLink} from '../SkipLink';
-import type {LinearXAxisOptions, LinearYAxisOptions} from '../../types';
 import {TooltipContent} from '../TooltipContent';
 
 import {Chart} from './Chart';
@@ -17,8 +20,8 @@ export interface StackedAreaChartProps {
   showLegend?: boolean;
   skipLinkText?: string;
   theme?: string;
-  xAxisOptions?: Partial<LinearXAxisOptions>;
-  yAxisOptions?: Partial<LinearYAxisOptions>;
+  xAxisOptions?: Partial<XAxisOptions>;
+  yAxisOptions?: Partial<YAxisOptions>;
 }
 
 export function StackedAreaChart({
@@ -37,14 +40,13 @@ export function StackedAreaChart({
     return null;
   }
 
-  const xAxisOptionsWithDefaults: Required<LinearXAxisOptions> = {
+  const xAxisOptionsWithDefaults: Required<XAxisOptions> = {
     labelFormatter: (value: string) => value,
-    xAxisLabels: [],
     hide: false,
     ...xAxisOptions,
   };
 
-  const yAxisOptionsWithDefaults: Required<LinearYAxisOptions> = {
+  const yAxisOptionsWithDefaults: Required<YAxisOptions> = {
     labelFormatter: (value: number) => value.toString(),
     integersOnly: false,
     ...yAxisOptions,

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/use-stacked-data.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/use-stacked-data.ts
@@ -1,12 +1,12 @@
 import {useMemo} from 'react';
 import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
-import type {DataSeries} from '@shopify/polaris-viz-core/src/types';
+import type {DataSeries, XAxisOptions} from '@shopify/polaris-viz-core';
 
-import type {LinearXAxisOptions} from '../../../types';
+import {useXAxisLabels} from '../../../hooks/useXAxisLabels';
 
 interface Props {
   data: DataSeries[];
-  xAxisOptions: LinearXAxisOptions;
+  xAxisOptions: Required<XAxisOptions>;
 }
 
 export function useStackedData({data, xAxisOptions}: Props) {
@@ -19,9 +19,11 @@ export function useStackedData({data, xAxisOptions}: Props) {
     [data],
   );
 
+  const labels = useXAxisLabels({data, xAxisOptions});
+
   const formattedData = useMemo(
     () =>
-      xAxisOptions.xAxisLabels.map((_, labelIndex) =>
+      labels.map((_, labelIndex) =>
         data.reduce((acc, {name, data}) => {
           const {value} = data[labelIndex];
 
@@ -29,12 +31,8 @@ export function useStackedData({data, xAxisOptions}: Props) {
           return Object.assign(acc, dataPoint);
         }, {}),
       ),
-    [xAxisOptions.xAxisLabels, data],
+    [labels, data],
   );
-
-  const labels = useMemo(() => {
-    return xAxisOptions.xAxisLabels.map(xAxisOptions.labelFormatter);
-  }, [xAxisOptions]);
 
   const stackedValues = useMemo(
     () => areaStack(formattedData),

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/use-y-scale.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/use-y-scale.ts
@@ -1,12 +1,12 @@
 import {useContext, useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
 import type {Series} from 'd3-shape';
+import type {LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {ChartContext} from '../../../components/ChartContainer';
 import {estimateStringWidth, shouldRoundScaleUp} from '../../../utilities';
 import {MIN_Y_LABEL_SPACE} from '../constants';
 import {DEFAULT_MAX_Y} from '../../../constants';
-import type {NumberLabelFormatter} from '../../../types';
 
 export function useYScale({
   drawableHeight,
@@ -20,7 +20,7 @@ export function useYScale({
     },
     string
   >[];
-  formatYAxisLabel: NumberLabelFormatter;
+  formatYAxisLabel: LabelFormatter;
 }) {
   const {characterWidths} = useContext(ChartContext);
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/Playground.stories.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import type {Story, Meta} from '@storybook/react';
+
+import {StackedAreaChart, StackedAreaChartProps} from '../StackedAreaChart';
+import {formatHourlyLabel} from '../../../components/LineChart/stories/utils.stories';
+export default {
+  title: 'polaris-viz/Default Charts/StackedAreaChart/Playground',
+  component: StackedAreaChart,
+  parameters: {
+    controls: {sort: 'requiredFirst', expanded: true},
+  },
+} as Meta;
+
+const Template: Story<StackedAreaChartProps> = (
+  args: StackedAreaChartProps,
+) => {
+  return <StackedAreaChart {...args} />;
+};
+
+export const WebData = Template.bind({});
+
+WebData.args = {
+  xAxisOptions: {
+    labelFormatter: formatHourlyLabel,
+  },
+  data: [
+    {
+      data: [
+        {
+          value: 0,
+          key: '2022-03-23T00:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T01:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T02:00:00-04:00',
+        },
+        {
+          value: 1,
+          key: '2022-03-23T03:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T04:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T05:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T06:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T07:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T08:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T09:00:00-04:00',
+        },
+        {
+          value: 3,
+          key: '2022-03-23T10:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T11:00:00-04:00',
+        },
+        {
+          value: 1,
+          key: '2022-03-23T12:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T13:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T14:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T15:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T16:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T17:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T18:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T19:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T20:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T21:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T22:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T23:00:00-04:00',
+        },
+      ],
+      name: 'First-time',
+    },
+    {
+      data: [
+        {
+          value: 0,
+          key: '2022-03-23T00:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T01:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T02:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T03:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T04:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T05:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T06:00:00-04:00',
+        },
+        {
+          value: 1,
+          key: '2022-03-23T07:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T08:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T09:00:00-04:00',
+        },
+        {
+          value: 1,
+          key: '2022-03-23T10:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T11:00:00-04:00',
+        },
+        {
+          value: 1,
+          key: '2022-03-23T12:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T13:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T14:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T15:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T16:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T17:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T18:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T19:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T20:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T21:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T22:00:00-04:00',
+        },
+        {
+          value: 0,
+          key: '2022-03-23T23:00:00-04:00',
+        },
+      ],
+      name: 'Returning',
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -3,12 +3,11 @@ import type {Story, Meta} from '@storybook/react';
 
 import {StackedAreaChart, StackedAreaChartProps} from '../StackedAreaChart';
 
-import {data, labels, formatYAxisLabel} from './utils.stories';
+import {data, formatYAxisLabel} from './utils.stories';
 import {LEGEND_CONTROL_ARGS, THEME_CONTROL_ARGS} from '../../../storybook';
 
 import {generateMultipleSeries} from '../../Docs/utilities';
 import type {RenderTooltipContentData} from '../types';
-import {formatHourlyLabel} from '../../../components/LineChart/stories/utils.stories';
 
 const TOOLTIP_CONTENT = {
   empty: undefined,
@@ -82,10 +81,9 @@ export default {
   },
 } as Meta;
 
-const defaultProps = {
+const DEFAULT_PROPS = {
   data,
   skipLinkText: 'Skip chart content',
-  xAxisOptions: {xAxisLabels: labels},
   yAxisOptions: {labelFormatter: formatYAxisLabel},
   isAnimated: true,
 };
@@ -96,25 +94,18 @@ const Template: Story<StackedAreaChartProps> = (
   return <StackedAreaChart {...args} />;
 };
 export const Default: Story<StackedAreaChartProps> = Template.bind({});
-Default.args = {
-  ...defaultProps,
-};
+Default.args = DEFAULT_PROPS;
 
 export const HideXAxisLabels: Story<StackedAreaChartProps> = Template.bind({});
 HideXAxisLabels.args = {
-  ...defaultProps,
-  xAxisOptions: {...defaultProps.xAxisOptions, hide: true},
+  ...DEFAULT_PROPS,
+  xAxisOptions: {hide: true},
 };
 
 export const OverwrittenSeriesColors: Story<StackedAreaChartProps> =
   Template.bind({});
 OverwrittenSeriesColors.args = {
-  ...defaultProps,
-  xAxisOptions: {
-    xAxisLabels: Array(5)
-      .fill(null)
-      .map(() => 'label'),
-  },
+  ...DEFAULT_PROPS,
   data: [
     {
       name: 'One',
@@ -145,258 +136,20 @@ OverwrittenSeriesColors.args = {
 export const SeriesColorsUpToFour = Template.bind({});
 
 SeriesColorsUpToFour.args = {
-  ...defaultProps,
+  ...DEFAULT_PROPS,
   data: generateMultipleSeries(4),
 };
 
 export const SeriesColorsFromFiveToSeven = Template.bind({});
 
 SeriesColorsFromFiveToSeven.args = {
-  ...defaultProps,
+  ...DEFAULT_PROPS,
   data: generateMultipleSeries(7),
 };
 
 export const SeriesColorsUpToFourteen = Template.bind({});
 
 SeriesColorsUpToFourteen.args = {
-  ...defaultProps,
+  ...DEFAULT_PROPS,
   data: generateMultipleSeries(14),
-};
-
-export const WebData = Template.bind({});
-
-WebData.args = {
-  xAxisOptions: {
-    labelFormatter: formatHourlyLabel,
-    xAxisLabels: [
-      '2022-03-23T00:00:00-04:00',
-      '2022-03-23T01:00:00-04:00',
-      '2022-03-23T02:00:00-04:00',
-      '2022-03-23T03:00:00-04:00',
-      '2022-03-23T04:00:00-04:00',
-      '2022-03-23T05:00:00-04:00',
-      '2022-03-23T06:00:00-04:00',
-      '2022-03-23T07:00:00-04:00',
-      '2022-03-23T08:00:00-04:00',
-      '2022-03-23T09:00:00-04:00',
-      '2022-03-23T10:00:00-04:00',
-      '2022-03-23T11:00:00-04:00',
-      '2022-03-23T12:00:00-04:00',
-      '2022-03-23T13:00:00-04:00',
-      '2022-03-23T14:00:00-04:00',
-      '2022-03-23T15:00:00-04:00',
-      '2022-03-23T16:00:00-04:00',
-      '2022-03-23T17:00:00-04:00',
-      '2022-03-23T18:00:00-04:00',
-      '2022-03-23T19:00:00-04:00',
-      '2022-03-23T20:00:00-04:00',
-      '2022-03-23T21:00:00-04:00',
-      '2022-03-23T22:00:00-04:00',
-      '2022-03-23T23:00:00-04:00',
-    ],
-  },
-  data: [
-    {
-      data: [
-        {
-          value: 0,
-          key: '2022-03-23T00:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T01:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T02:00:00-04:00',
-        },
-        {
-          value: 1,
-          key: '2022-03-23T03:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T04:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T05:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T06:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T07:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T08:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T09:00:00-04:00',
-        },
-        {
-          value: 3,
-          key: '2022-03-23T10:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T11:00:00-04:00',
-        },
-        {
-          value: 1,
-          key: '2022-03-23T12:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T13:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T14:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T15:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T16:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T17:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T18:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T19:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T20:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T21:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T22:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T23:00:00-04:00',
-        },
-      ],
-      name: 'First-time',
-    },
-    {
-      data: [
-        {
-          value: 0,
-          key: '2022-03-23T00:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T01:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T02:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T03:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T04:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T05:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T06:00:00-04:00',
-        },
-        {
-          value: 1,
-          key: '2022-03-23T07:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T08:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T09:00:00-04:00',
-        },
-        {
-          value: 1,
-          key: '2022-03-23T10:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T11:00:00-04:00',
-        },
-        {
-          value: 1,
-          key: '2022-03-23T12:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T13:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T14:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T15:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T16:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T17:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T18:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T19:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T20:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T21:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T22:00:00-04:00',
-        },
-        {
-          value: 0,
-          key: '2022-03-23T23:00:00-04:00',
-        },
-      ],
-      name: 'Returning',
-    },
-  ],
 };

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/utils.stories.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/utils.stories.ts
@@ -25,17 +25,7 @@ export const data = [
   },
 ];
 
-export const labels = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-];
-
-export const formatYAxisLabel = (value?: number) => {
+export const formatYAxisLabel = (value) => {
   const formatter = new Intl.NumberFormat('en').format;
   if (value == null) {
     return '-';

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -44,11 +44,6 @@ describe('<Chart />', () => {
         data: [
           {key: '1', value: 502},
           {key: '2', value: 1000},
-          {key: '3', value: 2000},
-          {key: '4', value: 1000},
-          {key: '5', value: 100},
-          {key: '6', value: 1000},
-          {key: '7', value: 5000},
         ],
         color: 'purple',
       },
@@ -57,22 +52,16 @@ describe('<Chart />', () => {
         data: [
           {key: '1', value: 106},
           {key: '2', value: 107},
-          {key: '3', value: 111},
-          {key: '4', value: 133},
-          {key: '5', value: 100},
-          {key: '6', value: 767},
-          {key: '7', value: 1766},
         ],
         color: 'teal',
       },
     ],
     xAxisOptions: {
-      xAxisLabels: ['Day 1', 'Day 2'],
       hide: false,
-      labelFormatter: (value) => `${value}`,
+      labelFormatter: (value) => `Day ${value}`,
     },
     yAxisOptions: {
-      labelFormatter: (val: number) => val.toString(),
+      labelFormatter: (value) => value.toString(),
       integersOnly: false,
     },
     dimensions: {width: 500, height: 250},
@@ -183,7 +172,9 @@ describe('<Chart />', () => {
 
     expect(chart).toContainReactComponent(VisuallyHiddenRows, {
       data: mockProps.data,
-      xAxisLabels: mockProps.xAxisOptions.xAxisLabels,
+      xAxisLabels: mockProps.data[0].data.map(({key}) =>
+        mockProps.xAxisOptions.labelFormatter(key),
+      ),
     });
   });
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -4,10 +4,13 @@ import type {
   DataSeries,
   ChartType,
   Dimensions,
+  XAxisOptions,
+  YAxisOptions,
 } from '@shopify/polaris-viz-core';
 import type {AnnotationLookupTable} from 'components/BarChart/types';
 
 import {ChartContext} from '../../components/ChartContainer';
+import {useXAxisLabels} from '../../hooks/useXAxisLabels';
 import {BarChartXAxisLabels} from '../BarChartXAxisLabels';
 import {LegendContainer, useLegend} from '../LegendContainer';
 import {GradientDefs} from '../shared';
@@ -43,11 +46,7 @@ import {
   useWatchColorVisionEvents,
   useReducedLabelIndexes,
 } from '../../hooks';
-import type {
-  RenderTooltipContentData,
-  XAxisOptions,
-  YAxisOptions,
-} from '../BarChart';
+import type {RenderTooltipContentData} from '../BarChart';
 import {AnnotationLine} from '../BarChart';
 
 import {BarGroup, StackedBarGroups} from './components';
@@ -106,17 +105,7 @@ export function Chart({
 
   const emptyState = data.length === 0;
 
-  const labels = useMemo(() => {
-    const labels: string[] = [];
-
-    data.forEach(({data}) => {
-      data.forEach(({key}, index) => {
-        labels[index] = xAxisOptions.labelFormatter?.(`${key}`) ?? `${key}`;
-      });
-    });
-
-    return labels;
-  }, [data, xAxisOptions]);
+  const labels = useXAxisLabels({data, xAxisOptions});
 
   const isStacked = type === 'stacked';
   const stackedValues = isStacked ? getStackedValues(data, labels) : null;

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import type {ChartType, DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  ChartType,
+  DataSeries,
+  XAxisOptions,
+  YAxisOptions,
+} from '@shopify/polaris-viz-core';
 
 import {ChartContainer} from '../../components/ChartContainer';
 import {useTheme, useThemeSeriesColors} from '../../hooks';
 import type {
   AnnotationLookupTable,
   RenderTooltipContentData,
-  XAxisOptions,
-  YAxisOptions,
 } from '../../components/BarChart';
 
 import {Chart} from './Chart';

--- a/packages/polaris-viz/src/components/VerticalBarChart/hooks/use-y-scale.ts
+++ b/packages/polaris-viz/src/components/VerticalBarChart/hooks/use-y-scale.ts
@@ -1,10 +1,10 @@
 import {useMemo} from 'react';
 import {scaleLinear} from 'd3-scale';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {shouldRoundScaleUp, getStackedMinMax} from '../../../utilities';
 import {MIN_Y_LABEL_SPACE} from '../constants';
-import type {NumberLabelFormatter, StackedSeries} from '../../../types';
+import type {StackedSeries} from '../../../types';
 
 export function useYScale({
   drawableHeight,
@@ -15,7 +15,7 @@ export function useYScale({
 }: {
   drawableHeight: number;
   data: DataSeries[];
-  formatYAxisLabel: NumberLabelFormatter;
+  formatYAxisLabel: LabelFormatter;
   stackedValues: StackedSeries[] | null;
   integersOnly: boolean;
 }) {

--- a/packages/polaris-viz/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
+++ b/packages/polaris-viz/src/components/VisuallyHiddenRows/VisuallyHiddenRows.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import type {DataSeries} from '@shopify/polaris-viz-core';
-
-import type {NumberLabelFormatter} from '../../types';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import styles from './VisuallyHiddenRows.scss';
 
 export interface Props {
   data: DataSeries[];
   xAxisLabels: string[];
-  formatYAxisLabel: NumberLabelFormatter;
+  formatYAxisLabel: LabelFormatter;
 }
 
 export const VisuallyHiddenRows = React.memo(function Rows({

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useState} from 'react';
 import type {ScaleLinear} from 'd3-scale';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 import {RoundedBorder} from '@shopify/polaris-viz-core';
 
 import {estimateStringWidth} from '../../../utilities';
@@ -10,7 +10,6 @@ import {
   HORIZONTAL_GROUP_LABEL_HEIGHT,
   HORIZONTAL_SPACE_BETWEEN_SINGLE,
 } from '../../../constants';
-import type {LabelFormatter} from '../../../types';
 import {
   useTheme,
   useWatchColorVisionEvents,

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -2,7 +2,7 @@ import React, {useMemo, useState} from 'react';
 import {animated, SpringValue} from '@react-spring/web';
 import {DataType} from '@shopify/polaris-viz-core';
 import type {ScaleLinear} from 'd3-scale';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {
   COLOR_VISION_GROUP_ITEM,
@@ -14,7 +14,7 @@ import {
   getOpacityStylesForActive,
   useWatchColorVisionEvents,
 } from '../../../hooks';
-import type {FormattedStackedSeries, LabelFormatter} from '../../../types';
+import type {FormattedStackedSeries} from '../../../types';
 import {GroupLabel} from '../GroupLabel';
 import {HorizontalStackedBars} from '../HorizontalStackedBars';
 import {HorizontalBars} from '../HorizontalBars';

--- a/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
+++ b/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
@@ -1,9 +1,8 @@
 import {useContext, useMemo} from 'react';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {HORIZONTAL_BAR_LABEL_OFFSET} from '../constants';
 import {estimateStringWidth} from '../utilities';
-import type {LabelFormatter} from '../types';
 import {ChartContext} from '../components';
 
 interface Props {

--- a/packages/polaris-viz/src/hooks/useHorizontalTicksAndScale.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalTicksAndScale.ts
@@ -1,8 +1,7 @@
+import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {extent} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
 import {useMemo} from 'react';
-
-import type {LabelFormatter} from '../types';
 
 interface Props {
   allNumbers: number[];

--- a/packages/polaris-viz/src/hooks/useHorizontalXScale.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalXScale.ts
@@ -1,8 +1,8 @@
+import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {useContext, useMemo} from 'react';
 
 import {ChartContext} from '../components';
 import {HORIZONTAL_LABEL_MIN_WIDTH} from '../constants';
-import type {LabelFormatter} from '../types';
 import {clamp, estimateStringWidth} from '../utilities';
 
 import {useHorizontalTicksAndScale} from './useHorizontalTicksAndScale';

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -4,10 +4,10 @@ import {
   useTheme,
   LINEAR_LABELS_INNER_PADDING,
 } from '@shopify/polaris-viz-core';
+import type {XAxisOptions} from '@shopify/polaris-viz-core';
 
 import {HORIZONTAL_LABEL_MIN_WIDTH} from '../constants';
 import {estimateStringWidth, clamp} from '../utilities';
-import type {LinearXAxisOptions} from '../types';
 import {ChartContext} from '../components';
 
 import {useLinearXScale} from './useLinearXScale';
@@ -18,7 +18,7 @@ interface Props {
   longestSeriesLength: number;
   width: number;
   labels: string[];
-  xAxisOptions: LinearXAxisOptions;
+  xAxisOptions: Required<XAxisOptions>;
   yAxisLabelWidth: number;
   theme?: string;
 }

--- a/packages/polaris-viz/src/hooks/useXAxisLabels.ts
+++ b/packages/polaris-viz/src/hooks/useXAxisLabels.ts
@@ -1,0 +1,29 @@
+import {useMemo} from 'react';
+import type {DataSeries, XAxisOptions} from '@shopify/polaris-viz-core';
+
+interface Props {
+  data: DataSeries[];
+  xAxisOptions: Required<XAxisOptions>;
+}
+
+export function useXAxisLabels({data, xAxisOptions}: Props) {
+  return useMemo(() => {
+    const labels: string[] = [];
+
+    if (data == null || data.length === 0) {
+      return [];
+    }
+
+    data.forEach((series) => {
+      if (series == null || series.data == null) {
+        return;
+      }
+
+      series.data.forEach(({key}, index) => {
+        labels[index] = xAxisOptions.labelFormatter?.(`${key}`) ?? `${key}`;
+      });
+    });
+
+    return labels;
+  }, [data, xAxisOptions]);
+}

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -1,16 +1,6 @@
 import type {Interpolation, InterpolatorFn} from '@react-spring/web';
 import type {Series, SeriesPoint} from 'd3-shape';
 
-export type LabelFormatter = (value: string | number | null) => string;
-
-export type StringLabelFormatter = (
-  value: string,
-  index?: number,
-  data?: string[],
-) => string;
-
-export type NumberLabelFormatter = (value: number) => string;
-
 export interface YAxisTick {
   value: number;
   formattedValue: string;
@@ -23,15 +13,6 @@ export interface SparkChartData {
 
 export type PathInterpolator = InterpolatorFn<readonly number[], string>;
 export type NumberInterpolator = InterpolatorFn<readonly number[], number>;
-
-export interface XAxisOptions {
-  labelFormatter?: StringLabelFormatter;
-  hide?: boolean;
-}
-export interface YAxisOptions {
-  labelFormatter?: NumberLabelFormatter;
-  integersOnly?: boolean;
-}
 
 // === Theme types === //
 export enum BarMargin {
@@ -71,17 +52,6 @@ export type GradientUnits = 'userSpaceOnUse' | 'objectBoundingBox';
 
 export interface CharacterWidths {
   [key: string]: number;
-}
-
-export interface LinearXAxisOptions {
-  labelFormatter: StringLabelFormatter;
-  xAxisLabels: string[];
-  hide?: boolean;
-}
-
-export interface LinearYAxisOptions {
-  labelFormatter: NumberLabelFormatter;
-  integersOnly: boolean;
 }
 
 export type AnimatedCoordinate = Interpolation<


### PR DESCRIPTION
## What does this implement/fix?

While working on https://github.com/Shopify/polaris-viz/issues/998 I noticed we had a few types that were being duplicated, or unecessary.

We had different components setting their own `XAxisOptions` and `YAxisOptions` that were very similar to the core types. 

We also had `LabelFormatter` which was a combonation of `StringLabelFormatter` & `NumberLabelFormatter`.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

Nothing visible.

- [ ] `dev type-check` passes.
- [ ] `yarn test` passes.
- [ ] All stories spot checked for issues.


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
