### PR TITLE
label series start with 1

### DIFF
--- a/packages/polaris-viz/src/components/Docs/utilities/index.ts
+++ b/packages/polaris-viz/src/components/Docs/utilities/index.ts
@@ -39,7 +39,7 @@ export const generateMultipleSeries = (
   return Array(quantity)
     .fill(null)
     .map((_, index) => ({
-      name: `Series ${index}`,
+      name: `Series ${index + 1}`,
       data: generateDataSet(dataSetLength),
     }));
 };


### PR DESCRIPTION
## What does this implement/fix?

Just a quick fix for the storybook. For the Series Colors charts we had labels displayed starting with series 0, I changed it to start with 1 😄  


## What do the changes look like?

Before:
<img width="1126" alt="Screen Shot 2022-07-18 at 9 58 19 AM" src="https://user-images.githubusercontent.com/64446645/179564454-e94798d2-227f-4902-8b4b-b5786b2dbbb2.png">

After:
<img width="1148" alt="Screen Shot 2022-07-18 at 9 58 58 AM" src="https://user-images.githubusercontent.com/64446645/179564488-b9abfcae-6eb6-49c2-8b6d-9b7a9c8b97ed.png">

## Storybook link

http://localhost:6006/?path=/docs/polaris-viz-charts-linechart--series-colors-from-five-to-seven


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
