### PR TITLE
adds zero line for simple stacked horizontal chart

### DIFF
--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../constants';
 import type {FormattedStackedSeries} from '../../../types';
 import {getGradientDefId} from '..';
+import {ZeroValueLine} from '../ZeroValueLine';
 
 import {StackedBar} from './components';
 import {useStackedGaps} from './hooks';
@@ -120,10 +121,6 @@ export function HorizontalStackedBars({
         const barId = getBarId(id, groupIndex, seriesIndex);
         const width = Math.abs(xScale(end) - xScale(start));
 
-        if (width === 0) {
-          return null;
-        }
-
         const borderRadius = getBorderRadius({
           lastIndexes,
           seriesIndex,
@@ -133,19 +130,33 @@ export function HorizontalStackedBars({
         const key = dataKeys[seriesIndex] ?? '';
         const ariaLabel = `${key} ${end}`;
 
+        const areSomeGreaterThanZero = stackedValues[groupIndex].some(
+          ([start, end]) => start + end > 0,
+        );
+
         return (
-          <StackedBar
-            activeBarIndex={activeBarIndex}
-            ariaLabel={ariaLabel}
-            borderRadius={borderRadius}
-            color={getGradientDefId(theme, seriesIndex, id)}
-            height={barHeight}
-            key={`${name}${barId}`}
-            seriesIndex={seriesIndex}
-            setActiveBarIndex={setActiveBarIndex}
-            width={width}
-            x={x}
-          />
+          <React.Fragment key={`stackedBar ${barId}`}>
+            {!areSomeGreaterThanZero ? (
+              <ZeroValueLine
+                x={x}
+                y={x + barHeight / 2}
+                direction="horizontal"
+              />
+            ) : (
+              <StackedBar
+                activeBarIndex={activeBarIndex}
+                ariaLabel={ariaLabel}
+                borderRadius={borderRadius}
+                color={getGradientDefId(theme, seriesIndex, id)}
+                height={barHeight}
+                key={`${name}${barId}`}
+                seriesIndex={seriesIndex}
+                setActiveBarIndex={setActiveBarIndex}
+                width={width}
+                x={x}
+              />
+            )}
+          </React.Fragment>
         );
       })}
     </animated.g>

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/tests/HorizontalStackedBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/tests/HorizontalStackedBars.test.tsx
@@ -40,7 +40,6 @@ const MOCK_PROPS: HorizontalStackedBarsProps = {
   dataKeys: ['Group 1', 'Group 2', 'Group 3'],
   groupIndex: 0,
   id: 'id',
-  isAnimated: false,
   name: 'stacked',
   stackedValues: STACKED_VALUES as FormattedStackedSeries[],
   xScale: scaleLinear(),
@@ -92,5 +91,47 @@ describe('<HorizontalStackedBars />', () => {
 
     expect(bars[0].props.borderRadius).toStrictEqual(BORDER_RADIUS.None);
     expect(bars[2].props.borderRadius).toStrictEqual(BORDER_RADIUS.Right);
+  });
+});
+
+describe('Zero Value', () => {
+  it('renders a line component when all passed values are zero', () => {
+    const chart = mount(
+      <svg>
+        <HorizontalStackedBars
+          {...MOCK_PROPS}
+          stackedValues={
+            [
+              [
+                [0, 0],
+                [0, 0],
+                [0, 0],
+              ],
+            ] as FormattedStackedSeries[]
+          }
+        />
+      </svg>,
+    );
+    expect(chart).toContainReactComponent('line');
+  });
+
+  it('does not render a line component when at least one passed value is not zero', () => {
+    const chart = mount(
+      <svg>
+        <HorizontalStackedBars
+          {...MOCK_PROPS}
+          stackedValues={
+            [
+              [
+                [0, 0],
+                [1, 0],
+                [0, 0],
+              ],
+            ] as FormattedStackedSeries[]
+          }
+        />
+      </svg>,
+    );
+    expect(chart).not.toContainReactComponent('line');
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

Zero values for simple stacked horizontal chart are displayed as a tick.

## Does this close any currently open issues?

Resolves #679

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="215" alt="Screen Shot 2022-07-26 at 9 39 38 AM" src="https://user-images.githubusercontent.com/64446645/181062543-172445af-e762-4d6d-a1d9-47ae2a6de619.png">|<img width="584" alt="Screen Shot 2022-07-26 at 9 22 03 AM" src="https://user-images.githubusercontent.com/64446645/181062721-cfc8d0ac-7981-4e4f-a377-4e5376229d72.png">|
 
## Storybook link

🎩[Simple Stacked](http://localhost:6006/?path=/story/polaris-viz-charts-simplebarchart--simple-stacked) 


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
