### PR TITLE
Change annotation data to use keys instead of indexes

### DIFF
--- a/packages/polaris-viz/src/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.tsx
@@ -37,23 +37,30 @@ export function Annotations({
   const [isShowingAllAnnotations, setIsShowingAllAnnotations] = useState(false);
   const [ref, setRef] = useState<SVGGElement | null>(null);
 
-  const annotations = useMemo(() => {
-    return Object.keys(annotationsLookupTable)
+  const {annotations, dataIndexes} = useMemo(() => {
+    const dataIndexes = {};
+
+    const annotations = Object.keys(annotationsLookupTable)
       .map((key) => {
-        const annotation = annotationsLookupTable[Number(key)];
+        const annotation = annotationsLookupTable[key];
 
         if (annotation == null) {
           return null;
         }
 
+        dataIndexes[key] = labels.indexOf(key);
+
         return annotation;
       })
       .filter(Boolean) as Annotation[];
-  }, [annotationsLookupTable]);
+
+    return {annotations, dataIndexes};
+  }, [annotationsLookupTable, labels]);
 
   const {positions, rowCount} = useAnnotationPositions({
     annotations,
     axisLabelWidth: xScale.bandwidth(),
+    dataIndexes,
     drawableWidth,
     isShowingAllAnnotations,
     onHeightChange,
@@ -90,9 +97,10 @@ export function Annotations({
         const hasContent = annotation.content != null;
         const isContentVisible = index === activeIndex && hasContent;
         const tabIndex = index + 1;
+        const ariaLabel = `${annotation.startKey}`;
 
         return (
-          <React.Fragment key={`annotation${index}${annotation.startIndex}`}>
+          <React.Fragment key={`annotation${index}${annotation.startKey}`}>
             <AnnotationLine
               size={drawableHeight}
               theme={theme}
@@ -100,7 +108,7 @@ export function Annotations({
               y={y + PILL_HEIGHT}
             />
             <AnnotationLabel
-              ariaLabel={labels[annotation.startIndex]}
+              ariaLabel={ariaLabel}
               index={index}
               isVisible={!isContentVisible}
               label={annotation.label}

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
@@ -19,6 +19,7 @@ import type {AnnotationPosition} from '../types';
 interface Props {
   annotations: Annotation[];
   axisLabelWidth: number;
+  dataIndexes: {[key: string]: string};
   drawableWidth: number;
   isShowingAllAnnotations: boolean;
   onHeightChange: (height: number) => void;
@@ -28,6 +29,7 @@ interface Props {
 export function useAnnotationPositions({
   annotations,
   axisLabelWidth,
+  dataIndexes,
   drawableWidth,
   isShowingAllAnnotations,
   onHeightChange,
@@ -46,7 +48,7 @@ export function useAnnotationPositions({
 
   const {positions} = useMemo(() => {
     const positions = annotations.map((annotation, dataIndex) => {
-      const xPosition = xScale(`${annotation.startIndex}`) ?? 0;
+      const xPosition = xScale(dataIndexes[annotation.startKey]) ?? 0;
 
       const textWidth = textWidths[dataIndex];
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -72,7 +72,7 @@ export function BarChart(props: BarChartProps) {
   const xAxisOptionsWithDefaults = getXAxisOptionsWithDefaults(xAxisOptions);
   const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
 
-  const annotationsLookupTable = normalizeData(annotations, 'startIndex');
+  const annotationsLookupTable = normalizeData(annotations, 'startKey');
 
   function renderTooltip(tooltipData: RenderTooltipContentData) {
     if (renderTooltipContent != null) {

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -420,7 +420,7 @@ SeriesColorsUpToFourteen.args = {
 
 const ANNOTATIONS: Annotation[] = [
   {
-    startIndex: 0,
+    startKey: 'Monday',
     label: 'Content and title',
     content: {
       title: 'GDPR rule change',
@@ -429,7 +429,7 @@ const ANNOTATIONS: Annotation[] = [
     },
   },
   {
-    startIndex: 2,
+    startKey: 'Wednesday',
     label: 'Title, content and no link string',
     content: {
       title: 'GDPR rule change',
@@ -439,7 +439,7 @@ const ANNOTATIONS: Annotation[] = [
     },
   },
   {
-    startIndex: 5,
+    startKey: 'Friday',
     label: 'Just content',
     content: {
       content:
@@ -447,7 +447,7 @@ const ANNOTATIONS: Annotation[] = [
     },
   },
   {
-    startIndex: 1,
+    startKey: 'Tuesday',
     label: 'This has everything',
     content: {
       title: 'GDPR rule change',
@@ -458,7 +458,7 @@ const ANNOTATIONS: Annotation[] = [
     },
   },
   {
-    startIndex: 6,
+    startKey: 'Saturday',
     label: 'No Content',
   },
 ];

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -121,8 +121,9 @@ export interface LegendData {
 
 export interface Annotation {
   label: string;
-  startIndex: number;
-  endIndex?: number;
+  startKey: string | number;
+  endKey?: string | number;
+  axis?: 'x' | 'y';
   content?: {
     content: string;
     linkText?: string;


### PR DESCRIPTION
## What does this implement/fix?

Based on upcoming y-axis annotation work, we need to change the data structure to accept keys instead of indexes so that we can correctly place the annotations for each axis.

![image](https://user-images.githubusercontent.com/149873/172417968-3ef3a863-bb40-4208-af1c-44ca570fbb97.png)
 