### PR TITLE
Use correct length for xScale

### DIFF
--- a/packages/polaris-viz-core/src/hooks/tests/useSparkLine.test.tsx
+++ b/packages/polaris-viz-core/src/hooks/tests/useSparkLine.test.tsx
@@ -71,9 +71,9 @@ describe('useSparkLine', () => {
   describe('maxXDomain', () => {
     it.each`
       lengths              | expected
-      ${[10, 5]}           | ${'10'}
-      ${[320, 0, 50, 100]} | ${'320'}
-      ${[0, 0, 50, 100]}   | ${'100'}
+      ${[10, 5]}           | ${'9'}
+      ${[320, 0, 50, 100]} | ${'319'}
+      ${[0, 0, 50, 100]}   | ${'99'}
     `(
       'is calculated based on the length of the longest data series',
       ({lengths, expected}) => {

--- a/packages/polaris-viz-core/src/hooks/useSparkLine.ts
+++ b/packages/polaris-viz-core/src/hooks/useSparkLine.ts
@@ -11,9 +11,9 @@ export function useSparkLine({
   height: number;
   svgMargin?: number;
 }) {
-  const dataLenghts = data.map((series) => series.data.length);
+  const dataLengths = data.map((series) => series.data.length - 1);
 
-  const maxDataLength = Math.max(...dataLenghts);
+  const maxDataLength = Math.max(...dataLengths);
 
   const yValues = Array.prototype.concat.apply(
     [],

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Added `ChartSkeleton` component
 
+### Changed
+
+- Fix issue where `<SparkLineChart />` doesn't go to the containers right edge.
+
 ## [1.5.0] - 2022-05-04
 
 ### Added


### PR DESCRIPTION
## What does this implement/fix?

When getting the values used for the xScale domain we were checking the length of the array, which was making the value one longer than we wanted.

If this was intentional we should set a default for `offsetRight` so we still use the offset by default but still allow the consumer to make the chart go edge to edge.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1049

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/167659956-66bd5df0-924d-4806-857d-c5ca282608e9.png)|![image](https://user-images.githubusercontent.com/149873/167659919-5bb547b6-7039-41e7-96ce-9fc8d0fc7d52.png)|

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
