### PR TITLE
Combo: Round secondary scale to nice number

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -99,6 +99,8 @@ export {
   changeColorOpacity,
   changeGradientOpacity,
   getAverageColor,
+  getClosestDivisibleNumber,
+  roundToDecimals,
 } from './utilities';
 export {
   useSparkBar,

--- a/packages/polaris-viz-core/src/utilities/getClosestDivisibleNumber.ts
+++ b/packages/polaris-viz-core/src/utilities/getClosestDivisibleNumber.ts
@@ -1,0 +1,18 @@
+export function getClosestDivisibleNumber(number: number, divisibleBy: number) {
+  const quotient = parseInt(`${number / divisibleBy}`, 10);
+
+  // 1st possible closest number
+  const n1 = divisibleBy * quotient;
+
+  // 2nd possible closest number
+  const n2 =
+    number * divisibleBy > 0
+      ? divisibleBy * (quotient + 1)
+      : divisibleBy * (quotient - 1);
+
+  if (Math.abs(number - n1) < Math.abs(number - n2)) {
+    return n1;
+  }
+
+  return n2;
+}

--- a/packages/polaris-viz-core/src/utilities/index.ts
+++ b/packages/polaris-viz-core/src/utilities/index.ts
@@ -17,3 +17,5 @@ export {clamp} from './clamp';
 export {getRoundedRectPath} from './getRoundedRectPath';
 export {changeColorOpacity, changeGradientOpacity} from './changeColorOpacity';
 export {getAverageColor} from './getAverageColor';
+export {getClosestDivisibleNumber} from './getClosestDivisibleNumber';
+export {roundToDecimals} from './roundToDecimals';

--- a/packages/polaris-viz-core/src/utilities/roundToDecimals.ts
+++ b/packages/polaris-viz-core/src/utilities/roundToDecimals.ts
@@ -1,0 +1,3 @@
+export function roundToDecimals(number: number, decimals: number) {
+  return parseFloat(number.toFixed(decimals));
+}

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -86,6 +86,7 @@ export function Chart({
     rightTicks,
     secondaryAxis,
     shouldPlaceZeroInMiddleOfChart,
+    ticksBetweenZeroAndMax,
     yScale,
   } = useDualAxisTicks({
     data,
@@ -105,6 +106,7 @@ export function Chart({
     secondaryAxis,
     yScale,
     shouldPlaceZeroInMiddleOfChart,
+    ticksBetweenZeroAndMax,
   });
 
   const horizontalMargin = selectedTheme.grid.horizontalMargin;

--- a/packages/polaris-viz/src/components/ComboChart/hooks/useDualAxisScale.ts
+++ b/packages/polaris-viz/src/components/ComboChart/hooks/useDualAxisScale.ts
@@ -1,4 +1,4 @@
-import {useYScale} from '@shopify/polaris-viz-core';
+import {getClosestDivisibleNumber, useYScale} from '@shopify/polaris-viz-core';
 import type {ScaleLinear} from 'd3-scale';
 
 import type {Axis} from '../types';
@@ -11,6 +11,7 @@ interface Props {
   primaryAxis: Axis;
   secondaryAxis: Axis;
   shouldPlaceZeroInMiddleOfChart: boolean;
+  ticksBetweenZeroAndMax: number;
   yScale: ScaleLinear<number, number>;
 }
 
@@ -21,6 +22,7 @@ export function useDualAxisScale({
   primaryAxis,
   secondaryAxis,
   shouldPlaceZeroInMiddleOfChart,
+  ticksBetweenZeroAndMax,
   yScale,
 }: Props) {
   const {secondaryDrawableHeight, secondaryMax, secondaryMin} =
@@ -37,7 +39,7 @@ export function useDualAxisScale({
     drawableHeight: secondaryDrawableHeight,
     formatYAxisLabel: secondaryAxis.yAxisOptions.labelFormatter,
     integersOnly: secondaryAxis.yAxisOptions.integersOnly,
-    max: secondaryMax,
+    max: getClosestDivisibleNumber(secondaryMax, ticksBetweenZeroAndMax),
     min: secondaryMin,
     // For non-source of truth, the ticks are exactly
     // what they should be, so we don't want to apply .nice()

--- a/packages/polaris-viz/src/components/ComboChart/hooks/useDualAxisTicks.ts
+++ b/packages/polaris-viz/src/components/ComboChart/hooks/useDualAxisTicks.ts
@@ -1,4 +1,8 @@
-import {useYScale} from '@shopify/polaris-viz-core';
+import {
+  getClosestDivisibleNumber,
+  roundToDecimals,
+  useYScale,
+} from '@shopify/polaris-viz-core';
 import type {DataGroup} from '@shopify/polaris-viz-core';
 
 import {getZeroIndex} from '../utilities/getZeroIndex';
@@ -60,21 +64,29 @@ export function useDualAxisTicks({data, drawableHeight}: Props) {
     zeroIndex,
   });
 
-  const secondaryMaxforTicks = Math.abs(
+  let secondaryMaxforTicks = Math.abs(
     doesOneChartContainAllNegativeValues
       ? secondaryAxis.min
       : secondaryAxis.max,
+  );
+
+  // Make the ticks a nice round number between
+  // 0 and max.
+  secondaryMaxforTicks = getClosestDivisibleNumber(
+    secondaryMaxforTicks,
+    ticksBetweenZeroAndMax,
   );
 
   const tickHeight = Math.abs(secondaryMaxforTicks / ticksBetweenZeroAndMax);
 
   const secondaryTicks = ticks.map((tick, index) => {
     const alteredIndex = index - zeroIndex;
+    const formattedValue = roundToDecimals(tickHeight * alteredIndex, 2);
 
     return {
       value: tickHeight * alteredIndex,
       formattedValue: secondaryAxis.yAxisOptions.labelFormatter(
-        `${tickHeight * alteredIndex}`,
+        `${formattedValue}`,
       ),
       yOffset: yScale(tick.value),
     };
@@ -93,5 +105,6 @@ export function useDualAxisTicks({data, drawableHeight}: Props) {
     secondaryAxis,
     yScale,
     shouldPlaceZeroInMiddleOfChart,
+    ticksBetweenZeroAndMax,
   };
 }


### PR DESCRIPTION
## What does this implement/fix?

The secondary `yScale` is generated based on the primary `yScale`. Because of this, the secondary ticks are generated based on the `drawable height / ticks` which results in some long decimal places.

Our new logic will try and find the closest number divisible by the number of current ticks.

We also round axis labels to 2 decimal places incase we can't get a nice number.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/176027023-739a1e00-61ab-4af6-821a-fa8627f9e9a0.png)|![image](https://user-images.githubusercontent.com/149873/176026954-d47d84c8-bc3b-4d9d-a215-77d77774e93b.png)|
