### PR TITLE
Measure the container with vanilla JS on mount

### DIFF
--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -20,6 +20,14 @@ import {
 
 import styles from './ChartContainer.scss';
 
+function hasValidDimensions(chartDimensions: Dimensions | null) {
+  if (chartDimensions == null) {
+    return false;
+  }
+
+  return chartDimensions.width > 0 || chartDimensions.height > 0;
+}
+
 interface Props {
   children: ReactElement;
   theme: string;
@@ -110,13 +118,13 @@ export const ChartContainer = (props: Props) => {
         ref={setRef}
         id={`chart_${value.id}`}
       >
-        {chartDimensions == null
+        {!hasValidDimensions(chartDimensions)
           ? null
           : cloneElement<{theme: string; dimensions: Dimensions}>(
               props.children,
               {
                 theme: printFriendlyTheme,
-                dimensions: chartDimensions,
+                dimensions: chartDimensions!,
               },
             )}
       </div>


### PR DESCRIPTION
## What does this implement/fix?

While working on annotations, I noticed that on first load the console would throw a bunch of errors because the `<rect>` elements used to render the annotations were negative/

<img width="576" alt="image" src="https://user-images.githubusercontent.com/149873/168278735-544de3da-4d17-49c6-971c-23376cd56763.png">

It looks the reasoning is because on initial load, the chart has a default width of `0` which throws the `drawableWidth` calculations off.

The chart loads normally because the correct width is used on the next render cycle after the `useResizeObserver()` hook has been called with the correct chart size.

## What do the changes look like?

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/149873/168278639-a5ec366e-a0ff-440b-8256-a4db28abeda7.png">

## Storybook link

http://localhost:6006/?path=/story/polaris-viz-default-charts-barchart--horizontal

Load the horizontal bar chart. No errors should be thrown around chart size.

### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
