### PR TITLE
Animate StackedArea chart

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -80,6 +80,13 @@ export const BARS_SORT_TRANSITION_CONFIG = {
   restVelocity: 200,
 };
 
+export const AREAS_LOAD_ANIMATION_CONFIG = {
+  mass: 1,
+  tension: 120,
+  friction: 20,
+  clamp: true,
+};
+
 export const LINES_LOAD_ANIMATION_CONFIG = {
   mass: 1,
   tension: 140,

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -79,6 +79,7 @@ export {
   ARC_DATA_CHANGE_ANIMATION_CONFIG,
   LEGENDS_TOP_MARGIN,
   LINE_SERIES_POINT_RADIUS,
+  AREAS_LOAD_ANIMATION_CONFIG,
 } from './constants';
 export {
   clamp,

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/tests/Area.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/tests/Area.test.tsx
@@ -32,15 +32,17 @@ describe('<Area />', () => {
     .x((_, index) => xScale(index))
     .y(([, lastPoint]) => yScale(lastPoint));
 
+  const mockValues = [
+    [163, 269],
+    [0, 0],
+  ] as StackedSeries;
   const mockProps: AreaProps = {
     activeLineIndex: -1,
     animationIndex: 1,
     areaGenerator,
     colors: ['red', 'green'],
-    data: [
-      [163, 269],
-      [0, 0],
-    ] as StackedSeries,
+    data: mockValues,
+    zeroLineValues: mockValues,
     duration: 300,
     id: 'stackedAreas-1',
     index: 0,

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -21,6 +21,7 @@ import {Area} from '..';
 interface Props {
   colors: Color[];
   stackedValues: StackedSeries[];
+  zeroLineValues: StackedSeries[];
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   theme: string;
@@ -32,6 +33,7 @@ export function StackedAreas({
   yScale,
   colors,
   theme,
+  zeroLineValues,
 }: Props) {
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
 
@@ -89,6 +91,7 @@ export function StackedAreas({
             areaGenerator={areaGenerator}
             colors={colors}
             data={data}
+            zeroLineValues={zeroLineValues[index]}
             duration={duration}
             id={id}
             index={index}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -10,6 +10,17 @@ jest.mock('d3-scale', () => ({
   scaleLinear: jest.requireActual('d3-scale').scaleLinear,
 }));
 
+const mockStackedValues = [
+  [
+    [163, 269],
+    [0, 0],
+  ],
+  [
+    [0, 163],
+    [0, 203],
+  ],
+] as StackedSeries[];
+
 describe('<StackedAreas />', () => {
   const mockProps = {
     transform: '',
@@ -17,16 +28,8 @@ describe('<StackedAreas />', () => {
     xScale: scaleLinear(),
     yScale: scaleLinear(),
     isAnimated: true,
-    stackedValues: [
-      [
-        [163, 269],
-        [0, 0],
-      ],
-      [
-        [0, 163],
-        [0, 203],
-      ],
-    ] as StackedSeries[],
+    stackedValues: mockStackedValues,
+    zeroLineValues: mockStackedValues,
   };
 
   it('renders a <Area /> for each stacked series', () => {
@@ -75,14 +78,16 @@ describe('<StackedAreas />', () => {
     });
 
     it('passes FAST_DURATION to <Area /> .length is greater than 10', () => {
+      const mockValues = new Array(11).fill([
+        [163, 269],
+        [0, 0],
+      ]);
       const stackedArea = mount(
         <svg>
           <StackedAreas
             {...mockProps}
-            stackedValues={new Array(11).fill([
-              [163, 269],
-              [0, 0],
-            ])}
+            stackedValues={mockValues}
+            zeroLineValues={mockValues}
           />
         </svg>,
       );


### PR DESCRIPTION
## What does this implement/fix?
Animates data changes on the StackedAreaChart

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

fix https://github.com/Shopify/polaris-viz/issues/1305


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
