### PR TITLE
Fix SimpleBarChart labels on Safari

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -15,6 +15,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Sped up `<BarChart/>` animations for large, single series data sets.
 
+### Fixed
+
+- `<SimpleBarChart/>` label positions on Safari
+
 ## [4.0.0] - 2022-06-23
 
 ### Added

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
@@ -39,26 +39,31 @@ export function Label({
   });
 
   return (
-    <animated.foreignObject
-      height={FONT_SIZE}
-      width={labelWidth}
-      aria-hidden="true"
-      y={y + labelYOffset}
+    // animating the foreignObject does not work on Safari,
+    // so we need to use a g instead
+    <animated.g
       style={{
         opacity: spring.opacity,
         transform: spring.transform,
       }}
     >
-      <div
-        style={{
-          fontSize: `${FONT_SIZE}px`,
-          color,
-          lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-          height: HORIZONTAL_BAR_LABEL_HEIGHT,
-        }}
+      <foreignObject
+        height={FONT_SIZE}
+        width={labelWidth}
+        aria-hidden="true"
+        y={y + labelYOffset}
       >
-        {label}
-      </div>
-    </animated.foreignObject>
+        <div
+          style={{
+            fontSize: `${FONT_SIZE}px`,
+            color,
+            lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
+            height: HORIZONTAL_BAR_LABEL_HEIGHT,
+          }}
+        >
+          {label}
+        </div>
+      </foreignObject>
+    </animated.g>
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

Fixes the position of labels on the SimpleBarChart on Safari.

The issue seems to be caused by Safari not applying CSS transforms on `<foreignObject>` properly. To solve it, I've moved the transform translate to a wrapping `<g>` tag

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="1277" alt="Screen Shot 2022-06-30 at 9 37 31 AM" src="https://user-images.githubusercontent.com/4037781/176691587-f2f50b00-073f-4576-9f7d-a16c89b27d3a.png">   |  <img width="1302" alt="Screen Shot 2022-06-30 at 9 37 45 AM" src="https://user-images.githubusercontent.com/4037781/176691567-79cef759-c91e-4796-9732-822d596d5012.png">

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
