### PR TITLE
Always position tooltip near top of chart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Tooltips will now stick along the yAxis (or xAxis for horizontal charts).
 
 ## [1.3.1] - 2022-04-18
 
 ### Changed
 
-- Tooltips will now stick along the yAxis (or xAxis for horizontal charts).
+- Export `TooltipData` & `TooltipContentProps` types.
 
 ## [1.3.0] - 2022-04-18
 

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -151,6 +151,7 @@ const ANNOTATION: Annotation[] = [
 export default {
   title: 'polaris-viz/Default Charts/BarChart',
   component: BarChart,
+  decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
   parameters: {
     horizontalMargin: 0,
     docs: {
@@ -165,7 +166,6 @@ export default {
       expanded: true,
     },
   },
-  decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
   argTypes: {
     annotations: {
       control: {

--- a/packages/polaris-viz/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -17,18 +17,23 @@ export function getAlteredHorizontalBarPosition(
 }
 
 function getNegativeOffset(props: AlteredPositionProps): AlteredPositionReturn {
-  const {bandwidth, currentX, currentY, tooltipDimensions} = props;
+  const {bandwidth, chartDimensions, currentX, currentY, tooltipDimensions} =
+    props;
 
   const flippedX = currentX * -1;
   const yOffset = (bandwidth - tooltipDimensions.height) / 2;
+  const rightAligned = chartDimensions.width - tooltipDimensions.width;
 
   const y = currentY - tooltipDimensions.height;
   if (flippedX - tooltipDimensions.width < 0) {
-    return {x: flippedX, y: y < 0 ? 0 : y};
+    return {
+      x: rightAligned,
+      y: y < 0 ? 0 : y,
+    };
   }
 
   return {
-    x: flippedX - tooltipDimensions.width - TOOLTIP_MARGIN,
+    x: rightAligned,
     y: currentY + HORIZONTAL_GROUP_LABEL_HEIGHT + yOffset,
   };
 }
@@ -44,16 +49,18 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
     chartDimensions,
   });
 
+  const right = chartDimensions.width - tooltipDimensions.width;
+
   if (isOutside.top && isOutside.right) {
     return {
-      x: chartDimensions.width - tooltipDimensions.width,
+      x: right,
       y: 0,
     };
   }
 
   if (isOutside.top && !isOutside.right) {
     return {
-      x: currentX + TOOLTIP_MARGIN,
+      x: right,
       y: 0,
     };
   }
@@ -61,13 +68,12 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
   if (!isOutside.right && !isOutside.bottom) {
     const yOffset = (bandwidth - tooltipDimensions.height) / 2;
     return {
-      x: currentX + TOOLTIP_MARGIN,
+      x: right,
       y: currentY + HORIZONTAL_GROUP_LABEL_HEIGHT + yOffset,
     };
   }
 
   if (isOutside.right) {
-    const x = currentX - tooltipDimensions.width;
     const y =
       currentY -
       tooltipDimensions.height +
@@ -76,20 +82,20 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
 
     if (y < 0) {
       return {
-        x,
+        x: right,
         y: bandwidth + HORIZONTAL_GROUP_LABEL_HEIGHT + TOOLTIP_MARGIN,
       };
     }
 
     return {
-      x,
+      x: right,
       y,
     };
   }
 
   if (isOutside.bottom) {
     return {
-      x: currentX + TOOLTIP_MARGIN,
+      x: right,
       y:
         chartDimensions.height -
         tooltipDimensions.height -

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -15,12 +15,11 @@ import type {
 } from '@shopify/polaris-viz-core';
 
 import type {RenderTooltipContentData} from '../../types';
+import {getAlteredLineChartPosition} from '../../utilities/getAlteredLineChartPosition';
 import {useXAxisLabels} from '../../hooks/useXAxisLabels';
 import {LinearXAxisLabels} from '../LinearXAxisLabels';
 import {useLegend, LegendContainer} from '../LegendContainer';
 import {
-  TooltipHorizontalOffset,
-  TooltipVerticalOffset,
   TooltipPosition,
   TooltipPositionParams,
   TooltipWrapper,
@@ -63,11 +62,6 @@ export interface ChartProps {
   theme?: string;
   dimensions?: Dimensions;
 }
-
-const TOOLTIP_POSITION = {
-  horizontal: TooltipHorizontalOffset.Left,
-  vertical: TooltipVerticalOffset.Center,
-};
 
 export function Chart({
   data,
@@ -186,6 +180,8 @@ export function Chart({
     index,
     eventType,
   }: TooltipPositionParams): TooltipPosition {
+    let activeIndex = 0;
+
     if (eventType === 'mouse') {
       const point = eventPointNative(event!);
 
@@ -197,32 +193,24 @@ export function Chart({
         return TOOLTIP_POSITION_DEFAULT_RETURN;
       }
 
-      const {svgX, svgY} = point;
+      const {svgX} = point;
 
       const closestIndex = Math.round(xScale.invert(svgX - chartStartPosition));
 
-      const activeIndex = clamp({
+      activeIndex = clamp({
         amount: closestIndex,
         min: 0,
         max: reversedSeries[longestSeriesIndex].data.length - 1,
       });
-
-      return {
-        x: svgX,
-        y: svgY,
-        position: TOOLTIP_POSITION,
-        activeIndex,
-      };
     } else {
-      const activeIndex = index ?? 0;
-
-      return {
-        x: xScale?.(activeIndex) ?? 0,
-        y: 0,
-        position: TOOLTIP_POSITION,
-        activeIndex,
-      };
+      activeIndex = index ?? 0;
     }
+
+    return {
+      x: chartStartPosition + xScale?.(activeIndex) ?? 0,
+      y: 0,
+      activeIndex,
+    };
   }
 
   return (
@@ -356,9 +344,9 @@ export function Chart({
       </svg>
 
       <TooltipWrapper
-        alwaysUpdatePosition
         chartDimensions={{width, height}}
         focusElementDataType={DataType.Point}
+        getAlteredPosition={getAlteredLineChartPosition}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}
         id={tooltipId.current}

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.scss
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.scss
@@ -2,7 +2,6 @@
 
 .Container {
   @include chart-container;
-  position: relative;
   user-select: none;
   max-width: 100%;
 }

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -22,7 +22,6 @@ interface TooltipWrapperProps {
   margin: Margin;
   parentRef: SVGSVGElement | null;
   focusElementDataType: DataType;
-  alwaysUpdatePosition?: boolean;
   bandwidth?: number;
   getAlteredPosition?: AlteredPosition;
   id?: string;
@@ -31,7 +30,6 @@ interface TooltipWrapperProps {
 
 export function TooltipWrapper(props: TooltipWrapperProps) {
   const {
-    alwaysUpdatePosition = false,
     bandwidth = 0,
     focusElementDataType,
     getAlteredPosition,
@@ -62,17 +60,14 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     (event: MouseEvent | TouchEvent) => {
       const newPosition = getPosition({event, eventType: 'mouse'});
 
-      if (
-        !alwaysUpdatePosition &&
-        activeIndexRef.current === newPosition.activeIndex
-      ) {
+      if (activeIndexRef.current === newPosition.activeIndex) {
         return;
       }
 
       setPosition(newPosition);
       onIndexChange?.(newPosition.activeIndex);
     },
-    [alwaysUpdatePosition, getPosition, onIndexChange],
+    [getPosition, onIndexChange],
   );
 
   const onMouseLeave = useCallback(() => {

--- a/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
@@ -99,7 +99,7 @@ export function getAlteredVerticalBarPosition(
     x = center.value;
   }
 
-  return {x, y};
+  return {x, y: props.margin.Top};
 }
 
 interface IsOutsideBoundsData {
@@ -222,11 +222,13 @@ export function getLeftPosition(
   const [value, props] = args;
 
   let x = value - props.tooltipDimensions.width;
+
   const wasOutsideBounds = isOutsideBounds({
     current: x,
     direction: 'x',
     alteredPosition: props,
   });
+
   if (wasOutsideBounds) {
     x = props.currentX + props.margin.Left + props.bandwidth + TOOLTIP_MARGIN;
   } else {

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -22,7 +22,11 @@ export {SkipLink} from './SkipLink';
 export {VisuallyHiddenRows} from './VisuallyHiddenRows';
 export {LinePreview} from './LinePreview';
 export type {LinePreviewProps} from './LinePreview';
-export {TooltipWrapper} from './TooltipWrapper';
+export {TooltipWrapper, TOOLTIP_MARGIN} from './TooltipWrapper';
+export type {
+  AlteredPositionProps,
+  AlteredPositionReturn,
+} from './TooltipWrapper';
 export {SimpleBarChart} from './SimpleBarChart';
 export type {SimpleBarChartProps} from './SimpleBarChart';
 export {ChartContext} from './ChartContainer';

--- a/packages/polaris-viz/src/utilities/getAlteredLineChartPosition.ts
+++ b/packages/polaris-viz/src/utilities/getAlteredLineChartPosition.ts
@@ -1,0 +1,48 @@
+import type {Dimensions} from '@shopify/polaris-viz-core';
+
+import {
+  AlteredPositionProps,
+  AlteredPositionReturn,
+  TOOLTIP_MARGIN,
+} from '../components';
+
+export function getAlteredLineChartPosition(
+  props: AlteredPositionProps,
+): AlteredPositionReturn {
+  let x = props.currentX - props.tooltipDimensions.width - TOOLTIP_MARGIN;
+
+  const {left: isOutsideLeft} = isOutsideBounds({
+    x,
+    y: 0,
+    tooltipDimensions: props.tooltipDimensions,
+    chartDimensions: props.chartDimensions,
+  });
+
+  if (isOutsideLeft) {
+    x = props.currentX + TOOLTIP_MARGIN;
+  }
+
+  return {x, y: props.margin.Top};
+}
+
+function isOutsideBounds({
+  x,
+  y,
+  tooltipDimensions,
+  chartDimensions,
+}: {
+  x: number;
+  y: number;
+  tooltipDimensions: Dimensions;
+  chartDimensions: Dimensions;
+}) {
+  const right = x + TOOLTIP_MARGIN + tooltipDimensions.width;
+  const bottom = y + tooltipDimensions.height;
+
+  return {
+    left: x <= 0,
+    right: right > chartDimensions.width,
+    bottom: bottom > chartDimensions.height,
+    top: y <= 0,
+  };
+}


### PR DESCRIPTION
## What does this implement/fix?

Lock the position of the tooltips to reduce eye movement when moving between points.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1025

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/163829276-bc50d477-5570-4783-a18a-fd3280fb2adc.mov

**After**

https://user-images.githubusercontent.com/149873/163829121-2a33bc78-3a9a-431f-9364-0ae71fa14fc5.mov
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
