### PR TITLE
Add empty state to simple normalized chart

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -120,6 +120,7 @@ export const NEUTRAL_SINGLE_GRADIENT = [
 
 export const DEFAULT_THEME: Theme = {
   seriesColors: {
+    empty: variables.colorGray140,
     comparison: variables.colorDarkComparison,
     single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
@@ -222,6 +223,7 @@ export const DEFAULT_THEME: Theme = {
 
 export const LIGHT_THEME: Theme = {
   seriesColors: {
+    empty: variables.colorGray20,
     comparison: variables.colorLightComparison,
     single: NEUTRAL_SINGLE_GRADIENT,
     upToFour: [
@@ -324,6 +326,7 @@ export const LIGHT_THEME: Theme = {
 export const PRINT_THEME = {
   ...LIGHT_THEME,
   seriesColors: {
+    empty: variables.colorGray20,
     comparison: variables.colorLightComparison,
     single: variables.colorIndigo90,
     upToFour: [

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -134,6 +134,7 @@ export interface TooltipTheme {
 }
 export interface SeriesColors {
   comparison: string;
+  empty: Color;
   single: Color;
   upToFour: Color[];
   fromFiveToSeven: Color[];

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - `useLegend` hook now accepts `DataGroup[]` and `DataSeries[]`
+- `<SimpleNormalizedChart/>` now displays an empty bar when data values are all zero or no data is passed
 
 ## [3.0.0] - 2022-06-20
 

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -81,6 +81,7 @@ export function Chart({
 
   const isVertical = direction === 'vertical';
   const bars = isVertical ? slicedData.reverse() : slicedData;
+  const isEmptyValues = slicedData.every(({value}) => !value);
 
   const isRightLabel = labelPosition.includes('right');
   const isBottomLabel = labelPosition.includes('bottom');
@@ -142,27 +143,41 @@ export function Chart({
             : styles.HorizontalBarContainer,
         )}
       >
-        {bars.map(({value, key}, index) => {
-          if (value == null || value === 0) {
-            return null;
-          }
+        {isEmptyValues ? (
+          <BarSegment
+            activeIndex={-1}
+            index={-1}
+            isAnimated={!prefersReducedMotion}
+            direction={direction}
+            size={size}
+            scale={100}
+            key="empty-bar"
+            color={selectedTheme.seriesColors.empty}
+            roundedCorners={selectedTheme.bar.hasRoundedCorners}
+          />
+        ) : (
+          bars.map(({value, key}, index) => {
+            if (value == null || value === 0) {
+              return null;
+            }
 
-          const colorIndex = isVertical ? bars.length - 1 - index : index;
+            const colorIndex = isVertical ? bars.length - 1 - index : index;
 
-          return (
-            <BarSegment
-              activeIndex={activeIndex}
-              index={colorIndex}
-              isAnimated={!prefersReducedMotion}
-              direction={direction}
-              size={size}
-              scale={xScale(value)}
-              key={`${key}-${index}`}
-              color={colors[colorIndex]}
-              roundedCorners={selectedTheme.bar.hasRoundedCorners}
-            />
-          );
-        })}
+            return (
+              <BarSegment
+                activeIndex={activeIndex}
+                index={colorIndex}
+                isAnimated={!prefersReducedMotion}
+                direction={direction}
+                size={size}
+                scale={xScale(value)}
+                key={`${key}-${index}`}
+                color={colors[colorIndex]}
+                roundedCorners={selectedTheme.bar.hasRoundedCorners}
+              />
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.scss
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.scss
@@ -26,6 +26,10 @@
   }
 }
 
+.RoundedCorners {
+  border-radius: 2px;
+}
+
 .horizontal-small {
   height: 16px;
 }

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
@@ -40,6 +40,7 @@ export function BarSegment({
 }: Props) {
   const scaleNeedsRounding = scale > 0 && scale < 1.5;
   const safeScale = scaleNeedsRounding ? 1.5 : scale;
+  const isMaxScale = scale >= 100;
 
   const delay = index * DELAY;
   const angle = direction === 'horizontal' ? 90 : 180;
@@ -63,7 +64,8 @@ export function BarSegment({
     <animated.div
       className={classNames(
         styles.Segment,
-        roundedCorners && styles[`${direction}-RoundedCorners`],
+        roundedCorners && !isMaxScale && styles[`${direction}-RoundedCorners`],
+        roundedCorners && isMaxScale && styles.RoundedCorners,
         styles[`${direction}-${size}`],
       )}
       style={{

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/tests/BarSegment.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/tests/BarSegment.test.tsx
@@ -33,6 +33,14 @@ describe('<BarSegment />', () => {
     });
   });
 
+  it('gives the child an all rounded corners class name when scale is 100', () => {
+    const barSegment = mount(<BarSegment {...mockProps} scale={100} />);
+
+    expect(barSegment).toContainReactComponent('div', {
+      className: 'Segment RoundedCorners horizontal-small',
+    });
+  });
+
   it('does not round up a 0 scale', () => {
     const barSegment = mount(<BarSegment {...mockProps} scale={0} />);
 

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
@@ -138,14 +138,59 @@ describe('<Chart />', () => {
       expect(barChart.findAll(BarSegment)).toHaveLength(4);
     });
 
-    it('renders 0 bars when given 0', () => {
+    it('renders empty bar when data is empty', () => {
       const lowEdgeProps = {
         data: [],
       };
 
-      const barChart = mount(<SimpleNormalizedChart {...lowEdgeProps} />);
+      const barChart = mountWithProvider(
+        <SimpleNormalizedChart {...lowEdgeProps} />,
+        {
+          themes: {
+            Default: {
+              seriesColors: {
+                empty: '#00A',
+              },
+            },
+          },
+        },
+      );
 
-      expect(barChart.findAll(BarSegment)).toHaveLength(0);
+      const barSegment = barChart.findAll(BarSegment);
+
+      expect(barSegment).toHaveLength(1);
+      expect(barSegment[0].props).toStrictEqual(
+        expect.objectContaining({scale: 100, color: '#00A'}),
+      );
+    });
+
+    it('renders empty bar when all data values are 0 or null', () => {
+      const lowEdgeProps = {
+        data: [
+          {name: 'Bin', data: [{key: 'April 1', value: 0}]},
+          {name: 'Stuff', data: [{key: 'May 1', value: null}]},
+        ],
+      };
+
+      const barChart = mountWithProvider(
+        <SimpleNormalizedChart {...lowEdgeProps} />,
+        {
+          themes: {
+            Default: {
+              seriesColors: {
+                empty: '#00A',
+              },
+            },
+          },
+        },
+      );
+
+      const barSegment = barChart.findAll(BarSegment);
+
+      expect(barSegment).toHaveLength(1);
+      expect(barSegment[0].props).toStrictEqual(
+        expect.objectContaining({scale: 100, color: '#00A'}),
+      );
     });
 
     it('does not render a bar for 0 values', () => {


### PR DESCRIPTION
## What does this implement/fix?

This PR adds an empty state to the `SimpleNormalizedChart` such that the bar is filled with a gray bar if the values of the data are 0. The goal is to have a visual representation of where the data visualization will be once there is data.

This pr also makes changes to the `BarSegment` behaviour such that all corners will be rounded if the scale of the bar is `100` (or full width/height).

~~We also opted to hide the bar if no data was provided since there wouldn't be a legend to support just a gray bar. This mimics the current behaviour.~~

We will now show a gray bar if there isn't any data. For vertical charts, the heigh is determined by the labels, so nothing will be shown since there wouldn't be any labels.

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

[UX Mocks](https://www.figma.com/file/vWNT5aIeEgVsFqPXFTUaUY/Simple-Normalized-empty-state?node-id=0%3A1)


## What do the changes look like?

| Before | After |
| ----- | ---- |
| <img width="716" alt="Screen Shot 2022-06-17 at 4 17 46 PM" src="https://user-images.githubusercontent.com/14793289/174395922-422f45f8-1a26-4d3a-ba33-a6160a4ee7f4.png"> | <img width="883" alt="Screen Shot 2022-06-21 at 7 50 12 PM" src="https://user-images.githubusercontent.com/14793289/174915015-c97bbc7d-85e4-4ac6-a0f2-20b05025ba49.png"> |
| <img width="323" alt="Screen Shot 2022-06-17 at 4 19 22 PM" src="https://user-images.githubusercontent.com/14793289/174396031-7bf7cf0e-a395-447f-b239-a4b0018879ab.png"> | <img width="206" alt="Screen Shot 2022-06-21 at 7 50 36 PM" src="https://user-images.githubusercontent.com/14793289/174915048-a220ddd3-d5ae-4303-8931-8430f296914e.png"> |

**Light theme** 
| Vertical | Horizontal |
| -------- | --------- |
| <img width="878" alt="Screen Shot 2022-06-21 at 7 51 40 PM" src="https://user-images.githubusercontent.com/14793289/174915068-f47368b7-0328-4d5a-9b3e-c48e3f5520cb.png"> |<img width="164" alt="Screen Shot 2022-06-21 at 7 51 48 PM" src="https://user-images.githubusercontent.com/14793289/174915060-8b4cc2c4-e0da-4c02-bfa2-9d172e8ef7be.png"> |


 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
