### PR TITLE
initial render of legends

### DIFF
--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -33,6 +33,7 @@ export interface ChartProps {
   data: DataSeries[];
   accessibilityLabel?: string;
   comparisonMetric?: Omit<ComparisonMetricProps, 'theme'>;
+  showLegend: boolean;
   total?: number;
   dimensions?: Dimensions;
   theme?: string;
@@ -44,13 +45,17 @@ export function Chart({
   accessibilityLabel = '',
   comparisonMetric,
   total,
+  showLegend = true,
   dimensions = {height: 0, width: 0},
   theme,
   labelFormatter,
 }: ChartProps) {
   const [activeIndex, setActiveIndex] = useState<number>(-1);
   const {width, height} = dimensions;
-  const diameter = Math.min(width, height);
+  const drawableHeight = height;
+  const drawableWidth = width - 200;
+
+  const diameter = Math.min(drawableHeight, drawableWidth);
   const radius = diameter / 2;
   const selectedTheme = useTheme(theme);
 
@@ -91,7 +96,7 @@ export function Chart({
     <div className={styles.DonutWrapper}>
       <div className={styles.Donut}>
         <span className={styles.VisuallyHidden}>{accessibilityLabel}</span>
-        <svg aria-hidden width={width} height={height}>
+        <svg aria-hidden width={drawableWidth} height={drawableWidth}>
           <g
             className={styles.DonutChart}
             transform={`translate(${radius} ${radius})`}
@@ -129,8 +134,8 @@ export function Chart({
                     })}
                   >
                     <Arc
-                      width={width}
-                      height={height}
+                      width={drawableWidth}
+                      height={drawableHeight}
                       radius={radius}
                       startAngle={startAngle}
                       endAngle={endAngle}
@@ -144,13 +149,13 @@ export function Chart({
             )}
           </g>
         </svg>
-
         {formattedValue && !emptyState && (
           <div
-            className={classNames(
-              styles.ContentWrapper,
-              comparisonMetric && styles.ContentWrapperWithComparison,
-            )}
+            className={styles.ContentWrapper}
+            style={{
+              height: drawableWidth,
+              width: drawableWidth,
+            }}
           >
             <p
               className={classNames(styles.ContentValue)}
@@ -171,17 +176,20 @@ export function Chart({
           </div>
         )}
       </div>
-      <div
-        style={{
-          width: `calc(100% - ${diameter}px)`,
-        }}
-      >
-        <LegendContainer
-          onHeightChange={() => {}}
-          colorVisionType=""
-          data={legendData}
-        />
-      </div>
+      {showLegend && (
+        <div
+          style={{
+            width: `calc(100% - ${diameter}px)`,
+          }}
+        >
+          <LegendContainer
+            onHeightChange={() => {}}
+            colorVisionType={COLOR_VISION_SINGLE_ITEM}
+            data={legendData}
+            theme={theme}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.scss
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.scss
@@ -10,23 +10,19 @@
 }
 
 .DonutWrapper {
+  position: relative;
   display: flex;
-  // flex-wrap: wrap;
+  align-items: center;
 }
 
 .ContentWrapper {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  justify-content: center;
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
   font-size: 20px;
-}
-
-.ContentWrapperWithComparison {
-  transform: translate(-50%, -40%);
+  pointer-events: none;
 }
 
 .ContentValue {

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<DonutChartProps> = {
     },
   },
   decorators: [
-    (Story) => <div style={{width: 400, height: 200}}>{Story()}</div>,
+    (Story) => <div style={{width: 400, height: 300}}>{Story()}</div>,
   ],
 };
 

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -9,6 +9,7 @@ import {Chart} from './Chart';
 export interface DonutChartProps {
   data: DataSeries[];
   comparisonMetric?: Omit<ComparisonMetricProps, 'theme'>;
+  showLegend?: boolean;
   theme?: string;
   labelFormatter?: LabelFormatter;
 }
@@ -17,6 +18,7 @@ export function DonutChart({
   data,
   theme,
   comparisonMetric,
+  showLegend = true,
   labelFormatter = (value) => `${value}`,
 }: DonutChartProps) {
   return (
@@ -25,6 +27,7 @@ export function DonutChart({
         data={data}
         labelFormatter={labelFormatter}
         comparisonMetric={comparisonMetric}
+        showLegend={showLegend}
       />
     </ChartContainer>
   );


### PR DESCRIPTION
## What does this implement/fix?
Initial rendering of Legends

TO DO: 
- [x] color a11y events
- [ ] Adapt the `<LegendContainer/>` component to render legends vertically. From what I understood, it currently only works with dynamic heights, but for donut we need to take into consideration dynamic widths too
- [ ] add a `labelPosition` prop to the Donut, similar to what we have in the `SimpleNormalizedChart`
- [ ] rename `labelPosition` to `legendPosition` everywhere


## Does this close any currently open issues?

closes https://github.com/Shopify/polaris-viz/issues/1138


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
