### PR TITLE
Add yAxis Annotations to LineChart & StackedAreaChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Added loading and error states to `<DonutChart/>`.
 - Added `type` prop to `<ChartSkeleton/>`.
+- Added yAxis annotations to `<LineChart />` & `<StackedAreaChart />`;
 
 ## [5.0.0] - 2022-07-07
 

--- a/packages/polaris-viz/src/components/Annotations/index.ts
+++ b/packages/polaris-viz/src/components/Annotations/index.ts
@@ -14,3 +14,4 @@ export type {AnnotationPosition} from './types';
 export {ShowMoreAnnotationsButton} from './components/ShowMoreAnnotationsButton';
 export {useShowMoreAnnotationsButton} from './hooks/useShowMoreAnnotationsButton';
 export {checkForHorizontalSpace} from './utilities/checkForHorizontalSpace';
+export {checkAvailableAnnotations} from './utilities/checkAvailableAnnotations';

--- a/packages/polaris-viz/src/components/Annotations/utilities/checkAvailableAnnotations.ts
+++ b/packages/polaris-viz/src/components/Annotations/utilities/checkAvailableAnnotations.ts
@@ -1,0 +1,12 @@
+import type {AnnotationLookupTable} from 'types';
+
+export function checkAvailableAnnotations(
+  annotationsLookupTable: AnnotationLookupTable,
+) {
+  const values = Object.values(annotationsLookupTable);
+
+  return {
+    hasXAxisAnnotations: values.some(({axis}) => axis === 'x'),
+    hasYAxisAnnotations: values.some(({axis}) => axis === 'y'),
+  };
+}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -15,6 +15,7 @@ import type {
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
 
+import {checkAvailableAnnotations} from '../../components/Annotations';
 import {useFormattedLabels} from '../../hooks/useFormattedLabels';
 import type {
   RenderTooltipContentData,
@@ -206,7 +207,9 @@ export function Chart({
     y: 0,
   };
 
-  const hasAnnotations = Object.keys(annotationsLookupTable).length > 0;
+  const {hasXAxisAnnotations, hasYAxisAnnotations} = checkAvailableAnnotations(
+    annotationsLookupTable,
+  );
 
   const labels = useFormattedLabels({
     data,
@@ -301,29 +304,30 @@ export function Chart({
           })}
         </g>
 
-        {hasAnnotations && (
-          <React.Fragment>
-            <g transform={`translate(${chartXPosition}, ${0})`}>
-              <HorizontalBarChartXAnnotations
-                annotationsLookupTable={annotationsLookupTable}
-                drawableHeight={annotationsDrawableHeight}
-                drawableWidth={drawableWidth}
-                onHeightChange={setAnnotationsHeight}
-                theme={theme}
-                xScale={xScale}
-              />
-            </g>
-            <g transform={`translate(${chartXPosition}, ${chartYPosition})`}>
-              <HorizontalBarChartYAnnotations
-                annotationsLookupTable={annotationsLookupTable}
-                drawableWidth={drawableWidth}
-                groupHeight={groupHeight}
-                labels={labels}
-                theme={theme}
-                zeroPosition={zeroPosition}
-              />
-            </g>
-          </React.Fragment>
+        {hasXAxisAnnotations && (
+          <g transform={`translate(${chartXPosition}, ${0})`}>
+            <HorizontalBarChartXAnnotations
+              annotationsLookupTable={annotationsLookupTable}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              onHeightChange={setAnnotationsHeight}
+              theme={theme}
+              xScale={xScale}
+            />
+          </g>
+        )}
+
+        {hasYAxisAnnotations && (
+          <g transform={`translate(${chartXPosition}, ${chartYPosition})`}>
+            <HorizontalBarChartYAnnotations
+              annotationsLookupTable={annotationsLookupTable}
+              drawableWidth={drawableWidth}
+              groupHeight={groupHeight}
+              labels={labels}
+              theme={theme}
+              zeroPosition={zeroPosition}
+            />
+          </g>
         )}
       </svg>
 

--- a/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
@@ -228,12 +228,13 @@ describe('<Chart />', () => {
       );
     });
 
-    it('renders <Annotations /> when provided', () => {
+    it('renders <HorizontalBarChartXAnnotations /> when provided', () => {
       const annotationsLookupTable = normalizeData(
         [
           {
             startKey: '1',
             label: 'Sales increase',
+            axis: 'x',
           },
         ],
         'startKey',
@@ -248,11 +249,62 @@ describe('<Chart />', () => {
       const group = chart.find('g');
 
       expect(chart).toContainReactComponent(HorizontalBarChartXAnnotations);
-      expect(chart).toContainReactComponent(HorizontalBarChartYAnnotations);
+      expect(chart).not.toContainReactComponent(HorizontalBarChartYAnnotations);
 
       expect(group?.props.transform).toStrictEqual(
         'translate(23.076923076923077, 33)',
       );
+    });
+
+    it('renders <HorizontalBarChartYAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(HorizontalBarChartYAnnotations);
+      expect(chart).not.toContainReactComponent(HorizontalBarChartXAnnotations);
+    });
+
+    it('renders <HorizontalBarChartXAnnotations /> & <HorizontalBarChartYAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '10',
+            label: 'Sales increase',
+            axis: 'x',
+          },
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(HorizontalBarChartYAnnotations);
+      expect(chart).toContainReactComponent(HorizontalBarChartXAnnotations);
     });
   });
 });

--- a/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/LineChart.stories.tsx
@@ -117,7 +117,7 @@ const Template: Story<LineChartProps> = (args: LineChartProps) => {
 
 export const Default: Story<LineChartProps> = Template.bind({});
 Default.args = {
- ...DEFAULT_PROPS,
+  ...DEFAULT_PROPS,
   xAxisOptions: {
     labelFormatter: formatXAxisLabel,
   },
@@ -235,7 +235,7 @@ const ANNOTATIONS: Annotation[] = [
   {
     startKey: '2020-04-02T12:00:00',
     label: 'Sales increase',
-    axis: 'x'
+    axis: 'x',
   },
   {
     startKey: '2020-04-06T12:00:00',
@@ -243,7 +243,20 @@ const ANNOTATIONS: Annotation[] = [
     content: {
       content: 'We ran a massive sale on our products. We made a lot of money!',
     },
-    axis: 'x'
+    axis: 'x',
+  },
+  {
+    startKey: '540',
+    label: 'Sales target',
+    axis: 'y',
+  },
+  {
+    startKey: '300',
+    label: 'Break-even',
+    axis: 'y',
+    content: {
+      content: 'This is our break-even point. We can sell for $10 per unit.',
+    },
   },
 ];
 

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -18,7 +18,7 @@ import {mockDefaultTheme} from '../../../test-utilities/mountWithProvider';
 import {TooltipAnimatedContainer} from '../../../components/TooltipWrapper';
 import {Chart, ChartProps} from '../Chart';
 import {YAxis} from '../../YAxis';
-import {Annotations} from '../../Annotations';
+import {Annotations, YAxisAnnotations} from '../../Annotations';
 import {normalizeData} from '../../../utilities';
 
 const MOCK_DATA: Required<LineChartDataSeriesWithDefaults> = {
@@ -370,6 +370,7 @@ describe('<Chart />', () => {
       const group = chart.find('g', {transform: 'translate(0,8)'});
 
       expect(chart).not.toContainReactComponent(Annotations);
+      expect(chart).not.toContainReactComponent(YAxisAnnotations);
       expect(group).toBeDefined();
     });
 
@@ -379,6 +380,7 @@ describe('<Chart />', () => {
           {
             startKey: '1',
             label: 'Sales increase',
+            axis: 'x',
           },
         ],
         'startKey',
@@ -393,7 +395,59 @@ describe('<Chart />', () => {
       const group = chart.find('g', {transform: 'translate(0,36)'});
 
       expect(chart).toContainReactComponent(Annotations);
+      expect(chart).not.toContainReactComponent(YAxisAnnotations);
       expect(group).toBeDefined();
+    });
+
+    it('renders <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
+      expect(chart).not.toContainReactComponent(Annotations);
+    });
+
+    it('renders <Annotations /> & <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '10',
+            label: 'Sales increase',
+            axis: 'x',
+          },
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
+      expect(chart).toContainReactComponent(Annotations);
     });
   });
 });

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/StackedAreaChart.stories.tsx
@@ -185,6 +185,19 @@ const ANNOTATIONS: Annotation[] = [
     },
     axis: 'x',
   },
+  {
+    startKey: '13000',
+    label: 'Sales target',
+    axis: 'y',
+  },
+  {
+    startKey: '7500',
+    label: 'Break-even',
+    axis: 'y',
+    content: {
+      content: 'This is our break-even point. We can sell for $10 per unit.',
+    },
+  },
 ];
 
 export const Annotations: Story<StackedAreaChartProps> = Template.bind({});

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -15,7 +15,7 @@ import {
 import {mountWithProvider, triggerSVGMouseMove} from '../../../test-utilities';
 import {StackedAreas} from '../components';
 import {Chart, Props} from '../Chart';
-import {Annotations} from '../../Annotations';
+import {Annotations, YAxisAnnotations} from '../../Annotations';
 import {normalizeData} from '../../../utilities';
 
 jest.mock('@shopify/polaris-viz-core/src/utilities/estimateStringWidth', () => {
@@ -35,6 +35,41 @@ jest.mock('../../../utilities', () => {
   };
 });
 
+const MOCK_PROPS: Props = {
+  annotationsLookupTable: {},
+  data: [
+    {
+      name: 'Asia',
+      data: [
+        {key: '1', value: 502},
+        {key: '2', value: 1000},
+      ],
+      color: 'purple',
+    },
+    {
+      name: 'Africa',
+      data: [
+        {key: '1', value: 106},
+        {key: '2', value: 107},
+      ],
+      color: 'teal',
+    },
+  ],
+  xAxisOptions: {
+    hide: false,
+    labelFormatter: (value) => `Day ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `${value}`,
+    integersOnly: false,
+  },
+  dimensions: {width: 500, height: 250},
+  isAnimated: true,
+  renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
+  showLegend: false,
+  theme: 'Default',
+};
+
 describe('<Chart />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -44,48 +79,13 @@ describe('<Chart />', () => {
     jest.useRealTimers();
   });
 
-  const mockProps: Props = {
-    annotationsLookupTable: {},
-    data: [
-      {
-        name: 'Asia',
-        data: [
-          {key: '1', value: 502},
-          {key: '2', value: 1000},
-        ],
-        color: 'purple',
-      },
-      {
-        name: 'Africa',
-        data: [
-          {key: '1', value: 106},
-          {key: '2', value: 107},
-        ],
-        color: 'teal',
-      },
-    ],
-    xAxisOptions: {
-      hide: false,
-      labelFormatter: (value) => `Day ${value}`,
-    },
-    yAxisOptions: {
-      labelFormatter: (value) => `${value}`,
-      integersOnly: false,
-    },
-    dimensions: {width: 500, height: 250},
-    isAnimated: true,
-    renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
-    showLegend: false,
-    theme: 'Default',
-  };
-
   it('renders an SVG', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).toContainReactComponent('svg');
   });
 
   it('renders a YAxis', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).toContainReactComponent(YAxis, {
       ticks: [
         {value: 0, formattedValue: '0', yOffset: 212},
@@ -96,7 +96,7 @@ describe('<Chart />', () => {
   });
 
   it('renders a StackedAreas', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).toContainReactComponent(StackedAreas, {
       colors: ['purple', 'teal'],
       isAnimated: true,
@@ -105,7 +105,7 @@ describe('<Chart />', () => {
   });
 
   it('passes calculated values to StackedAreas', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     const values = chart.find(StackedAreas)!.props.stackedValues;
     expect(values.toString()).toStrictEqual(
       [
@@ -122,13 +122,13 @@ describe('<Chart />', () => {
   });
 
   it('does not have an active Point if there is not an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).not.toContainReactComponent(Point, {visuallyHidden: false});
   });
 
   it('sets an active point and tooltip position on svg mouse or touch interaction', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -141,12 +141,12 @@ describe('<Chart />', () => {
   });
 
   it('does not render a <Crosshair /> if there is no active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).not.toContainReactComponent(Crosshair);
   });
 
   it('renders a <Crosshair /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -154,13 +154,13 @@ describe('<Chart />', () => {
   });
 
   it('does not render a <TooltipAnimatedContainer /> if there is no active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).not.toContainReactComponent(TooltipAnimatedContainer);
   });
 
   it('renders a <TooltipAnimatedContainer /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -168,7 +168,7 @@ describe('<Chart />', () => {
   });
 
   it('renders tooltip content inside a <TooltipWrapper /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -177,19 +177,19 @@ describe('<Chart />', () => {
   });
 
   it('renders <VisuallyHiddenRows />', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).toContainReactComponent(VisuallyHiddenRows, {
-      data: mockProps.data,
-      xAxisLabels: mockProps.data[0].data.map(({key}) =>
-        mockProps.xAxisOptions.labelFormatter(key),
+      data: MOCK_PROPS.data,
+      xAxisLabels: MOCK_PROPS.data[0].data.map(({key}) =>
+        MOCK_PROPS.xAxisOptions.labelFormatter(key),
       ),
     });
   });
 
   it('renders <HorizontalGridLines />', () => {
     const updatedProps = {
-      ...mockProps,
+      ...MOCK_PROPS,
       gridOtions: {horizontalOverflow: true},
     };
     const chart = mount(<Chart {...updatedProps} />);
@@ -199,7 +199,7 @@ describe('<Chart />', () => {
 
   it("doesn't render <HorizontalGridLines /> when theme disables them", () => {
     const chart = mountWithProvider(
-      <Chart {...mockProps} />,
+      <Chart {...MOCK_PROPS} />,
       mockDefaultTheme({grid: {showHorizontalLines: false}}),
     );
 
@@ -208,7 +208,7 @@ describe('<Chart />', () => {
 
   describe('showLegend', () => {
     it('does not render <LegendContainer /> when false', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
       const svg = chart.find('svg');
 
       expect(chart).not.toContainReactComponent(LegendContainer);
@@ -217,7 +217,7 @@ describe('<Chart />', () => {
     });
 
     it('renders <LegendContainer /> when true', () => {
-      const chart = mount(<Chart {...mockProps} showLegend />);
+      const chart = mount(<Chart {...MOCK_PROPS} showLegend />);
 
       expect(chart).toContainReactComponent(LegendContainer);
     });
@@ -225,10 +225,11 @@ describe('<Chart />', () => {
 
   describe('annotationsLookupTable', () => {
     it('does not render <Annotations /> when empty', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
       const group = chart.find('g', {transform: 'translate(0,8)'});
 
       expect(chart).not.toContainReactComponent(Annotations);
+      expect(chart).not.toContainReactComponent(YAxisAnnotations);
       expect(group).toBeDefined();
     });
 
@@ -238,6 +239,7 @@ describe('<Chart />', () => {
           {
             startKey: '1',
             label: 'Sales increase',
+            axis: 'x',
           },
         ],
         'startKey',
@@ -245,14 +247,66 @@ describe('<Chart />', () => {
 
       const chart = mount(
         <Chart
-          {...mockProps}
+          {...MOCK_PROPS}
           annotationsLookupTable={annotationsLookupTable}
         />,
       );
       const group = chart.find('g', {transform: 'translate(0,36)'});
 
       expect(chart).toContainReactComponent(Annotations);
+      expect(chart).not.toContainReactComponent(YAxisAnnotations);
       expect(group).toBeDefined();
+    });
+
+    it('renders <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
+      expect(chart).not.toContainReactComponent(Annotations);
+    });
+
+    it('renders <Annotations /> & <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '10',
+            label: 'Sales increase',
+            axis: 'x',
+          },
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
+      expect(chart).toContainReactComponent(Annotations);
     });
   });
 });

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -16,7 +16,11 @@ import type {
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
 
-import {YAxisAnnotations, Annotations} from '../Annotations';
+import {
+  YAxisAnnotations,
+  Annotations,
+  checkAvailableAnnotations,
+} from '../Annotations';
 import type {
   RenderTooltipContentData,
   AnnotationLookupTable,
@@ -184,7 +188,9 @@ export function Chart({
     seriesColors: barColors,
   });
 
-  const hasAnnotations = Object.keys(annotationsLookupTable).length > 0;
+  const {hasXAxisAnnotations, hasYAxisAnnotations} = checkAvailableAnnotations(
+    annotationsLookupTable,
+  );
 
   return (
     <div className={styles.ChartContainer} style={{height, width}}>
@@ -260,34 +266,35 @@ export function Chart({
           />
         </g>
 
-        {hasAnnotations && (
-          <React.Fragment>
-            <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
-              <Annotations
-                annotationsLookupTable={annotationsLookupTable}
-                axisLabelWidth={xScale.bandwidth()}
-                drawableHeight={annotationsDrawableHeight}
-                drawableWidth={drawableWidth}
-                labels={labels}
-                onHeightChange={setAnnotationsHeight}
-                theme={theme}
-                xScale={xScale}
-              />
-            </g>
-            <g
-              transform={`translate(${chartXPosition},${chartYPosition})`}
-              tabIndex={-1}
-            >
-              <YAxisAnnotations
-                annotationsLookupTable={annotationsLookupTable}
-                drawableHeight={annotationsDrawableHeight}
-                drawableWidth={drawableWidth}
-                theme={theme}
-                ticks={ticks}
-                yScale={yScale}
-              />
-            </g>
-          </React.Fragment>
+        {hasXAxisAnnotations && (
+          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
+            <Annotations
+              annotationsLookupTable={annotationsLookupTable}
+              axisLabelWidth={xScale.bandwidth()}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              labels={labels}
+              onHeightChange={setAnnotationsHeight}
+              theme={theme}
+              xScale={xScale}
+            />
+          </g>
+        )}
+
+        {hasYAxisAnnotations && (
+          <g
+            transform={`translate(${chartXPosition},${chartYPosition})`}
+            tabIndex={-1}
+          >
+            <YAxisAnnotations
+              annotationsLookupTable={annotationsLookupTable}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              theme={theme}
+              ticks={ticks}
+              yScale={yScale}
+            />
+          </g>
         )}
       </svg>
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -9,7 +9,7 @@ import {TooltipAnimatedContainer} from '../../../components/TooltipWrapper';
 import {Chart, Props} from '../Chart';
 import {StackedBarGroups} from '../components';
 import {LegendContainer} from '../../LegendContainer';
-import {Annotations} from '../../Annotations';
+import {Annotations, YAxisAnnotations} from '../../Annotations';
 import {normalizeData} from '../../../utilities';
 
 jest.mock('@shopify/polaris-viz-core/src/utilities', () => {
@@ -27,6 +27,44 @@ jest.mock('../../../utilities/eventPoint', () => {
   };
 });
 
+const renderTooltipContent = () => <p>Mock Tooltip</p>;
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      data: [
+        {key: 'stuff 1', value: 10},
+        {key: 'stuff 2', value: 20},
+        {key: 'stuff 3', value: 30},
+      ],
+      color: 'black',
+      name: 'LABEL1',
+    },
+    {
+      data: [
+        {key: 'stuff 1', value: 10},
+        {key: 'stuff 2', value: 20},
+        {key: 'stuff 3', value: 30},
+      ],
+      color: 'red',
+      name: 'LABEL2',
+    },
+  ],
+  dimensions: {width: 500, height: 250},
+  renderTooltipContent,
+  xAxisOptions: {
+    labelFormatter: jest.fn((value) => `${value}`),
+    hide: false,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `${value}`,
+    integersOnly: false,
+  },
+  type: 'default',
+  showLegend: false,
+  theme: 'Default',
+};
+
 describe('Chart />', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -37,76 +75,38 @@ describe('Chart />', () => {
     jest.useRealTimers();
   });
 
-  const renderTooltipContent = () => <p>Mock Tooltip</p>;
-
-  const mockProps: Props = {
-    data: [
-      {
-        data: [
-          {key: 'stuff 1', value: 10},
-          {key: 'stuff 2', value: 20},
-          {key: 'stuff 3', value: 30},
-        ],
-        color: 'black',
-        name: 'LABEL1',
-      },
-      {
-        data: [
-          {key: 'stuff 1', value: 10},
-          {key: 'stuff 2', value: 20},
-          {key: 'stuff 3', value: 30},
-        ],
-        color: 'red',
-        name: 'LABEL2',
-      },
-    ],
-    dimensions: {width: 500, height: 250},
-    renderTooltipContent,
-    xAxisOptions: {
-      labelFormatter: jest.fn((value) => `${value}`),
-      hide: false,
-    },
-    yAxisOptions: {
-      labelFormatter: (value) => `${value}`,
-      integersOnly: false,
-    },
-    type: 'default',
-    showLegend: false,
-    theme: 'Default',
-  };
-
   it('renders an SVG element', () => {
-    const multiSeriesBarChart = mount(<Chart {...mockProps} />);
+    const multiSeriesBarChart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(multiSeriesBarChart).toContainReactComponent('svg');
   });
 
   it('renders an Labels', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).toContainReactComponent(XAxis);
   });
 
   it('does not render Labels if it is hidden', () => {
     const chart = mount(
       <Chart
-        {...mockProps}
-        xAxisOptions={{...mockProps.xAxisOptions, hide: true}}
+        {...MOCK_PROPS}
+        xAxisOptions={{...MOCK_PROPS.xAxisOptions, hide: true}}
       />,
     );
     expect(chart).not.toContainReactComponent(XAxis);
   });
 
   it('renders an yAxis', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
     expect(chart).toContainReactComponent(YAxis);
   });
 
   it('formats the x axis labels', () => {
     const chart = mount(
       <Chart
-        {...mockProps}
+        {...MOCK_PROPS}
         xAxisOptions={{
-          ...mockProps.xAxisOptions,
+          ...MOCK_PROPS.xAxisOptions,
           labelFormatter: (value) => `${value} pickles`,
         }}
       />,
@@ -118,13 +118,13 @@ describe('Chart />', () => {
   });
 
   it('does not render <TooltipAnimatedContainer /> if there is no active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(chart).not.toContainReactComponent(TooltipAnimatedContainer);
   });
 
   it('renders tooltip content inside a <TooltipAnimatedContainer /> if there is an active point', () => {
-    const chart = mount(<Chart {...mockProps} />);
+    const chart = mount(<Chart {...MOCK_PROPS} />);
 
     triggerSVGMouseMove(chart);
 
@@ -135,7 +135,7 @@ describe('Chart />', () => {
 
   describe('empty state', () => {
     it('does not render tooltip for empty state', () => {
-      const chart = mount(<Chart {...mockProps} data={[]} />);
+      const chart = mount(<Chart {...MOCK_PROPS} data={[]} />);
 
       expect(chart).not.toContainReactText('Mock Tooltip');
       expect(chart).not.toContainReactComponent(TooltipAnimatedContainer);
@@ -144,7 +144,7 @@ describe('Chart />', () => {
 
   describe('<StackedBarGroups />', () => {
     it('renders StackedBarGroups if type is stacked', () => {
-      const chart = mount(<Chart {...mockProps} type="stacked" />);
+      const chart = mount(<Chart {...MOCK_PROPS} type="stacked" />);
 
       expect(chart).toContainReactComponent(StackedBarGroups);
     });
@@ -153,7 +153,7 @@ describe('Chart />', () => {
   describe('gridOptions.showHorizontalLines', () => {
     it('does not render HorizontalGridLines when false', () => {
       const chart = mountWithProvider(
-        <Chart {...mockProps} />,
+        <Chart {...MOCK_PROPS} />,
         mockDefaultTheme({grid: {showHorizontalLines: false}}),
       );
 
@@ -161,7 +161,7 @@ describe('Chart />', () => {
     });
 
     it('renders HorizontalGridLines when true', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
 
       expect(chart).toContainReactComponent(HorizontalGridLines);
     });
@@ -169,7 +169,7 @@ describe('Chart />', () => {
 
   describe('showLegend', () => {
     it('does not render <LegendContainer /> when false', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
       const svg = chart.find('svg');
 
       expect(chart).not.toContainReactComponent(LegendContainer);
@@ -178,7 +178,7 @@ describe('Chart />', () => {
     });
 
     it('renders <LegendContainer /> when true', () => {
-      const chart = mount(<Chart {...mockProps} showLegend />);
+      const chart = mount(<Chart {...MOCK_PROPS} showLegend />);
 
       expect(chart).toContainReactComponent(LegendContainer);
     });
@@ -186,24 +186,76 @@ describe('Chart />', () => {
 
   describe('annotationsLookupTable', () => {
     it('does not render <Annotations /> when empty', () => {
-      const chart = mount(<Chart {...mockProps} />);
+      const chart = mount(<Chart {...MOCK_PROPS} />);
 
       expect(chart).not.toContainReactComponent(Annotations);
+      expect(chart).not.toContainReactComponent(YAxisAnnotations);
     });
 
     it('renders <Annotations /> when not empty', () => {
       const annotationsLookupTable = normalizeData(
-        [{label: '', startIndex: 0}],
+        [{label: '', startIndex: 0, axis: 'x'}],
         'startIndex',
       );
 
       const chart = mount(
         <Chart
-          {...mockProps}
+          {...MOCK_PROPS}
           annotationsLookupTable={annotationsLookupTable}
         />,
       );
 
+      expect(chart).toContainReactComponent(Annotations);
+    });
+
+    it('renders <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
+      expect(chart).not.toContainReactComponent(Annotations);
+    });
+
+    it('renders <Annotations /> & <YAXisAnnotations /> when provided', () => {
+      const annotationsLookupTable = normalizeData(
+        [
+          {
+            startKey: '10',
+            label: 'Sales increase',
+            axis: 'x',
+          },
+          {
+            startKey: '1',
+            label: 'Sales increase',
+            axis: 'y',
+          },
+        ],
+        'startKey',
+      );
+
+      const chart = mount(
+        <Chart
+          {...MOCK_PROPS}
+          annotationsLookupTable={annotationsLookupTable}
+        />,
+      );
+
+      expect(chart).toContainReactComponent(YAxisAnnotations);
       expect(chart).toContainReactComponent(Annotations);
     });
   });

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -36,9 +36,9 @@ export function useLinearLabelsAndDimensions({
   const {characterWidths} = useContext(ChartContext);
 
   const horizontalMargin = selectedTheme.grid.horizontalMargin;
-  let chartStartPosition = yAxisLabelWidth + horizontalMargin;
+  let chartXPosition = yAxisLabelWidth + horizontalMargin;
 
-  let drawableWidth = width - chartStartPosition - horizontalMargin;
+  let drawableWidth = width - chartXPosition - horizontalMargin;
 
   const longestSeriesLastIndex = useMemo(
     () =>
@@ -95,7 +95,7 @@ export function useLinearLabelsAndDimensions({
   }, [drawableWidth, visibleLabelsCount, longestLabelWidth]);
 
   drawableWidth -= labelWidth;
-  chartStartPosition += labelWidth / 2;
+  chartXPosition += labelWidth / 2;
 
   const {xScale} = useLinearXScale({
     drawableWidth,
@@ -103,7 +103,7 @@ export function useLinearLabelsAndDimensions({
   });
 
   return {
-    chartStartPosition,
+    chartXPosition,
     drawableWidth,
     xAxisDetails: {
       labelWidth,


### PR DESCRIPTION
## What does this implement/fix?

Enables yAxis annotations in `<LineChart />` & `<StackedAreaChart />`.

Also splits the rendering of each annotation type and adds better tests.

## What do the changes look like?

![image](https://user-images.githubusercontent.com/149873/177815029-621b6261-a7c6-462a-8910-287f24435005.png)

![image](https://user-images.githubusercontent.com/149873/177815113-aec0f520-d681-46fb-b640-63995a22b7ac.png)

## Storybook link

- [ ] [LineChart](https://6062ad4a2d14cd0021539c1b-zxgsorgdoj.chromatic.com/?path=/story/polaris-viz-charts-linechart--annotations)
- [ ] [StackedAreaChart](https://6062ad4a2d14cd0021539c1b-zxgsorgdoj.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart--annotations)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
