### PR TITLE
use standard data shape in SimpleNormalizedChart allow color overwrites

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- `<SimpleNormalizedChart/>` series colors can now be overwritten by using the `color` key in the `DataSeries` passed to the `data` prop
+- `<SimpleNormalizedChart/>` when passing `DataSeries.isComparison: true` to the `data` prop, the corresponding bar will now use the coparison color defined in the `Theme`
+
+### Changed
+
+- `<SimpleNormalizedChart/>` now accepts `DataSeries[]` in `data` prop, instead of `DataPoint[]`
 
 ## [1.11.1] - 2022-06-02
 

--- a/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
@@ -110,20 +110,40 @@ export const SampleSimpleNormalizedChart = ({theme} = {theme: 'Default'}) => {
       theme={theme}
       data={[
         {
-          key: 'Direct',
-          value: 200,
+          name: 'Direct',
+          data: [
+            {
+              key: 'April 2022',
+              value: 200,
+            },
+          ],
         },
         {
-          key: 'Facebook',
-          value: 100,
+          name: 'Facebook',
+          data: [
+            {
+              key: 'April 2022',
+              value: 100,
+            },
+          ],
         },
         {
-          key: 'Twitter',
-          value: 100,
+          name: 'Twitter',
+          data: [
+            {
+              key: 'April 2022',
+              value: 100,
+            },
+          ],
         },
         {
-          key: 'Google',
-          value: 20,
+          name: 'Google',
+          data: [
+            {
+              key: 'April 2022',
+              value: 20,
+            },
+          ],
         },
       ]}
       labelFormatter={(value) => `$${value}`}

--- a/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
@@ -319,12 +319,40 @@ export function WebComponents() {
                 ]}
                 data={[
                   {
-                    key: 'Direct',
-                    value: 200,
+                    name: 'Direct',
+                    data: [
+                      {
+                        key: 'April 2022',
+                        value: 200,
+                      },
+                    ],
                   },
                   {
-                    key: 'Facebook',
-                    value: 100,
+                    name: 'Facebook',
+                    data: [
+                      {
+                        key: 'April 2022',
+                        value: 100,
+                      },
+                    ],
+                  },
+                  {
+                    name: 'Twitter',
+                    data: [
+                      {
+                        key: 'April 2022',
+                        value: 100,
+                      },
+                    ],
+                  },
+                  {
+                    name: 'Google',
+                    data: [
+                      {
+                        key: 'April 2022',
+                        value: 20,
+                      },
+                    ],
                   },
                 ]}
                 labelFormatter={(value) => `$${value}`}

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
-  DataPoint,
-  DEFAULT_THEME_NAME,
+  ChartProps,
   Direction,
   LabelFormatter,
+  DEFAULT_CHART_PROPS,
 } from '@shopify/polaris-viz-core';
+import type {WithRequired} from '@shopify/polaris-viz-core';
 
 import type {ComparisonMetricProps} from '../ComparisonMetric';
 import {ChartContainer} from '../ChartContainer';
@@ -12,25 +13,28 @@ import {ChartContainer} from '../ChartContainer';
 import {Chart} from './Chart';
 import type {Size, LabelPosition} from './types';
 
-export interface SimpleNormalizedChartProps {
-  data: DataPoint[];
+export type SimpleNormalizedChartProps = {
   comparisonMetrics?: Omit<ComparisonMetricProps, 'theme'>[];
   labelFormatter?: LabelFormatter;
   labelPosition?: LabelPosition;
   direction?: Direction;
   size?: Size;
-  theme?: string;
-}
+} & ChartProps;
 
-export function SimpleNormalizedChart({
-  comparisonMetrics = [],
-  data,
-  labelFormatter = (value) => `${value}`,
-  labelPosition = 'top-left',
-  direction = 'horizontal',
-  size = 'small',
-  theme = DEFAULT_THEME_NAME,
-}: SimpleNormalizedChartProps) {
+export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
+  const {
+    comparisonMetrics = [],
+    data,
+    labelFormatter = (value) => `${value}`,
+    labelPosition = 'top-left',
+    direction = 'horizontal',
+    size = 'small',
+    theme,
+  }: WithRequired<SimpleNormalizedChartProps, 'theme'> = {
+    ...DEFAULT_CHART_PROPS,
+    ...props,
+  };
+
   return (
     <ChartContainer theme={theme}>
       <Chart

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/SimpleNormalizedChart.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/SimpleNormalizedChart.stories.tsx
@@ -5,7 +5,7 @@ import {
   SimpleNormalizedChart,
   SimpleNormalizedChartProps,
 } from '../SimpleNormalizedChart';
-import {THEME_CONTROL_ARGS} from '../../../storybook';
+import {THEME_CONTROL_ARGS, DATA_ARGS} from '../../../storybook';
 import {PageWithSizingInfo} from '../../Docs/stories/components/PageWithSizingInfo';
 
 export default {
@@ -17,17 +17,17 @@ export default {
       page: PageWithSizingInfo,
       description: {
         component:
-          "Used for positive datasets with two to four items. If your dataset has more than four items, consider grouping the fourth item and the remainder into an “other” category before passing data to the component.  ",
+          'Used for positive datasets with two to four items. If your dataset has more than four items, consider grouping the fourth item and the remainder into an “other” category before passing data to the component.  ',
       },
     },
   },
   argTypes: {
-    data: {
-      description:
-        'Gives the user the ability to define how the bars should look like. The data object also gives the ability to add comparison metric indicators.',
-    },
+    data: DATA_ARGS,
     direction: {description: 'Determines the direction of the chart.'},
-    size: {description: 'Determines the width of the chart.'},
+    size: {
+      description:
+        'Determines the width or height of the bar segments depending on `direction`.',
+    },
     labelPosition: {
       description: 'Determines the position of the labels.',
     },
@@ -44,22 +44,43 @@ const Template: Story<SimpleNormalizedChartProps> = (
 const defaultProps: SimpleNormalizedChartProps = {
   data: [
     {
-      key: 'Direct',
-      value: 200,
+      name: 'Direct',
+      data: [
+        {
+          key: 'April 2022',
+          value: 200,
+        },
+      ],
     },
     {
-      key: 'Facebook',
-      value: 100,
+      name: 'Facebook',
+      data: [
+        {
+          key: 'April 2022',
+          value: 100,
+        },
+      ],
     },
     {
-      key: 'Twitter',
-      value: 100,
+      name: 'Twitter',
+      data: [
+        {
+          key: 'April 2022',
+          value: 100,
+        },
+      ],
     },
     {
-      key: 'Google',
-      value: 20,
+      name: 'Google',
+      data: [
+        {
+          key: 'April 2022',
+          value: 20,
+        },
+      ],
     },
   ],
+
   direction: 'horizontal',
   size: 'small',
   labelPosition: 'top-left',
@@ -76,6 +97,17 @@ const defaultProps: SimpleNormalizedChartProps = {
 
 export const Default = Template.bind({});
 Default.args = defaultProps;
+
+export const OverwrittenSeriesColors = Template.bind({});
+OverwrittenSeriesColors.args = {
+  ...defaultProps,
+  data: defaultProps.data.map((item, index) => {
+    if (index === 0) {
+      return {...item, color: 'lime'};
+    }
+    return item;
+  }),
+};
 
 export const VerticalSmall = Template.bind({});
 VerticalSmall.args = {
@@ -98,8 +130,12 @@ export const DynamicData = () => {
       const newValue = Math.floor(Math.random() * 200);
       return {
         ...item,
-        value: newValue,
-        formattedValue: `$${newValue}`,
+        data: [
+          {
+            ...item.data[0],
+            value: newValue,
+          },
+        ],
       };
     });
     setData(newData);

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
@@ -9,10 +9,42 @@ import type {SimpleNormalizedChartProps} from '../SimpleNormalizedChart';
 describe('<Chart />', () => {
   const mockProps: SimpleNormalizedChartProps = {
     data: [
-      {key: 'label0', value: 993.9266809283133},
-      {key: 'label1', value: 666.4681407384194},
-      {key: 'label2', value: 500},
-      {key: 'label3', value: 200},
+      {
+        name: 'label0',
+        data: [
+          {
+            key: 'April 2022',
+            value: 993.9266809283133,
+          },
+        ],
+      },
+      {
+        name: 'label1',
+        data: [
+          {
+            key: 'April 2022',
+            value: 666.4681407384194,
+          },
+        ],
+      },
+      {
+        name: 'label2',
+        data: [
+          {
+            key: 'April 2022',
+            value: 500,
+          },
+        ],
+      },
+      {
+        name: 'label3',
+        data: [
+          {
+            key: 'April 2022',
+            value: 200,
+          },
+        ],
+      },
     ],
     labelFormatter: (value) => `$${Number(value).toFixed(2)}`,
   };
@@ -28,22 +60,77 @@ describe('<Chart />', () => {
       const highEdgeProps = {
         data: [
           {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'Google',
-            value: 666.4681407384194,
+            name: 'Google',
+            data: [
+              {
+                key: 'April 1',
+                value: 666.4681407384194,
+              },
+            ],
           },
-          {key: 'Yahoo', value: 500},
-          {key: 'Bing', value: 200},
           {
-            key: 'DuckDuck',
-            value: 993.9266809283133,
+            name: 'Yahoo',
+            data: [
+              {
+                key: 'April 1',
+                value: 500,
+              },
+            ],
           },
-          {key: 'Goog', value: 666.4681407384194},
-          {key: 'Yah', value: 500},
-          {key: 'Bin', value: 200},
+          {
+            name: 'Bing',
+            data: [
+              {
+                key: 'April 1',
+                value: 200,
+              },
+            ],
+          },
+          {
+            name: 'DuckDuck',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
+          },
+          {
+            name: 'Goog',
+            data: [
+              {
+                key: 'April 1',
+                value: 666.4681407384194,
+              },
+            ],
+          },
+          {
+            name: 'Yah',
+            data: [
+              {
+                key: 'April 1',
+                value: 500,
+              },
+            ],
+          },
+          {
+            name: 'Bin',
+            data: [
+              {
+                key: 'April 1',
+                value: 200,
+              },
+            ],
+          },
         ],
       };
       const barChart = mount(<SimpleNormalizedChart {...highEdgeProps} />);
@@ -65,8 +152,8 @@ describe('<Chart />', () => {
       const barChart = mount(
         <SimpleNormalizedChart
           data={[
-            {key: 'Bin', value: 200},
-            {key: 'Stuff', value: 0},
+            {name: 'Bin', data: [{key: 'April 1', value: 200}]},
+            {name: 'Stuff', data: [{key: 'April 1', value: 0}]},
           ]}
         />,
       );
@@ -80,28 +167,58 @@ describe('<Chart />', () => {
       const highEdgeProps = {
         data: [
           {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo1',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo1',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo2',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo2',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo3',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo3',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo4',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo4',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo5',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo5',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
         ],
       };
@@ -115,12 +232,17 @@ describe('<Chart />', () => {
       const lowEdgeProps = {
         data: [
           {
-            key: 'DuckDuckGo',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo',
+            data: [
+              {
+                key: 'April 1',
+                value: 993.9266809283133,
+              },
+            ],
           },
           {
-            key: 'DuckDuckGo1',
-            value: 993.9266809283133,
+            name: 'DuckDuckGo1',
+            data: [{key: 'April 1', value: 993.9266809283133}],
           },
         ],
       };

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/SimpleNormalizedChart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/SimpleNormalizedChart.test.tsx
@@ -10,11 +10,44 @@ import {Chart} from '../Chart';
 
 const mockProps: SimpleNormalizedChartProps = {
   data: [
-    {key: 'label0', value: 993.9266809283133},
-    {key: 'label1', value: 666.4681407384194},
-    {key: 'label2', value: 500},
-    {key: 'label3', value: 200},
+    {
+      name: 'label0',
+      data: [
+        {
+          key: 'April 2022',
+          value: 993.9266809283133,
+        },
+      ],
+    },
+    {
+      name: 'label1',
+      data: [
+        {
+          key: 'April 2022',
+          value: 666.4681407384194,
+        },
+      ],
+    },
+    {
+      name: 'label2',
+      data: [
+        {
+          key: 'April 2022',
+          value: 500,
+        },
+      ],
+    },
+    {
+      name: 'label3',
+      data: [
+        {
+          key: 'April 2022',
+          value: 200,
+        },
+      ],
+    },
   ],
+
   labelFormatter: (value) => `$${Number(value).toFixed(2)}`,
 };
 

--- a/packages/polaris-viz/src/storybook/index.ts
+++ b/packages/polaris-viz/src/storybook/index.ts
@@ -44,3 +44,8 @@ export const LEGEND_CONTROL_ARGS = {
 
 export const RENDER_TOOLTIP_DESCRIPTION =
   'This accepts a function that is called to render the tooltip content. When necessary it calls `formatXAxisLabel` and/or `formatYAxisLabel` to format the DataSeries[] values and passes them to `<TooltipContent />`. [RenderTooltipContentData type definition.]()';
+
+export const DATA_ARGS = {
+  description:
+    'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
+};


### PR DESCRIPTION
## What does this implement/fix?
Changes the `SimpleNormalizedChart` implementation so it uses `DataSeries[]` instead of `DataPoint[]. This change allows users to take advantage of `DataSeries.color` to overwrite a series color, as well as `DataSeries.isComparison` to use the default comparison styles.


## Does this close any currently open issues?

solve https://github.com/Shopify/polaris-viz/issues/1151

## What do the changes look like?
<img width="662" alt="Screen Shot 2022-06-06 at 9 25 29 AM" src="https://user-images.githubusercontent.com/4037781/172169437-2f4e127b-e02c-4818-82f6-46c22aece9af.png">

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
