### PR TITLE
updated trendIndicator positive color from #039c86 to #03ab92

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -187,7 +187,7 @@ export const DEFAULT_THEME: Theme = {
     valueColor: variables.colorGray00,
     backgroundColor: variables.colorGray150,
     trendIndicator: {
-      positive: '#039c86',
+      positive: '#03AB92',
       negative: '#f24f62',
       neutral: '#8C9196',
     },


### PR DESCRIPTION
## What does this implement/fix?

Changed trendIndicator positive color from #039c86 to #03ab92

## Does this close any currently open issues?

Resolves #1169 


## What do the changes look like?

Before
<img width="786" alt="Screen Shot 2022-06-03 at 9 21 30 AM" src="https://user-images.githubusercontent.com/64446645/171905848-c82b7d63-83c4-4d95-bdd1-c76e1ae37c5f.png">

After

<img width="664" alt="Screen Shot 2022-06-03 at 9 22 21 AM" src="https://user-images.githubusercontent.com/64446645/171905955-f0d9f230-43ba-4a36-884e-891a06031bfa.png">

## Storybook link

(http://localhost:6006/?path=/story/polaris-viz-simple-charts-simplenormalizedchart--default)


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
