### PR TITLE
Combo: Render Tooltip

### DIFF
--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -18,6 +18,7 @@ export interface DataSeries {
 export interface DataGroup {
   shape: Shape;
   series: DataSeries[];
+  name?: string;
   yAxisOptions?: YAxisOptions;
 }
 

--- a/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
@@ -7,15 +7,20 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {DataGroup} from '@shopify/polaris-viz-core';
 
+import {flattenDataGroupToDataSeries} from '../../utilities/flattenDataGroupToDataSeries';
+import {TooltipContent} from '../TooltipContent';
 import {getXAxisOptionsWithDefaults} from '../../utilities';
 import {ChartContainer} from '../ChartContainer';
 import {usePrefersReducedMotion} from '../../hooks';
+import type {RenderTooltipContentData} from '../../types';
 
 import {Chart} from './Chart';
+import {formatDataForTooltip} from './utilities/formatDataForTooltip';
 
 export type ComboChartProps = {
   data: DataGroup[];
   isAnimated?: boolean;
+  renderTooltipContent?(data: RenderTooltipContentData): React.ReactNode;
   showLegend?: boolean;
   theme?: string;
   xAxisOptions?: Partial<XAxisOptions>;
@@ -25,6 +30,7 @@ export function ComboChart(props: ComboChartProps) {
   const {
     data,
     isAnimated,
+    renderTooltipContent,
     showLegend = true,
     theme,
     xAxisOptions,
@@ -37,11 +43,28 @@ export function ComboChart(props: ComboChartProps) {
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
 
+  function renderTooltip(tooltipData: RenderTooltipContentData) {
+    if (renderTooltipContent != null) {
+      return renderTooltipContent({
+        ...tooltipData,
+        dataSeries: flattenDataGroupToDataSeries(data),
+      });
+    }
+
+    const {title, formattedData} = formatDataForTooltip({
+      data: tooltipData,
+      xAxisOptions: xAxisOptionsWithDefaults,
+    });
+
+    return <TooltipContent data={formattedData} theme={theme} title={title} />;
+  }
+
   return (
     <ChartContainer theme={theme}>
       <Chart
         data={data}
         isAnimated={isAnimated && !prefersReducedMotion}
+        renderTooltipContent={renderTooltip}
         showLegend={showLegend}
         theme={theme}
         xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/ComboChart/components/ComboLineChart/ComboLineChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/components/ComboLineChart/ComboLineChart.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import {Color, DataGroup, LineSeries} from '@shopify/polaris-viz-core';
 
-import {PointsAndCrosshair} from '../../../LineChart/components';
+import {PointsAndCrosshair} from '../../../LineChart';
 import {useFormatData} from '../../../LineChart/hooks';
 import {getLineChartDataWithDefaults} from '../../../../utilities/getLineChartDataWithDefaults';
 
 interface ComboLineChartProps {
+  activeIndex: number | null;
   colors: Color[];
   data: DataGroup;
   drawableHeight: number;
@@ -17,6 +18,7 @@ interface ComboLineChartProps {
 }
 
 export function ComboLineChart({
+  activeIndex,
   colors,
   data,
   drawableHeight,
@@ -50,7 +52,7 @@ export function ComboLineChart({
         );
       })}
       <PointsAndCrosshair
-        activeIndex={3}
+        activeIndex={activeIndex}
         drawableHeight={drawableHeight}
         emptyState={false}
         isAnimated={isAnimated}

--- a/packages/polaris-viz/src/components/ComboChart/hooks/useComboChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/ComboChart/hooks/useComboChartTooltipContent.ts
@@ -1,0 +1,71 @@
+import {ReactNode, useCallback} from 'react';
+import type {Color, DataGroup, Shape} from '@shopify/polaris-viz-core';
+
+import {flattenDataGroupToDataSeries} from '../../../utilities/flattenDataGroupToDataSeries';
+import {getYAxisOptionsWithDefaults} from '../../../utilities';
+import type {
+  RenderTooltipContentData,
+  RenderTooltipDataPoint,
+} from '../../../types';
+
+export interface Props {
+  data: DataGroup[];
+  seriesColors: Color[];
+  renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+}
+
+export function useComboChartTooltipContent({
+  data,
+  renderTooltipContent,
+  seriesColors,
+}: Props) {
+  return useCallback(
+    (activeIndex: number) => {
+      if (activeIndex === -1) {
+        return null;
+      }
+
+      const tooltipData: RenderTooltipContentData['data'] = [];
+
+      let index = 0;
+
+      data.forEach(({shape, name, series, yAxisOptions}) => {
+        const yAxisOptionsWithDefaults =
+          getYAxisOptionsWithDefaults(yAxisOptions);
+
+        const data: {
+          shape: Shape;
+          data: RenderTooltipDataPoint[];
+          name?: string;
+        } = {
+          shape,
+          name,
+          data: [],
+        };
+
+        series.forEach(({name, data: seriesData, color, isComparison}) => {
+          const {value} = seriesData[activeIndex];
+
+          data.data.push({
+            key: `${name}`,
+            value: yAxisOptionsWithDefaults.labelFormatter(value),
+            color: color ?? seriesColors[index],
+            isComparison,
+          });
+
+          index++;
+        });
+
+        tooltipData.push(data);
+      });
+
+      return renderTooltipContent({
+        data: tooltipData,
+        activeIndex,
+        title: `${data[0].series[0].data[activeIndex].key}`,
+        dataSeries: flattenDataGroupToDataSeries(data),
+      });
+    },
+    [data, seriesColors, renderTooltipContent],
+  );
+}

--- a/packages/polaris-viz/src/components/ComboChart/stories/ComboChart.stories.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/stories/ComboChart.stories.tsx
@@ -47,6 +47,7 @@ const CONTAINER_HEIGHT = 500;
 const DATA: DataGroup[] = [
   {
     shape: 'Bar',
+    name: 'Sales',
     series: [
       {
         name: 'POS',
@@ -83,6 +84,7 @@ const DATA: DataGroup[] = [
   },
   {
     shape: 'Line',
+    name: 'Sessions',
     series: [
       {
         name: 'Sessions from Google ads',

--- a/packages/polaris-viz/src/components/ComboChart/utilities/formatDataForTooltip.ts
+++ b/packages/polaris-viz/src/components/ComboChart/utilities/formatDataForTooltip.ts
@@ -1,0 +1,31 @@
+import type {XAxisOptions} from '@shopify/polaris-viz-core';
+
+import type {TooltipData, RenderTooltipContentData} from '../../../types';
+
+interface Props {
+  data: RenderTooltipContentData;
+  xAxisOptions: Required<XAxisOptions>;
+}
+
+export function formatDataForTooltip({data, xAxisOptions}: Props): {
+  formattedData: TooltipData[];
+  title: string | undefined;
+} {
+  const formattedData = data.data.map((data) => {
+    return {
+      ...data,
+      data: data.data.map((values) => {
+        return {
+          ...values,
+          key: `${values.key}`,
+          value: `${values.value}`,
+        };
+      }),
+    };
+  });
+
+  return {
+    formattedData,
+    title: data.title ? xAxisOptions.labelFormatter(data.title) : undefined,
+  };
+}

--- a/packages/polaris-viz/src/components/LineChart/index.ts
+++ b/packages/polaris-viz/src/components/LineChart/index.ts
@@ -1,2 +1,3 @@
 export {LineChart} from './LineChart';
 export type {LineChartProps} from './LineChart';
+export {PointsAndCrosshair} from './components/PointsAndCrosshair';

--- a/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
@@ -31,7 +31,7 @@ const TOOLTIP_CONTENT = {
         }}
       >
         {data[0].data.map(({key, value}) => (
-          <div>{`${key}: ${formatYAxisLabel(value!)}`}</div>
+          <div>{`${key}: ${formatYAxisLabel(+value!)}`}</div>
         ))}
       </div>
     );

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -18,10 +18,7 @@ import type {
 } from '@shopify/polaris-viz-core';
 
 import {PILL_HEIGHT, Annotations} from '../Annotations';
-import type {
-  RenderTooltipContentData,
-  AnnotationLookupTable,
-} from '../../types';
+import {getVerticalBarChartTooltipPosition} from '../../utilities/getVerticalBarChartTooltipPosition';
 import {useXAxisLabels} from '../../hooks/useXAxisLabels';
 import {XAxis} from '../XAxis';
 import {LegendContainer, useLegend} from '../LegendContainer';
@@ -40,11 +37,7 @@ import {
   TooltipWrapper,
   TOOLTIP_POSITION_DEFAULT_RETURN,
 } from '../TooltipWrapper';
-import {
-  eventPointNative,
-  getStackedValues,
-  getStackedMinMax,
-} from '../../utilities';
+import {getStackedValues, getStackedMinMax} from '../../utilities';
 import {YAxis} from '../YAxis';
 import {HorizontalGridLines} from '../HorizontalGridLines';
 import {
@@ -54,6 +47,10 @@ import {
   useWatchColorVisionEvents,
   useReducedLabelIndexes,
 } from '../../hooks';
+import type {
+  RenderTooltipContentData,
+  AnnotationLookupTable,
+} from '../../types';
 
 import {VerticalBarGroup} from './components';
 import styles from './Chart.scss';
@@ -345,32 +342,15 @@ export function Chart({
     index,
     eventType,
   }: TooltipPositionParams): TooltipPosition {
-    if (eventType === 'mouse' && event) {
-      const point = eventPointNative(event);
-
-      if (point == null) {
-        return TOOLTIP_POSITION_DEFAULT_RETURN;
-      }
-
-      const {svgX, svgY} = point;
-      const currentPoint = svgX - chartXPosition;
-      const activeIndex = Math.floor(currentPoint / xScale.step());
-
-      if (
-        activeIndex < 0 ||
-        activeIndex > sortedData.length - 1 ||
-        svgY <= chartYPosition ||
-        svgY > drawableHeight + Number(Margin.Bottom) + labelHeight
-      ) {
-        return TOOLTIP_POSITION_DEFAULT_RETURN;
-      }
-
-      return formatPositionForTooltip(activeIndex);
-    } else if (index != null) {
-      return formatPositionForTooltip(index);
-    }
-
-    return TOOLTIP_POSITION_DEFAULT_RETURN;
+    return getVerticalBarChartTooltipPosition({
+      tooltipPosition: {event, index, eventType},
+      chartXPosition,
+      formatPositionForTooltip,
+      maxIndex: sortedData.length - 1,
+      step: xScale.step(),
+      yMin: Margin.Top,
+      yMax: drawableHeight + Number(Margin.Bottom) + labelHeight,
+    });
   }
 }
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/hooks/useVerticalBarChart.ts
+++ b/packages/polaris-viz/src/components/VerticalBarChart/hooks/useVerticalBarChart.ts
@@ -1,6 +1,7 @@
 import {DataSeries, useTheme} from '@shopify/polaris-viz-core';
 import {useMemo} from 'react';
 
+import {sortBarChartData} from '../../../utilities/sortBarChartData';
 import {BarMargin} from '../../../types';
 
 import {useXScale} from './useXScale';
@@ -20,11 +21,7 @@ export function useVerticalBarChart({
 }: Props) {
   const selectedTheme = useTheme(theme);
 
-  const sortedData = labels.map((_, index) => {
-    return data
-      .map((type) => type.data[index].value)
-      .filter((value) => value !== null) as number[];
-  });
+  const sortedData = sortBarChartData(labels, data);
 
   const areAllNegative = useMemo(() => {
     return ![...sortedData]

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -21,7 +21,11 @@ export {SkipLink} from './SkipLink';
 export {VisuallyHiddenRows} from './VisuallyHiddenRows';
 export {LinePreview} from './LinePreview';
 export type {LinePreviewProps} from './LinePreview';
-export {TooltipWrapper} from './TooltipWrapper';
+export {
+  TooltipWrapper,
+  TOOLTIP_POSITION_DEFAULT_RETURN,
+} from './TooltipWrapper';
+export type {TooltipPosition, TooltipPositionParams} from './TooltipWrapper';
 export {SimpleBarChart} from './SimpleBarChart';
 export type {SimpleBarChartProps} from './SimpleBarChart';
 export {Legend} from './Legend';

--- a/packages/polaris-viz/src/hooks/useThemeSeriesColorsForDataGroup.ts
+++ b/packages/polaris-viz/src/hooks/useThemeSeriesColorsForDataGroup.ts
@@ -1,4 +1,6 @@
-import type {DataGroup, DataSeries, Theme} from '@shopify/polaris-viz-core';
+import type {DataGroup, Theme} from '@shopify/polaris-viz-core';
+
+import {flattenDataGroupToDataSeries} from '../utilities/flattenDataGroupToDataSeries';
 
 import {useThemeSeriesColors} from './useThemeSeriesColors';
 
@@ -6,9 +8,7 @@ export function useThemeSeriesColorsForDataGroup(
   data: DataGroup[],
   selectedTheme: Theme,
 ) {
-  const series = data.reduce<DataSeries[]>((previous, {series}) => {
-    return previous.concat(series);
-  }, []);
+  const series = flattenDataGroupToDataSeries(data);
 
   return useThemeSeriesColors(series, selectedTheme);
 }

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -1,10 +1,5 @@
 import type {Interpolation, InterpolatorFn} from '@react-spring/web';
-import type {
-  Color,
-  DataPoint,
-  DataSeries,
-  Shape,
-} from '@shopify/polaris-viz-core';
+import type {Color, DataSeries, Shape} from '@shopify/polaris-viz-core';
 import type {Series, SeriesPoint} from 'd3-shape';
 
 export interface YAxisTick {
@@ -65,9 +60,11 @@ export type AnimatedCoordinate = Interpolation<
     }
 >;
 
-export interface RenderTooltipDataPoint extends DataPoint {
+export interface RenderTooltipDataPoint {
   color?: Color;
   isComparison?: boolean;
+  key: number | string;
+  value: number | string | null;
 }
 
 export interface RenderTooltipContentData {

--- a/packages/polaris-viz/src/utilities/flattenDataGroupToDataSeries.ts
+++ b/packages/polaris-viz/src/utilities/flattenDataGroupToDataSeries.ts
@@ -1,0 +1,7 @@
+import type {DataGroup, DataSeries} from '@shopify/polaris-viz-core';
+
+export function flattenDataGroupToDataSeries(data: DataGroup[]) {
+  return data.reduce<DataSeries[]>((previous, {series}) => {
+    return previous.concat(series);
+  }, []);
+}

--- a/packages/polaris-viz/src/utilities/getVerticalBarChartTooltipPosition.ts
+++ b/packages/polaris-viz/src/utilities/getVerticalBarChartTooltipPosition.ts
@@ -1,0 +1,53 @@
+import {TOOLTIP_POSITION_DEFAULT_RETURN} from '../components/';
+import type {TooltipPosition, TooltipPositionParams} from '../components';
+
+import {eventPointNative} from './eventPoint';
+
+interface Props {
+  tooltipPosition: TooltipPositionParams;
+  chartXPosition: number;
+  step: number;
+  maxIndex: number;
+  yMin: number;
+  yMax: number;
+  formatPositionForTooltip: (index: number) => TooltipPosition;
+}
+
+export function getVerticalBarChartTooltipPosition({
+  chartXPosition,
+  formatPositionForTooltip,
+  maxIndex,
+  step,
+  tooltipPosition,
+  yMax,
+  yMin,
+}: Props): TooltipPosition {
+  const {event, index, eventType} = tooltipPosition;
+
+  if (eventType === 'mouse' && event) {
+    const point = eventPointNative(event);
+
+    if (point == null) {
+      return TOOLTIP_POSITION_DEFAULT_RETURN;
+    }
+
+    const {svgX, svgY} = point;
+    const currentPoint = svgX - chartXPosition;
+    const activeIndex = Math.floor(currentPoint / step);
+
+    if (
+      activeIndex < 0 ||
+      activeIndex > maxIndex ||
+      svgY <= yMin ||
+      svgY > yMax
+    ) {
+      return TOOLTIP_POSITION_DEFAULT_RETURN;
+    }
+
+    return formatPositionForTooltip(activeIndex);
+  } else if (index != null) {
+    return formatPositionForTooltip(index);
+  }
+
+  return TOOLTIP_POSITION_DEFAULT_RETURN;
+}

--- a/packages/polaris-viz/src/utilities/sortBarChartData.ts
+++ b/packages/polaris-viz/src/utilities/sortBarChartData.ts
@@ -1,0 +1,9 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+export function sortBarChartData(labels: string[], data: DataSeries[]) {
+  return labels.map((_, index) => {
+    return data
+      .map((type) => type.data[index].value)
+      .filter((value) => value !== null) as number[];
+  });
+}


### PR DESCRIPTION
## What does this implement/fix?

Render `<Tooltip />` when a user interacts with the chart.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1218

## What do the changes look like?

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/149873/175093006-0dbb379f-dd0d-4876-81bf-b65faa0d14bb.png">
 