### PR TITLE
Make theme required for non-root components

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -58,7 +58,7 @@ export interface LineSeriesProps {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   activeLineIndex?: number;
-  theme?: string;
+  theme: string;
   type?: 'default' | 'spark';
 }
 
@@ -68,7 +68,7 @@ export function LineSeries({
   index = 0,
   isAnimated,
   svgDimensions,
-  theme = 'Default',
+  theme,
   type = 'default',
   xScale,
   yScale,

--- a/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
+++ b/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
@@ -20,7 +20,7 @@ interface SparkBarSeriesProps {
   shouldAnimate: boolean;
   useTransition: typeof useTransition;
   width: number;
-  theme?: string;
+  theme: string;
 }
 
 export function SparkBarSeries({

--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -93,6 +93,8 @@ export const colorBlack = variables.colorBlack;
 export const colorPurpleDark = variables.colorPurpleDark;
 export const colorTeal = variables.colorTeal;
 
+export const DEFAULT_THEME_NAME = 'Default';
+
 export const NEUTRAL_SINGLE_GRADIENT = [
   {offset: 0, color: variables.colorIndigo90},
   {offset: 85, color: variables.colorBlue90},

--- a/packages/polaris-viz-core/src/hooks/useTheme.ts
+++ b/packages/polaris-viz-core/src/hooks/useTheme.ts
@@ -1,9 +1,10 @@
 import {useContext} from 'react';
 
+import {DEFAULT_THEME_NAME} from '../constants';
 import type {Theme} from '../types';
 import {PolarisVizContext} from '../contexts/PolarisVizContext';
 
-export function useTheme(themeName = 'Default'): Theme {
+export function useTheme(themeName = DEFAULT_THEME_NAME): Theme {
   const {themes} = useContext(PolarisVizContext);
 
   if (Object.prototype.hasOwnProperty.call(themes, themeName)) {

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -73,6 +73,7 @@ export {
   COLOR_VISION_ACTIVE_OPACITY,
   COLOR_VISION_FADED_OPACITY,
   BORDER_RADIUS,
+  DEFAULT_THEME_NAME,
 } from './constants';
 export {
   clamp,

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -200,15 +200,6 @@ export interface SparkBarChartProps {
   accessibilityLabel?: string;
   isAnimated?: boolean;
   theme?: string;
-}
-
-export interface SparkBarChartProps {
-  data: DataSeries[];
-  dataOffsetRight?: number;
-  dataOffsetLeft?: number;
-  accessibilityLabel?: string;
-  isAnimated?: boolean;
-  theme?: string;
   dimensions?: Dimensions;
 }
 

--- a/packages/polaris-viz-native/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz-native/src/components/ChartContainer/ChartContainer.tsx
@@ -1,6 +1,7 @@
 import React, {useState, ReactElement, cloneElement} from 'react';
 import {View} from 'react-native';
 import {
+  DEFAULT_THEME_NAME,
   Dimensions,
   paddingStringToObject,
   useTheme,
@@ -12,7 +13,11 @@ interface Props {
   sparkChart?: boolean;
 }
 
-export function ChartContainer({theme, children, sparkChart = false}: Props) {
+export function ChartContainer({
+  theme = DEFAULT_THEME_NAME,
+  children,
+  sparkChart = false,
+}: Props) {
   const [chartDimensions, setChartDimensions] =
     useState<Dimensions | null>(null);
 

--- a/packages/polaris-viz-native/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/polaris-viz-native/src/components/SparkBarChart/SparkBarChart.tsx
@@ -6,6 +6,7 @@ import {
   SparkBarChartProps,
   ANIMATION_MARGIN,
   SparkBarSeries,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
 import {usePrefersReducedMotion} from '../../hooks';
@@ -17,7 +18,7 @@ export function SparkBarChart({
   isAnimated = false,
   dataOffsetRight = 0,
   dataOffsetLeft = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: SparkBarChartProps) {
   return (
     <ChartContainer theme={theme} sparkChart>
@@ -38,7 +39,7 @@ function Chart({
   accessibilityLabel,
   dataOffsetRight = 0,
   dataOffsetLeft = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
   isAnimated,
 }: SparkBarChartProps) {
   const {

--- a/packages/polaris-viz-native/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz-native/src/components/SparkLineChart/SparkLineChart.tsx
@@ -9,6 +9,7 @@ import {
   LineSeries,
   usePolarisVizContext,
   Dimensions,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
 import {usePrefersReducedMotion} from '../../hooks';
@@ -22,7 +23,7 @@ export function SparkLineChart({
   isAnimated = true,
   offsetLeft = 0,
   offsetRight = 0,
-  theme = 'Default',
+  theme = DEFAULT_THEME_NAME,
 }: SparkLineChartProps) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const shouldAnimate = !prefersReducedMotion && isAnimated;
@@ -51,7 +52,7 @@ function Chart({
   isAnimated = true,
   offsetLeft = 0,
   offsetRight = 0,
-  theme = 'Default',
+  theme = DEFAULT_THEME_NAME,
   dimensions = {width: 0, height: 0},
 }: ChartProps) {
   const {width, height} = dimensions;

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -4,6 +4,7 @@ import {
   ChartType,
   DataSeries,
   ChartState,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 import type {
   Direction,
@@ -55,7 +56,7 @@ export function BarChart({
   renderTooltipContent,
   showLegend = true,
   skipLinkText,
-  theme,
+  theme = DEFAULT_THEME_NAME,
   type = 'default',
   xAxisOptions,
   yAxisOptions,
@@ -139,7 +140,7 @@ export function BarChart({
       )}
       <ChartContainer theme={theme}>
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           ChartByDirection
         )}

--- a/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/BarChartXAxisLabels/BarChartXAxisLabels.tsx
@@ -13,7 +13,7 @@ export interface BarChartXAxisLabelsProps {
   onHeightChange: Dispatch<SetStateAction<number>>;
   xScale: ScaleBand<string>;
   reducedLabelIndexes?: number[];
-  theme?: string;
+  theme: string;
 }
 
 export function BarChartXAxisLabels({

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -22,7 +22,7 @@ import styles from './ChartContainer.scss';
 
 interface Props {
   children: ReactElement;
-  theme?: string;
+  theme: string;
   sparkChart?: boolean;
 }
 

--- a/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable node/callback-return */
 import React, {useRef, useEffect} from 'react';
-import type {Dimensions} from '@shopify/polaris-viz-core';
 import {
+  DEFAULT_THEME_NAME,
+  Dimensions,
   useTheme,
   paddingStringToObject,
   FONT_SIZE,
@@ -21,7 +22,7 @@ const INITIAL_DELAY = 200;
 const NUMBER_OF_BRICKS = 5;
 const TEXT_DROP_SHADOW_SIZE = 3;
 export interface ChartSkeletonProps {
-  theme?: string;
+  theme: string;
   dimensions?: Dimensions;
   state?: ChartState;
   errorText?: string;
@@ -29,7 +30,7 @@ export interface ChartSkeletonProps {
 
 export function ChartSkeleton({
   dimensions,
-  theme = 'Default',
+  theme = DEFAULT_THEME_NAME,
   state = ChartState.Loading,
   errorText = 'Could not load the chart',
 }: ChartSkeletonProps) {

--- a/packages/polaris-viz/src/components/ChartSkeleton/stories/ChartSkeleton.stories.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/stories/ChartSkeleton.stories.tsx
@@ -4,7 +4,7 @@ import type {Story, Meta} from '@storybook/react';
 import {ChartSkeleton, ChartSkeletonProps} from '../';
 import {ChartContainer} from '../../ChartContainer';
 import {CHART_STATE_CONTROL_ARGS} from '../../../storybook';
-import {ChartState} from '@shopify/polaris-viz-core';
+import {ChartState, DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
 export default {
   title: 'polaris-viz/Subcomponents/ChartSkeleton',
@@ -25,7 +25,7 @@ export default {
 
 const Template: Story<ChartSkeletonProps> = (args: ChartSkeletonProps) => {
   return (
-    <ChartContainer>
+    <ChartContainer theme={DEFAULT_THEME_NAME}>
       <ChartSkeleton {...args} />
     </ChartContainer>
   );

--- a/packages/polaris-viz/src/components/Crosshair/Crosshair.tsx
+++ b/packages/polaris-viz/src/components/Crosshair/Crosshair.tsx
@@ -9,7 +9,7 @@ interface Props {
   height: number;
 
   opacity?: number;
-  theme?: string;
+  theme: string;
 }
 
 export function Crosshair({x, height, opacity = 1, theme}: Props) {

--- a/packages/polaris-viz/src/components/Docs/stories/components/ComponentContainer/ComponentContainer.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/ComponentContainer/ComponentContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Source} from '@storybook/addon-docs';
+import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
 import {classNames} from '../../../../../utilities';
 import {useTheme} from '../../../../../hooks';
@@ -12,7 +13,7 @@ export function ComponentContainer({
   description,
   link,
   center,
-  theme = 'Default',
+  theme = DEFAULT_THEME_NAME,
   codeSample,
 }: {
   chart: JSX.Element;

--- a/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
@@ -202,6 +202,7 @@ export const SampleLegendContainer = ({theme} = {theme: 'Default'}) => {
             },
           ]}
           onHeightChange={() => {}}
+          theme={theme}
         />
       </div>
     </SimpleContainer>

--- a/packages/polaris-viz/src/components/Docs/stories/components/SimpleContainer/SimpleContainer.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SimpleContainer/SimpleContainer.tsx
@@ -1,3 +1,4 @@
+import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 import React, {ReactNode} from 'react';
 
 import {useTheme} from '../../../../../hooks';
@@ -5,7 +6,7 @@ import {useTheme} from '../../../../../hooks';
 export const SimpleContainer = ({
   children,
   height,
-  theme = 'Default',
+  theme = DEFAULT_THEME_NAME,
 }: {
   children: ReactNode;
   height?: number;

--- a/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
-// import {PolarisVizProvider} from '../';
 import {WebPolarisVizProvider as PolarisVizProvider} from '../../../../WebPolarisVizProvider';
 import {
   BarChart,
@@ -90,6 +90,7 @@ export function WebComponents() {
                   ],
                 },
               ]}
+              theme={DEFAULT_THEME_NAME}
             />
           }
         />
@@ -126,6 +127,7 @@ export function WebComponents() {
                   ],
                 },
               ]}
+              theme={DEFAULT_THEME_NAME}
             />
           }
         />
@@ -288,6 +290,7 @@ export function WebComponents() {
                   ],
                 },
               ]}
+              theme={DEFAULT_THEME_NAME}
             />
           }
         />
@@ -325,6 +328,7 @@ export function WebComponents() {
                   },
                 ]}
                 labelFormatter={(value) => `$${value}`}
+                theme={DEFAULT_THEME_NAME}
               />
             </div>
           }

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -58,7 +58,7 @@ export interface ChartProps {
   yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
   dimensions?: Dimensions;
-  theme?: string;
+  theme: string;
 }
 
 export function Chart({

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -21,7 +21,7 @@ export interface HorizontalBarChartProps {
   yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
   isAnimated?: boolean;
-  theme?: string;
+  theme: string;
   type?: ChartType;
   dimensions?: Dimensions;
 }

--- a/packages/polaris-viz/src/components/HorizontalBarChartXAxisLabels/HorizontalBarChartXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChartXAxisLabels/HorizontalBarChartXAxisLabels.tsx
@@ -13,7 +13,7 @@ interface HorizontalBarChartXAxisLabelsProps {
   onHeightChange: Dispatch<SetStateAction<number>>;
   xScale: ScaleLinear<number, number>;
   ticks: number[];
-  theme?: string;
+  theme: string;
 }
 
 export function HorizontalBarChartXAxisLabels({

--- a/packages/polaris-viz/src/components/HorizontalGridLines/HorizontalGridLines.tsx
+++ b/packages/polaris-viz/src/components/HorizontalGridLines/HorizontalGridLines.tsx
@@ -8,7 +8,7 @@ interface Props {
   transform: {x: number; y: number};
   width: number;
 
-  theme?: string;
+  theme: string;
 }
 
 export const HorizontalGridLines = React.memo(function HorizontalGridLines({

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -18,7 +18,7 @@ export interface LegendContainerProps {
   colorVisionType: string;
   data: LegendData[];
   onHeightChange: Dispatch<SetStateAction<number>>;
-  theme?: string;
+  theme: string;
 }
 
 export function LegendContainer({

--- a/packages/polaris-viz/src/components/LegendContainer/components/Legend/Legend.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/Legend/Legend.tsx
@@ -7,7 +7,7 @@ export interface LegendProps {
   data: LegendData[];
   activeIndex?: number;
   colorVisionType?: string;
-  theme?: string;
+  theme: string;
 }
 
 export function Legend({

--- a/packages/polaris-viz/src/components/LegendContainer/components/LegendItem/LegendItem.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/LegendItem/LegendItem.tsx
@@ -15,7 +15,7 @@ export interface LegendItemProps {
   legend: LegendData;
   activeIndex?: number;
   colorVisionType?: string;
-  theme?: string;
+  theme: string;
 }
 
 export function LegendItem({
@@ -51,6 +51,7 @@ export function LegendItem({
         shape={legend.shape}
         color={legend.color}
         isComparison={legend.isComparison}
+        theme={theme}
       />
       <span style={{color: selectedTheme.tooltip.textColor}}>
         {legend.name}

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -9,6 +9,7 @@ import {
   COLOR_VISION_SINGLE_ITEM,
   LineChartDataSeriesWithDefaults,
   clamp,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 import type {
   DataPoint,
@@ -74,7 +75,7 @@ export function Chart({
   isAnimated,
   xAxisOptions,
   yAxisOptions,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: ChartProps) {
   useColorVisionEvents(data.length > 1);
 

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -37,7 +37,7 @@ export interface LineChartProps {
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
   showLegend?: boolean;
   skipLinkText?: string;
-  theme?: string;
+  theme: string;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
 }
@@ -129,7 +129,7 @@ export function LineChart({
       )}
       <ChartContainer theme={theme}>
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
             data={dataWithDefaults}

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -34,7 +34,7 @@ interface PointsProps {
           },
         number
       >;
-  theme?: string;
+  theme: string;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
 }

--- a/packages/polaris-viz/src/components/LinearXAxisLabels/LinearXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/LinearXAxisLabels/LinearXAxisLabels.tsx
@@ -13,7 +13,7 @@ interface LinearXAxisLabelsProps {
   onHeightChange: Dispatch<SetStateAction<number>>;
   xScale: ScaleLinear<number, number>;
   reducedLabelIndexes?: number[];
-  theme?: string;
+  theme: string;
 }
 
 export function LinearXAxisLabels({

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -1,5 +1,9 @@
 import React, {useCallback, useMemo} from 'react';
-import {uniqueId, COLOR_VISION_SINGLE_ITEM} from '@shopify/polaris-viz-core';
+import {
+  uniqueId,
+  COLOR_VISION_SINGLE_ITEM,
+  DEFAULT_THEME_NAME,
+} from '@shopify/polaris-viz-core';
 import type {
   ChartType,
   DataSeries,
@@ -40,7 +44,7 @@ export function Chart({
   dimensions,
   isAnimated,
   showLegend,
-  theme,
+  theme = DEFAULT_THEME_NAME,
   type,
   xAxisOptions,
   yAxisOptions,

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -18,7 +18,7 @@ export interface SimpleBarChartProps {
   data: DataSeries[];
   isAnimated?: boolean;
   showLegend?: boolean;
-  theme?: string;
+  theme: string;
   type?: ChartType;
   xAxisOptions?: XAxisOptions;
 }

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -1,7 +1,10 @@
 import React, {useState} from 'react';
 import {sum} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
-import {COLOR_VISION_SINGLE_ITEM} from '@shopify/polaris-viz-core';
+import {
+  COLOR_VISION_SINGLE_ITEM,
+  DEFAULT_THEME_NAME,
+} from '@shopify/polaris-viz-core';
 import type {
   DataPoint,
   Direction,
@@ -39,7 +42,7 @@ export function Chart({
   labelPosition = 'top-left',
   direction = 'horizontal',
   size = 'small',
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: ChartProps) {
   useColorVisionEvents();
 

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import type {
+import {
   DataPoint,
+  DEFAULT_THEME_NAME,
   Direction,
   LabelFormatter,
 } from '@shopify/polaris-viz-core';
@@ -28,7 +29,7 @@ export function SimpleNormalizedChart({
   labelPosition = 'top-left',
   direction = 'horizontal',
   size = 'small',
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: SimpleNormalizedChartProps) {
   return (
     <ChartContainer theme={theme}>

--- a/packages/polaris-viz/src/components/SparkBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/Chart.tsx
@@ -5,6 +5,7 @@ import {
   SparkBarChartProps,
   ANIMATION_MARGIN,
   SparkBarSeries,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
 import {usePrefersReducedMotion} from '../../hooks';
@@ -23,7 +24,7 @@ export function Chart({
   isAnimated = false,
   dataOffsetRight = 0,
   dataOffsetLeft = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: Props) {
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const shouldAnimate = !prefersReducedMotion && isAnimated;

--- a/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
@@ -1,4 +1,7 @@
-import type {SparkBarChartProps} from '@shopify/polaris-viz-core';
+import {
+  DEFAULT_THEME_NAME,
+  SparkBarChartProps,
+} from '@shopify/polaris-viz-core';
 import React from 'react';
 
 import {ChartContainer} from '../ChartContainer';
@@ -11,7 +14,7 @@ export function SparkBarChart({
   isAnimated = false,
   dataOffsetRight = 0,
   dataOffsetLeft = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: SparkBarChartProps) {
   return (
     <ChartContainer theme={theme} sparkChart>

--- a/packages/polaris-viz/src/components/SparkLineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/Chart.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import {scaleLinear} from 'd3-scale';
-import {LineSeries, useSparkLine} from '@shopify/polaris-viz-core';
+import {
+  DEFAULT_THEME_NAME,
+  LineSeries,
+  useSparkLine,
+} from '@shopify/polaris-viz-core';
 import type {Dimensions} from '@shopify/polaris-viz-core';
 
 import {useThemeSeriesColors} from '../../hooks/useThemeSeriesColors';
@@ -23,7 +27,7 @@ export function Chart({
   isAnimated = false,
   offsetLeft = 0,
   offsetRight = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: Props) {
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(data, selectedTheme);

--- a/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import {DataSeries, DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
 import {ChartContainer} from '../ChartContainer';
 
@@ -20,7 +20,7 @@ export function SparkLineChart({
   isAnimated = false,
   offsetLeft = 0,
   offsetRight = 0,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: SparkLineChartProps) {
   return (
     <ChartContainer theme={theme} sparkChart>

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -1,12 +1,11 @@
 import React, {useState, useMemo, useRef} from 'react';
 import {line} from 'd3-shape';
-import type {
+import {
   DataSeries,
   DataPoint,
   XAxisOptions,
   YAxisOptions,
-} from '@shopify/polaris-viz-core';
-import {
+  DEFAULT_THEME_NAME,
   uniqueId,
   curveStepRounded,
   DataType,
@@ -69,7 +68,7 @@ export function Chart({
   renderTooltipContent,
   isAnimated,
   showLegend,
-  theme,
+  theme = DEFAULT_THEME_NAME,
   yAxisOptions,
 }: Props) {
   useColorVisionEvents(data.length > 1);

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -27,7 +27,7 @@ export interface StackedAreaChartProps {
   isAnimated?: boolean;
   showLegend?: boolean;
   skipLinkText?: string;
-  theme?: string;
+  theme: string;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
 }
@@ -77,7 +77,7 @@ export function StackedAreaChart({
       )}
       <ChartContainer theme={theme}>
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
             data={data}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
@@ -35,7 +35,7 @@ interface PointsProps {
   tooltipId: string;
   xScale: any;
   yScale: any;
-  theme?: string;
+  theme: string;
 }
 
 export function Points({

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -29,7 +29,7 @@ interface Props {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   isAnimated: boolean;
-  theme?: string;
+  theme: string;
 }
 
 export function Areas({

--- a/packages/polaris-viz/src/components/TextLine/TextLine.tsx
+++ b/packages/polaris-viz/src/components/TextLine/TextLine.tsx
@@ -7,7 +7,7 @@ import type {FormattedLine} from '../../types';
 interface TextLineProps {
   index: number;
   line: FormattedLine[];
-  theme?: string;
+  theme: string;
 }
 
 export function TextLine({index, line, theme}: TextLineProps) {

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -18,7 +18,7 @@ export interface TooltipContentProps {
   data: TooltipData[];
   annotations?: TooltipAnnotation[];
   title?: string;
-  theme?: string;
+  theme: string;
 }
 
 const FONT_SIZE_OFFSET = 1.061;

--- a/packages/polaris-viz/src/components/TooltipContent/components/AnnotationRow/AnnotationRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/AnnotationRow/AnnotationRow.tsx
@@ -15,7 +15,7 @@ interface Props {
   index: number;
   label: string;
   value: string;
-  theme?: string;
+  theme: string;
 }
 
 export function AnnotationRow({

--- a/packages/polaris-viz/src/components/TooltipContent/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/Annotations/Annotations.tsx
@@ -8,7 +8,7 @@ import styles from './Annotations.scss';
 interface Props {
   activeIndex: number;
   annotations: TooltipAnnotation[];
-  theme?: string;
+  theme: string;
 }
 
 export function Annotations({activeIndex, annotations, theme}: Props) {

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -21,7 +21,7 @@ interface Props {
   value: string;
   color?: Color;
   isComparison?: boolean;
-  theme?: string;
+  theme: string;
 }
 
 export function TooltipRow({

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -69,7 +69,7 @@ export interface Props {
   dimensions?: Dimensions;
   emptyStateText?: string;
   isAnimated?: boolean;
-  theme?: string;
+  theme: string;
 }
 
 export function Chart({

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -23,7 +23,7 @@ export interface VerticalBarChartProps {
   barOptions?: {isStacked: boolean};
   emptyStateText?: string;
   isAnimated?: boolean;
-  theme?: string;
+  theme: string;
   type?: ChartType;
   dimensions?: Dimensions;
 }

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
@@ -28,7 +28,7 @@ interface StackedBarGroupsProps {
   stackedValues: StackedSeries[];
   xScale: ScaleBand<string>;
   yScale: ScaleLinear<number, number>;
-  theme?: string;
+  theme: string;
 }
 
 export function StackedBarGroups({

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
@@ -30,7 +30,7 @@ interface StackProps {
   width: number;
   x: number | undefined;
   yScale: ScaleLinear<number, number>;
-  theme?: string;
+  theme: string;
 }
 
 export function Stack({

--- a/packages/polaris-viz/src/components/YAxis/YAxis.tsx
+++ b/packages/polaris-viz/src/components/YAxis/YAxis.tsx
@@ -9,7 +9,7 @@ interface Props {
   textAlign: 'left' | 'right';
   width: number;
 
-  theme?: string;
+  theme: string;
 }
 
 const PADDING_SIZE = 1;

--- a/packages/polaris-viz/src/components/shared/GradientDefs/GradientDefs.tsx
+++ b/packages/polaris-viz/src/components/shared/GradientDefs/GradientDefs.tsx
@@ -14,7 +14,7 @@ interface GradientDefsProps {
   id: string;
   direction?: Direction;
   seriesColors?: Color[];
-  theme?: string;
+  theme: string;
   gradientUnits?: GradientUnits;
 }
 
@@ -22,7 +22,7 @@ export function GradientDefs({
   direction = 'vertical',
   id,
   seriesColors = [],
-  theme = 'Default',
+  theme,
   size = '100%',
   gradientUnits,
 }: GradientDefsProps) {

--- a/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
+++ b/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
@@ -11,7 +11,7 @@ export interface GroupLabelProps {
   containerWidth: number;
   label: string;
   zeroPosition: number;
-  theme?: string;
+  theme: string;
 }
 
 export function GroupLabel({

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -35,7 +35,7 @@ export interface HorizontalBarsProps {
   xScale: ScaleLinear<number, number>;
   zeroPosition: number;
   animationDelay?: number;
-  theme?: string;
+  theme: string;
 }
 
 export function HorizontalBars({

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -41,7 +41,7 @@ export interface HorizontalGroupProps {
   name: string;
   opacity: SpringValue<number>;
   stackedValues: FormattedStackedSeries[];
-  theme?: string;
+  theme: string;
   transform: SpringValue<string>;
   xAxisOptions: Required<XAxisOptions>;
   xScale: ScaleLinear<number, number>;

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -31,7 +31,7 @@ export interface HorizontalStackedBarsProps {
   name: string;
   stackedValues: FormattedStackedSeries[];
   xScale: ScaleLinear<number, number>;
-  theme?: string;
+  theme: string;
 }
 
 function getBorderRadius({

--- a/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.tsx
+++ b/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.tsx
@@ -9,7 +9,7 @@ interface Props {
   color: Color;
   isComparison?: boolean;
   shape?: Shape;
-  theme?: string;
+  theme: string;
 }
 
 export function SeriesIcon({

--- a/packages/polaris-viz/src/hooks/useHorizontalSeriesColors.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalSeriesColors.ts
@@ -6,7 +6,7 @@ import {getSeriesColors} from './useThemeSeriesColors';
 
 interface Props {
   data: DataSeries[];
-  theme?: string;
+  theme: string;
 }
 
 export function useHorizontalSeriesColors({data, theme}: Props) {

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -21,7 +21,7 @@ interface Props {
   labels: string[];
   xAxisOptions: Required<XAxisOptions>;
   yAxisLabelWidth: number;
-  theme?: string;
+  theme: string;
 }
 
 export function useLinearLabelsAndDimensions({


### PR DESCRIPTION
## What does this implement/fix?

https://github.com/Shopify/polaris-viz/discussions/1110

Based on the discussion above, we're going to make the `theme` prop required for non-root chart components.