### PR TITLE
Display dots on bars

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -95,6 +95,7 @@ export {
   changeColorOpacity,
   changeGradientOpacity,
   getAverageColor,
+  getColorFromGradient,
 } from './utilities';
 export {
   useSparkBar,

--- a/packages/polaris-viz-core/src/utilities/getColorFromGradient.ts
+++ b/packages/polaris-viz-core/src/utilities/getColorFromGradient.ts
@@ -1,0 +1,20 @@
+/* eslint-disable id-length */
+import type {GradientStop} from '../types';
+
+import {hexToRGB} from './hexToRGB';
+
+export function getColorFromGradient(
+  gradient: GradientStop[],
+  percent: number,
+) {
+  const firstColor = hexToRGB(gradient[0].color);
+  const lastColor = hexToRGB(gradient[gradient.length - 1].color);
+
+  const remainingPercent = 1 - percent;
+
+  const r = Math.round(lastColor.r * percent + firstColor.r * remainingPercent);
+  const g = Math.round(lastColor.g * percent + firstColor.g * remainingPercent);
+  const b = Math.round(lastColor.b * percent + firstColor.b * remainingPercent);
+
+  return `rgb(${r},${g},${b})`;
+}

--- a/packages/polaris-viz-core/src/utilities/hexToRGB.ts
+++ b/packages/polaris-viz-core/src/utilities/hexToRGB.ts
@@ -1,0 +1,12 @@
+/* eslint-disable id-length */
+
+export function hexToRGB(hex: string) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16),
+      }
+    : {r: 0, g: 0, b: 0};
+}

--- a/packages/polaris-viz-core/src/utilities/index.ts
+++ b/packages/polaris-viz-core/src/utilities/index.ts
@@ -17,3 +17,5 @@ export {clamp} from './clamp';
 export {getRoundedRectPath} from './getRoundedRectPath';
 export {changeColorOpacity, changeGradientOpacity} from './changeColorOpacity';
 export {getAverageColor} from './getAverageColor';
+export {getColorFromGradient} from './getColorFromGradient';
+export {hexToRGB} from './hexToRGB';

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationLine/AnnotationLine.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationLine/AnnotationLine.tsx
@@ -1,40 +1,51 @@
+import {useTheme} from '@shopify/polaris-viz-core';
 import React from 'react';
+
+import type {AnnotationLine as AnnotationLineType} from '../../types';
+import {PILL_HEIGHT} from '../../constants';
 
 import styles from './AnnotationLine.scss';
 
 const CARET_SIZE = 9;
-const CARET_Y_OFFSET = -11;
+const CARET_Y_OFFSET = 11;
+const DOT_SIZE = 4;
 
 export interface AnnotationLineProps {
-  color: string;
-  drawableSize: number;
-  x: number;
-  y: number;
+  line: AnnotationLineType;
   theme?: string;
 }
 
-export function AnnotationLine({
-  color,
-  drawableSize,
-  x,
-  y,
-}: AnnotationLineProps) {
+export function AnnotationLine({line, theme}: AnnotationLineProps) {
+  const selectedTheme = useTheme(theme);
+
+  const {height, color, x, y} = line;
+
   return (
     <React.Fragment>
       <line
         className={styles.Line}
-        stroke={color}
+        stroke={selectedTheme.annotations.backgroundColor}
         strokeWidth="1"
         strokeDasharray="3 2"
         x1={x}
         x2={x}
         y1={y}
-        y2={drawableSize}
+        y2={height}
       />
       <path
         d="M5.80929 14.3661C5.05774 15.017 3.94222 15.017 3.19067 14.3661L-2.25902e-05 11.5L0 0.5L8.99998 0.500013L8.99997 11.5L5.80929 14.3661Z"
-        transform={`translate(${x - CARET_SIZE / 2}, ${y + CARET_Y_OFFSET})`}
-        fill={color}
+        transform={`translate(${x - CARET_SIZE / 2}, ${
+          y + PILL_HEIGHT - CARET_Y_OFFSET
+        })`}
+        fill={selectedTheme.annotations.backgroundColor}
+      />
+      <circle
+        cx={x}
+        cy={height}
+        r={DOT_SIZE}
+        fill={color as string}
+        stroke={selectedTheme.chartContainer.backgroundColor}
+        strokeWidth="2"
       />
     </React.Fragment>
   );

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
@@ -1,26 +1,18 @@
+import {useContext, useMemo} from 'react';
 import {
   ChartContext,
   clamp,
   estimateStringWidth,
 } from '@shopify/polaris-viz-core';
 import type {ScaleBand} from 'd3-scale';
-import {useContext, useEffect, useMemo} from 'react';
 
-import {
-  COLLAPSED_PILL_COUNT,
-  PILL_HEIGHT,
-  PILL_PADDING,
-  PILL_ROW_GAP,
-} from '../constants';
+import {PILL_HEIGHT, PILL_PADDING, PILL_ROW_GAP} from '../constants';
 import type {Annotation} from '../../../types';
-import type {AnnotationPosition} from '../types';
 
 interface Props {
   annotations: Annotation[];
   barWidth: number;
   drawableWidth: number;
-  isShowingAllAnnotations: boolean;
-  onHeightChange: (height: number) => void;
   xScale: ScaleBand<string>;
 }
 
@@ -28,13 +20,8 @@ export function useAnnotationPositions({
   annotations,
   barWidth,
   drawableWidth,
-  isShowingAllAnnotations,
-  onHeightChange,
   xScale,
-}: Props): {
-  positions: AnnotationPosition[];
-  rowCount: number;
-} {
+}: Props) {
   const {characterWidths} = useContext(ChartContext);
 
   const textWidths = useMemo(() => {
@@ -43,7 +30,7 @@ export function useAnnotationPositions({
     });
   }, [annotations, characterWidths]);
 
-  const {positions} = useMemo(() => {
+  return useMemo(() => {
     const positions = annotations.map((annotation, dataIndex) => {
       const xPosition = xScale(`${annotation.startIndex}`) ?? 0;
 
@@ -122,33 +109,6 @@ export function useAnnotationPositions({
       current.y = row * PILL_HEIGHT + row * PILL_ROW_GAP;
     });
 
-    return {positions};
+    return positions;
   }, [annotations, textWidths, barWidth, xScale, drawableWidth]);
-
-  const totalRowHeight = useMemo(() => {
-    return (
-      positions.reduce((total, {y, row}) => {
-        if (!isShowingAllAnnotations && row > COLLAPSED_PILL_COUNT) {
-          return total;
-        }
-
-        if (y > total) {
-          return y;
-        }
-        return total;
-      }, 0) +
-      PILL_HEIGHT +
-      PILL_ROW_GAP
-    );
-  }, [isShowingAllAnnotations, positions]);
-
-  const rowCount = useMemo(() => {
-    return Math.max(...positions.map(({row}) => row)) + 1;
-  }, [positions]);
-
-  useEffect(() => {
-    onHeightChange(totalRowHeight);
-  }, [onHeightChange, totalRowHeight]);
-
-  return {positions, rowCount};
 }

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotations.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotations.ts
@@ -1,0 +1,108 @@
+import {
+  Color,
+  DataSeries,
+  getColorFromGradient,
+  GradientStop,
+  isGradientType,
+  useTheme,
+} from '@shopify/polaris-viz-core';
+import type {ScaleBand, ScaleLinear} from 'd3-scale';
+import {useMemo} from 'react';
+
+import type {Annotation, AnnotationLookupTable} from '../../../types';
+import type {AnnotationsWithData} from '../types';
+
+import {useAnnotationPositions} from './useAnnotationPositions';
+
+interface Props {
+  annotationsHeight: number;
+  annotationsLookupTable: AnnotationLookupTable;
+  barWidth: number;
+  colors: Color[];
+  data: DataSeries[];
+  drawableHeight: number;
+  drawableWidth: number;
+  xScale: ScaleBand<string>;
+  yScale: ScaleLinear<number, number>;
+  theme?: string;
+}
+
+export function useAnnotations({
+  annotationsHeight,
+  annotationsLookupTable,
+  barWidth,
+  colors,
+  data,
+  drawableHeight,
+  drawableWidth,
+  theme,
+  xScale,
+  yScale,
+}: Props) {
+  const selectedTheme = useTheme(theme);
+
+  const seriesCount = data.length;
+  const hasEvenSeriesCount = seriesCount % 2 === 0;
+
+  const annotations = useMemo(() => {
+    return Object.keys(annotationsLookupTable)
+      .map((key) => {
+        const numberedKey = Number(key);
+
+        const annotation = annotationsLookupTable[
+          numberedKey
+        ] as AnnotationsWithData;
+
+        if (annotation == null) {
+          return null;
+        }
+
+        return annotation;
+      })
+      .filter(Boolean) as Annotation[];
+  }, [annotationsLookupTable]);
+
+  const positions = useAnnotationPositions({
+    annotations,
+    barWidth,
+    drawableWidth,
+    xScale,
+  });
+
+  const annotationsWithData = annotations.map((annotation, index) => {
+    const annotationsWithData: AnnotationsWithData = {
+      ...annotation,
+      line: {
+        color: selectedTheme.annotations.backgroundColor,
+        height: annotationsHeight + yScale(0),
+        x: positions[index].lineX,
+        y: positions[index].y,
+      },
+      position: positions[index],
+    };
+
+    if (!hasEvenSeriesCount) {
+      const seriesIndex = Math.round(seriesCount / 2) - 1;
+
+      const {value} = data[seriesIndex].data[annotation.startIndex];
+      const height = yScale(value ?? 0);
+
+      const barHeight = drawableHeight - height;
+
+      const percentage = barHeight / drawableHeight;
+      const color = isGradientType(colors[seriesIndex])
+        ? getColorFromGradient(
+            colors[seriesIndex] as GradientStop[],
+            percentage,
+          )
+        : colors[seriesIndex];
+
+      annotationsWithData.line.height = annotationsHeight + height;
+      annotationsWithData.line.color = color;
+    }
+
+    return annotationsWithData;
+  });
+
+  return {annotations: annotationsWithData, positions};
+}

--- a/packages/polaris-viz/src/components/Annotations/types.ts
+++ b/packages/polaris-viz/src/components/Annotations/types.ts
@@ -1,3 +1,7 @@
+import type {Color} from '@shopify/polaris-viz-core';
+
+import type {Annotation} from '../../types';
+
 export interface AnnotationPosition {
   index: number;
   left: number;
@@ -6,4 +10,16 @@ export interface AnnotationPosition {
   row: number;
   width: number;
   y: number;
+}
+
+export interface AnnotationLine {
+  color: Color;
+  height: number;
+  x: number;
+  y: number;
+}
+
+export interface AnnotationsWithData extends Annotation {
+  line: AnnotationLine;
+  position: AnnotationPosition;
 }

--- a/packages/polaris-viz/src/components/BarChart/stories/Annotations.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/Annotations.stories.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import type {Story, Meta} from '@storybook/react';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import {BarChart, BarChartProps} from '../../../components';
+import type {Annotation} from '../../../types';
+
+import {default as BarChartStory} from './BarChart.stories';
+
+const DATA: DataSeries[] = [
+  {
+    name: 'Breakfast',
+    data: [
+      {key: 'Monday', value: 3},
+      {key: 'Tuesday', value: -7},
+      {key: 'Wednesday', value: -7},
+      {key: 'Thursday', value: -8},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 0},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Lunch',
+    data: [
+      {key: 'Monday', value: 4},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -10},
+      {key: 'Thursday', value: 15},
+      {key: 'Friday', value: 8},
+      {key: 'Saturday', value: 50},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Dinner',
+    data: [
+      {key: 'Monday', value: 7},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -15},
+      {key: 'Thursday', value: -12},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 5},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+];
+
+const DATA_WITH_COLOR: DataSeries[] = [
+  {
+    name: 'Breakfast',
+    data: [
+      {key: 'Monday', value: 3},
+      {key: 'Tuesday', value: -7},
+      {key: 'Wednesday', value: 4},
+      {key: 'Thursday', value: 8},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 0},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Lunch',
+    color: 'lime',
+    data: [
+      {key: 'Monday', value: 4},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: 5},
+      {key: 'Thursday', value: 15},
+      {key: 'Friday', value: 8},
+      {key: 'Saturday', value: 50},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Dinner',
+    data: [
+      {key: 'Monday', value: 7},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: 6},
+      {key: 'Thursday', value: 12},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 5},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+];
+
+export default {
+  title: 'polaris-viz/Default Charts/BarChart/Annotations',
+  component: BarChart,
+  decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
+  parameters: BarChartStory.parameters,
+  argTypes: BarChartStory.argTypes,
+} as Meta;
+
+const Template: Story<BarChartProps> = (args: BarChartProps) => {
+  return <BarChart {...args} />;
+};
+
+const ANNOTATIONS: Annotation[] = [
+  {
+    startIndex: 0,
+    label: 'BOGO Sale',
+  },
+  {
+    startIndex: 2,
+    label: 'GDPR rule change',
+    content: {
+      title: 'GDPR rule change',
+      content:
+        'New GDPR rules that prevent the unauthorized tracking of user sessions came into effect on Thursday, June 1.',
+      linkUrl: 'https://shopify.com',
+    },
+  },
+  {
+    startIndex: 5,
+    label: 'Viral Tweet',
+  },
+];
+
+export const Default: Story<BarChartProps> = Template.bind({});
+
+Default.args = {
+  data: DATA,
+  xAxisOptions: {},
+  isAnimated: false,
+  showLegend: true,
+  annotations: ANNOTATIONS,
+};
+
+export const EvenSeriesCount: Story<BarChartProps> = Template.bind({});
+
+EvenSeriesCount.args = {
+  data: DATA.slice(0, 2),
+  xAxisOptions: {},
+  isAnimated: false,
+  showLegend: true,
+  annotations: ANNOTATIONS,
+};
+
+export const OverwittenSeriesColors: Story<BarChartProps> = Template.bind({});
+
+OverwittenSeriesColors.args = {
+  data: DATA_WITH_COLOR,
+  xAxisOptions: {},
+  isAnimated: false,
+  showLegend: true,
+  annotations: ANNOTATIONS,
+};

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -3,7 +3,6 @@ import type {Story, Meta} from '@storybook/react';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 
 import {BarChart, BarChartProps} from '../../../components';
-import type {Annotation} from '../../../types';
 
 import {SquareColorPreview} from '../../SquareColorPreview';
 import {PolarisVizProvider} from '../../../';
@@ -414,81 +413,4 @@ export const SeriesColorsUpToFourteen = Template.bind({});
 
 SeriesColorsUpToFourteen.args = {
   data: generateMultipleSeries(7),
-};
-
-function CustomContent() {
-  return (
-    <div>
-      <h1>Custom Content</h1>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer
-        elementum, ipsum id semper dictum, ipsum nisi consectetur lacus, sed
-        pretium massa nisi ac ipsum.
-      </p>
-      <a href="https://www.google.com">Google</a>
-    </div>
-  );
-}
-
-const ANNOTATIONS: Annotation[] = [
-  {
-    startIndex: 0,
-    label: 'Content and title',
-    tooltipData: {
-      key: 'Median',
-      value: '1.5 hours',
-    },
-    content: {
-      title: 'GDPR rule change',
-      content:
-        'New GDPR rules that prevent the unauthorized tracking of user sessions came into effect on Thursday, June 1.',
-    },
-  },
-  {
-    startIndex: 2,
-    label: 'Title, content and no link string',
-    tooltipData: {
-      key: 'Median',
-      value: '1.5 hours',
-    },
-    content: {
-      title: 'GDPR rule change',
-      content:
-        'New GDPR rules that prevent the unauthorized tracking of user sessions came into effect on Thursday, June 1.',
-      linkUrl: 'https://shopify.com',
-    },
-  },
-  {
-    startIndex: 5,
-    label: 'Just content',
-    content: {
-      content:
-        'New GDPR rules that prevent the unauthorized tracking of user sessions came into effect on Thursday, June 1.',
-    },
-    tooltipData: {
-      key: 'Median',
-      value: '1.5 hours',
-    },
-  },
-  {
-    startIndex: 1,
-    label: 'This has everything',
-    content: {
-      title: 'GDPR rule change',
-      content:
-        'New GDPR rules that prevent the unauthorized tracking of user sessions came into effect on Thursday, June 1.',
-      linkUrl: 'https://shopify.com',
-      linkText: 'Custom link text',
-    },
-  },
-];
-
-export const Annotations: Story<BarChartProps> = Template.bind({});
-
-Annotations.args = {
-  data: DATA,
-  xAxisOptions: {},
-  isAnimated: false,
-  showLegend: true,
-  annotations: ANNOTATIONS,
 };

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -312,13 +312,16 @@ export function Chart({
         </g>
         <g transform={`translate(${chartXPosition},${Margin.Top})`}>
           <Annotations
+            annotationsHeight={annotationsHeight}
             annotationsLookupTable={annotationsLookupTable}
-            barWidth={xScale.bandwidth()}
+            colors={barColors}
+            data={data}
             drawableHeight={chartYPosition + drawableHeight}
             drawableWidth={drawableWidth}
             onHeightChange={setAnnotationsHeight}
             theme={theme}
             xScale={xScale}
+            yScale={yScale}
           />
         </g>
       </svg>

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -6,7 +6,6 @@ import type {
   Shape,
 } from '@shopify/polaris-viz-core';
 import type {Series, SeriesPoint} from 'd3-shape';
-import type {ReactNode} from 'react';
 
 export interface YAxisTick {
   value: number;


### PR DESCRIPTION
## What does this implement/fix?

Instead of displaying lines that go over the bars, we're going to draw the line to the top of the bar.

- If the chart has an even number of bars, we draw a line between the bars to the 0 line.
- The color of the dot should match the current color of the bar.

## What do the changes look like?

| Odd  | Even  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/168900313-1953e490-c6b9-4b58-9d47-073c782cc9fe.png)|![image](https://user-images.githubusercontent.com/149873/168900367-7d655880-3002-4823-a0bd-623a2f82e8ce.png)|
 