### PR TITLE
Upgrade typescript to 4.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "shelljs": "^0.8.3",
     "shx": "^0.3.2",
     "size-limit": "^5.0.1",
-    "typescript": "~4.3.2"
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "concurrently": "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19586,10 +19586,10 @@ typescript@^4.3.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-typescript@~4.3.2:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
## What does this implement/fix?

VSCode typescript engine kept failing locally because the typescript version was outdated.