### PR TITLE
Account for series with no series.data items

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -106,7 +106,7 @@ export function LineSeries({
     .slice(-1);
 
   const lastLinePointCoordinates =
-    lastLinePoint.value != null
+    lastLinePoint?.value != null
       ? {
           x: xScale(Number(lastLinePoint.key)),
           y: yScale(lastLinePoint.value),

--- a/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
@@ -6,7 +6,7 @@ import {scaleLinear} from 'd3-scale';
 import {mountWithProvider} from '../../../test-utilities';
 import '@shopify/react-testing/matchers';
 
-import {LineSeries} from '../LineSeries';
+import {LineSeries, LineSeriesProps} from '../LineSeries';
 import {Area} from '../components';
 
 const someScale = scaleLinear().domain([0, 100]).range([0, 100]);
@@ -23,7 +23,7 @@ const mockData = {
   ],
 };
 
-const defaultProps = {
+const defaultProps: LineSeriesProps = {
   xScale: someScale,
   yScale: someScale,
   data: mockData,
@@ -34,6 +34,16 @@ const defaultProps = {
 };
 
 describe('<LineSeries />', () => {
+  it('renders when data.data is empty', () => {
+    const lineSeries = mountWithProvider(
+      <svg>
+        <LineSeries {...defaultProps} data={{color: 'red', data: []}} />
+      </svg>,
+    );
+
+    expect(lineSeries).toContainReactComponent('svg');
+  });
+
   describe('svgDimensions', () => {
     it('gets passed to <Rect/>', () => {
       const lineSeries = mountWithProvider(

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where `<LineSeries />` would crash if the `data` array was empty.
 
 ## [1.10.1] - 2022-05-26
 


### PR DESCRIPTION
## What does this implement/fix?

There was a test in `web` that was passing `DataSeries`, but with no `series.data` items. This was causing the chart to crash because we expected _some_ items.

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="1056" alt="image" src="https://user-images.githubusercontent.com/149873/170551997-355e0703-8328-478a-8b1c-d60e3d97c4bc.png">|<img width="1065" alt="image" src="https://user-images.githubusercontent.com/149873/170551934-19d6c8d4-de38-4bb2-ae3f-7318ba1b5a38.png">|
 
## Storybook link

Change the LineChart stories to use the data below. The chart should render with no data. It shouldn't crash the page.

```
export const data = [
  {
    name: 'Apr 1 – Apr 14, 2020',
    data: [],
  },
];
```


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
