### PR TITLE
Apply horizontalMargin to yAxis

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where `grid.horizontalMargin` was not being applied to `<YAxis />` in `<VerticalBarChart />`, `<LineChart />` & `<StackedAreaChart />`;
 
 ## [6.0.2] - 2022-07-20
 

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -63,7 +63,6 @@ export default {
   title: 'polaris-viz/Charts/BarChart',
   component: BarChart,
   parameters: {
-    horizontalMargin: 0,
     docs: {
       page: PageWithSizingInfo,
       description: {

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -191,28 +191,23 @@ export function Chart({
           />
         )}
 
-        <g transform={`translate(${horizontalMargin},0)`} aria-hidden="true">
-          <YAxis
-            ticks={leftTicks}
-            textAlign="right"
-            width={leftTickWidth}
-            theme={theme}
-          />
-        </g>
+        <YAxis
+          ticks={leftTicks}
+          textAlign="right"
+          width={leftTickWidth}
+          theme={theme}
+          x={horizontalMargin}
+          y={0}
+        />
 
-        <g
-          transform={`translate(${
-            chartXPosition + drawableWidth + Y_AXIS_CHART_SPACING
-          },0)`}
-          aria-hidden="true"
-        >
-          <YAxis
-            ticks={rightTicks}
-            textAlign="left"
-            width={rightTickWidth}
-            theme={theme}
-          />
-        </g>
+        <YAxis
+          ticks={rightTicks}
+          textAlign="left"
+          width={rightTickWidth}
+          theme={theme}
+          x={chartXPosition + drawableWidth + Y_AXIS_CHART_SPACING}
+          y={0}
+        />
 
         <g transform={`translate(${chartXPosition},${0})`}>
           <ComboBarChart

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -260,15 +260,15 @@ export function Chart({
           />
         ) : null}
 
-        <g transform={`translate(0,${chartYPosition})`}>
-          <YAxis
-            ticks={ticks}
-            width={yAxisLabelWidth}
-            textAlign="right"
-            theme={theme}
-            ariaHidden
-          />
-        </g>
+        <YAxis
+          ticks={ticks}
+          width={yAxisLabelWidth}
+          textAlign="right"
+          theme={theme}
+          ariaHidden
+          x={selectedTheme.grid.horizontalMargin}
+          y={chartYPosition}
+        />
 
         {emptyState ? null : (
           <VisuallyHiddenRows

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -361,6 +361,19 @@ describe('<Chart />', () => {
     });
   });
 
+  describe('gridOptions.horizontalMargin', () => {
+    it('applies horizontalMargin to chart', () => {
+      const chart = mountWithProvider(
+        <Chart {...MOCK_PROPS} />,
+        mockDefaultTheme({grid: {horizontalMargin: 75}}),
+      );
+
+      expect(chart).toContainReactComponent(YAxis, {
+        x: 75,
+      });
+    });
+  });
+
   describe('showLegend', () => {
     it('does not render <LegendContainer /> when false', () => {
       const chart = mount(<Chart {...MOCK_PROPS} />);

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -257,14 +257,14 @@ export function Chart({
           />
         ) : null}
 
-        <g transform={`translate(0,${chartYPosition})`}>
-          <YAxis
-            ticks={ticks}
-            width={yAxisLabelWidth}
-            textAlign="right"
-            theme={theme}
-          />
-        </g>
+        <YAxis
+          ticks={ticks}
+          width={yAxisLabelWidth}
+          textAlign="right"
+          theme={theme}
+          x={selectedTheme.grid.horizontalMargin}
+          y={chartYPosition}
+        />
 
         <VisuallyHiddenRows
           data={data}

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -185,23 +185,38 @@ describe('<Chart />', () => {
     });
   });
 
-  it('renders <HorizontalGridLines />', () => {
-    const updatedProps = {
-      ...MOCK_PROPS,
-      gridOtions: {horizontalOverflow: true},
-    };
-    const chart = mount(<Chart {...updatedProps} />);
+  describe('gridOptions.showHorizontalLines', () => {
+    it('renders <HorizontalGridLines />', () => {
+      const updatedProps = {
+        ...MOCK_PROPS,
+        gridOtions: {horizontalOverflow: true},
+      };
+      const chart = mount(<Chart {...updatedProps} />);
 
-    expect(chart).toContainReactComponent(HorizontalGridLines);
+      expect(chart).toContainReactComponent(HorizontalGridLines);
+    });
+
+    it("doesn't render <HorizontalGridLines /> when theme disables them", () => {
+      const chart = mountWithProvider(
+        <Chart {...MOCK_PROPS} />,
+        mockDefaultTheme({grid: {showHorizontalLines: false}}),
+      );
+
+      expect(chart).not.toContainReactComponent(HorizontalGridLines);
+    });
   });
 
-  it("doesn't render <HorizontalGridLines /> when theme disables them", () => {
-    const chart = mountWithProvider(
-      <Chart {...MOCK_PROPS} />,
-      mockDefaultTheme({grid: {showHorizontalLines: false}}),
-    );
+  describe('gridOptions.horizontalMargin', () => {
+    it('applies horizontalMargin to chart', () => {
+      const chart = mountWithProvider(
+        <Chart {...MOCK_PROPS} />,
+        mockDefaultTheme({grid: {horizontalMargin: 75}}),
+      );
 
-    expect(chart).not.toContainReactComponent(HorizontalGridLines);
+      expect(chart).toContainReactComponent(YAxis, {
+        x: 75,
+      });
+    });
   });
 
   describe('showLegend', () => {

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -148,9 +148,9 @@ export function Chart({
   }, [characterWidths, initialTicks]);
 
   const horizontalMargin = selectedTheme.grid.horizontalMargin;
-  const chartXPosition =
-    yAxisLabelWidth + Y_AXIS_CHART_SPACING + horizontalMargin;
-  const drawableWidth = width - chartXPosition - horizontalMargin * 2;
+  const yAxisWidth = yAxisLabelWidth + Y_AXIS_CHART_SPACING;
+  const chartXPosition = yAxisWidth + horizontalMargin;
+  const drawableWidth = width - chartXPosition - horizontalMargin;
   const annotationsDrawableHeight =
     chartYPosition + drawableHeight + ANNOTATIONS_LABELS_OFFSET;
 
@@ -237,14 +237,14 @@ export function Chart({
           />
         ) : null}
 
-        <g transform={`translate(0,${chartYPosition})`} aria-hidden="true">
-          <YAxis
-            ticks={ticks}
-            textAlign="right"
-            width={yAxisLabelWidth}
-            theme={theme}
-          />
-        </g>
+        <YAxis
+          ticks={ticks}
+          textAlign="right"
+          width={yAxisLabelWidth}
+          theme={theme}
+          x={chartXPosition - yAxisWidth}
+          y={chartYPosition}
+        />
 
         <g transform={`translate(${chartXPosition},${chartYPosition})`}>
           <VerticalBarGroup

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -167,6 +167,20 @@ describe('Chart />', () => {
     });
   });
 
+  describe('gridOptions.horizontalMargin', () => {
+    it('applies horizontalMargin to chart', () => {
+      const chart = mountWithProvider(
+        <Chart {...MOCK_PROPS} />,
+        mockDefaultTheme({grid: {horizontalMargin: 75}}),
+      );
+
+      expect(chart).toContainReactComponent(YAxis, {
+        x: 75,
+        y: 5,
+      });
+    });
+  });
+
   describe('showLegend', () => {
     it('does not render <LegendContainer /> when false', () => {
       const chart = mount(<Chart {...MOCK_PROPS} />);

--- a/packages/polaris-viz/src/components/YAxis/YAxis.tsx
+++ b/packages/polaris-viz/src/components/YAxis/YAxis.tsx
@@ -8,17 +8,27 @@ interface Props {
   ticks: YAxisTick[];
   textAlign: 'left' | 'right';
   width: number;
+  x: number;
+  y: number;
   ariaHidden?: boolean;
   theme: string;
 }
 
 const PADDING_SIZE = 2;
 
-function Axis({ticks, width, textAlign, theme, ariaHidden = false}: Props) {
+function Axis({
+  ticks,
+  width,
+  textAlign,
+  theme,
+  ariaHidden = false,
+  x,
+  y,
+}: Props) {
   const selectedTheme = useTheme(theme);
 
   return (
-    <React.Fragment>
+    <g transform={`translate(${x},${y})`} aria-hidden="true">
       {ticks.map(({value, formattedValue, yOffset}) => {
         return (
           <foreignObject
@@ -47,7 +57,7 @@ function Axis({ticks, width, textAlign, theme, ariaHidden = false}: Props) {
           </foreignObject>
         );
       })}
-    </React.Fragment>
+    </g>
   );
 }
 

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -36,7 +36,7 @@ export function useLinearLabelsAndDimensions({
   const {characterWidths} = useChartContext();
 
   const horizontalMargin = selectedTheme.grid.horizontalMargin;
-  let chartXPosition = yAxisLabelWidth + horizontalMargin;
+  let chartXPosition = horizontalMargin + yAxisLabelWidth;
 
   let drawableWidth = width - chartXPosition - horizontalMargin;
 


### PR DESCRIPTION
## What does this implement/fix?

We weren't applying a x value to the yAxis in Bar, Line and StackedArea charts. This meant that the `grid.horizontalMargin` was not being applied.

NOTE: We should probably figure out a way to display our charts inside a container so we can visually catch these issues as well as handle them in tests. It's a little too easy to miss these when the chart blends into the background of the story.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/180060356-394cff7e-bd27-4af8-b792-9b24e723c1f2.png)|![image](https://user-images.githubusercontent.com/149873/180060252-ba02b850-80f1-49bc-8c0e-a6664d232244.png)|

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
