### PR TITLE
Add a11y to funnel chart

### DIFF
--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -132,17 +132,19 @@ export function Chart({
   };
   return (
     <svg role="list" viewBox={`0 0 ${width} ${height}`} xmlns={XMLNS}>
-      <FunnelChartXAxisLabels
-        chartHeight={height}
-        chartX={0}
-        chartY={drawableHeight}
-        labels={labels}
-        labelWidth={barWidth}
-        onHeightChange={setLabelHeight}
-        reducedLabelIndexes={reducedLabelIndexes}
-        theme={theme}
-        xScale={labelXScale}
-      />
+      <g aria-hidden="true">
+        <FunnelChartXAxisLabels
+          chartHeight={height}
+          chartX={0}
+          chartY={drawableHeight}
+          labels={labels}
+          labelWidth={barWidth}
+          onHeightChange={setLabelHeight}
+          reducedLabelIndexes={reducedLabelIndexes}
+          theme={theme}
+          xScale={labelXScale}
+        />
+      </g>
 
       <g mask={`url(#${maskId}-${theme}-grad)`}>
         <LinearGradientWithStops gradient={barsGradient} id={`${gradientId}`} />
@@ -156,28 +158,34 @@ export function Chart({
       </g>
 
       <mask id={`${maskId}-${theme}-grad`}>
-        {dataSeries.map((dataPoint) => {
-          const barHeight = getBarHeight(dataPoint.value || 0);
-          const xPosition = xScale(dataPoint.key as string);
-          const x = xPosition == null ? 0 : xPosition;
-          const barWidth = xScale.bandwidth();
-          return (
-            <React.Fragment key={dataPoint.key}>
-              <Bar
-                width={barWidth}
-                height={barHeight}
-                color={MASK_HIGHLIGHT_COLOR}
-                x={x}
-                y={drawableHeight - barHeight}
-                borderRadius={
-                  selectedTheme.bar.hasRoundedCorners
-                    ? BORDER_RADIUS.Top
-                    : BORDER_RADIUS.None
-                }
-              />
-            </React.Fragment>
-          );
-        })}
+        <g role="list">
+          {dataSeries.map((dataPoint) => {
+            const barHeight = getBarHeight(dataPoint.value || 0);
+            const xPosition = xScale(dataPoint.key as string);
+            const x = xPosition == null ? 0 : xPosition;
+            const barWidth = xScale.bandwidth();
+            return (
+              <g
+                role="listitem"
+                aria-label={dataPoint.key as string}
+                key={dataPoint.key}
+              >
+                <Bar
+                  width={barWidth}
+                  height={barHeight}
+                  color={MASK_HIGHLIGHT_COLOR}
+                  x={x}
+                  y={drawableHeight - barHeight}
+                  borderRadius={
+                    selectedTheme.bar.hasRoundedCorners
+                      ? BORDER_RADIUS.Top
+                      : BORDER_RADIUS.None
+                  }
+                />
+              </g>
+            );
+          })}
+        </g>
       </mask>
 
       {dataSeries.map((dataPoint, index) => {
@@ -197,15 +205,17 @@ export function Chart({
 
         return (
           <React.Fragment key={dataPoint.key}>
-            <Label
-              barHeight={0}
-              label={formattedYValue}
-              labelWidth={barWidth}
-              x={x}
-              y={height - barHeight - Y_AXIS_LABEL_VERTICAL_OFFSET}
-              size="large"
-              color={selectedTheme.xAxis.labelColor}
-            />
+            <g aria-hidden="true">
+              <Label
+                barHeight={0}
+                label={formattedYValue}
+                labelWidth={barWidth}
+                x={x}
+                y={height - barHeight - Y_AXIS_LABEL_VERTICAL_OFFSET}
+                size="large"
+                color={selectedTheme.xAxis.labelColor}
+              />
+            </g>
             <g mask={`url(#${connectorGradientId}-${index})`}>
               <LinearGradientWithStops
                 gradient={connectorGradient}
@@ -235,15 +245,17 @@ export function Chart({
                 fill={MASK_HIGHLIGHT_COLOR}
               />
             </mask>
-            <Label
-              barHeight={0}
-              label={percentLabel}
-              labelWidth={barWidth}
-              x={x + barWidth}
-              y={height - nextBarHeight - PERCENT_LABEL_VERTICAL_OFFSET}
-              size="small"
-              color={changeColorOpacity(selectedTheme.xAxis.labelColor, 0.7)}
-            />
+            <g aria-hidden="true">
+              <Label
+                barHeight={0}
+                label={percentLabel}
+                labelWidth={barWidth}
+                x={x + barWidth}
+                y={height - nextBarHeight - PERCENT_LABEL_VERTICAL_OFFSET}
+                size="small"
+                color={changeColorOpacity(selectedTheme.xAxis.labelColor, 0.7)}
+              />
+            </g>
           </React.Fragment>
         );
       })}

--- a/packages/polaris-viz/src/components/FunnelChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/stories/Playground.stories.tsx
@@ -31,7 +31,7 @@ const data = [
         key: 'Added to carts',
       },
       {
-        value: 0,
+        value: 4,
         key: 'Orders',
       },
     ],


### PR DESCRIPTION
## What does this implement/fix?
Closes: https://github.com/Shopify/polaris-viz/issues/1022

This adds accessibility elements and attributes such as `<g />` and `aria-label` noted from the [Polaris Viz Accessibility Strategy doc](https://docs.google.com/document/d/1nPJV0fuB5a75rThKfivHP4-V6owgDNwcAOlCtrK8-ac/edit#) to the Funnel Chart

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
