### PR TITLE
Add X-Axis Arrows to Funnel Chart

### DIFF
--- a/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisArrows.tsx
+++ b/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisArrows.tsx
@@ -1,0 +1,56 @@
+import React, {Dispatch, SetStateAction} from 'react';
+
+import {useLabels, TextLine} from '../Labels';
+
+const ARROW_WIDTH = 11;
+const ARROW_HEIGHT = 9;
+
+export interface BarChartXAxisArrowsProps {
+  chartHeight: number;
+  onHeightChange: Dispatch<SetStateAction<number>>;
+  x: number;
+  index: number;
+  chartX: number;
+  chartY: number;
+  labelWidth: number;
+  theme?: string;
+}
+
+export function BarChartXAxisArrows({
+  chartHeight,
+  onHeightChange,
+  x,
+  index,
+  chartX,
+  chartY,
+  labelWidth,
+  theme,
+}: BarChartXAxisArrowsProps) {
+  const {lines} = useLabels({
+    labels: ['→'],
+    targetWidth: labelWidth,
+    onHeightChange,
+    chartHeight,
+  });
+  const firstLine = lines[0];
+  const firstLabel = firstLine[0];
+
+  const areLabelsVertical = firstLabel.transform?.includes('rotate(-90)');
+  const getArrowTransform = () => {
+    if (areLabelsVertical) {
+      return `translate(${chartX + x - labelWidth / 2 + ARROW_WIDTH / 2},${
+        chartY + ARROW_HEIGHT
+      })`;
+    }
+
+    return `translate(${chartX - labelWidth + x},${chartY})`;
+  };
+
+  const arrowLine = [{...firstLabel, transform: undefined}];
+
+  return (
+    <g transform={getArrowTransform()} key={`${index}-arrow`}>
+      <TextLine line={arrowLine} index={index} theme={theme} />
+    </g>
+  );
+}

--- a/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisLabels.tsx
@@ -3,6 +3,8 @@ import type {ScaleBand} from 'd3-scale';
 
 import {useLabels, TextLine, shouldSkipLabel} from '../Labels';
 
+import {BarChartXAxisArrows} from './BarChartXAxisArrows';
+
 export interface BarChartXAxisLabelsProps {
   chartX: number;
   chartY: number;
@@ -43,8 +45,22 @@ export function BarChartXAxisLabels({
         const x = xScale(index.toString()) ?? 0;
 
         return (
-          <g transform={`translate(${chartX + x},${chartY})`} key={index}>
-            <TextLine line={line} index={index} theme={theme} />
+          <g key={`label-group-${index}`}>
+            {index === 0 ? null : (
+              <BarChartXAxisArrows
+                chartHeight={chartHeight}
+                onHeightChange={onHeightChange}
+                x={x}
+                index={index}
+                chartX={chartX}
+                chartY={chartY}
+                labelWidth={labelWidth}
+                theme={theme}
+              />
+            )}
+            <g transform={`translate(${chartX + x},${chartY})`} key={index}>
+              <TextLine line={line} index={index} theme={theme} />
+            </g>
           </g>
         );
       })}


### PR DESCRIPTION
To be merged after 
- `adds-yaxisoptions` - https://github.com/Shopify/polaris-viz/pull/1035

## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->
Adding arrows in-between the x-axis arrows to convey the idea that the labels/categories are connected in a left-to-right manner on the funnel chart. 

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->
#### Figma design
![image](https://user-images.githubusercontent.com/101414309/165805202-5b64d3e6-f1eb-4ca6-9195-67ed7ca71b9a.png)
_https://www.figma.com/file/jvX6M6bBpdc9PR5iI170Kz/Subscriber-Level-Metrics?node-id=1602%3A50151_ 


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->
Fixes https://github.com/Shopify/polaris-viz/issues/1033 

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant
-->
| Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/101414309/165805960-41d3bf27-8c7a-4f5e-a1b5-de71701c1bdd.png) | ![image](https://user-images.githubusercontent.com/101414309/165805571-23423aae-7105-4657-894b-6ef0f190056b.png) |

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->
http://localhost:6006/?path=/story/polaris-viz-default-charts-funnelchart-playground--single-values 


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
