### PR TITLE
Scope focus style to ChartContainer children

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.scss
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.scss
@@ -1,8 +1,11 @@
+@import '../../../../polaris-viz/src/styles/common';
+
 .Group {
+  @include no-outline;
   pointer-events: none;
 }
 
 .Line {
-  outline: none;
+  @include no-outline;
   pointer-events: auto;
 }

--- a/packages/polaris-viz/src/components/Arc/Arc.scss
+++ b/packages/polaris-viz/src/components/Arc/Arc.scss
@@ -1,3 +1,5 @@
+@import '../../styles/common';
+
 .Arc {
-  outline: none;
+  @include no-outline;
 }

--- a/packages/polaris-viz/src/components/Arc/Arc.tsx
+++ b/packages/polaris-viz/src/components/Arc/Arc.tsx
@@ -137,6 +137,7 @@ export function Arc({
             index,
           }),
         }}
+        className={classNames(styles.Arc)}
         {...getColorVisionEventAttrs({
           type: COLOR_VISION_SINGLE_ITEM,
           index,

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.scss
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.scss
@@ -2,4 +2,8 @@
 
 .ChartContainer {
   @include chart-container;
+
+  * {
+    @include focus-outline;
+  }
 }

--- a/packages/polaris-viz/src/components/ConicGradientWithStops/ConicGradientWithStops.scss
+++ b/packages/polaris-viz/src/components/ConicGradientWithStops/ConicGradientWithStops.scss
@@ -1,3 +1,0 @@
-.Arc {
-  outline: none;
-}

--- a/packages/polaris-viz/src/components/ConicGradientWithStops/ConicGradientWithStops.tsx
+++ b/packages/polaris-viz/src/components/ConicGradientWithStops/ConicGradientWithStops.tsx
@@ -3,8 +3,6 @@ import type {GradientStop} from '@shopify/polaris-viz-core';
 
 import {createCSSConicGradient} from '../../utilities';
 
-import styles from './ConicGradientWithStops.scss';
-
 export interface ConicGradientWithStopsProps {
   gradient: GradientStop[];
   height: number;
@@ -25,7 +23,6 @@ export function ConicGradientWithStops({
   return (
     <foreignObject x={x} y={y} width={width} height={height}>
       <div
-        className={styles.Gradient}
         style={{
           width: `${width}px`,
           height: `${height}px`,

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -7,6 +7,7 @@
   border-radius: 2px;
   display: flex;
   gap: 8px;
+  @include focus-outline;
 }
 
 .TextContainer {

--- a/packages/polaris-viz/src/styles/_common.scss
+++ b/packages/polaris-viz/src/styles/_common.scss
@@ -8,9 +8,3 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-
-*:focus,
-*:focus-visible {
-  outline: 2px solid $color-blue-70;
-  outline-offset: 2px;
-}

--- a/packages/polaris-viz/src/styles/shared/_accessibility.scss
+++ b/packages/polaris-viz/src/styles/shared/_accessibility.scss
@@ -18,7 +18,16 @@
 
   &:focus,
   &:focus-visible {
-    outline: none;
+    // stylelint-disable-next-line declaration-no-important
+    outline: none !important;
+  }
+}
+
+@mixin focus-outline {
+  &:focus,
+  &:focus-visible {
+    outline: 2px solid $color-blue-70;
+    outline-offset: 2px;
   }
 }
 


### PR DESCRIPTION
## What does this implement/fix?

Our focus styles were not scoped to polaris-viz and were affecting pages that also included our stylesheet.

![image](https://user-images.githubusercontent.com/149873/182630543-4c9d5b7f-4e9e-4ced-9117-3e495cdd2e43.png)

Now we're going to only apply our focus styles to children of `<ChartContainer />` or any components we export out to the consumer (`<Legend />`) for example.
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
