### PR TITLE
Zero values consistency

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -179,7 +179,7 @@ export const DEFAULT_THEME: Theme = {
   },
   bar: {
     hasRoundedCorners: true,
-    zeroAsMinHeight: false,
+    zeroValueColor: variables.colorGray80,
   },
   grid: {
     showVerticalLines: false,
@@ -281,7 +281,7 @@ export const LIGHT_THEME: Theme = {
   },
   bar: {
     hasRoundedCorners: true,
-    zeroAsMinHeight: false,
+    zeroValueColor: variables.colorGray70,
   },
   grid: {
     showVerticalLines: false,

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -76,10 +76,7 @@ export interface ArcTheme {
 
 export interface BarTheme {
   hasRoundedCorners: boolean;
-  /**
-   * @deprecated This prop is experimental and not ready for general use. If you want to use this, come talk to us in #polaris-data-viz
-   */
-  zeroAsMinHeight: boolean;
+  zeroValueColor: string;
 }
 
 export interface XAxisTheme {

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -263,6 +263,7 @@ export function Chart({
             xScale={xScale}
             yAxisOptions={yAxisOptions}
             yScale={yScale}
+            areAllNegative={areAllNegative}
           />
         </g>
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/Bar/Bar.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/Bar/Bar.tsx
@@ -6,6 +6,7 @@ import {
   getRoundedRectPath,
 } from '@shopify/polaris-viz-core';
 
+import {ZeroValueLine} from '../../../shared/ZeroValueLine';
 import {BARS_TRANSITION_CONFIG} from '../../../../constants';
 
 import styles from './Bar.scss';
@@ -23,6 +24,7 @@ interface Props {
   borderRadius?: string;
   isAnimated?: boolean;
   role?: string;
+  areAllNegative?: boolean;
 }
 
 export const Bar = React.memo(function Bar({
@@ -38,8 +40,10 @@ export const Bar = React.memo(function Bar({
   width,
   x,
   zeroPosition,
+  areAllNegative,
 }: Props) {
   const treatAsNegative = rawValue < 0 || rawValue === 0;
+  const zeroValue = rawValue === 0;
 
   const yPosition = useMemo(() => {
     return treatAsNegative ? zeroPosition + height : zeroPosition - height;
@@ -81,18 +85,27 @@ export const Bar = React.memo(function Bar({
       }}
       aria-hidden="true"
     >
-      <path
-        data-id={`bar-${index}`}
-        data-index={index}
-        data-type={DataType.Bar}
-        d={path}
-        fill={color}
-        aria-label={ariaLabel}
-        role={role}
-        style={style}
-        className={styles.Bar}
-        aria-hidden="true"
-      />
+      {!zeroValue ? (
+        <path
+          data-id={`bar-${index}`}
+          data-index={index}
+          data-type={DataType.Bar}
+          d={path}
+          fill={color}
+          aria-label={ariaLabel}
+          role={role}
+          style={style}
+          className={styles.Bar}
+          aria-hidden="true"
+        />
+      ) : (
+        <ZeroValueLine
+          x={x + width / 2}
+          y={yPosition}
+          direction="vertical"
+          areAllNegative={areAllNegative}
+        />
+      )}
     </animated.g>
   );
 });

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/Bar/tests/Bar.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/Bar/tests/Bar.test.tsx
@@ -89,4 +89,16 @@ describe('<Bar/>', () => {
       });
     });
   });
+
+  describe('zero value', () => {
+    it('renders a line component when passed value is zero', () => {
+      const bar = mount(
+        <svg>
+          <Bar {...defaultProps} rawValue={0} />
+        </svg>,
+      );
+
+      expect(bar).toContainReactComponent('line');
+    });
+  });
 });

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -50,7 +50,6 @@ describe('<BarGroup/>', () => {
     ariaLabel: 'Aria Label',
     hasRoundedCorners: false,
     isSubdued: false,
-    zeroAsMinHeight: false,
     isAnimated: false,
     gapWidth: 10,
   };
@@ -93,44 +92,6 @@ describe('<BarGroup/>', () => {
     expect(barGroup).toContainReactComponent('rect', {x: 35});
     expect(barGroup).toContainReactComponent('rect', {x: 60});
     expect(barGroup).toContainReactComponent('rect', {x: 85});
-  });
-
-  describe('zeroAsMinHeight', () => {
-    it('passes the min bar height to 0 bars if true', () => {
-      const barGroup = mount(
-        <svg>
-          <BarGroup {...mockProps} zeroAsMinHeight data={[0]} />,
-        </svg>,
-      );
-
-      const barHeight = barGroup.find(Bar)!.props.height;
-
-      expect(barHeight).toBe(MIN_BAR_HEIGHT);
-    });
-
-    it('does not pass the min bar height to 0 bars if false', () => {
-      const barGroup = mount(
-        <svg>
-          <BarGroup {...mockProps} zeroAsMinHeight={false} data={[0]} />,
-        </svg>,
-      );
-
-      const barHeight = barGroup.find(Bar)!.props.height;
-
-      expect(barHeight).toBe(0);
-    });
-
-    it('passes the min bar height to non-zero bar if false', () => {
-      const barGroup = mount(
-        <svg>
-          <BarGroup {...mockProps} data={[1, 500]} zeroAsMinHeight={false} />,
-        </svg>,
-      );
-
-      const barHeight = barGroup.find(Bar)!.props.height;
-
-      expect(barHeight).toBe(MIN_BAR_HEIGHT);
-    });
   });
 
   describe('colors', () => {

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
@@ -31,6 +31,7 @@ interface VerticalBarGroupProps {
   yAxisOptions: Required<YAxisOptions>;
   yScale: ScaleLinear<number, number>;
   indexOffset?: number;
+  areAllNegative?: boolean;
 }
 
 export function VerticalBarGroup({
@@ -48,6 +49,7 @@ export function VerticalBarGroup({
   xScale,
   yScale,
   yAxisOptions,
+  areAllNegative,
 }: VerticalBarGroupProps) {
   const selectedTheme = useTheme(theme);
 
@@ -116,7 +118,7 @@ export function VerticalBarGroup({
             width={xScale.bandwidth()}
             x={xPosition == null ? 0 : xPosition}
             yScale={yScale}
-            zeroAsMinHeight={selectedTheme.bar.zeroAsMinHeight}
+            areAllNegative={areAllNegative}
           />
         );
       })}

--- a/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
@@ -10,6 +10,8 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {Direction} from '@shopify/polaris-viz-core';
 
+import {ZeroValueLine} from '../ZeroValueLine';
+
 import styles from './Bar.scss';
 
 export interface BarProps {
@@ -72,21 +74,29 @@ export const Bar = React.memo(function Bar({
       role="img"
       aria-label={ariaLabel}
     >
-      <animated.path
-        d={spring.pathD}
-        data-id={`bar-${index}`}
-        data-index={index}
-        data-type={DataType.Bar}
-        fill={color}
-        aria-hidden="true"
-        style={{
-          transform: `translate(${x}px, ${y}px) ${transform}`,
-          opacity: isActive
-            ? COLOR_VISION_ACTIVE_OPACITY
-            : COLOR_VISION_FADED_OPACITY,
-        }}
-        className={styles.Bar}
-      />
+      {width !== 0 ? (
+        <animated.path
+          d={spring.pathD}
+          data-id={`bar-${index}`}
+          data-index={index}
+          data-type={DataType.Bar}
+          fill={color}
+          aria-hidden="true"
+          style={{
+            transform: `translate(${x}px, ${y}px) ${transform}`,
+            opacity: isActive
+              ? COLOR_VISION_ACTIVE_OPACITY
+              : COLOR_VISION_FADED_OPACITY,
+          }}
+          className={styles.Bar}
+        />
+      ) : (
+        <ZeroValueLine
+          x={x}
+          y={y + height / 2}
+          direction={animationDirection}
+        />
+      )}
     </g>
   );
 });

--- a/packages/polaris-viz/src/components/shared/Bar/tests/Bar.test.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/tests/Bar.test.tsx
@@ -36,3 +36,14 @@ describe('<Bar />', () => {
     );
   });
 });
+
+describe('Zero Value', () => {
+  it('renders a line component when passed value is zero', () => {
+    const bar = mount(
+      <svg>
+        <Bar {...MOCK_PROPS} width={0} />
+      </svg>,
+    );
+    expect(bar).toContainReactComponent('line');
+  });
+});

--- a/packages/polaris-viz/src/components/shared/ZeroValueLine/ZeroValueLine.test.tsx
+++ b/packages/polaris-viz/src/components/shared/ZeroValueLine/ZeroValueLine.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+
+import {ZERO_VALUE_LINE_HEIGHT} from '../../../constants';
+
+import {ZeroValueLine, ZeroValueLineProps} from './ZeroValueLine';
+
+const MOCK_PROPS: ZeroValueLineProps = {
+  x: 10,
+  y: 20,
+  direction: 'vertical',
+  theme: 'Default',
+};
+
+describe('<ZeroValueLine />', () => {
+  it('renders a line', () => {
+    const chart = mount(
+      <svg>
+        <ZeroValueLine {...MOCK_PROPS} />
+      </svg>,
+    );
+
+    expect(chart).toContainReactComponent('line', {
+      strokeWidth: '1',
+    });
+  });
+
+  describe('direction', () => {
+    it('renders a vertical line when vertical', () => {
+      const chart = mount(
+        <svg>
+          <ZeroValueLine {...MOCK_PROPS} />
+        </svg>,
+      );
+
+      expect(chart).toContainReactComponent('line', {
+        x1: 10,
+        x2: 10,
+        y1: 20,
+        y2: 20 - ZERO_VALUE_LINE_HEIGHT,
+      });
+    });
+
+    it('renders a horizontal line when horizontal', () => {
+      const chart = mount(
+        <svg>
+          <ZeroValueLine {...MOCK_PROPS} direction="horizontal" />
+        </svg>,
+      );
+
+      expect(chart).toContainReactComponent('line', {
+        x1: 10,
+        x2: 10 + ZERO_VALUE_LINE_HEIGHT,
+        y1: 20,
+        y2: 20,
+      });
+    });
+  });
+});

--- a/packages/polaris-viz/src/components/shared/ZeroValueLine/ZeroValueLine.tsx
+++ b/packages/polaris-viz/src/components/shared/ZeroValueLine/ZeroValueLine.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {useTheme, Direction} from '@shopify/polaris-viz-core';
+
+import {ZERO_VALUE_LINE_HEIGHT} from '../../../constants';
+
+export interface ZeroValueLineProps {
+  x: number;
+  y: number;
+  areAllNegative?: boolean;
+  theme?: string;
+  direction?: Direction;
+}
+
+function getZeroValueLineCoords({
+  x,
+  y,
+  direction,
+  areAllNegative,
+}: ZeroValueLineProps) {
+  if (direction === 'vertical') {
+    return {
+      x1: x,
+      x2: x,
+      y1: y,
+      y2: !areAllNegative
+        ? y - ZERO_VALUE_LINE_HEIGHT
+        : y + ZERO_VALUE_LINE_HEIGHT,
+    };
+  }
+
+  return {
+    x1: x,
+    x2: !areAllNegative
+      ? x + ZERO_VALUE_LINE_HEIGHT
+      : x - ZERO_VALUE_LINE_HEIGHT,
+    y1: y,
+    y2: y,
+  };
+}
+
+export function ZeroValueLine({
+  x,
+  y,
+  theme,
+  direction = 'vertical',
+  areAllNegative,
+}: ZeroValueLineProps) {
+  const selectedTheme = useTheme(theme);
+
+  return (
+    <React.Fragment>
+      <line
+        stroke={selectedTheme.bar.zeroValueColor}
+        strokeWidth="1"
+        {...getZeroValueLineCoords({x, y, direction, areAllNegative})}
+      />
+    </React.Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/shared/ZeroValueLine/index.ts
+++ b/packages/polaris-viz/src/components/shared/ZeroValueLine/index.ts
@@ -1,0 +1,1 @@
+export {ZeroValueLine} from './ZeroValueLine';

--- a/packages/polaris-viz/src/constants.ts
+++ b/packages/polaris-viz/src/constants.ts
@@ -75,3 +75,4 @@ export const COLLAPSED_ANNOTATIONS_COUNT = 3;
 export const MAX_ANIMATED_SERIES_LENGTH = 1000;
 export const PREVIEW_ICON_SIZE = 12;
 export const ARC_PAD_ANGLE = 0.02;
+export const ZERO_VALUE_LINE_HEIGHT = 6;


### PR DESCRIPTION
## What does this implement/fix?

Zero value bars are represented by a gray tick mark in the center of where the bar would normally go.


## Does this close any currently open issues?

Resolves #1253 

## What do the changes look like?

Before:
<img width="675" alt="Screen Shot 2022-07-06 at 9 48 04 AM" src="https://user-images.githubusercontent.com/64446645/177608727-86e17813-c678-42de-951c-424b0319766e.png">
<img width="654" alt="Screen Shot 2022-07-06 at 9 48 23 AM" src="https://user-images.githubusercontent.com/64446645/177608781-2e18d89b-4fa8-4d8e-9cec-e85ed1417d9c.png">

After:
<img width="626" alt="Screen Shot 2022-07-06 at 9 49 01 AM" src="https://user-images.githubusercontent.com/64446645/177608833-f08b9c33-c1b0-4352-81e7-75b4759105f9.png">
<img width="643" alt="Screen Shot 2022-07-06 at 9 49 23 AM" src="https://user-images.githubusercontent.com/64446645/177608902-532ce35f-dc0b-4512-9bb2-d87901e2977e.png">
<img width="629" alt="Screen Shot 2022-07-08 at 10 07 01 AM" src="https://user-images.githubusercontent.com/64446645/178039642-be95204b-5534-4665-85e6-60d2fcad5ed7.png">


 
## Storybook link

🎩 http://localhost:6006/?path=/docs/polaris-viz-charts-barchart--default 


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
