### PR TITLE
Uses `sparkArea` and `hasPoint` theme settings in SparkLineChart

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -128,7 +128,11 @@ export function LineSeries({
       ];
 
   const showPoint =
-    isSparkChart && !data.isComparison && lastLinePointCoordinates != null;
+    isSparkChart &&
+    !data.isComparison &&
+    lastLinePointCoordinates != null &&
+    selectedTheme.line.hasPoint;
+
   const {x: lastX = 0, y: lastY = 0} = lastLinePointCoordinates ?? {};
   const lineStyle = getLineStyle({
     isComparison: data.isComparison,
@@ -203,7 +207,12 @@ export function LineSeries({
           </Mask>
         </Defs>
 
-        <Area series={data} areaPath={areaPath} type={type} />
+        <Area
+          series={data}
+          areaPath={areaPath}
+          type={type}
+          sparkArea={selectedTheme.line.sparkArea}
+        />
 
         <Rect
           x="0"

--- a/packages/polaris-viz-core/src/components/LineSeries/components/Area/Area.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/components/Area/Area.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type {LineChartDataSeriesWithDefaults} from '../../../../types';
+import type {LineChartDataSeriesWithDefaults, Color} from '../../../../types';
 import {DefaultArea} from '../DefaultArea';
 import {SparkArea} from '../SparkArea';
 
@@ -8,16 +8,19 @@ interface Props {
   series: LineChartDataSeriesWithDefaults;
   areaPath: string;
   type: 'default' | 'spark';
+  sparkArea?: Color | null;
 }
 
-export function Area({areaPath, series, type}: Props) {
+export function Area({areaPath, series, type, sparkArea}: Props) {
   if (series.isComparison === true) {
     return null;
   }
 
   switch (type) {
     case 'spark':
-      return <SparkArea color={series.color!} areaPath={areaPath} />;
+      return (
+        <SparkArea color={sparkArea || series.color!} areaPath={areaPath} />
+      );
     default:
     case 'default':
       return <DefaultArea series={series} areaPath={areaPath} />;

--- a/packages/polaris-viz-core/src/components/LineSeries/components/Area/tests/Area.test.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/components/Area/tests/Area.test.tsx
@@ -6,6 +6,7 @@ import {Area} from '../Area';
 import {LineChartDataSeriesWithDefaults} from '../../../../../types';
 import {DefaultArea} from '../../DefaultArea';
 import {SparkArea} from '../../SparkArea';
+import {LinearGradientWithStops} from '../../../../../components';
 
 const SERIES: LineChartDataSeriesWithDefaults = {
   data: [],
@@ -45,6 +46,49 @@ describe('<Area />', () => {
       );
 
       expect(area).toContainReactComponent(SparkArea);
+    });
+  });
+
+  describe('color', () => {
+    const sparkArea = '#008000';
+
+    it('renders theme sparkArea when provided', () => {
+      const area = mount(
+        <svg>
+          <Area
+            series={SERIES}
+            areaPath=""
+            type="spark"
+            sparkArea={sparkArea}
+          />
+        </svg>,
+      );
+
+      expect(area).toContainReactComponentTimes(LinearGradientWithStops, 1, {
+        gradient: [
+          {
+            color: sparkArea,
+            offset: 0,
+          },
+        ],
+      });
+    });
+
+    it('renders line color', () => {
+      const area = mount(
+        <svg>
+          <Area series={SERIES} areaPath="" type="spark" />
+        </svg>,
+      );
+
+      expect(area).toContainReactComponentTimes(LinearGradientWithStops, 1, {
+        gradient: [
+          {
+            color: 'red',
+            offset: 0,
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
@@ -131,5 +131,36 @@ describe('<LineSeries />', () => {
         });
       });
     });
+
+    describe('theme.line.hasPoint', () => {
+      it('renders a point if true', () => {
+        const lineSeries = mountWithProvider(
+          <svg>
+            <LineSeries {...defaultProps} type="spark" />
+          </svg>,
+        );
+
+        expect(lineSeries).toContainReactComponentTimes('circle', 1);
+      });
+
+      it('does not render a point if false', () => {
+        const lineSeries = mountWithProvider(
+          <svg>
+            <LineSeries {...defaultProps} type="spark" />
+          </svg>,
+          {
+            themes: {
+              Default: {
+                line: {
+                  hasPoint: false,
+                },
+              },
+            },
+          },
+        );
+
+        expect(lineSeries).not.toContainReactComponentTimes('circle', 1);
+      });
+    });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

Use `sparkArea` and `hasPoint` in `<SparkLineChart />`

The Custom Storefronts has been working on designing some widgets for the new Oxygen channel in admin. While working through comps it was discovered that while the documentation mentions `SparkArea` in the theme props, it actually is not connected to the chart. Additionally the `hasPoint` setting also does nothing. 

After speaking with @envex on the topic it was agreed I would open a PR to begin the discussion around how we can implement these settings. ave you reviewed your changes with UX? Is there a design that should be referenced? -->

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

![image](https://user-images.githubusercontent.com/5941111/167213585-c93b636f-1999-49e9-9dd6-ca5d16f93a74.png)
![image](https://user-images.githubusercontent.com/5941111/167215113-97a3379a-4a2b-439f-ae4b-c26013d90551.png)


 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.
