### PR TITLE
Remove top margin from altered tooltip height

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed height calculation from `useLegends()`.
 
 ## [6.0.1] - 2022-07-18
 

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import {mount, Root} from '@shopify/react-testing';
-import type {DataSeries, DataGroup} from '@shopify/polaris-viz-core';
+import {
+  DataSeries,
+  DataGroup,
+  LEGENDS_TOP_MARGIN,
+} from '@shopify/polaris-viz-core';
 
 import {useLegend, Props} from '../useLegend';
 
@@ -61,7 +65,7 @@ describe('useLegend()', () => {
           {name: 'Lunch', shape: 'Bar'},
           {name: 'Dinner', shape: 'Bar'},
         ],
-        height: 100,
+        height: MOCK_PROPS.dimensions!.height - LEGENDS_TOP_MARGIN,
         width: 100,
         isLegendMounted: false,
       });

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
@@ -1,9 +1,10 @@
 import {useMemo, useState} from 'react';
-import type {
+import {
   Color,
   Dimensions,
   DataGroup,
   Direction,
+  LEGENDS_TOP_MARGIN,
 } from '@shopify/polaris-viz-core';
 
 import type {LegendData} from '../../../types';
@@ -18,7 +19,7 @@ function getAlteredDimensions(
   const isHorizontal = direction === 'horizontal';
 
   return {
-    height: isHorizontal ? height - legendsHeight : height,
+    height: isHorizontal ? height - legendsHeight - LEGENDS_TOP_MARGIN : height,
     width: !isHorizontal ? width - legendsWidth : width,
   };
 }


### PR DESCRIPTION
## What does this implement/fix?

When we implemented the new legend positions we forgot to remove the top margin from the new height, which caused the legends to be spaced too low.

NOTE: This will also require tweaks for vertical legends, but it'll require a little bit more work and this is needed to unblock notebooks.

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="1135" alt="image" src="https://user-images.githubusercontent.com/149873/180013139-1d0a0499-64eb-4fdd-8dc6-75a6dea9f019.png">|<img width="1140" alt="image" src="https://user-images.githubusercontent.com/149873/180012988-e3a66685-07a3-47e1-a4a2-52fcb9b74cfb.png">|

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
