### PR TITLE
Fix animation for horizontal bars

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed horizontal bar charts not animating their bars in on mount.
 
 ## [7.0.0] - 2022-08-12
 

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -6,7 +6,6 @@ import {
   BoundingRect,
   HORIZONTAL_SPACE_BETWEEN_CHART_AND_AXIS,
   useAriaLabel,
-  useChartContext,
   LINE_HEIGHT,
 } from '@shopify/polaris-viz-core';
 import type {
@@ -16,6 +15,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
+import {animated} from '@react-spring/web';
 
 import {checkAvailableAnnotations} from '../../components/Annotations';
 import {useFormattedLabels} from '../../hooks/useFormattedLabels';
@@ -38,12 +38,7 @@ import {
   useHorizontalXScale,
   useTheme,
 } from '../../hooks';
-import {
-  XMLNS,
-  ChartMargin,
-  HORIZONTAL_BAR_GROUP_DELAY,
-  ANNOTATIONS_LABELS_OFFSET,
-} from '../../constants';
+import {XMLNS, ChartMargin, ANNOTATIONS_LABELS_OFFSET} from '../../constants';
 import {eventPointNative, formatDataIntoGroups} from '../../utilities';
 import {
   TOOLTIP_POSITION_DEFAULT_RETURN,
@@ -82,7 +77,6 @@ export function Chart({
 }: ChartProps) {
   useColorVisionEvents(data.length > 1);
 
-  const {shouldAnimate} = useChartContext();
   const selectedTheme = useTheme();
   const id = useMemo(() => uniqueId('HorizontalBarChart'), []);
 
@@ -247,32 +241,27 @@ export function Chart({
               key: item.key,
             });
 
-            const animationDelay = shouldAnimate
-              ? (HORIZONTAL_BAR_GROUP_DELAY * index) / data.length
-              : 0;
-
             return (
-              <HorizontalGroup
-                animationDelay={animationDelay}
-                areAllNegative={areAllNegative}
-                ariaLabel={ariaLabel}
-                barHeight={barHeight}
-                containerWidth={width}
-                data={data}
-                groupHeight={groupHeight}
-                id={id}
-                index={index}
-                isSimple={false}
-                isStacked={isStacked}
-                name={name}
-                opacity={opacity}
-                stackedValues={stackedValues}
-                transform={transform}
-                xAxisOptions={xAxisOptions}
-                xScale={xScale}
-                yAxisOptions={yAxisOptions}
-                zeroPosition={zeroPosition}
-              />
+              <animated.g key={`group-${name}`} style={{opacity, transform}}>
+                <HorizontalGroup
+                  areAllNegative={areAllNegative}
+                  ariaLabel={ariaLabel}
+                  barHeight={barHeight}
+                  containerWidth={width}
+                  data={data}
+                  groupHeight={groupHeight}
+                  id={id}
+                  index={index}
+                  isSimple={false}
+                  isStacked={isStacked}
+                  name={name}
+                  stackedValues={stackedValues}
+                  xAxisOptions={xAxisOptions}
+                  xScale={xScale}
+                  yAxisOptions={yAxisOptions}
+                  zeroPosition={zeroPosition}
+                />
+              </animated.g>
             );
           })}
         </g>

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -3,7 +3,6 @@ import {
   uniqueId,
   COLOR_VISION_SINGLE_ITEM,
   useAriaLabel,
-  useChartContext,
 } from '@shopify/polaris-viz-core';
 import type {
   ChartType,
@@ -12,6 +11,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
+import {animated} from '@react-spring/web';
 
 import {LegendContainer, useLegend} from '../../components/LegendContainer';
 import {GradientDefs, HorizontalGroup} from '../shared';
@@ -25,7 +25,7 @@ import {
   useHorizontalStackedValues,
   useColorVisionEvents,
 } from '../../hooks';
-import {XMLNS, HORIZONTAL_BAR_GROUP_DELAY} from '../../constants';
+import {XMLNS} from '../../constants';
 
 import styles from './Chart.scss';
 
@@ -47,7 +47,6 @@ export function Chart({
   yAxisOptions,
 }: ChartProps) {
   useColorVisionEvents(data.length > 1);
-  const {shouldAnimate} = useChartContext();
 
   const id = useMemo(() => uniqueId('SimpleBarChart'), []);
 
@@ -139,32 +138,33 @@ export function Chart({
             key: data[0].data[item.index]?.key,
           });
 
-          const animationDelay = shouldAnimate
-            ? (HORIZONTAL_BAR_GROUP_DELAY * index) / data.length
-            : 0;
-
           return (
-            <HorizontalGroup
-              animationDelay={animationDelay}
-              areAllNegative={areAllNegative}
-              ariaLabel={ariaLabel}
-              barHeight={barHeight}
-              containerWidth={width}
-              data={data}
-              groupHeight={groupHeight}
-              id={id}
-              index={index}
-              isSimple
-              isStacked={isStacked}
-              name={name}
-              opacity={opacity}
-              stackedValues={stackedValues}
-              transform={transform}
-              xAxisOptions={xAxisOptions}
-              xScale={xScale}
-              yAxisOptions={yAxisOptions}
-              zeroPosition={zeroPosition}
-            />
+            <animated.g
+              key={`group-${name}`}
+              style={{
+                opacity,
+                transform,
+              }}
+            >
+              <HorizontalGroup
+                areAllNegative={areAllNegative}
+                ariaLabel={ariaLabel}
+                barHeight={barHeight}
+                containerWidth={width}
+                data={data}
+                groupHeight={groupHeight}
+                id={id}
+                index={index}
+                isSimple
+                isStacked={isStacked}
+                name={name}
+                stackedValues={stackedValues}
+                xAxisOptions={xAxisOptions}
+                xScale={xScale}
+                yAxisOptions={yAxisOptions}
+                zeroPosition={zeroPosition}
+              />
+            </animated.g>
           );
         })}
       </svg>

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/SimpleBarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/SimpleBarChart.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import type {Story, Meta} from '@storybook/react';
 
 import {SimpleBarChart, SimpleBarChartProps} from '../SimpleBarChart';
@@ -91,4 +91,105 @@ export const SimpleStacked: Story<SimpleBarChartProps> = Template.bind({});
 SimpleStacked.args = {
   data: SERIES,
   type: 'stacked',
+};
+
+export const DynamicData = () => {
+  const [data, setData] = useState([
+    {
+      name: 'BCFM 2019',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 3,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 7,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 4,
+        },
+      ],
+    },
+    {
+      name: 'BCFM 2020',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 1,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 2,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 5,
+        },
+      ],
+    },
+  ]);
+
+  const onClick = () => {
+    const newData = data.map((series) => {
+      return {
+        ...series,
+        data: series.data.map(({key}) => {
+          const newValue = Math.floor(Math.random() * 200);
+          return {
+            key,
+            value: newValue,
+          };
+        }),
+      };
+    });
+
+    setData(newData);
+  };
+
+  return (
+    <>
+      <div style={{height: '500px', width: 800}}>
+        <SimpleBarChart data={data} showLegend={true} />
+      </div>
+      <button
+        style={{
+          position: 'absolute',
+          top: '10px',
+          left: '10px',
+        }}
+        onClick={onClick}
+      >
+        Change Data
+      </button>
+    </>
+  );
+};
+
+export const Sorting = () => {
+  const [data, setData] = useState(SINGLE_SERIES);
+
+  const onClick = () => {
+    setData([
+      {
+        ...data[0],
+        data: [...data[0].data].sort(() => (Math.random() > 0.5 ? 1 : -1)),
+      },
+    ]);
+  };
+
+  return (
+    <>
+      <div style={{height: '500px', width: 800}}>
+        <SimpleBarChart
+          data={[{...data[0], data: [...data[0].data.slice(0, 5)]}]}
+          showLegend={true}
+        />
+      </div>
+      <button onClick={onClick} style={{marginRight: 10}}>
+        Shuffle Position
+      </button>
+    </>
+  );
 };

--- a/packages/polaris-viz/src/components/shared/Bar/tests/Bar.test.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/tests/Bar.test.tsx
@@ -14,7 +14,6 @@ const MOCK_PROPS: BarProps = {
   width: 100,
   x: 5,
   y: 10,
-  transform: 'scaleX(-10)',
 };
 
 const mockPropsForHoverZone: Props = {
@@ -41,11 +40,9 @@ describe('<Bar />', () => {
         <Bar {...MOCK_PROPS} />
       </svg>,
     );
-    const path = bar.find('path');
+    const group = bar.find('g');
 
-    expect(path?.props?.style?.transform).toStrictEqual(
-      ' translate(5px, 10px) scaleX(-10)',
-    );
+    expect(group?.props?.transform).toStrictEqual('translate(5, 10)');
   });
 });
 

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -16,11 +16,12 @@ import {
   HORIZONTAL_SPACE_BETWEEN_SINGLE,
 } from '../../../constants';
 import {useTheme, useWatchColorVisionEvents} from '../../../hooks';
-import {Bar} from '../Bar';
 import {getGradientDefId} from '../GradientDefs';
 
-import {Label} from './components';
+import {Label, Bar} from './components';
 import styles from './HorizontalBars.scss';
+
+const SERIES_DELAY = 150;
 
 export interface HorizontalBarsProps {
   activeGroupIndex: number;
@@ -40,7 +41,7 @@ export interface HorizontalBarsProps {
 
 export function HorizontalBars({
   activeGroupIndex,
-  animationDelay,
+  animationDelay = 0,
   barHeight,
   data,
   groupIndex,
@@ -76,6 +77,9 @@ export function HorizontalBars({
         if (data[seriesIndex].data[groupIndex] == null) {
           return;
         }
+
+        const seriesAnimationDelay =
+          animationDelay + SERIES_DELAY * seriesIndex;
 
         const {value} = data[seriesIndex].data[groupIndex];
 
@@ -113,7 +117,8 @@ export function HorizontalBars({
         return (
           <React.Fragment key={`series-${seriesIndex}-${id}-${name}`}>
             <Bar
-              animationDelay={animationDelay}
+              animationDelay={seriesAnimationDelay}
+              areAllNegative={areAllNegative}
               color={`url(#${getGradientDefId(theme, seriesIndex, id)})`}
               height={barHeight}
               index={groupIndex}
@@ -122,11 +127,10 @@ export function HorizontalBars({
               width={width}
               x={0}
               y={y}
-              areAllNegative={areAllNegative}
             />
             {isSimple && (
               <Label
-                animationDelay={animationDelay}
+                animationDelay={seriesAnimationDelay}
                 barHeight={barHeight}
                 color={
                   data[seriesIndex].isComparison

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import {animated, useSpring} from '@react-spring/web';
-import {useChartContext} from '@shopify/polaris-viz-core';
 
-import {
-  HORIZONTAL_BAR_LABEL_HEIGHT,
-  BARS_TRANSITION_CONFIG,
-  FONT_SIZE,
-} from '../../../../../constants';
+import {useBarSpringConfig} from '../../../../../hooks/useBarSpringConfig';
+import {HORIZONTAL_BAR_LABEL_HEIGHT, FONT_SIZE} from '../../../../../constants';
 
 export interface LabelProps {
   barHeight: number;
@@ -27,15 +23,14 @@ export function Label({
   x,
   y,
 }: LabelProps) {
-  const {shouldAnimate} = useChartContext();
   const labelYOffset = (barHeight - HORIZONTAL_BAR_LABEL_HEIGHT) / 2;
+
+  const springConfig = useBarSpringConfig({animationDelay});
 
   const spring = useSpring({
     from: {transform: 'translateX(0px)', opacity: 0},
     to: {opacity: 1, transform: `translateX(${x}px)`},
-    delay: shouldAnimate ? animationDelay : 0,
-    config: BARS_TRANSITION_CONFIG,
-    default: {immediate: !shouldAnimate},
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/index.ts
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/index.ts
@@ -1,1 +1,2 @@
 export {Label} from './Label';
+export {Bar} from '../../Bar';

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -1,10 +1,10 @@
 import React, {useMemo, useState} from 'react';
-import {animated, SpringValue} from '@react-spring/web';
 import {
   DataType,
   getColorVisionEventAttrs,
   COLOR_VISION_GROUP_ITEM,
   getColorVisionStylesForActiveIndex,
+  LOAD_ANIMATION_DURATION,
 } from '@shopify/polaris-viz-core';
 import type {ScaleLinear} from 'd3-scale';
 import type {
@@ -26,7 +26,6 @@ import {HorizontalBars} from '../HorizontalBars';
 import style from './HorizontalGroup.scss';
 
 export interface HorizontalGroupProps {
-  animationDelay: number;
   areAllNegative: boolean;
   ariaLabel: string;
   barHeight: number;
@@ -38,9 +37,7 @@ export interface HorizontalGroupProps {
   isSimple: boolean;
   isStacked: boolean;
   name: string;
-  opacity: SpringValue<number>;
   stackedValues: FormattedStackedSeries[];
-  transform: SpringValue<string>;
   xAxisOptions: Required<XAxisOptions>;
   xScale: ScaleLinear<number, number>;
   yAxisOptions: Required<YAxisOptions>;
@@ -48,7 +45,6 @@ export interface HorizontalGroupProps {
 }
 
 export function HorizontalGroup({
-  animationDelay,
   areAllNegative,
   ariaLabel,
   barHeight,
@@ -60,9 +56,7 @@ export function HorizontalGroup({
   isSimple,
   isStacked,
   name,
-  opacity,
   stackedValues,
-  transform,
   xAxisOptions,
   yAxisOptions,
   xScale,
@@ -91,73 +85,70 @@ export function HorizontalGroup({
     return HORIZONTAL_GROUP_LABEL_HEIGHT + barPlusSpaceHeight * data.length;
   }, [barHeight, data.length, isStacked]);
 
+  const animationDelay =
+    index * (LOAD_ANIMATION_DURATION / data[0].data.length);
+
   return (
-    <animated.g
-      key={`group-${name}`}
-      style={{
-        opacity,
-        transform,
-      }}
+    <g
+      style={getColorVisionStylesForActiveIndex({
+        activeIndex: activeGroupIndex,
+        index,
+      })}
+      {...getColorVisionEventAttrs({
+        type: COLOR_VISION_GROUP_ITEM,
+        index,
+      })}
+      data-type={DataType.BarGroup}
+      data-index={index}
+      aria-hidden="false"
+      aria-label={ariaLabel}
+      role="list"
+      className={style.Group}
     >
-      <g
-        style={getColorVisionStylesForActiveIndex({
-          activeIndex: activeGroupIndex,
-          index,
-        })}
-        {...getColorVisionEventAttrs({
-          type: COLOR_VISION_GROUP_ITEM,
-          index,
-        })}
-        data-type={DataType.BarGroup}
-        data-index={index}
-        aria-hidden="false"
-        aria-label={ariaLabel}
-        role="list"
-        className={style.Group}
-      >
-        <rect
-          fill="transparent"
-          height={groupHeight}
-          width={containerWidth}
-          y={-(groupHeight - rowHeight) / 2}
+      <rect
+        fill="transparent"
+        height={groupHeight}
+        width={containerWidth}
+        y={-(groupHeight - rowHeight) / 2}
+      />
+
+      <GroupLabel
+        areAllNegative={areAllNegative}
+        containerWidth={containerWidth}
+        label={yAxisOptions.labelFormatter(name)}
+        zeroPosition={zeroPosition}
+      />
+
+      {isStacked ? (
+        <HorizontalStackedBars
+          activeGroupIndex={activeGroupIndex}
+          animationDelay={animationDelay}
+          ariaLabel={ariaLabel}
+          barHeight={barHeight}
+          dataKeys={dataKeys}
+          groupIndex={index}
+          id={id}
+          name={name}
+          stackedValues={stackedValues}
+          xScale={xScale}
         />
-        <GroupLabel
-          areAllNegative={areAllNegative}
-          containerWidth={containerWidth}
-          label={yAxisOptions.labelFormatter(name)}
+      ) : (
+        <HorizontalBars
+          animationDelay={animationDelay}
+          activeGroupIndex={activeGroupIndex}
+          barHeight={barHeight}
+          data={data}
+          groupIndex={index}
+          id={id}
+          isSimple={isSimple}
+          labelFormatter={xAxisOptions.labelFormatter}
+          name={name}
+          xScale={xScale}
           zeroPosition={zeroPosition}
+          containerWidth={containerWidth}
+          areAllNegative={areAllNegative}
         />
-        {isStacked ? (
-          <HorizontalStackedBars
-            activeGroupIndex={activeGroupIndex}
-            animationDelay={animationDelay}
-            ariaLabel={ariaLabel}
-            barHeight={barHeight}
-            dataKeys={dataKeys}
-            groupIndex={index}
-            id={id}
-            name={name}
-            stackedValues={stackedValues}
-            xScale={xScale}
-          />
-        ) : (
-          <HorizontalBars
-            activeGroupIndex={activeGroupIndex}
-            animationDelay={animationDelay}
-            barHeight={barHeight}
-            data={data}
-            groupIndex={index}
-            id={id}
-            isSimple={isSimple}
-            labelFormatter={xAxisOptions.labelFormatter}
-            name={name}
-            xScale={xScale}
-            zeroPosition={zeroPosition}
-            containerWidth={containerWidth}
-            areAllNegative={areAllNegative}
-          />
-        )}
-      </g>
-    </animated.g>
+      )}
+    </g>
   );
 }

--- a/packages/polaris-viz/src/components/shared/index.ts
+++ b/packages/polaris-viz/src/components/shared/index.ts
@@ -1,6 +1,6 @@
 export {GradientDefs, getGradientDefId} from './GradientDefs';
 export {GroupLabel} from './GroupLabel';
-export {Bar} from './Bar';
 export {HorizontalBars, Label} from './HorizontalBars';
 export {HorizontalStackedBars} from './HorizontalStackedBars';
 export {HorizontalGroup} from './HorizontalGroup';
+export {Bar} from './Bar';

--- a/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
+++ b/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
@@ -1,0 +1,24 @@
+import {useRef} from 'react';
+import {
+  BARS_LOAD_ANIMATION_CONFIG,
+  BARS_TRANSITION_CONFIG,
+  useChartContext,
+} from '@shopify/polaris-viz-core';
+
+interface Props {
+  animationDelay?: number;
+}
+
+export function useBarSpringConfig({animationDelay = 0}: Props) {
+  const isMounted = useRef(false);
+  const {shouldAnimate} = useChartContext();
+
+  return {
+    config: isMounted.current
+      ? BARS_TRANSITION_CONFIG
+      : BARS_LOAD_ANIMATION_CONFIG,
+    default: {immediate: !shouldAnimate},
+    delay: isMounted.current ? 0 : animationDelay,
+    onRest: () => (isMounted.current = true),
+  };
+}


### PR DESCRIPTION
## What does this implement/fix?

Horizontal Bars were not animating and we're also animating up on mount (fixed in https://github.com/Shopify/polaris-viz/pull/1357).

## What do the changes look like?

**Old and busted**

https://user-images.githubusercontent.com/149873/184178398-6994b274-b280-46c4-a2c8-711a4bfd705f.mov

**New and shiny**

https://user-images.githubusercontent.com/149873/184179309-a034ccd4-1a29-4e2d-813e-b63f44e47406.mov

## Storybook link

- [HorizontalBarChart](https://6062ad4a2d14cd0021539c1b-slbqyxkzau.chromatic.com/?path=/story/polaris-viz-charts-barchart--default&args=direction:horizontal)
- [SimpleBarChart](https://6062ad4a2d14cd0021539c1b-slbqyxkzau.chromatic.com/?path=/story/polaris-viz-charts-simplebarchart--default)

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
