### PR TITLE
Make theme optional for consumer components

### DIFF
--- a/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
@@ -22,7 +22,7 @@ const INITIAL_DELAY = 200;
 const NUMBER_OF_BRICKS = 5;
 const TEXT_DROP_SHADOW_SIZE = 3;
 export interface ChartSkeletonProps {
-  theme: string;
+  theme?: string;
   dimensions?: Dimensions;
   state?: ChartState;
   errorText?: string;

--- a/packages/polaris-viz/src/components/LegendContainer/components/Legend/Legend.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/Legend/Legend.tsx
@@ -1,3 +1,4 @@
+import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 import React from 'react';
 
 import type {LegendData} from '../../types';
@@ -7,14 +8,14 @@ export interface LegendProps {
   data: LegendData[];
   activeIndex?: number;
   colorVisionType?: string;
-  theme: string;
+  theme?: string;
 }
 
 export function Legend({
   activeIndex = -1,
   colorVisionType,
   data,
-  theme,
+  theme = DEFAULT_THEME_NAME,
 }: LegendProps) {
   const items = data.map((legend, index) => {
     return (

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -4,6 +4,7 @@ import {
   useTheme,
   COLOR_VISION_SINGLE_ITEM,
   changeColorOpacity,
+  DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
 import {useWatchColorVisionEvents} from '../../hooks';
@@ -18,7 +19,7 @@ export interface TooltipContentProps {
   data: TooltipData[];
   annotations?: TooltipAnnotation[];
   title?: string;
-  theme: string;
+  theme?: string;
 }
 
 const FONT_SIZE_OFFSET = 1.061;
@@ -27,7 +28,7 @@ const PREVIEW_WIDTH = 14;
 export function TooltipContent({
   annotations = [],
   data,
-  theme,
+  theme = DEFAULT_THEME_NAME,
   title,
 }: TooltipContentProps) {
   const [activeIndex, setActiveIndex] = useState(-1);


### PR DESCRIPTION
## What does this implement/fix?

We missed a few places when making `theme` optional.

#### Question

```
All root-level chart components, or subcomponents exported to consumers should have optional theme?
everything else has required theme
```

Aside from putting a comment in the `index.ts` file, how can we enforce this rule? 

Could it be scripted, or tested?
