### PR TITLE
@juggle/resize-observer is now a dependency

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -15,6 +15,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - `<SimpleNormalizedChart/>` now accepts `DataSeries[]` in `data` prop, instead of `DataPoint[]`
+- Changed `@juggle/resize-observer` library as dependency.
 
 ## [1.11.1] - 2022-06-02
 

--- a/packages/polaris-viz/package.json
+++ b/packages/polaris-viz/package.json
@@ -27,6 +27,7 @@
     "!*.stories.*"
   ],
   "dependencies": {
+    "@juggle/resize-observer": "^3.3.1",
     "@react-spring/web": "^9.4.5",
     "@shopify/polaris-viz-core": "^1.11.1",
     "d3-array": "2.4.0",
@@ -46,7 +47,6 @@
     "@types/d3-shape": "^1.3.2"
   },
   "peerDependencies": {
-    "@juggle/resize-observer": "^3.3.1",
     "react": "^16.8.6 || ^17.0.0",
     "react-dom": "^16.8.6 || ^17.0.0"
   }

--- a/packages/polaris-viz/src/components/Docs/stories/GettingStartedWithWeb.stories.mdx
+++ b/packages/polaris-viz/src/components/Docs/stories/GettingStartedWithWeb.stories.mdx
@@ -61,9 +61,6 @@ import '@shopify/polaris-viz/build/esm/styles.css';
 
 <Title type="h2">Peer dependencies</Title>
 
-Polaris Viz has peer dependencies on:
+Polaris Viz has `react@^16.8.6` as a peer dependency.
 
-- `react@^16.8.6`
-- `@juggle/resize-observer@^3.3.1`
-
-You are responsible for providing these packages in your project. By requiring these packages as `peerDependencies` we can be sure there won't be duplicate packages included due to version mismatches.
+You are responsible for providing this package in your project. By requiring this package as `peerDependencies` we can be sure there won't be duplicate packages included due to version mismatches.


### PR DESCRIPTION
## What does this implement/fix?

Moved `@juggle/resize-observer` to a dependency instead of a peer-dep based on feedback from outside consumers.

The package is small enough that the team was ok with just including it.
