### PR TITLE
added aria-hidden to hide xAxes Labels and yAxes Labels

### DIFF
--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -257,6 +257,7 @@ export function Chart({
             reducedLabelIndexes={xAxisDetails.reducedLabelIndexes}
             theme={theme}
             xScale={xScale}
+            ariaHidden
           />
         )}
 
@@ -280,6 +281,7 @@ export function Chart({
             width={yAxisLabelWidth}
             textAlign="right"
             theme={theme}
+            ariaHidden
           />
         </g>
 

--- a/packages/polaris-viz/src/components/LinearXAxisLabels/LinearXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/LinearXAxisLabels/LinearXAxisLabels.tsx
@@ -14,6 +14,7 @@ interface LinearXAxisLabelsProps {
   xScale: ScaleLinear<number, number>;
   reducedLabelIndexes?: number[];
   theme: string;
+  ariaHidden?: boolean;
 }
 
 export function LinearXAxisLabels({
@@ -26,6 +27,7 @@ export function LinearXAxisLabels({
   reducedLabelIndexes,
   theme,
   xScale,
+  ariaHidden = false,
 }: LinearXAxisLabelsProps) {
   const {lines} = useLabels({
     chartHeight,
@@ -44,7 +46,11 @@ export function LinearXAxisLabels({
         const x = xScale(index) ?? 0;
 
         return (
-          <g transform={`translate(${chartX + x},${chartY})`} key={index}>
+          <g
+            transform={`translate(${chartX + x},${chartY})`}
+            key={index}
+            aria-hidden={ariaHidden}
+          >
             <TextLine line={line} index={index} theme={theme} />
           </g>
         );

--- a/packages/polaris-viz/src/components/YAxis/YAxis.tsx
+++ b/packages/polaris-viz/src/components/YAxis/YAxis.tsx
@@ -8,13 +8,13 @@ interface Props {
   ticks: YAxisTick[];
   textAlign: 'left' | 'right';
   width: number;
-
+  ariaHidden?: boolean;
   theme: string;
 }
 
 const PADDING_SIZE = 1;
 
-function Axis({ticks, width, textAlign, theme}: Props) {
+function Axis({ticks, width, textAlign, theme, ariaHidden = false}: Props) {
   const selectedTheme = useTheme(theme);
 
   return (
@@ -23,6 +23,7 @@ function Axis({ticks, width, textAlign, theme}: Props) {
         return (
           <foreignObject
             key={value}
+            aria-hidden={ariaHidden}
             transform={`translate(${selectedTheme.grid.horizontalMargin},${
               yOffset - LINE_HEIGHT / 2
             })`}


### PR DESCRIPTION
## What does this implement/fix?

added aria-hidden to hide xAxes Labels and yAxes Labels


## Does this close any currently open issues?

Resolves #989

## What do the changes look like?

Before:
![image](https://user-images.githubusercontent.com/64446645/172245761-51ddae52-225a-4130-bddb-2fd0bfa62aad.png)

After:
<img width="312" alt="Screen Shot 2022-06-07 at 8 40 24 AM" src="https://user-images.githubusercontent.com/64446645/172428337-978f4201-5ab8-4e2e-b97c-a40716708ab8.png">



## Storybook link

http://localhost:6006/?path=/story/polaris-viz-default-charts-linechart--default

### Before merging

- [x] Check your changes on a variety of browsers and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
