### PR TITLE
Use correct colors in AnnotationContent

### DIFF
--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
@@ -102,7 +102,7 @@ export function AnnotationContent({
         {title != null && (
           <p
             className={styles.Title}
-            style={{color: selectedTheme.annotations.titleColor}}
+            style={{color: selectedTheme.tooltip.textColor}}
             role="heading"
             aria-level={2}
           >
@@ -111,7 +111,7 @@ export function AnnotationContent({
         )}
         <p
           className={styles.Content}
-          style={{color: selectedTheme.annotations.textColor}}
+          style={{color: selectedTheme.tooltip.textColor}}
           data-is-annotation-content
         >
           {content}


### PR DESCRIPTION
## What does this implement/fix?

The colors used in `<AnnotationContent />` were wrong and should be consistent with tooltips.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/177617763-3207a1f2-0cbe-4ef3-9dc6-c604d27598e9.png)|![image](https://user-images.githubusercontent.com/149873/177617645-1736dcdf-56e2-4f6f-a055-a60b829996d0.png)|
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

