### PR TITLE
fixes funnelChart labels in Safari

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -18,6 +18,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - `<SimpleBarChart/>` label positions on Safari
+- `FunnelChart` labels in Safari
 
 ## [4.0.0] - 2022-06-23
 

--- a/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
@@ -43,32 +43,37 @@ export function Label({
   const fontSize = FONT_SIZES[size];
 
   return (
-    <foreignObject
-      height={LABEL_HEIGHT}
-      width={labelWidth}
-      aria-hidden="true"
-      y={y + labelYOffset}
+    /* To display labels correctly in Safari, we need to wrap foreignObject in group element
+    and apply the transform property on the group element. */
+    <g
       style={{
         transform: `translateX(${x}px)`,
       }}
     >
-      <div
-        className={styles.Label}
-        style={{
-          fontSize: `${fontSize}px`,
-          color,
-          lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-          height: HORIZONTAL_BAR_LABEL_HEIGHT,
-        }}
+      <foreignObject
+        height={LABEL_HEIGHT}
+        width={labelWidth}
+        aria-hidden="true"
+        y={y + labelYOffset}
       >
-        <span
+        <div
+          className={styles.Label}
           style={{
-            backgroundColor,
+            fontSize: `${fontSize}px`,
+            color,
+            lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
+            height: HORIZONTAL_BAR_LABEL_HEIGHT,
           }}
         >
-          {label}
-        </span>
-      </div>
-    </foreignObject>
+          <span
+            style={{
+              backgroundColor,
+            }}
+          >
+            {label}
+          </span>
+        </div>
+      </foreignObject>
+    </g>
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

Fixes `FunnelChart` labels in Safari


## What do the changes look like?

Before:
<img width="911" alt="Screen Shot 2022-06-30 at 9 24 59 AM" src="https://user-images.githubusercontent.com/64446645/176736659-8962ae3a-e891-4ef6-8046-a3cdd310ccf7.png">


After:
<img width="1080" alt="Screen Shot 2022-06-30 at 10 02 01 AM" src="https://user-images.githubusercontent.com/64446645/176736420-2714f385-6a2e-41b5-89bc-99c14db3ea11.png">


 
## Storybook link

(http://localhost:6006/?path=/docs/polaris-viz-charts-funnelchart--default)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
