### PR TITLE
Fix delay calculation

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Sped up `<BarChart/>` animations for large, single series data sets.
 
 ## [4.0.0] - 2022-06-23
 

--- a/packages/polaris-viz/src/components/BarChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/Playground.stories.tsx
@@ -284,3 +284,15 @@ export const SingleSeriesMultipleBars: Story<BarChartProps> = (
 SingleSeriesMultipleBars.args = {
   data: MULTIPLE_BARS_DATA,
 };
+
+export const LotsOfSingleBars: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <div style={{width: 600, height: 400}}>
+      <BarChart {...args} />
+    </div>
+  );
+};
+
+LotsOfSingleBars.args = {
+  data: [DATA[0]],
+};

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -8,6 +8,7 @@ import {
   COLOR_VISION_GROUP_ITEM,
   COLOR_VISION_SINGLE_ITEM,
   BoundingRect,
+  LOAD_ANIMATION_DURATION,
 } from '@shopify/polaris-viz-core';
 import type {
   DataSeries,
@@ -310,8 +311,12 @@ export function Chart({
           ) : (
             sortedData.map((item, index) => {
               const xPosition = xScale(index.toString());
+              const animationDelay =
+                index * (LOAD_ANIMATION_DURATION / sortedData.length);
+
               return (
                 <BarGroup
+                  animationDelay={animationDelay}
                   isAnimated={isAnimated}
                   gapWidth={gapWidth}
                   key={index}

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -23,13 +23,13 @@ import {Bar} from '../Bar';
 import {BAR_SPACING} from '../../constants';
 import {
   MIN_BAR_HEIGHT,
-  LOAD_ANIMATION_DURATION,
   MASK_HIGHLIGHT_COLOR,
   SHAPE_ANIMATION_HEIGHT_BUFFER,
 } from '../../../../constants';
 import styles from '../../Chart.scss';
 
 interface Props {
+  animationDelay: number;
   x: number;
   yScale: ScaleLinear<number, number>;
   width: number;
@@ -46,6 +46,7 @@ interface Props {
 }
 
 export function BarGroup({
+  animationDelay,
   x,
   data,
   yScale,
@@ -135,9 +136,7 @@ export function BarGroup({
                 borderRadius={
                   hasRoundedCorners ? BORDER_RADIUS.Top : BORDER_RADIUS.None
                 }
-                animationDelay={
-                  barGroupIndex * (LOAD_ANIMATION_DURATION / dataLength)
-                }
+                animationDelay={animationDelay}
                 isAnimated={shouldAnimate}
               />
             </g>


### PR DESCRIPTION
## What does this implement/fix?

When we were calculating the delay for BarChart we were using the count for the bars in each series instead of the entire data set. This was causing the delay calculation to always divide by 1 instead of the larger data set length.

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/175962758-a5cbae56-55ec-4016-ab30-e123888c88b8.mp4

**After** 

https://user-images.githubusercontent.com/149873/175962624-225984bf-32f3-4fed-b3e9-48c971fbcd5c.mov

## Storybook link

http://localhost:6006/?path=/story/polaris-viz-charts-barchart-playground--lots-of-single-bars

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
