### PR TITLE
Consume single SparkBarSeries in SparkBars

### DIFF
--- a/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
+++ b/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
@@ -1,0 +1,146 @@
+import React, {useMemo} from 'react';
+import type {DataSeries} from 'types';
+import type {useTransition} from '@react-spring/core';
+
+import {usePolarisVizContext, useSparkBar, useTheme} from '../../hooks';
+import {LinearGradientWithStops} from '../LinearGradientWithStops';
+import {getAnimationTrail, getSeriesColors, uniqueId} from '../../utilities';
+import {Bar} from '../Bar';
+import {
+  BARS_TRANSITION_CONFIG,
+  BORDER_RADIUS,
+  STROKE_WIDTH,
+} from '../../constants';
+
+interface SparkBarSeriesProps {
+  data: DataSeries[];
+  dataOffsetLeft: number;
+  dataOffsetRight: number;
+  height: number;
+  shouldAnimate: boolean;
+  useTransition: typeof useTransition;
+  width: number;
+  theme?: string;
+}
+
+export function SparkBarSeries({
+  data,
+  dataOffsetLeft,
+  dataOffsetRight,
+  height,
+  shouldAnimate,
+  theme,
+  useTransition,
+  width,
+}: SparkBarSeriesProps) {
+  const selectedTheme = useTheme(theme);
+  const [seriesColor] = getSeriesColors(1, selectedTheme);
+
+  const {
+    // eslint-disable-next-line id-length
+    components: {Defs, Mask, G, Path, Rect},
+    animated,
+  } = usePolarisVizContext();
+
+  const AnimatedG = animated(G);
+
+  const id = useMemo(() => uniqueId('sparkbar-series'), []);
+  const clipId = useMemo(() => uniqueId('sparkbar-series-clip'), []);
+
+  const {
+    borderRadius,
+    dataWithIndex,
+    color,
+    getBarHeight,
+    strokeDasharray,
+    strokeDashoffset,
+    lineShape,
+    comparisonData,
+    xScale,
+    yScale,
+    barWidth,
+  } = useSparkBar({
+    data,
+    height,
+    dataOffsetLeft,
+    dataOffsetRight,
+    width,
+    seriesColor,
+  });
+
+  const transitions = useTransition(dataWithIndex, {
+    key: ({index}: {index: number}) => index,
+    from: {height: 0},
+    leave: {height: 0},
+    enter: ({value: {value}}) => ({
+      height: getBarHeight(value == null ? 0 : value),
+    }),
+    update: ({value: {value}}) => ({
+      height: getBarHeight(value == null ? 0 : value),
+    }),
+    default: {immediate: !shouldAnimate},
+    trail: shouldAnimate ? getAnimationTrail(dataWithIndex.length) : 0,
+    config: BARS_TRANSITION_CONFIG,
+  });
+
+  return (
+    <React.Fragment>
+      <Defs>
+        <LinearGradientWithStops
+          id={id}
+          gradient={color}
+          gradientUnits="userSpaceOnUse"
+          y1="100%"
+          y2="0%"
+        />
+      </Defs>
+
+      <Mask id={clipId}>
+        <AnimatedG opacity={comparisonData ? '0.9' : '1'}>
+          {transitions(({height: barHeight}, item, _transition, index) => {
+            const xPosition = xScale(index.toString());
+            const height = shouldAnimate
+              ? barHeight
+              : getBarHeight(item.value.value ?? 0);
+
+            return (
+              <Bar
+                borderRadius={
+                  selectedTheme.bar.hasRoundedCorners
+                    ? borderRadius
+                    : BORDER_RADIUS.None
+                }
+                key={index}
+                x={xPosition == null ? 0 : xPosition}
+                yScale={yScale}
+                value={item.value.value}
+                width={barWidth}
+                height={height}
+                fill="white"
+              />
+            );
+          })}
+        </AnimatedG>
+      </Mask>
+
+      <Rect
+        fill={`url(#${id})`}
+        width={width}
+        height={height}
+        mask={`url(#${clipId})`}
+      />
+
+      {comparisonData == null ? null : (
+        <Path
+          stroke={selectedTheme.seriesColors.comparison}
+          strokeWidth={STROKE_WIDTH}
+          d={lineShape!}
+          strokeLinecap="round"
+          opacity="0.9"
+          strokeDashoffset={strokeDashoffset}
+          strokeDasharray={strokeDasharray}
+        />
+      )}
+    </React.Fragment>
+  );
+}

--- a/packages/polaris-viz-core/src/components/SparkBarSeries/index.ts
+++ b/packages/polaris-viz-core/src/components/SparkBarSeries/index.ts
@@ -1,0 +1,1 @@
+export {SparkBarSeries} from './SparkBarSeries';

--- a/packages/polaris-viz-core/src/components/index.ts
+++ b/packages/polaris-viz-core/src/components/index.ts
@@ -3,3 +3,4 @@ export {LinearGradientWithStops} from './LinearGradientWithStops';
 export {LineSeries} from './LineSeries';
 export {Bar} from './Bar';
 export type {PolarisVizProviderProps} from './PolarisVizProvider';
+export {SparkBarSeries} from './SparkBarSeries';

--- a/packages/polaris-viz-core/src/hooks/useSparkBar.ts
+++ b/packages/polaris-viz-core/src/hooks/useSparkBar.ts
@@ -103,7 +103,7 @@ export function useSparkBar({
   const strokeDasharray = `${barWidth - STROKE_WIDTH} ${barGap}`;
 
   const getBarHeight = useCallback(
-    ({value}) => {
+    (value: number) => {
       const height = Math.abs(yScale(value) - yScale(0));
       return Math.max(height, BAR_MIN_HEIGHT_RATIO * barWidth);
     },

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -106,6 +106,7 @@ export {
   LineSeries,
   LinearGradientWithStops,
   PolarisVizProvider,
+  SparkBarSeries,
 } from './components';
 export {ChartContext} from './contexts';
 export type {PolarisVizProviderProps} from './components';

--- a/packages/polaris-viz/src/components/SparkBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/Chart.tsx
@@ -1,19 +1,10 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import {useTransition} from '@react-spring/web';
 import {
-  LinearGradientWithStops,
-  getSeriesColors,
-  useTheme,
-  Bar,
-  useSparkBar,
   Dimensions,
   SparkBarChartProps,
-  BARS_TRANSITION_CONFIG,
-  getAnimationTrail,
   ANIMATION_MARGIN,
-  STROKE_WIDTH,
-  uniqueId,
-  BORDER_RADIUS,
+  SparkBarSeries,
 } from '@shopify/polaris-viz-core';
 
 import {usePrefersReducedMotion} from '../../hooks';
@@ -35,46 +26,9 @@ export function Chart({
   theme,
 }: Props) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
-  const selectedTheme = useTheme(theme);
-  const [seriesColor] = getSeriesColors(1, selectedTheme);
-
-  const {width, height} = dimensions ?? {width: 0, height: 0};
-  const id = useMemo(() => uniqueId('sparkbar'), []);
-  const clipId = useMemo(() => uniqueId('clip'), []);
-
   const shouldAnimate = !prefersReducedMotion && isAnimated;
 
-  const {
-    borderRadius,
-    dataWithIndex,
-    color,
-    getBarHeight,
-    strokeDasharray,
-    strokeDashoffset,
-    lineShape,
-    comparisonData,
-    xScale,
-    yScale,
-    barWidth,
-  } = useSparkBar({
-    data,
-    height,
-    dataOffsetLeft,
-    dataOffsetRight,
-    width,
-    seriesColor,
-  });
-
-  const transitions = useTransition(dataWithIndex, {
-    key: ({index}: {index: number}) => index,
-    from: {height: 0},
-    leave: {height: 0},
-    enter: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
-    update: ({value}) => ({height: getBarHeight(value == null ? 0 : value)}),
-    default: {immediate: !shouldAnimate},
-    trail: shouldAnimate ? getAnimationTrail(dataWithIndex.length) : 0,
-    config: BARS_TRANSITION_CONFIG,
-  });
+  const {width, height} = dimensions ?? {width: 0, height: 0};
 
   const viewboxHeight = height + ANIMATION_MARGIN * 2;
 
@@ -95,62 +49,16 @@ export function Chart({
         height={viewboxHeight}
         width={width}
       >
-        <defs>
-          <LinearGradientWithStops
-            id={id}
-            gradient={color}
-            gradientUnits="userSpaceOnUse"
-            y1="100%"
-            y2="0%"
-          />
-        </defs>
-
-        <mask id={clipId}>
-          <g opacity={comparisonData ? '0.9' : '1'}>
-            {transitions(({height: barHeight}, item, _transition, index) => {
-              const xPosition = xScale(index.toString());
-              const height = shouldAnimate
-                ? barHeight
-                : getBarHeight(item.value ?? 0);
-
-              return (
-                <Bar
-                  borderRadius={
-                    selectedTheme.bar.hasRoundedCorners
-                      ? borderRadius
-                      : BORDER_RADIUS.None
-                  }
-                  key={index}
-                  x={xPosition == null ? 0 : xPosition}
-                  yScale={yScale}
-                  value={item.value.value}
-                  width={barWidth}
-                  height={height}
-                  fill="white"
-                />
-              );
-            })}
-          </g>
-        </mask>
-
-        <rect
-          fill={`url(#${id})`}
-          width={width}
+        <SparkBarSeries
+          data={data}
+          dataOffsetLeft={dataOffsetLeft}
+          dataOffsetRight={dataOffsetRight}
           height={height}
-          mask={`url(#${clipId})`}
+          shouldAnimate={shouldAnimate}
+          theme={theme}
+          useTransition={useTransition}
+          width={width}
         />
-
-        {comparisonData == null ? null : (
-          <path
-            stroke={selectedTheme.seriesColors.comparison}
-            strokeWidth={STROKE_WIDTH}
-            d={lineShape!}
-            className={styles.ComparisonLine}
-            opacity="0.9"
-            strokeDashoffset={strokeDashoffset}
-            strokeDasharray={strokeDasharray}
-          />
-        )}
       </svg>
     </React.Fragment>
   );

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -23,6 +23,6 @@ Use this sandbox to import `@shopify/polaris-viz-native` components and test the
 
 ### Additional Context on building with the sandbox
 
-If you notice file updates are not being picked up, abort the `yarn sandbox` command using `CTRL+C` and then run `yarn start -c`. This will clear the metro cache.
+If you notice file updates are not being picked up, abort the `yarn sandbox` command using `CTRL+C` and then run `yarn sandbox -c`. This will clear the metro cache.
 
 Any file changes within the libraries will automatically trigger the metro bundler to rebuild. However, because `demo-rn` consumes the libraries `build` folders you will also need to rebuild the packages themselves. A `dev` command has been added to the root `package.json`. `yarn dev` will automatically rebuild `polaris-viz-core` and `polaris-viz-native` as soon as any `tsx` or `ts` files are changed (with the exception of `.d.ts`).


### PR DESCRIPTION
## What does this implement/fix?

Combine rendering logic for both web and native `SparkBarChart` components. 

Originally as part of https://github.com/Shopify/polaris-viz/issues/995 we wanted to create a single `BarSeries` component that rendered any of our bar scenarios, but regular and spark charts are different enough that I think it makes more sense to have `BarSeries` and `SparkBarSeries` components in core.

## Does this close any currently open issues?

https://github.com/Shopify/polaris-viz/issues/995
