### PR TITLE
a11y improvements on funnel chart

### DIFF
--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -157,34 +157,31 @@ export function Chart({
       </g>
 
       <mask id={`${maskId}-${theme}-grad`}>
-        <g role="list">
-          {dataSeries.map((dataPoint) => {
-            const barHeight = getBarHeight(dataPoint.value || 0);
-            const xPosition = xScale(dataPoint.key as string);
-            const x = xPosition == null ? 0 : xPosition;
-            const barWidth = xScale.bandwidth();
-            return (
-              <g
-                role="listitem"
-                aria-label={dataPoint.key as string}
-                key={dataPoint.key}
-              >
-                <Bar
-                  width={barWidth}
-                  height={barHeight}
-                  color={MASK_HIGHLIGHT_COLOR}
-                  x={x}
-                  y={drawableHeight - barHeight}
-                  borderRadius={
-                    selectedTheme.bar.hasRoundedCorners
-                      ? BORDER_RADIUS.Top
-                      : BORDER_RADIUS.None
-                  }
-                />
-              </g>
-            );
-          })}
-        </g>
+        {dataSeries.map((dataPoint) => {
+          const barHeight = getBarHeight(dataPoint.value || 0);
+          const xPosition = xScale(dataPoint.key as string);
+          const x = xPosition == null ? 0 : xPosition;
+          const barWidth = xScale.bandwidth();
+          return (
+            <g key={dataPoint.key} role="listitem">
+              <Bar
+                ariaLabel={`${xAxisOptions.labelFormatter(
+                  dataPoint.key,
+                )}: ${yAxisOptions.labelFormatter(dataPoint.value)}`}
+                width={barWidth}
+                height={barHeight}
+                color={MASK_HIGHLIGHT_COLOR}
+                x={x}
+                y={drawableHeight - barHeight}
+                borderRadius={
+                  selectedTheme.bar.hasRoundedCorners
+                    ? BORDER_RADIUS.Top
+                    : BORDER_RADIUS.None
+                }
+              />
+            </g>
+          );
+        })}
       </mask>
 
       {dataSeries.map((dataPoint, index) => {
@@ -200,7 +197,7 @@ export function Chart({
 
         const percentLabel = handlePercentLabelFormatter(percentCalculation);
         const barHeight = getBarHeight(dataPoint.value || 0);
-        const formattedYValue = yAxisOptions?.labelFormatter(yAxisValue) || '0';
+        const formattedYValue = yAxisOptions.labelFormatter(yAxisValue);
 
         return (
           <React.Fragment key={dataPoint.key}>

--- a/packages/polaris-viz/src/components/FunnelChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/stories/Playground.stories.tsx
@@ -53,5 +53,4 @@ export const SingleValues = SingleValuesTemplate.bind({});
 
 SingleValues.args = {
   data,
-  xAxisOptions: {},
 };

--- a/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
@@ -26,6 +26,7 @@ export interface BarProps {
   isAnimated?: boolean;
   needsMinWidth?: boolean;
   transform?: string;
+  ariaLabel?: string;
 }
 
 export const Bar = React.memo(function Bar({
@@ -42,6 +43,7 @@ export const Bar = React.memo(function Bar({
   width,
   x,
   y,
+  ariaLabel,
 }: BarProps) {
   const getPath = useCallback(
     (height = 0, width = 0) => {
@@ -61,8 +63,15 @@ export const Bar = React.memo(function Bar({
     default: {immediate: !isAnimated},
   });
 
+  const ariaHidden = !ariaLabel;
+
   return (
-    <g className={styles.Group} aria-hidden="true">
+    <g
+      className={styles.Group}
+      aria-hidden={ariaHidden}
+      role="img"
+      aria-label={ariaLabel}
+    >
       <animated.path
         d={spring.pathD}
         data-id={`bar-${index}`}


### PR DESCRIPTION
## What does this implement/fix?
Suggesting some changes to a11y structure so we have better screen reader support on the funnel chart

## What do the changes look like?

### Before:
- Screen readers didn't know what value each bar represented
- The screen reader would refer to the each bar as an "empty group"

https://user-images.githubusercontent.com/4037781/169414571-3c88b7cf-ec1b-4237-bf56-58ade653c7b8.mp4

### Before:
- Screen readers will read the formatted label + the value of each bar
- The screen reader would refer to the each bar as a list item that contains an image

https://user-images.githubusercontent.com/4037781/169414576-deb4f163-251d-4ab6-ac84-842f223c9e6a.mp4



## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
