### PR TITLE
Don't allow tooltip to render outside chart

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -140,4 +140,5 @@ export type {
   LineChartDataSeriesWithDefaults,
   ChartProps,
   WithRequired,
+  BoundingRect,
 } from './types';

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -36,6 +36,11 @@ export interface Dimensions {
   height: number;
 }
 
+export interface BoundingRect extends Dimensions {
+  x: number;
+  y: number;
+}
+
 export type Color = string | GradientStop[];
 
 export interface XAxisOptions {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -16,6 +16,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - `<SimpleNormalizedChart/>` now accepts `DataSeries[]` in `data` prop, instead of `DataPoint[]`
 - Changed `@juggle/resize-observer` library as dependency.
+- Stop tooltip from rendering outside of `<BarChart />` when only a single series is provided.
 
 ## [1.11.1] - 2022-06-02
 

--- a/packages/polaris-viz/src/components/BarChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/Playground.stories.tsx
@@ -258,3 +258,29 @@ SingleValues.args = {
   type: 'stacked',
   data: DATA,
 };
+
+const MULTIPLE_BARS_DATA = [...new Array(3)].fill(null).map(() => {
+  return {
+    name: 'total_sales OVER day',
+    data: [
+      {
+        key: 'Apr 30, 2022',
+        value: Math.random(),
+      },
+    ],
+  };
+});
+
+export const SingleSeriesMultipleBars: Story<BarChartProps> = (
+  args: BarChartProps,
+) => {
+  return (
+    <div style={{width: 600, height: 400}}>
+      <BarChart {...args} />
+    </div>
+  );
+};
+
+SingleSeriesMultipleBars.args = {
+  data: MULTIPLE_BARS_DATA,
+};

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -3,6 +3,7 @@ import {
   uniqueId,
   DataType,
   COLOR_VISION_SINGLE_ITEM,
+  BoundingRect,
 } from '@shopify/polaris-viz-core';
 import type {
   DataSeries,
@@ -180,6 +181,12 @@ export function Chart({
   const zeroPosition = longestLabel.negative + xScale(0);
 
   const labelWidth = drawableWidth / ticks.length;
+  const chartBounds: BoundingRect = {
+    width,
+    height,
+    x: chartStartPosition,
+    y: 0,
+  };
 
   return (
     <div
@@ -297,7 +304,7 @@ export function Chart({
       </svg>
       <TooltipWrapper
         bandwidth={groupBarsAreaHeight}
-        chartDimensions={{width, height}}
+        chartBounds={chartBounds}
         focusElementDataType={DataType.BarGroup}
         getAlteredPosition={getAlteredHorizontalBarPosition}
         getMarkup={getTooltipMarkup}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/utilities/getAlteredHorizontalBarPosition.ts
@@ -1,4 +1,4 @@
-import type {Dimensions} from '@shopify/polaris-viz-core';
+import type {BoundingRect, Dimensions} from '@shopify/polaris-viz-core';
 
 import {HORIZONTAL_GROUP_LABEL_HEIGHT} from '../../../constants';
 import {
@@ -34,19 +34,18 @@ function getNegativeOffset(props: AlteredPositionProps): AlteredPositionReturn {
 }
 
 function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
-  const {bandwidth, currentX, currentY, tooltipDimensions, chartDimensions} =
-    props;
+  const {bandwidth, currentX, currentY, tooltipDimensions, chartBounds} = props;
 
   const isOutside = isOutsideBounds({
     x: currentX,
     y: currentY,
     tooltipDimensions,
-    chartDimensions,
+    chartBounds,
   });
 
   if (isOutside.top && isOutside.right) {
     return {
-      x: chartDimensions.width - tooltipDimensions.width,
+      x: chartBounds.width - tooltipDimensions.width,
       y: 0,
     };
   }
@@ -91,7 +90,7 @@ function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
     return {
       x: currentX + TOOLTIP_MARGIN,
       y:
-        chartDimensions.height -
+        chartBounds.height -
         tooltipDimensions.height -
         HORIZONTAL_GROUP_LABEL_HEIGHT,
     };
@@ -104,20 +103,20 @@ function isOutsideBounds({
   x,
   y,
   tooltipDimensions,
-  chartDimensions,
+  chartBounds,
 }: {
   x: number;
   y: number;
   tooltipDimensions: Dimensions;
-  chartDimensions: Dimensions;
+  chartBounds: BoundingRect;
 }) {
   const right = x + TOOLTIP_MARGIN + tooltipDimensions.width;
   const bottom = y + tooltipDimensions.height;
 
   return {
     left: x <= 0,
-    right: right > chartDimensions.width,
-    bottom: bottom > chartDimensions.height,
+    right: right > chartBounds.width,
+    bottom: bottom > chartBounds.height,
     top: y <= 0,
   };
 }

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -10,6 +10,7 @@ import {
   LineChartDataSeriesWithDefaults,
   clamp,
   DEFAULT_THEME_NAME,
+  BoundingRect,
 } from '@shopify/polaris-viz-core';
 import type {
   DataPoint,
@@ -232,6 +233,13 @@ export function Chart({
     }
   }
 
+  const chartBounds: BoundingRect = {
+    width,
+    height,
+    x: chartStartPosition,
+    y: Margin.Top,
+  };
+
   return (
     <div className={styles.Container} style={{width, height}}>
       <svg
@@ -340,7 +348,7 @@ export function Chart({
 
       <TooltipWrapper
         alwaysUpdatePosition
-        chartDimensions={{width, height}}
+        chartBounds={chartBounds}
         focusElementDataType={DataType.Point}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -24,7 +24,7 @@ interface PointsProps {
   gradientId: string;
   longestSeriesIndex: number;
   tooltipId: string;
-  getXPosition: ({isCrosshair}?: {isCrosshair: boolean}) =>
+  getXPosition: ({isCrosshair}: {isCrosshair: boolean}) =>
     | number
     | Interpolation<
         | DOMPoint

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -12,6 +12,7 @@ import {
   Dimensions,
   useYScale,
   COLOR_VISION_SINGLE_ITEM,
+  BoundingRect,
 } from '@shopify/polaris-viz-core';
 
 import type {RenderTooltipContentData} from '../../types';
@@ -193,6 +194,13 @@ export function Chart({
     return null;
   }
 
+  const chartBounds: BoundingRect = {
+    width,
+    height,
+    x: chartStartPosition,
+    y: Margin.Top,
+  };
+
   return (
     <div className={styles.Container} style={{height, width}}>
       <svg
@@ -291,7 +299,7 @@ export function Chart({
       </svg>
       <TooltipWrapper
         alwaysUpdatePosition
-        chartDimensions={{width, height}}
+        chartBounds={chartBounds}
         focusElementDataType={DataType.Point}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
-import type {DataType, Dimensions} from '@shopify/polaris-viz-core';
+import type {DataType, BoundingRect} from '@shopify/polaris-viz-core';
 
 import type {Margin} from '../../types';
 
@@ -16,7 +16,7 @@ import {TooltipAnimatedContainer} from './components/TooltipAnimatedContainer';
 import type {AlteredPosition} from './utilities';
 
 interface TooltipWrapperProps {
-  chartDimensions: Dimensions;
+  chartBounds: BoundingRect;
   getMarkup: (index: number) => ReactNode;
   getPosition: (data: TooltipPositionParams) => TooltipPosition;
   margin: Margin;
@@ -160,7 +160,7 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     <TooltipAnimatedContainer
       activePointIndex={position.activeIndex}
       bandwidth={bandwidth}
-      chartDimensions={props.chartDimensions}
+      chartBounds={props.chartBounds}
       currentX={position.x}
       currentY={position.y}
       id={id}

--- a/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useRef, useState, ReactNode} from 'react';
 import {useSpring, animated} from '@react-spring/web';
-import type {Dimensions} from '@shopify/polaris-viz-core';
+import type {BoundingRect, Dimensions} from '@shopify/polaris-viz-core';
 
 import type {Margin} from '../../../types';
 import styles from '../TooltipContainer.scss';
@@ -15,7 +15,7 @@ export interface TooltipAnimatedContainerProps {
   activePointIndex: number;
   currentX: number;
   currentY: number;
-  chartDimensions: Dimensions;
+  chartBounds: BoundingRect;
   getAlteredPosition?: AlteredPosition;
   position?: TooltipPositionOffset;
   id?: string;
@@ -25,7 +25,7 @@ export interface TooltipAnimatedContainerProps {
 export function TooltipAnimatedContainer({
   activePointIndex,
   bandwidth = 0,
-  chartDimensions,
+  chartBounds,
   children,
   currentX,
   currentY,
@@ -54,7 +54,7 @@ export function TooltipAnimatedContainer({
         currentY,
         position,
         tooltipDimensions,
-        chartDimensions,
+        chartBounds,
         margin,
         bandwidth,
       });

--- a/packages/polaris-viz/src/components/TooltipWrapper/tests/utils.test.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/tests/utils.test.ts
@@ -7,14 +7,21 @@ import {
   getRightPosition,
   getVerticalCenterPosition,
 } from '../utilities';
+import type {AlteredPositionProps} from '../utilities';
 
 const MARGIN = {Top: 0, Left: 0, Right: 0, Bottom: 0};
-const BASE_PROPS = {
-  chartDimensions: {height: 100, width: 100},
+const BASE_PROPS: AlteredPositionProps = {
+  chartBounds: {height: 100, width: 100, x: 0, y: 0},
   tooltipDimensions: {height: 20, width: 20},
   margin: MARGIN,
   bandwidth: 40,
-} as any;
+  currentX: 0,
+  currentY: 0,
+  position: {
+    horizontal: 0,
+    vertical: 0,
+  },
+};
 
 describe('getInlinePosition()', () => {
   it('returns altered values', () => {

--- a/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
@@ -1,4 +1,4 @@
-import type {Dimensions} from '@shopify/polaris-viz-core';
+import {BoundingRect, clamp, Dimensions} from '@shopify/polaris-viz-core';
 
 import type {TooltipPositionOffset} from '../TooltipWrapper';
 import type {Margin} from '../../types';
@@ -13,7 +13,7 @@ export interface AlteredPositionProps {
   currentY: number;
   position: TooltipPositionOffset;
   tooltipDimensions: Dimensions;
-  chartDimensions: Dimensions;
+  chartBounds: BoundingRect;
   margin: Margin;
   bandwidth: number;
 }
@@ -34,7 +34,7 @@ export type AlteredPosition = (
 export function getAlteredVerticalBarPosition(
   props: AlteredPositionProps,
 ): AlteredPositionReturn {
-  const {currentX, currentY, position} = props;
+  const {currentX, currentY, position, chartBounds} = props;
 
   const newPosition = {...position};
 
@@ -99,7 +99,14 @@ export function getAlteredVerticalBarPosition(
     x = center.value;
   }
 
-  return {x, y};
+  return {
+    x: clamp({
+      amount: x,
+      min: chartBounds.x ?? 0,
+      max: chartBounds.width,
+    }),
+    y,
+  };
 }
 
 interface IsOutsideBoundsData {
@@ -115,14 +122,14 @@ function isOutsideBounds(data: IsOutsideBoundsData): boolean {
     const isLeft = current < alteredPosition.margin.Left;
     const isRight =
       current + alteredPosition.tooltipDimensions.width >
-      alteredPosition.chartDimensions.width - alteredPosition.margin.Right;
+      alteredPosition.chartBounds.width - alteredPosition.margin.Right;
 
     return isLeft || isRight;
   } else {
     const isAbove = current < 0;
     const isBelow =
       current + alteredPosition.tooltipDimensions.height >
-      alteredPosition.chartDimensions.height - alteredPosition.margin.Bottom;
+      alteredPosition.chartBounds.height - alteredPosition.margin.Bottom;
 
     return isAbove || isBelow;
   }
@@ -147,7 +154,7 @@ export function getInlinePosition(
 
   if (wasOutsideBounds) {
     const bottom = y + props.tooltipDimensions.height;
-    const offset = bottom - props.chartDimensions.height;
+    const offset = bottom - props.chartBounds.height;
 
     y -= offset + props.margin.Bottom;
   }
@@ -171,7 +178,7 @@ export function getVerticalCenterPosition(
     if (y <= 0) {
       y = 0;
     } else {
-      y = props.chartDimensions.height - props.tooltipDimensions.height;
+      y = props.chartBounds.height - props.tooltipDimensions.height;
     }
   }
 
@@ -277,7 +284,7 @@ export function getCenterPosition(
 
   if (wasOutsideBounds) {
     x =
-      props.chartDimensions.width -
+      props.chartBounds.width -
       props.tooltipDimensions.width -
       TOOLTIP_MARGIN * 2;
   }

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -7,6 +7,7 @@ import {
   estimateStringWidth,
   COLOR_VISION_GROUP_ITEM,
   COLOR_VISION_SINGLE_ITEM,
+  BoundingRect,
 } from '@shopify/polaris-viz-core';
 import type {
   DataSeries,
@@ -147,9 +148,18 @@ export function Chart({
   }, [characterWidths, initialTicks]);
 
   const horizontalMargin = selectedTheme.grid.horizontalMargin;
-  const chartStartPosition =
+  const chartXPosition =
     yAxisLabelWidth + Y_AXIS_CHART_SPACING + horizontalMargin;
-  const drawableWidth = width - chartStartPosition - horizontalMargin * 2;
+  const chartYPosition =
+    drawableHeight + LABEL_AREA_TOP_SPACING + (Margin.Top as number);
+  const drawableWidth = width - chartXPosition - horizontalMargin * 2;
+
+  const chartBounds: BoundingRect = {
+    width,
+    height,
+    x: chartXPosition,
+    y: chartYPosition,
+  };
 
   const hideXAxis = xAxisOptions.hide ?? selectedTheme.xAxis.hide;
 
@@ -221,10 +231,8 @@ export function Chart({
         {hideXAxis ? null : (
           <BarChartXAxisLabels
             chartHeight={height}
-            chartX={chartStartPosition}
-            chartY={
-              drawableHeight + LABEL_AREA_TOP_SPACING + (Margin.Top as number)
-            }
+            chartX={chartXPosition}
+            chartY={chartYPosition}
             labels={labels}
             labelWidth={xScale.bandwidth()}
             onHeightChange={setLabelHeight}
@@ -247,7 +255,7 @@ export function Chart({
           <HorizontalGridLines
             ticks={ticks}
             transform={{
-              x: selectedTheme.grid.horizontalOverflow ? 0 : chartStartPosition,
+              x: selectedTheme.grid.horizontalOverflow ? 0 : chartXPosition,
               y: Margin.Top,
             }}
             width={width}
@@ -264,7 +272,7 @@ export function Chart({
           />
         </g>
 
-        <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
+        <g transform={`translate(${chartXPosition},${Margin.Top})`}>
           {stackedValues != null ? (
             <StackedBarGroups
               accessibilityData={accessibilityData}
@@ -303,7 +311,7 @@ export function Chart({
             })
           )}
         </g>
-        <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
+        <g transform={`translate(${chartXPosition},${Margin.Top})`}>
           {Object.keys(annotationsLookupTable).map((key, dataIndex) => {
             const annotation = annotationsLookupTable[Number(key)];
 
@@ -334,7 +342,7 @@ export function Chart({
 
       <TooltipWrapper
         bandwidth={xScale.bandwidth()}
-        chartDimensions={{width, height}}
+        chartBounds={chartBounds}
         focusElementDataType={DataType.BarGroup}
         getMarkup={getTooltipMarkup}
         getPosition={getTooltipPosition}
@@ -366,7 +374,7 @@ export function Chart({
         ? sortedData[index].reduce(sumPositiveData, 0)
         : Math.max(...sortedDataPos);
 
-    const x = xPosition + chartStartPosition;
+    const x = xPosition + chartXPosition;
     const y = yScale(highestValuePos) + (Margin.Top as number);
 
     return {
@@ -395,7 +403,7 @@ export function Chart({
       }
 
       const {svgX, svgY} = point;
-      const currentPoint = svgX - chartStartPosition;
+      const currentPoint = svgX - chartXPosition;
       const activeIndex = Math.floor(currentPoint / xScale.step());
 
       if (


### PR DESCRIPTION
## What does this implement/fix?

If a chart only has a single series, don't allow the tooltip to render outside the chart bounds.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/38661

## What do the changes look like?

| Before | After |
| --- | --- |
| <img width="640" alt="image" src="https://user-images.githubusercontent.com/149873/172702491-a11039ca-012c-43f2-a218-8b653b54bdef.png"> | <img width="671" alt="image" src="https://user-images.githubusercontent.com/149873/172701874-8e12eecb-539c-4acb-9f63-963b6c59537c.png"> |

 
## Storybook link

http://localhost:6006/?path=/story/polaris-viz-default-charts-barchart--series-colors-from-five-to-seven

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
