### PR TITLE
fixes cut off labels for line chart and bar chart

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -152,7 +152,12 @@ export const decorators = [
           NoxAxisLabels: {
             xAxis: {hide: true},
           },
-          NoOverflow: {grid: {horizontalOverflow: false}},
+          NoOverflow: {
+            grid: {horizontalOverflow: false},
+            chartContainer: {
+              padding: '20px',
+            },
+          },
           Positive: {
             bar: {
               color: 'rgb(0, 164, 124)',

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -182,6 +182,9 @@ const NoOverflowStyleTemplate: Story<BarChartProps> = (args: BarChartProps) => {
     <PolarisVizProvider
       themes={{
         Default: {
+          chartContainer: {
+            padding: '20px',
+          },
           grid: {
             horizontalOverflow: false,
             horizontalMargin: 0,
@@ -215,6 +218,9 @@ const WithoutRoundedCornersTemplate: Story<BarChartProps> = (
         Default: {
           bar: {
             hasRoundedCorners: false,
+          },
+          chartContainer: {
+            padding: '20px',
           },
         },
       }}


### PR DESCRIPTION
## What does this implement/fix?

Fixes labels that were cut off for 
- LineChart - No Overflow Style
- BarChart - No Overflow Style
- BarChart - Without Rounded Corners


## Does this close any currently open issues?

Resolves #1268 


## What do the changes look like?
<img width="867" alt="Screen Shot 2022-07-18 at 2 15 38 PM" src="https://user-images.githubusercontent.com/64446645/179619125-0a03e10d-bbf4-462a-92a6-46015ddbdc4b.png">

<img width="901" alt="Screen Shot 2022-07-18 at 2 16 23 PM" src="https://user-images.githubusercontent.com/64446645/179619141-cb5f0649-a6f3-4a96-a51b-01ab49161396.png">
<img width="881" alt="Screen Shot 2022-07-18 at 2 16 42 PM" src="https://user-images.githubusercontent.com/64446645/179619157-87d766ca-6e52-4098-b36f-b2084e3fa6a2.png">

 
## Storybook link
 🎩 
http://localhost:6006/?path=/story/polaris-viz-charts-barchart--no-overflow-style
http://localhost:6006/?path=/story/polaris-viz-charts-barchart--without-rounded-corners
http://localhost:6006/?path=/story/polaris-viz-charts-linechart--no-overflow-style


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
