### PR TITLE
Bump use-debounce to 8.0.2

### DIFF
--- a/packages/polaris-viz/package.json
+++ b/packages/polaris-viz/package.json
@@ -38,7 +38,7 @@
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.3.2",
     "fast-deep-equal": "^3.1.3",
-    "use-debounce": "^3.3.0"
+    "use-debounce": "8.0.2"
   },
   "devDependencies": {
     "@shopify/react-testing": "^3.3.3",

--- a/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
@@ -14,7 +14,7 @@ import {
   usePrevious,
   useTheme,
 } from '@shopify/polaris-viz-core';
-import {useDebouncedCallback} from 'use-debounce/lib';
+import {useDebouncedCallback} from 'use-debounce';
 import type {SkeletonType} from 'components/ChartSkeleton';
 
 import {ChartErrorBoundary} from '../../../ChartErrorBoundary';
@@ -65,7 +65,7 @@ export function ChartDimensions({
     setChartDimensions({width, height});
   }, [entry, previousEntry?.contentRect.width]);
 
-  const [debouncedUpdateDimensions] = useDebouncedCallback(() => {
+  const debouncedUpdateDimensions = useDebouncedCallback(() => {
     updateDimensions();
   }, 100);
 

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/useWatchColorVisionEvents.tsx
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/useWatchColorVisionEvents.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import {useDebouncedCallback} from 'use-debounce/lib';
 import {useChartContext} from '@shopify/polaris-viz-core';
 
 import {useCallbackRef} from '..';
@@ -17,9 +16,7 @@ interface Props {
 }
 
 export function useWatchColorVisionEvents({type, onIndexChange}: Props) {
-  const [debounced] = useDebouncedCallback(onIndexChange, 0);
-
-  const onIndexChangeCallback = useCallbackRef(debounced);
+  const onIndexChangeCallback = useCallbackRef(onIndexChange);
   const {id} = useChartContext();
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20160,10 +20160,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-debounce@^3.3.0:
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/use-debounce/-/use-debounce-3.4.3.tgz"
-  integrity sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==
+use-debounce@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-8.0.2.tgz#bd1b522c7b5b5d9dc249824fd2e4c3e4137b1ea9"
+  integrity sha512-4yCQ4FmlmYNpcHXJk1E19chO1X58fH4+QrwKpa5nkx3d7szHR3MjheRgECLvHivp3ClUqEom+SHOGB9zBz+qlw==
 
 use-subscription@^1.0.0:
   version "1.5.1"


### PR DESCRIPTION
## What does this implement/fix?

When debugging an issue in notebooks, the app was crashing because `use-debounce/lib` could not be found. I'm assuming because notebooks used a newer version.

Bumping the version allows us to link up to notebooks without issue now.

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
