### PR TITLE
increases hover target zone for vertical and horizontal charts

### DIFF
--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
@@ -107,7 +107,7 @@ export function VerticalBarGroup({
             data={item}
             gapWidth={gapWidth}
             hasRoundedCorners={selectedTheme.bar.hasRoundedCorners}
-            height={drawableHeight}
+            drawableHeight={drawableHeight}
             indexOffset={indexOffset}
             key={index}
             width={xScale.bandwidth()}

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -10,6 +10,7 @@ import {
   useChartContext,
 } from '@shopify/polaris-viz-core';
 
+import {getHoverZoneOffset} from '../../../utilities';
 import {
   HORIZONTAL_BAR_LABEL_OFFSET,
   HORIZONTAL_GROUP_LABEL_HEIGHT,
@@ -34,6 +35,7 @@ export interface HorizontalBarsProps {
   xScale: ScaleLinear<number, number>;
   zeroPosition: number;
   animationDelay?: number;
+  containerWidth: number;
 }
 
 export function HorizontalBars({
@@ -48,6 +50,7 @@ export function HorizontalBars({
   name,
   xScale,
   zeroPosition,
+  containerWidth,
 }: HorizontalBarsProps) {
   const selectedTheme = useTheme();
   const {characterWidths, theme} = useChartContext();
@@ -75,7 +78,7 @@ export function HorizontalBars({
 
         const {value} = data[seriesIndex].data[groupIndex];
 
-        if (value == null || !value) {
+        if (value == null) {
           return null;
         }
 
@@ -97,6 +100,14 @@ export function HorizontalBars({
           HORIZONTAL_SPACE_BETWEEN_SINGLE * seriesIndex;
         const negativeX = (width + leftLabelOffset) * -1;
         const x = isNegative ? negativeX : width + HORIZONTAL_BAR_LABEL_OFFSET;
+
+        const {clampedSize} = getHoverZoneOffset({
+          barSize: width,
+          zeroPosition: xScale(0),
+          max: containerWidth - x,
+          position: 'horizontal',
+          isNegative: value < 0,
+        });
 
         return (
           <React.Fragment key={`series-${seriesIndex}-${id}-${name}`}>
@@ -131,7 +142,7 @@ export function HorizontalBars({
               className={styles.Bar}
               x={0}
               y={y - HORIZONTAL_SPACE_BETWEEN_SINGLE / 2}
-              width={width}
+              width={clampedSize}
               height={barHeight + HORIZONTAL_SPACE_BETWEEN_SINGLE}
               fill="transparent"
               style={{transform: isNegative ? 'scaleX(-1)' : ''}}

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -154,6 +154,7 @@ export function HorizontalGroup({
             name={name}
             xScale={xScale}
             zeroPosition={zeroPosition}
+            containerWidth={containerWidth}
           />
         )}
       </g>

--- a/packages/polaris-viz/src/constants.ts
+++ b/packages/polaris-viz/src/constants.ts
@@ -77,3 +77,4 @@ export const ZERO_VALUE_LINE_HEIGHT = 6;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 export const IS_TEST = process.env.NODE_ENV === 'test';
 export const WARN_FOR_DEVELOPMENT = IS_DEVELOPMENT && !IS_TEST;
+export const HOVER_TARGET_ZONE = 48;

--- a/packages/polaris-viz/src/utilities/getHoverZoneOffset.ts
+++ b/packages/polaris-viz/src/utilities/getHoverZoneOffset.ts
@@ -1,0 +1,48 @@
+import {clamp} from '@shopify/polaris-viz-core';
+
+import {HOVER_TARGET_ZONE} from '../constants';
+
+interface Props {
+  barSize: number;
+  zeroPosition: number;
+  max: number;
+  position: 'vertical' | 'horizontal';
+  isNegative: boolean;
+}
+
+export function getHoverZoneOffset({
+  barSize,
+  zeroPosition,
+  max,
+  isNegative,
+  position,
+}: Props) {
+  let offset = HOVER_TARGET_ZONE;
+  const chartMaxSize = max - zeroPosition;
+  const chartNegativeMaxSize = max - chartMaxSize;
+  let clampedSize;
+
+  if (position === 'horizontal') {
+    if (barSize + offset >= chartMaxSize) {
+      offset = chartMaxSize - barSize;
+    }
+  } else if (barSize + offset >= chartNegativeMaxSize) {
+    offset = chartNegativeMaxSize - barSize;
+  }
+
+  if (isNegative) {
+    clampedSize = clamp({
+      amount: barSize + offset,
+      min: barSize,
+      max,
+    });
+  } else {
+    clampedSize = clamp({
+      amount: barSize + offset,
+      min: barSize,
+      max: max - zeroPosition,
+    });
+  }
+
+  return {clampedSize, offset};
+}

--- a/packages/polaris-viz/src/utilities/index.ts
+++ b/packages/polaris-viz/src/utilities/index.ts
@@ -16,3 +16,4 @@ export {
   getYAxisOptionsWithDefaults,
   getXAxisOptionsWithDefaults,
 } from './getAxisOptions';
+export {getHoverZoneOffset} from './getHoverZoneOffset';


### PR DESCRIPTION
## What does this implement/fix?

Increases the hover target zone for the vertical  and horizontal bars by 48px.

## Does this close any currently open issues?

Resolves #1273 

## What do the changes look like?

<img width="795" alt="Screen Shot 2022-07-18 at 8 47 54 AM" src="https://user-images.githubusercontent.com/64446645/179561728-4d4c85a3-389e-4a6a-8a32-e6de745b04b7.png">

<img width="765" alt="Screen Shot 2022-07-18 at 8 47 35 AM" src="https://user-images.githubusercontent.com/64446645/179561872-72e3b1ec-83bd-4ca2-b4c1-152312f1552f.png">

<img width="1093" alt="Screen Shot 2022-07-18 at 10 22 36 AM" src="https://user-images.githubusercontent.com/64446645/179568211-75ed5a10-b5d1-409e-a272-fbbc2925f44e.png">


 
## Storybook link

🎩 (http://localhost:6006/?path=/docs/polaris-viz-charts-barchart--default)


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
