### PR TITLE
export ChartSkeleton and ChartState

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Re-export `ChartState` type  from `@shopify/polaris-viz-core`
+- Export `ChartSkeleton` subcomponent
 
 ## [1.7.1] - 2022-05-18
 

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -11,6 +11,7 @@ export {
   SimpleBarChart,
   PolarisVizProvider,
   TooltipContent,
+  ChartSkeleton,
 } from './components';
 
 export type {
@@ -56,4 +57,5 @@ export type {
   PartialTheme,
   GradientStop,
   DataPoint,
+  ChartState,
 } from '@shopify/polaris-viz-core';


### PR DESCRIPTION
## What does this implement/fix?
Exporting ChartState and ChartSkeleton from polaris-viz, so people don't need to reach to polaris-viz-core

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.
