### PR TITLE
displays annotations on LineChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `annotations` to `StackedAreaChartProps`.
+- Added `annotations` to `StackedAreaChartProps` and `LineChartProps`
 
 ### Changed
 

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -18,6 +18,7 @@ import {
 import {
   getXAxisOptionsWithDefaults,
   getYAxisOptionsWithDefaults,
+  normalizeData,
 } from '../../utilities';
 import {ChartContainer} from '../../components/ChartContainer';
 import {ChartSkeleton} from '../../components/ChartSkeleton';
@@ -28,11 +29,12 @@ import {
   usePrefersReducedMotion,
   useTheme,
 } from '../../hooks';
-import type {TooltipOptions} from '../../types';
+import type {Annotation, TooltipOptions} from '../../types';
 
 import {Chart} from './Chart';
 
 export type LineChartProps = {
+  annotations?: Annotation[];
   state?: ChartState;
   errorText?: string;
   emptyStateText?: string;
@@ -45,6 +47,7 @@ export type LineChartProps = {
 
 export function LineChart(props: LineChartProps) {
   const {
+    annotations = [],
     data,
     state,
     errorText,
@@ -71,6 +74,7 @@ export function LineChart(props: LineChartProps) {
   const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
 
   const renderTooltip = useRenderTooltipContent({tooltipOptions, theme, data});
+  const annotationsLookupTable = normalizeData(annotations, 'startKey');
 
   const getOpacityByDataLength = (dataLength: number) => {
     if (dataLength <= 4) {
@@ -123,6 +127,7 @@ export function LineChart(props: LineChartProps) {
           <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
+            annotationsLookupTable={annotationsLookupTable}
             data={dataWithDefaults}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
@@ -9,11 +9,12 @@ import {
   RENDER_TOOLTIP_DESCRIPTION,
   THEME_CONTROL_ARGS,
   CHART_STATE_CONTROL_ARGS,
+  ANNOTATIONS_ARGS,
 } from '../../../storybook';
 
 import {generateMultipleSeries} from '../../Docs/utilities';
 import {PageWithSizingInfo} from '../../Docs/stories/components/PageWithSizingInfo';
-import type {RenderTooltipContentData} from '../../../types';
+import type {Annotation, RenderTooltipContentData} from '../../../types';
 
 const TOOLTIP_CONTENT = {
   empty: undefined,
@@ -60,6 +61,7 @@ export default {
     },
   },
   argTypes: {
+    annotations: ANNOTATIONS_ARGS,
     data: {
       description:
         'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
@@ -102,28 +104,33 @@ export default {
   },
 } as Meta;
 
+const DEFAULT_PROPS = {
+  data,
+  skipLinkText: 'Skip chart content',
+  yAxisOptions: {labelFormatter: formatYAxisLabel},
+  isAnimated: true,
+};
+
 const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return <LineChart {...args} />;
 };
 
 export const Default: Story<LineChartProps> = Template.bind({});
 Default.args = {
-  data,
+ ...DEFAULT_PROPS,
   xAxisOptions: {
     labelFormatter: formatXAxisLabel,
   },
-  yAxisOptions: {labelFormatter: formatYAxisLabel},
   showLegend: true,
 };
 
 export const HideXAxisLabels: Story<LineChartProps> = Template.bind({});
 HideXAxisLabels.args = {
-  data,
+  ...DEFAULT_PROPS,
   xAxisOptions: {
     labelFormatter: formatXAxisLabel,
     hide: true,
   },
-  yAxisOptions: {labelFormatter: formatYAxisLabel},
 };
 
 export const NoOverflowStyle: Story<LineChartProps> = Template.bind({});
@@ -222,4 +229,25 @@ export const SeriesColorsUpToFourteen: Story<LineChartProps> = Template.bind(
 
 SeriesColorsUpToFourteen.args = {
   data: generateMultipleSeries(14),
+};
+
+const ANNOTATIONS: Annotation[] = [
+  {
+    startKey: '2020-04-02T12:00:00',
+    label: 'Sales increase',
+  },
+  {
+    startKey: '2020-04-06T12:00:00',
+    label: 'Super Big Sale',
+    content: {
+      content: 'We ran a massive sale on our products. We made a lot of money!',
+    },
+  },
+];
+
+export const Annotations: Story<LineChartProps> = Template.bind({});
+
+Annotations.args = {
+  ...DEFAULT_PROPS,
+  annotations: ANNOTATIONS,
 };

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -19,6 +19,8 @@ import {mockDefaultTheme} from '../../../test-utilities/mountWithProvider';
 import {TooltipAnimatedContainer} from '../../../components/TooltipWrapper';
 import {Chart, ChartProps} from '../Chart';
 import {YAxis} from '../../YAxis';
+import {Annotations} from '../../Annotations';
+import {normalizeData} from '../../../utilities';
 
 const MOCK_DATA: Required<LineChartDataSeriesWithDefaults> = {
   name: 'Primary',
@@ -45,6 +47,7 @@ const yAxisOptions: Required<YAxisOptions> = {
 
 const MOCK_PROPS: ChartProps = {
   data: [MOCK_DATA],
+  annotationsLookupTable: {},
   dimensions: {width: 500, height: 250},
   xAxisOptions,
   yAxisOptions,
@@ -65,7 +68,7 @@ jest.mock('../../../utilities', () => {
     getPathLength: () => 0,
     getPointAtLength: () => ({x: 0, y: 0}),
     eventPointNative: () => {
-      return {clientX: 200, clientY: 100, svgX: 200, svgY: 100};
+      return {clientX: 200, clientY: 200, svgX: 200, svgY: 200};
     },
   };
 });
@@ -377,6 +380,41 @@ describe('<Chart />', () => {
       const chart = mount(<Chart {...MOCK_PROPS} showLegend />);
 
       expect(chart).toContainReactComponent(LegendContainer);
+    });
+  });
+
+  describe('annotationsLookupTable', () => {
+    it('does not render <Annotations /> when empty', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+      const group = chart.find('g');
+
+      expect(chart).not.toContainReactComponent(Annotations);
+
+      expect(group?.props.transform).toStrictEqual('translate(116,222)');
+    });
+
+    it('renders <Annotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '1',
+            label: 'Sales increase',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+      const group = chart.find('g');
+
+      expect(chart).toContainReactComponent(Annotations);
+
+      expect(group?.props.transform).toStrictEqual('translate(116,222)');
     });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

Adds Annotations to `LineChart`


## Does this close any currently open issues?

Resolves #1235 


## What do the changes look like?

<img width="1146" alt="Screen Shot 2022-06-29 at 1 18 26 PM" src="https://user-images.githubusercontent.com/64446645/176537241-000a7ff3-0fd6-456e-a3c3-f5d38151606d.png">
 
## Storybook link

(http://localhost:6006/?path=/story/polaris-viz-charts-linechart--annotations)

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
