### PR TITLE
display zeroValueLine for negative horizontal bar chart

### DIFF
--- a/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
@@ -28,6 +28,7 @@ export interface BarProps {
   isAnimated?: boolean;
   transform?: string;
   ariaLabel?: string;
+  areAllNegative?: boolean;
 }
 
 export const Bar = React.memo(function Bar({
@@ -44,6 +45,7 @@ export const Bar = React.memo(function Bar({
   x,
   y,
   ariaLabel,
+  areAllNegative,
 }: BarProps) {
   const getPath = useCallback(
     (height = 0, width = 0) => {
@@ -93,6 +95,7 @@ export const Bar = React.memo(function Bar({
           x={x}
           y={y + height / 2}
           direction={animationDirection}
+          areAllNegative={areAllNegative}
         />
       )}
     </g>

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -34,8 +34,9 @@ export interface HorizontalBarsProps {
   name: string;
   xScale: ScaleLinear<number, number>;
   zeroPosition: number;
-  animationDelay?: number;
   containerWidth: number;
+  animationDelay?: number;
+  areAllNegative?: boolean;
 }
 
 export function HorizontalBars({
@@ -51,6 +52,7 @@ export function HorizontalBars({
   xScale,
   zeroPosition,
   containerWidth,
+  areAllNegative,
 }: HorizontalBarsProps) {
   const selectedTheme = useTheme();
   const {characterWidths, theme} = useChartContext();
@@ -122,6 +124,7 @@ export function HorizontalBars({
               width={width}
               x={0}
               y={y}
+              areAllNegative={areAllNegative}
             />
             {isSimple && (
               <Label

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -155,6 +155,7 @@ export function HorizontalGroup({
             xScale={xScale}
             zeroPosition={zeroPosition}
             containerWidth={containerWidth}
+            areAllNegative={areAllNegative}
           />
         )}
       </g>

--- a/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
@@ -157,7 +157,7 @@ describe('useDataForHorizontalChart()', () => {
     expect(data.allNumbers).toStrictEqual([0, 0, 0]);
   });
 
-  it('areAllNegative returns false when all numbers are 0', () => {
+  it('areAllNegative returns true when all numbers are 0', () => {
     function TestComponent() {
       const data = useDataForHorizontalChart({
         ...MOCK_PROPS,
@@ -180,6 +180,6 @@ describe('useDataForHorizontalChart()', () => {
 
     const data = JSON.parse(result.domNode?.dataset.data ?? '');
 
-    expect(data.areAllNegative).toStrictEqual(false);
+    expect(data.areAllNegative).toStrictEqual(true);
   });
 });

--- a/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
+++ b/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
@@ -70,9 +70,7 @@ export function useDataForHorizontalChart({
   ]);
 
   const areAllNegative = useMemo(() => {
-    return !allNumbers.some((num) => {
-      return num >= 0;
-    });
+    return !allNumbers.some((num) => num !== null && num > 0);
   }, [allNumbers]);
 
   return {


### PR DESCRIPTION
## What does this implement/fix?

We were not handling properly `zeroValueLine` for the negative horizontal bar chart.


## What do the changes look like?

Before  

<img width="732" alt="Screen Shot 2022-08-01 at 8 51 42 AM" src="https://user-images.githubusercontent.com/64446645/182202327-6a43e660-a600-409a-a97c-e96e77ec1259.png">


After
<img width="678" alt="Screen Shot 2022-08-01 at 9 39 40 AM" src="https://user-images.githubusercontent.com/64446645/182202353-ef307618-275e-4a91-9bb7-8574bae575d4.png">


 
## Storybook link

[Negative bar chart](http://localhost:6006/?path=/story/polaris-viz-charts-barchart--negative-only&args=direction:horizontal)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
