### PR TITLE
Allow yAxis annotations to stack

### DIFF
--- a/packages/polaris-viz/src/components/Annotations/hooks/useYAxisAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useYAxisAnnotationPositions.ts
@@ -107,7 +107,7 @@ export function useYAxisAnnotationPositions({
             const top = current.y;
             const bottom = current.y + PILL_HEIGHT;
 
-            if (next.y > top && next.y < bottom) {
+            if (current.row === next.row && next.y > top && next.y < bottom) {
               next.row = nextRow;
 
               checkAgain = true;


### PR DESCRIPTION
## What does this implement/fix?

Allow yAxis annotations to stack if there's room horizontally on different rows.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/177838952-8ff2fbf8-280c-4eb5-ac82-f83537491d1d.png)|![image](https://user-images.githubusercontent.com/149873/177838828-ccaafea1-e2d0-4ba3-bc03-22962843c055.png)|
 
## Storybook link

http://localhost:6006/?path=/story/polaris-viz-charts-barchart-playground--annotation-mania

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
