### PR TITLE
Add line.showArea value to theme

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -203,7 +203,9 @@ export function LineSeries({
           </Mask>
         </Defs>
 
-        <Area series={data} areaPath={areaPath} type={type} />
+        {selectedTheme.line.hasArea && (
+          <Area series={data} areaPath={areaPath} type={type} />
+        )}
 
         <Rect
           x="0"

--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -148,15 +148,10 @@ export const DEFAULT_THEME: Theme = {
     minHeight: 200,
   },
   line: {
-    sparkArea: [
-      {offset: 0, color: 'rgba(92, 105, 208, 0)'},
-      {offset: 100, color: 'rgba(92, 105, 208, 0.15)'},
-    ],
+    hasArea: true,
     hasSpline: true,
-    style: 'solid',
-    hasPoint: true,
     width: 2,
-    pointStroke: variables.colorGray160,
+    pointStroke: 'variables.colorGray160',
   },
   bar: {
     hasRoundedCorners: true,
@@ -244,13 +239,8 @@ export const LIGHT_THEME: Theme = {
     backgroundColor: variables.colorGray00,
   },
   line: {
-    sparkArea: [
-      {offset: 0, color: 'rgba(92, 105, 208, 0)'},
-      {offset: 100, color: 'rgba(92, 105, 208, 0.15)'},
-    ],
+    hasArea: true,
     hasSpline: true,
-    style: 'solid',
-    hasPoint: true,
     width: 2,
     pointStroke: variables.colorGray00,
   },

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -98,10 +98,8 @@ export interface ChartContainerTheme {
 }
 
 export interface LineTheme {
-  sparkArea: Color | null;
+  hasArea: boolean;
   hasSpline: boolean;
-  style: LineStyle;
-  hasPoint: boolean;
   width: number;
   pointStroke: string;
 }

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -14,6 +14,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Fix issue where `<SparkLineChart />` doesn't go to the containers right edge.
+- Changed `line.sparkArea` to `line.hasArea` from line theme.
+- `line.hasArea` now accepts a boolean to determine when we render the area below a line series.
+
+### Removed
+
+- Removed `line.style` & `line.hasPoint` from line theme.
 
 ## [1.5.0] - 2022-05-04
 

--- a/packages/polaris-viz/src/components/Docs/stories/ThemeDefinition.stories.mdx
+++ b/packages/polaris-viz/src/components/Docs/stories/ThemeDefinition.stories.mdx
@@ -805,7 +805,7 @@ export interface GradientStop {
   <PropertyTable.Row
     property="xAxis.showTicks"
     type="boolean"
-    description="determines wether or not to show the ticks vertical lines indicating the labels on the X Axis"
+    description="determines whether or not to show the ticks vertical lines indicating the labels on the X Axis"
     chartsAffected={[
       'BarChart',
       'LineChart',
@@ -828,7 +828,7 @@ export interface GradientStop {
     property="xAxis.hide"
     type="boolean"
     z
-    description="determines wether or not to show the X Axis"
+    description="determines whether or not to show the X Axis"
     chartsAffected={[
       'BarChart',
       'LineChart',
@@ -1018,28 +1018,16 @@ export interface GradientStop {
 
 <PropertyTable>
   <PropertyTable.Row
-    property="line.sparkArea"
+    property="line.hasArea"
     type="string"
-    description="a CSS color string applied to the area under the line of Sparklines"
+    description="determines whether or not to show the area under the line"
     chartsAffected={['SparkLineChart']}
   />
   <PropertyTable.Row
     property="line.hasSpline"
     type="boolean"
-    description="determines wether or not to use curved lines"
+    description="determines whether or not to use curved lines"
     chartsAffected={['LineChart', 'StackedAreaChart', 'SparkLineChart']}
-  />
-  <PropertyTable.Row
-    property="line.style"
-    type={['"solid"', '"dashed"', '"dotted"']}
-    description="determines wether or not to use curved lines"
-    chartsAffected={['LineChart', 'SparkLineChart']}
-  />
-  <PropertyTable.Row
-    property="line.hasPoint"
-    type={'boolean'}
-    description="determines wether or not to show a circle at the end of the line. Does not get applied on non-solid lines"
-    chartsAffected={['SparkLineChart']}
   />
   <PropertyTable.Row
     property="line.width"


### PR DESCRIPTION
## What does this implement/fix?

Cleaned up a few unused theme properties and added `line.showArea` to allow consumers to toggle the area below a line series on/off.

## What do the changes look like?

| true  | false  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/168285445-7af2f858-31f7-42ac-997f-f02837f880d1.png)|![image](https://user-images.githubusercontent.com/149873/168285494-bf6e02cf-b1af-4801-a7d4-ef17c3d3d652.png)|
 
### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.
