### PR TITLE
Render annotations in StackedAreaChart

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -99,6 +99,7 @@ export {
   changeColorOpacity,
   changeGradientOpacity,
   getAverageColor,
+  getValueFromXScale,
 } from './utilities';
 export {
   useSparkBar,

--- a/packages/polaris-viz-core/src/utilities/getValueFromXScale.ts
+++ b/packages/polaris-viz-core/src/utilities/getValueFromXScale.ts
@@ -1,0 +1,12 @@
+import {ScaleBand, scaleLinear, ScaleLinear} from 'd3-scale';
+
+export function getValueFromXScale(
+  index: number | string,
+  xScale: ScaleLinear<number, number> | ScaleBand<string>,
+) {
+  if (xScale instanceof scaleLinear) {
+    return (xScale as ScaleLinear<number, number>)(Number(index)) ?? 0;
+  }
+
+  return (xScale as ScaleBand<string>)(`${index}`) ?? 0;
+}

--- a/packages/polaris-viz-core/src/utilities/index.ts
+++ b/packages/polaris-viz-core/src/utilities/index.ts
@@ -17,3 +17,4 @@ export {clamp} from './clamp';
 export {getRoundedRectPath} from './getRoundedRectPath';
 export {changeColorOpacity, changeGradientOpacity} from './changeColorOpacity';
 export {getAverageColor} from './getAverageColor';
+export {getValueFromXScale} from './getValueFromXScale';

--- a/packages/polaris-viz-core/src/utilities/stories/getValueFromXScale.stories.mdx
+++ b/packages/polaris-viz-core/src/utilities/stories/getValueFromXScale.stories.mdx
@@ -1,0 +1,33 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks';
+
+import {
+  Divider,
+  Title,
+  UtilitiesHeader,
+} from '../../../../polaris-viz/src/components/Docs/stories/components';
+
+<Meta
+  title="Shared/Utilities/getValueFromXScale"
+  parameters={{
+    viewMode: 'docs',
+    docsOnly: true,
+  }}
+/>
+
+<UtilitiesHeader />
+
+<Title type="h3">
+  <code>getValueFromXScale()</code>
+</Title>
+
+<p>
+  Return a value from xScale regardless of xScale type. Depending on if the
+  scale provided is <code>ScaleLinear</code> or <code>ScaleBand</scale>, the type of index needs to be either <code>string</code> or <code>number</code>.
+</p>
+
+```tsx
+getValueFromXScale(1, xScale);
+
+// Output:
+// 15px
+```

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added `annotations` to `StackedAreaChartProps`.
+
 ### Changed
 
 - Sped up `<BarChart/>` animations for large, single series data sets.

--- a/packages/polaris-viz/src/components/Annotations/Annotations.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.test.tsx
@@ -63,6 +63,7 @@ const ANNOTATIONS: Annotation[] = [
 
 const MOCK_PROPS: AnnotationsProps = {
   annotationsLookupTable: normalizeData(ANNOTATIONS, 'startKey'),
+  axisLabelWidth: 50,
   drawableHeight: 200,
   drawableWidth: 600,
   labels: [

--- a/packages/polaris-viz/src/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo, useState} from 'react';
-import type {ScaleBand} from 'd3-scale';
+import type {ScaleBand, ScaleLinear} from 'd3-scale';
 
 import type {Annotation, AnnotationLookupTable} from '../../types';
 import {useSVGBlurEvent} from '../../hooks/useSVGBlurEvent';
@@ -17,16 +17,18 @@ import {isShowMoreAnnotationsButtonVisible} from './utilities/isShowMoreAnnotati
 
 export interface AnnotationsProps {
   annotationsLookupTable: AnnotationLookupTable;
+  axisLabelWidth: number;
   drawableHeight: number;
   drawableWidth: number;
   labels: string[];
   onHeightChange: (height: number) => void;
   theme: string;
-  xScale: ScaleBand<string>;
+  xScale: ScaleLinear<number, number> | ScaleBand<string>;
 }
 
 export function Annotations({
   annotationsLookupTable,
+  axisLabelWidth,
   drawableHeight,
   drawableWidth,
   labels,
@@ -60,7 +62,7 @@ export function Annotations({
 
   const {hiddenAnnotationsCount, positions, rowCount} = useAnnotationPositions({
     annotations,
-    axisLabelWidth: xScale.bandwidth(),
+    axisLabelWidth,
     dataIndexes,
     drawableWidth,
     isShowingAllAnnotations,
@@ -128,6 +130,7 @@ export function Annotations({
               />
               <AnnotationLabel
                 ariaLabel={ariaLabel}
+                hasContent={hasContent}
                 index={index}
                 isVisible={!isContentVisible}
                 label={annotation.label}

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@shopify/polaris-viz-core/src/utilities', () => ({
 const MOCK_PROPS: AnnotationLabelProps = {
   ariaLabel: 'Aria string',
   index: 0,
+  hasContent: false,
   isVisible: true,
   label: 'Label',
   position: {
@@ -74,14 +75,6 @@ describe('<AnnotationLabel />', () => {
         </svg>,
       );
 
-      expect(chart).toContainReactComponent('line', {
-        x1: 10,
-        x2: 90,
-        y1: 17,
-        y2: 17,
-        strokeWidth: 1,
-      });
-
       expect(chart).toContainReactComponent('button', {
         'aria-label': 'Aria string: Label',
         'aria-describedby': 'annotation-content-0',
@@ -114,6 +107,34 @@ describe('<AnnotationLabel />', () => {
       button?.trigger('onFocus');
 
       expect(MOCK_PROPS.setActiveIndex).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('hasContent', () => {
+    it('renders a line when true', () => {
+      const chart = mount(
+        <svg>
+          <AnnotationLabel {...MOCK_PROPS} hasContent />
+        </svg>,
+      );
+
+      expect(chart).toContainReactComponent('line', {
+        x1: 10,
+        x2: 90,
+        y1: 17,
+        y2: 17,
+        strokeWidth: 1,
+      });
+    });
+
+    it('renders no line when false', () => {
+      const chart = mount(
+        <svg>
+          <AnnotationLabel {...MOCK_PROPS} />
+        </svg>,
+      );
+
+      expect(chart).not.toContainReactComponent('line');
     });
   });
 });

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.tsx
@@ -9,6 +9,7 @@ import styles from './AnnotationLabel.scss';
 
 export interface AnnotationLabelProps {
   ariaLabel: string;
+  hasContent: boolean;
   index: number;
   isVisible: boolean;
   label: string;
@@ -23,6 +24,7 @@ const CONTENT_LINE_OFFSET = 3;
 
 export function AnnotationLabel({
   ariaLabel,
+  hasContent,
   index,
   isVisible,
   label,
@@ -58,15 +60,17 @@ export function AnnotationLabel({
         x={PILL_PADDING}
       />
       <React.Fragment>
-        <line
-          x1={PILL_PADDING}
-          x2={width - PILL_PADDING}
-          y1={PILL_HEIGHT - CONTENT_LINE_OFFSET}
-          y2={PILL_HEIGHT - CONTENT_LINE_OFFSET}
-          stroke={selectedTheme.annotations.textColor}
-          strokeDasharray="1, 3"
-          strokeWidth={1}
-        />
+        {hasContent && (
+          <line
+            x1={PILL_PADDING}
+            x2={width - PILL_PADDING}
+            y1={PILL_HEIGHT - CONTENT_LINE_OFFSET}
+            y2={PILL_HEIGHT - CONTENT_LINE_OFFSET}
+            stroke={selectedTheme.annotations.textColor}
+            strokeDasharray="1, 3"
+            strokeWidth={1}
+          />
+        )}
         <foreignObject
           height={PILL_HEIGHT}
           width={width}

--- a/packages/polaris-viz/src/components/Annotations/hooks/tests/useAnnotationPositions.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/hooks/tests/useAnnotationPositions.test.tsx
@@ -7,6 +7,7 @@ import {useAnnotationPositions, Props} from '../useAnnotationPositions';
 jest.mock('@shopify/polaris-viz-core/src/utilities', () => ({
   ...jest.requireActual('@shopify/polaris-viz-core/src/utilities'),
   estimateStringWidth: jest.fn(() => 50),
+  getValueFromScale: jest.fn(() => 50),
 }));
 
 jest.mock('d3-scale', () => ({

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
@@ -3,8 +3,9 @@ import {
   ChartContext,
   clamp,
   estimateStringWidth,
+  getValueFromXScale,
 } from '@shopify/polaris-viz-core';
-import type {ScaleBand} from 'd3-scale';
+import type {ScaleBand, ScaleLinear} from 'd3-scale';
 
 import {
   COLLAPSED_PILL_COUNT,
@@ -25,7 +26,7 @@ export interface Props {
   drawableWidth: number;
   isShowingAllAnnotations: boolean;
   onHeightChange: (height: number) => void;
-  xScale: ScaleBand<string>;
+  xScale: ScaleLinear<number, number> | ScaleBand<string>;
 }
 
 export function useAnnotationPositions({
@@ -51,7 +52,10 @@ export function useAnnotationPositions({
 
   const {positions, hiddenAnnotationsCount} = useMemo(() => {
     const positions = annotations.map((annotation, dataIndex) => {
-      const xPosition = xScale(dataIndexes[annotation.startKey]) ?? 0;
+      const xPosition = getValueFromXScale(
+        dataIndexes[annotation.startKey],
+        xScale,
+      );
 
       const textWidth = textWidths[dataIndex];
 

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -14,6 +14,7 @@ import {
   THEME_CONTROL_ARGS,
   TYPE_CONTROL_ARGS,
   CHART_STATE_CONTROL_ARGS,
+  ANNOTATIONS_ARGS,
 } from '../../../storybook';
 
 import {generateMultipleSeries} from '../../Docs/utilities';
@@ -153,9 +154,7 @@ export default {
   },
   decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
   argTypes: {
-    annotations: {
-      description: 'An array of annotations to show on the chart.',
-    },
+    annotations: ANNOTATIONS_ARGS,
     data: {
       description:
         'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -65,7 +65,7 @@ jest.mock('../../../utilities', () => {
     getPathLength: () => 0,
     getPointAtLength: () => ({x: 0, y: 0}),
     eventPointNative: () => {
-      return {clientX: 0, clientY: 0, svgX: 0, svgY: 0};
+      return {clientX: 200, clientY: 100, svgX: 200, svgY: 100};
     },
   };
 });
@@ -311,7 +311,7 @@ describe('<Chart />', () => {
           />,
         );
 
-        const pointColor = chart.find(Point).prop('color');
+        const pointColor = chart.find(Point)?.prop('color');
 
         expect(pointColor).toContain('url(#lineChartGradient-');
       });

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -10,16 +10,18 @@ import type {XAxisOptions, YAxisOptions} from '@shopify/polaris-viz-core';
 import {
   getXAxisOptionsWithDefaults,
   getYAxisOptionsWithDefaults,
+  normalizeData,
 } from '../../utilities';
 import {ChartContainer} from '../ChartContainer';
 import {ChartSkeleton} from '../ChartSkeleton';
 import {SkipLink} from '../SkipLink';
-import type {TooltipOptions} from '../../types';
+import type {Annotation, TooltipOptions} from '../../types';
 import {useRenderTooltipContent} from '../../hooks';
 
 import {Chart} from './Chart';
 
 export type StackedAreaChartProps = {
+  annotations?: Annotation[];
   tooltipOptions?: TooltipOptions;
   state?: ChartState;
   errorText?: string;
@@ -32,6 +34,7 @@ export type StackedAreaChartProps = {
 
 export function StackedAreaChart(props: StackedAreaChartProps) {
   const {
+    annotations = [],
     xAxisOptions,
     yAxisOptions,
     data,
@@ -56,6 +59,8 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
   const xAxisOptionsWithDefaults = getXAxisOptionsWithDefaults(xAxisOptions);
   const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
 
+  const annotationsLookupTable = normalizeData(annotations, 'startKey');
+
   return (
     <React.Fragment>
       {skipLinkText == null || skipLinkText.length === 0 ? null : (
@@ -66,6 +71,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
           <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
+            annotationsLookupTable={annotationsLookupTable}
             data={data}
             isAnimated={isAnimated}
             renderTooltipContent={renderTooltip}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
@@ -8,23 +8,24 @@ import {
   COLOR_VISION_SINGLE_ITEM,
   changeColorOpacity,
   changeGradientOpacity,
+  Color,
 } from '@shopify/polaris-viz-core';
+import type {ScaleLinear} from 'd3-scale';
 
 import {Point} from '../../../';
-import type {AnimatedCoordinate} from '../../../../types';
+import type {AnimatedCoordinate, GetXPosition} from '../../../../types';
 import {
   usePrefersReducedMotion,
   useTheme,
   useWatchColorVisionEvents,
 } from '../../../../hooks';
-import {LineChartMargin as Margin, colorWhite} from '../../../../constants';
+import {colorWhite} from '../../../../constants';
 
 interface PointsProps {
   activePointIndex: number | null;
   animatedCoordinates: AnimatedCoordinate[] | null;
-  colors: any;
-  chartStartPosition: number;
-  getXPosition: any;
+  colors: Color[];
+  getXPosition: GetXPosition;
   isAnimated: boolean;
   stackedValues: Series<
     {
@@ -33,8 +34,8 @@ interface PointsProps {
     string
   >[];
   tooltipId: string;
-  xScale: any;
-  yScale: any;
+  xScale: ScaleLinear<number, number>;
+  yScale: ScaleLinear<number, number>;
   theme: string;
 }
 
@@ -42,7 +43,6 @@ export function Points({
   activePointIndex,
   animatedCoordinates,
   colors,
-  chartStartPosition,
   getXPosition,
   isAnimated,
   stackedValues,
@@ -64,7 +64,7 @@ export function Points({
   });
 
   return (
-    <g transform={`translate(${chartStartPosition},${Margin.Top})`}>
+    <React.Fragment>
       {stackedValues.map((_, stackIndex) => {
         if (activePointIndex == null) {
           return null;
@@ -138,6 +138,6 @@ export function Points({
           />
         );
       })}
-    </g>
+    </React.Fragment>
   );
 }

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -9,10 +9,11 @@ import {
   RENDER_TOOLTIP_DESCRIPTION,
   THEME_CONTROL_ARGS,
   CHART_STATE_CONTROL_ARGS,
+  ANNOTATIONS_ARGS,
 } from '../../../storybook';
 
 import {generateMultipleSeries} from '../../Docs/utilities';
-import type {RenderTooltipContentData} from '../../../types';
+import type {Annotation, RenderTooltipContentData} from '../../../types';
 
 import {PageWithSizingInfo} from '../../Docs/stories/components/PageWithSizingInfo';
 
@@ -54,6 +55,7 @@ export default {
   },
   decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
   argTypes: {
+    annotations: ANNOTATIONS_ARGS,
     data: {
       description:
         'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
@@ -167,4 +169,25 @@ export const SeriesColorsUpToFourteen = Template.bind({});
 SeriesColorsUpToFourteen.args = {
   ...DEFAULT_PROPS,
   data: generateMultipleSeries(14),
+};
+
+const ANNOTATIONS: Annotation[] = [
+  {
+    startKey: 'February',
+    label: 'Sales increase',
+  },
+  {
+    startKey: 'May',
+    label: 'Super Big Sale',
+    content: {
+      content: 'We ran a massive sale on our products. We made a lot of money!',
+    },
+  },
+];
+
+export const Annotations: Story<StackedAreaChartProps> = Template.bind({});
+
+Annotations.args = {
+  ...DEFAULT_PROPS,
+  annotations: ANNOTATIONS,
 };

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -15,6 +15,7 @@ import {
 import {mountWithProvider, triggerSVGMouseMove} from '../../../test-utilities';
 import {StackedAreas} from '../components';
 import {Chart, Props} from '../Chart';
+import {Annotations} from '../../Annotations';
 
 jest.mock('@shopify/polaris-viz-core/src/utilities/estimateStringWidth', () => {
   return {
@@ -28,7 +29,7 @@ jest.mock('../../../utilities', () => {
     getPathLength: () => 0,
     getPointAtLength: jest.fn(() => ({x: 0, y: 0})),
     eventPointNative: () => {
-      return {clientX: 0, clientY: 0, svgX: 0, svgY: 0};
+      return {clientX: 100, clientY: 100, svgX: 100, svgY: 100};
     },
   };
 });
@@ -43,6 +44,7 @@ describe('<Chart />', () => {
   });
 
   const mockProps: Props = {
+    annotationsLookupTable: {},
     data: [
       {
         name: 'Asia',
@@ -66,13 +68,14 @@ describe('<Chart />', () => {
       labelFormatter: (value) => `Day ${value}`,
     },
     yAxisOptions: {
-      labelFormatter: (value) => value.toString(),
+      labelFormatter: (value) => `${value}`,
       integersOnly: false,
     },
     dimensions: {width: 500, height: 250},
     isAnimated: true,
     renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
     showLegend: false,
+    theme: 'Default',
   };
 
   it('renders an SVG', () => {
@@ -216,6 +219,26 @@ describe('<Chart />', () => {
       const chart = mount(<Chart {...mockProps} showLegend />);
 
       expect(chart).toContainReactComponent(LegendContainer);
+    });
+  });
+
+  describe('annotationsLookupTable', () => {
+    it('does not render <Annotations /> when false', () => {
+      const chart = mount(<Chart {...mockProps} />);
+      const group = chart.find('g');
+
+      expect(chart).not.toContainReactComponent(Annotations);
+
+      expect(group?.props.transform).toStrictEqual('translate(16,236)');
+    });
+
+    it('renders <LegendContainer /> when true', () => {
+      const chart = mount(<Chart {...mockProps} showLegend />);
+      const group = chart.find('g');
+
+      expect(chart).not.toContainReactComponent(Annotations);
+
+      expect(group?.props.transform).toStrictEqual('translate(16,191)');
     });
   });
 });

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -34,6 +34,7 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
   const {
     alwaysUpdatePosition = false,
     bandwidth = 0,
+    chartBounds,
     focusElementDataType,
     getAlteredPosition,
     getPosition,
@@ -64,6 +65,13 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
       const newPosition = getPosition({event, eventType: 'mouse'});
 
       if (
+        alwaysUpdatePosition &&
+        (newPosition.x < chartBounds.x || newPosition.y < chartBounds.y)
+      ) {
+        return;
+      }
+
+      if (
         !alwaysUpdatePosition &&
         activeIndexRef.current === newPosition.activeIndex
       ) {
@@ -77,7 +85,7 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
       setPosition(newPosition);
       onIndexChange?.(newPosition.activeIndex);
     },
-    [alwaysUpdatePosition, getPosition, onIndexChange],
+    [alwaysUpdatePosition, chartBounds, getPosition, onIndexChange],
   );
 
   const onMouseLeave = useCallback(() => {
@@ -165,7 +173,7 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     <TooltipAnimatedContainer
       activePointIndex={position.activeIndex}
       bandwidth={bandwidth}
-      chartBounds={props.chartBounds}
+      chartBounds={chartBounds}
       currentX={position.x}
       currentY={position.y}
       id={id}

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -18,7 +18,7 @@ import type {
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
 
-import {PILL_HEIGHT, Annotations} from '../Annotations';
+import {Annotations} from '../Annotations';
 import type {
   RenderTooltipContentData,
   AnnotationLookupTable,
@@ -28,6 +28,7 @@ import {BarChartXAxisLabels} from '../BarChartXAxisLabels';
 import {LegendContainer, useLegend} from '../LegendContainer';
 import {GradientDefs} from '../shared';
 import {
+  ANNOTATIONS_LABELS_OFFSET,
   BarChartMargin as Margin,
   LABEL_AREA_TOP_SPACING,
   XMLNS,
@@ -61,8 +62,6 @@ import {BarGroup, StackedBarGroups} from './components';
 import {useXScale} from './hooks';
 import {MIN_Y_LABEL_SPACE} from './constants';
 import styles from './Chart.scss';
-
-const ANNOTATIONS_LABELS_OFFSET = 10;
 
 export interface Props {
   data: DataSeries[];
@@ -99,7 +98,7 @@ export function Chart({
   const [svgRef, setSvgRef] = useState<SVGSVGElement | null>(null);
   const id = useMemo(() => uniqueId('VerticalBarChart'), []);
   const [labelHeight, setLabelHeight] = useState(0);
-  const [annotationsHeight, setAnnotationsHeight] = useState(PILL_HEIGHT);
+  const [annotationsHeight, setAnnotationsHeight] = useState(0);
 
   useWatchColorVisionEvents({
     type: COLOR_VISION_GROUP_ITEM,
@@ -130,12 +129,9 @@ export function Chart({
     dataLength: data[0] ? data[0].data.length : 0,
   });
 
+  const chartYPosition = (Margin.Top as number) + annotationsHeight;
   const drawableHeight =
-    height -
-    annotationsHeight -
-    labelHeight -
-    LABEL_AREA_TOP_SPACING -
-    Margin.Top;
+    height - chartYPosition - labelHeight - LABEL_AREA_TOP_SPACING;
 
   const {min, max} = getStackedMinMax({
     stackedValues,
@@ -165,7 +161,6 @@ export function Chart({
   const horizontalMargin = selectedTheme.grid.horizontalMargin;
   const chartXPosition =
     yAxisLabelWidth + Y_AXIS_CHART_SPACING + horizontalMargin;
-  const chartYPosition = (Margin.Top as number) + annotationsHeight;
   const drawableWidth = width - chartXPosition - horizontalMargin * 2;
   const annotationsDrawableHeight =
     chartYPosition + drawableHeight + ANNOTATIONS_LABELS_OFFSET;
@@ -340,6 +335,7 @@ export function Chart({
           <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
             <Annotations
               annotationsLookupTable={annotationsLookupTable}
+              axisLabelWidth={xScale.bandwidth()}
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={labels}

--- a/packages/polaris-viz/src/constants.ts
+++ b/packages/polaris-viz/src/constants.ts
@@ -69,3 +69,4 @@ export const DEFAULT_LEGEND_HEIGHT = 29;
 export const LEGENDS_TOP_MARGIN = 16;
 export const PREVIEW_ICON_SIZE = 12;
 export const BAR_CONTAINER_TEXT_HEIGHT = 48;
+export const ANNOTATIONS_LABELS_OFFSET = 10;

--- a/packages/polaris-viz/src/storybook/index.ts
+++ b/packages/polaris-viz/src/storybook/index.ts
@@ -49,3 +49,7 @@ export const DATA_ARGS = {
   description:
     'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
 };
+
+export const ANNOTATIONS_ARGS = {
+  description: 'An array of annotations to show on the chart.',
+};

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -146,3 +146,20 @@ export interface Annotation {
 export interface AnnotationLookupTable {
   [key: number]: Annotation;
 }
+
+export type GetXPosition = ({
+  isCrosshair,
+  index,
+}?: {
+  isCrosshair: boolean;
+  index: number | null;
+}) =>
+  | number
+  | Interpolation<
+      | DOMPoint
+      | {
+          x: number;
+          y: number;
+        },
+      number
+    >;


### PR DESCRIPTION
## What does this implement/fix?

Adds vertical annotations to `StackedAreaChart`.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1236

## What do the changes look like?

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/149873/176267754-dc0368c3-8880-4e87-86e5-ad02fe0a0120.png">
 
## Storybook link

http://localhost:6006/?path=/story/polaris-viz-charts-stackedareachart--annotations

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
