### PR TITLE
Change hasRoundedCorners to borderRadius

### DIFF
--- a/packages/polaris-viz-core/src/components/Bar/Bar.tsx
+++ b/packages/polaris-viz-core/src/components/Bar/Bar.tsx
@@ -2,7 +2,6 @@ import React, {useMemo} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import type {SpringValue} from '@react-spring/core';
 
-import {BORDER_RADIUS} from '../../constants';
 import {getRoundedRectPath} from '../../utilities/getRoundedRectPath';
 import {usePolarisVizContext} from '../../hooks';
 
@@ -16,12 +15,12 @@ export interface Props {
   width: number;
   x: number;
   yScale: ScaleLinear<number, number>;
-  borderRadius?: string;
+  borderRadius?: number;
   height?: Height;
 }
 
 export function Bar({
-  borderRadius = BORDER_RADIUS.None,
+  borderRadius = 0,
   fill,
   height,
   value,
@@ -75,7 +74,7 @@ export function Bar({
       return getRoundedRectPath({
         height: heightValue,
         width,
-        borderRadius,
+        borderRadius: `${borderRadius} ${borderRadius} 0 0`,
       });
     };
 

--- a/packages/polaris-viz-core/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
+++ b/packages/polaris-viz-core/src/components/PolarisVizProvider/tests/PolarisVizProvider.test.tsx
@@ -51,7 +51,7 @@ describe('<PolarisVizProvider />', () => {
           themes={{
             Dark: {
               bar: {
-                hasRoundedCorners: false,
+                borderRadius: 3,
               },
             },
           }}
@@ -66,7 +66,7 @@ describe('<PolarisVizProvider />', () => {
           ...DEFAULT_THEME,
           bar: {
             ...DEFAULT_THEME.bar,
-            hasRoundedCorners: false,
+            borderRadius: 3,
           },
         }),
       );

--- a/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
+++ b/packages/polaris-viz-core/src/components/SparkBarSeries/SparkBarSeries.tsx
@@ -6,11 +6,7 @@ import {usePolarisVizContext, useSparkBar, useTheme} from '../../hooks';
 import {LinearGradientWithStops} from '../LinearGradientWithStops';
 import {getAnimationTrail, getSeriesColors, uniqueId} from '../../utilities';
 import {Bar} from '../Bar';
-import {
-  BARS_TRANSITION_CONFIG,
-  BORDER_RADIUS,
-  STROKE_WIDTH,
-} from '../../constants';
+import {BARS_TRANSITION_CONFIG, STROKE_WIDTH} from '../../constants';
 import type {TargetLine} from '../../types';
 
 interface SparkBarSeriesProps {
@@ -47,7 +43,6 @@ export function SparkBarSeries({
   const clipId = useMemo(() => uniqueId('sparkbar-series-clip'), []);
 
   const {
-    borderRadius,
     dataWithIndex,
     color,
     getBarHeight,
@@ -106,11 +101,7 @@ export function SparkBarSeries({
 
             return (
               <Bar
-                borderRadius={
-                  selectedTheme.bar.hasRoundedCorners
-                    ? borderRadius
-                    : BORDER_RADIUS.None
-                }
+                borderRadius={selectedTheme.bar.borderRadius}
                 key={index}
                 x={xPosition == null ? 0 : xPosition}
                 yScale={yScale}

--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -195,8 +195,8 @@ export const DEFAULT_THEME: Theme = {
     thickness: DONUT_CHART_THICKNESS,
   },
   bar: {
-    hasRoundedCorners: true,
     zeroValueColor: variables.colorGray80,
+    borderRadius: 3,
   },
   grid: {
     showHorizontalLines: true,
@@ -295,8 +295,8 @@ export const LIGHT_THEME: Theme = {
     thickness: 18,
   },
   bar: {
-    hasRoundedCorners: true,
     zeroValueColor: variables.colorGray70,
+    borderRadius: 3,
   },
   grid: {
     showHorizontalLines: true,

--- a/packages/polaris-viz-core/src/hooks/tests/useSparkBar.test.tsx
+++ b/packages/polaris-viz-core/src/hooks/tests/useSparkBar.test.tsx
@@ -119,40 +119,4 @@ describe('useSparkBar', () => {
       },
     );
   });
-
-  describe('borderRadius', () => {
-    it.each`
-      width     | expected
-      ${100}    | ${'20 20 0 0'}
-      ${53}     | ${'10 10 0 0'}
-      ${11.237} | ${'2 2 0 0'}
-    `('returns a borderRadius based on width', ({width, expected}) => {
-      const TestComponent = () => {
-        const {borderRadius} = useSparkBar({
-          data: [
-            {
-              data: [
-                {key: '1', value: 1},
-                {key: '2', value: 2},
-              ],
-              isComparison: true,
-            },
-          ],
-          height: 300,
-          targetLine: {
-            offsetLeft: 0,
-            offsetRight: 0,
-            value: 0,
-          },
-          width,
-          seriesColor: 'red',
-        });
-
-        return <div>{borderRadius.toString()}</div>;
-      };
-
-      const mockComponent = mount(<TestComponent />);
-      expect(mockComponent.text()).toBe(expected);
-    });
-  });
 });

--- a/packages/polaris-viz-core/src/hooks/useSparkBar.ts
+++ b/packages/polaris-viz-core/src/hooks/useSparkBar.ts
@@ -115,9 +115,6 @@ export function useSparkBar({
         },
       ];
 
-  const radius = Math.floor(barWidth / 2);
-  const borderRadius = `${radius} ${radius} 0 0`;
-
   return {
     dataWithIndex,
     color,
@@ -127,7 +124,6 @@ export function useSparkBar({
     getBarHeight,
     xScale,
     yScale,
-    borderRadius,
     targetLineYPosition,
     targetLineX1: 0 - offsetLeft,
     targetLineX2: width + offsetRight,

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -76,8 +76,8 @@ export interface ArcTheme {
 }
 
 export interface BarTheme {
-  hasRoundedCorners: boolean;
   zeroValueColor: string;
+  borderRadius: number;
 }
 
 export interface XAxisTheme {

--- a/packages/polaris-viz-core/src/utilities/getRoundedRectPath.ts
+++ b/packages/polaris-viz-core/src/utilities/getRoundedRectPath.ts
@@ -16,17 +16,15 @@ export function getRoundedRectPath({borderRadius, height, width}: Props) {
     return '';
   }
 
-  const {topLeft, topRight, bottomRight, bottomLeft} =
+  let {topLeft, topRight, bottomRight, bottomLeft} =
     borderRadiusStringToObject(borderRadius);
 
-  const minWidth = Math.max(topLeft + topRight, bottomLeft + bottomRight);
-  const minHeight = Math.max(topLeft + bottomLeft, topRight + bottomRight);
+  const smallestSize = Math.min(height, width);
 
-  // Return a basic rect if the rounded arcs
-  // would make the rect bigger than the min size.
-  if (height < minHeight || width < minWidth) {
-    return `m 0 0 h ${width} v ${height} h -${width} z`;
-  }
+  topLeft = Math.min(topLeft, smallestSize / 2);
+  topRight = Math.min(topRight, smallestSize / 2);
+  bottomRight = Math.min(bottomRight, smallestSize / 2);
+  bottomLeft = Math.min(bottomLeft, smallestSize / 2);
 
   const top = topLeft + topRight;
   const right = topRight + bottomRight;

--- a/packages/polaris-viz-core/src/utilities/stories/getRoundedRectPath.chromatic.stories.tsx
+++ b/packages/polaris-viz-core/src/utilities/stories/getRoundedRectPath.chromatic.stories.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {getRoundedRectPath} from '../getRoundedRectPath';
+
+const DIMENSIONS = {
+  horizontal: [
+    {
+      height: 5,
+      width: 100,
+    },
+    {
+      height: 20,
+      width: 100,
+    },
+  ],
+  vertical: [
+    {
+      height: 100,
+      width: 5,
+    },
+    {
+      height: 100,
+      width: 10,
+    },
+  ],
+};
+
+const RADIUS_CASES = [
+  '0 0 0 0',
+  '2 0 0 0',
+  '2 2 0 0',
+  '2 2 2 0',
+  '2 2 2 2',
+  '0 0 0 2',
+  '0 0 2 2',
+  '0 2 2 2',
+  '0 2 0 2',
+  '2 0 2 0',
+  '0 2 2 0',
+];
+
+const BORDER_RADIUS = [2, 5, 100];
+
+const DIRECTIONS = ['horizontal', 'vertical'];
+
+DIRECTIONS.forEach((direction) => {
+  const stories = storiesOf(
+    `Chromatic/Utilities/getRoundedRectPath`,
+    module,
+  ).addParameters({chromatic: {disableSnapshot: false}});
+
+  stories.add(direction, () => {
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gap: '20px',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+        }}
+      >
+        {BORDER_RADIUS.map((borderRadius) => {
+          return RADIUS_CASES.map((radiusCase) => {
+            const borderRadiusString = radiusCase.replace(
+              /2/g,
+              `${borderRadius}`,
+            );
+
+            return (
+              <div>
+                <p>
+                  <strong>{borderRadiusString}</strong>
+                </p>
+                <div style={{display: 'flex', gap: 10}}>
+                  {Object.values(DIMENSIONS[direction]).map(
+                    ({height, width}) => {
+                      return (
+                        <svg height={height} width={width}>
+                          <path
+                            d={getRoundedRectPath({
+                              height,
+                              width,
+                              borderRadius: borderRadiusString,
+                            })}
+                            height={height}
+                            width={width}
+                            fill="red"
+                          />
+                        </svg>
+                      );
+                    },
+                  )}
+                </div>
+              </div>
+            );
+          });
+        })}
+      </div>
+    );
+  });
+});

--- a/packages/polaris-viz-core/src/utilities/tests/createThemes.test.ts
+++ b/packages/polaris-viz-core/src/utilities/tests/createThemes.test.ts
@@ -5,7 +5,7 @@ describe('createTheme', () => {
   it('generates a theme with default values, from the partial theme provided', () => {
     const result = createTheme({
       bar: {
-        hasRoundedCorners: false,
+        borderRadius: 5,
       },
     });
     expect(result).not.toStrictEqual(DEFAULT_THEME);
@@ -14,7 +14,7 @@ describe('createTheme', () => {
       expect.objectContaining({
         bar: {
           ...DEFAULT_THEME.bar,
-          hasRoundedCorners: false,
+          borderRadius: 5,
         },
       }),
     );
@@ -26,7 +26,7 @@ describe('createThemes', () => {
     const result = createThemes({
       Default: {
         bar: {
-          hasRoundedCorners: false,
+          borderRadius: 5,
         },
       },
     });
@@ -38,7 +38,7 @@ describe('createThemes', () => {
           ...DEFAULT_THEME,
           bar: {
             ...DEFAULT_THEME.bar,
-            hasRoundedCorners: false,
+            borderRadius: 5,
           },
         },
       }),
@@ -50,7 +50,7 @@ describe('createThemes', () => {
       Default: DEFAULT_THEME,
       SomeTheme: {
         bar: {
-          hasRoundedCorners: false,
+          borderRadius: 0,
         },
       },
     });
@@ -62,7 +62,7 @@ describe('createThemes', () => {
           ...DEFAULT_THEME,
           bar: {
             ...DEFAULT_THEME.bar,
-            hasRoundedCorners: false,
+            borderRadius: 0,
           },
         },
       }),

--- a/packages/polaris-viz-core/src/utilities/tests/getRoundedRectPath.test.ts
+++ b/packages/polaris-viz-core/src/utilities/tests/getRoundedRectPath.test.ts
@@ -47,13 +47,27 @@ describe('getRoundedRectPath()', () => {
     expect(makeDSingleLine(result)).toStrictEqual(EXPECTED_RESULTS[test]);
   });
 
-  it('returns a non-rounded rect if arcs are smaller than overall size', () => {
+  it('clamps the radius if the borderRadius is larger than the height', () => {
     const result = getRoundedRectPath({
-      height: 1,
-      width: 1,
-      borderRadius: BORDER_RADIUS.Left,
+      height: 5,
+      width: 100,
+      borderRadius: '0 10 10 0',
     });
 
-    expect(result).toStrictEqual('m 0 0 h 1 v 1 h -1 z');
+    expect(makeDSingleLine(result)).toStrictEqual(
+      'M0,0 h97.5 a2.5,2.5 0 0 1 2.5,2.5 v0 a2.5,2.5 0 0 1 -2.5,2.5 h-97.5 a0,0 0 0 1 -0,-0 v-5 a0,0 0 0 1 0,-0 Z',
+    );
+  });
+
+  it('clamps the radius if the borderRadius is larger than the width', () => {
+    const result = getRoundedRectPath({
+      height: 100,
+      width: 5,
+      borderRadius: '10 0 0 10',
+    });
+
+    expect(makeDSingleLine(result)).toStrictEqual(
+      'M2.5,0 h2.5 a0,0 0 0 1 0,0 v100 a0,0 0 0 1 -0,0 h-2.5 a2.5,2.5 0 0 1 -2.5,-2.5 v-95 a2.5,2.5 0 0 1 2.5,-2.5 Z',
+    );
   });
 });

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Fixed bug where points in `<StackedAreaChart />` were in the wrong positions when `StackedAreaChart.isAnimated=false`.
 
+### Changed
+
+- Replaced bar chart `hasRoundedCorners` by `borderRadius`.
+
 ## [6.6.1] - 2022-08-10
 
 ### Fixed

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -13,7 +13,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Replaced bar chart `hasRoundedCorners` by `borderRadius`.
+- Replaced `bar.hasRoundedCorners` with `bar.borderRadius` which now accepts a `number`
 
 ## [6.6.1] - 2022-08-10
 

--- a/packages/polaris-viz/src/chromatic/stories/Themes.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/chromatic/stories/Themes.chromatic.stories.tsx
@@ -55,7 +55,7 @@ const THEME = {
     horizontalMargin: [0, 20],
   },
   bar: {
-    hasRoundedCorners: [false],
+    borderRadius: [0, 5, 10],
     zeroValueColor: ['lime'],
   },
   xAxis: {

--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.stories.tsx
@@ -121,7 +121,19 @@ export default {
 } as Meta;
 
 const Template: Story<BarChartProps> = (args: BarChartProps) => {
-  return <BarChart {...args} />;
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          chartContainer: {
+            padding: '20px',
+          },
+        },
+      }}
+    >
+      <BarChart {...args} />
+    </PolarisVizProvider>
+  );
 };
 
 export const Default: Story<BarChartProps> = Template.bind({});
@@ -216,7 +228,7 @@ const WithoutRoundedCornersTemplate: Story<BarChartProps> = (
       themes={{
         Default: {
           bar: {
-            hasRoundedCorners: false,
+            borderRadius: 0,
           },
           chartContainer: {
             padding: '20px',

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/FunnelSkeleton/FunnelSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/FunnelSkeleton/FunnelSkeleton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   useTheme,
   useUniqueId,
-  BORDER_RADIUS,
   changeColorOpacity,
   ChartState,
 } from '@shopify/polaris-viz-core';
@@ -48,7 +47,6 @@ export function FunnelSkeleton({
             return (
               <React.Fragment key={`${id}${index}`}>
                 <Bar
-                  borderRadius={BORDER_RADIUS.Top}
                   color={gridColor}
                   x={segmentWidth * index}
                   y={height - barHeight}

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleBarSkeleton/SimpleBarSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleBarSkeleton/SimpleBarSkeleton.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  useTheme,
-  ChartState,
-  BORDER_RADIUS,
-  useUniqueId,
-} from '@shopify/polaris-viz-core';
+import {useTheme, ChartState, useUniqueId} from '@shopify/polaris-viz-core';
 
 import type {ChartSkeletonProps} from '../../ChartSkeleton';
 import {ErrorText} from '../ErrorText';
@@ -20,7 +15,7 @@ export function SimpleBarSkeleton({
 
   const {
     grid: {color: gridColor},
-    bar: {hasRoundedCorners},
+    bar: {borderRadius},
   } = useTheme();
 
   const id = useUniqueId('simple-bar-skeleton');
@@ -30,9 +25,7 @@ export function SimpleBarSkeleton({
       style={{
         display: 'inline-block',
         background: gridColor,
-        borderRadius: hasRoundedCorners
-          ? `${BORDER_RADIUS.All}px`
-          : BORDER_RADIUS.None,
+        borderRadius,
       }}
     />
   );

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  useTheme,
-  ChartState,
-  BORDER_RADIUS,
-  useUniqueId,
-} from '@shopify/polaris-viz-core';
+import {useTheme, ChartState, useUniqueId} from '@shopify/polaris-viz-core';
 
 import type {ChartSkeletonProps} from '../../ChartSkeleton';
 import {ErrorText} from '../ErrorText';
@@ -20,7 +15,7 @@ export function SimpleNormalizedSkeleton({
 
   const {
     grid: {color: gridColor},
-    bar: {hasRoundedCorners},
+    bar: {borderRadius},
     chartContainer: {padding},
   } = useTheme();
 
@@ -30,9 +25,7 @@ export function SimpleNormalizedSkeleton({
     <span
       style={{
         background: gridColor,
-        borderRadius: hasRoundedCorners
-          ? `${BORDER_RADIUS.All}px`
-          : BORDER_RADIUS.None,
+        borderRadius,
       }}
     />
   );

--- a/packages/polaris-viz/src/components/Docs/stories/bar.stories.mdx
+++ b/packages/polaris-viz/src/components/Docs/stories/bar.stories.mdx
@@ -1,6 +1,5 @@
 import {Meta, Story, Canvas} from '@storybook/addon-docs/blocks';
 
-import {PolarisVizProvider} from '../../../';
 import {
   Divider,
   ComponentContainer,
@@ -31,13 +30,16 @@ import {
 
 <PropertyTable>
   <PropertyTable.Row
-    property="bar.hasRoundedCorners"
-    type="boolean"
+    property="bar.borderRadius"
+    type="number"
     description="determines whether the bar should have sharp or round corners"
     chartsAffected={[
       'BarChart',
       'MultiSeriesBarChart',
       'SimpleNormalizedChart',
+      'FunnelChart',
+      'SparkBarChart',
+      'ComboChart',
     ]}
   />
 </PropertyTable>
@@ -48,32 +50,12 @@ import {
 
 <ComponentContainer
   codeSample={`
-    <PolarisVizProvider
-      themes={{
-        Default: {
-          bar: {
-            hasRoundedCorners: false,
-          }
-        }
-      }}
-    >
       <BarChart data={data} />
-    </PolarisVizProvider>
     `}
   center
   chart={
     <div style={{width: '350px', height: '140px'}}>
-      <PolarisVizProvider
-        themes={{
-          Default: {
-            bar: {
-              hasRoundedCorners: true,
-            },
-          },
-        }}
-      >
-        <SampleBarChart showLegend={false} />
-      </PolarisVizProvider>
+      <SampleBarChart showLegend={false} />
     </div>
   }
 />

--- a/packages/polaris-viz/src/components/Docs/stories/createThemeUtility.stories.mdx
+++ b/packages/polaris-viz/src/components/Docs/stories/createThemeUtility.stories.mdx
@@ -2,6 +2,7 @@ import {Meta} from '@storybook/addon-docs/blocks';
 
 import {PolarisVizProvider} from '@shopify/polaris-viz';
 import {Title} from './components';
+import {BORDER_RADIUS} from '../../../../../polaris-viz-core/src/constants.ts';
 
 <Meta
   title="Shared/Themes/createTheme Utility"
@@ -61,7 +62,7 @@ import {createTheme} from '@shopify/polaris-viz';
 
 const myDefaultTheme = createTheme({
   barTheme: {
-    hasRoundedCorners: false,
+    borderRadius: 1,
   },
   chartContainer: {
     backgroundColor: 'red',

--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -9,7 +9,6 @@ import {
   isGradientType,
   LinearGradientWithStops,
   GradientStop,
-  BORDER_RADIUS,
   useTheme,
   getAverageColor,
   changeColorOpacity,
@@ -184,11 +183,6 @@ export function Chart({
                   portalTo={maskRef}
                   index={index}
                   drawableHeight={drawableHeight}
-                  borderRadius={
-                    selectedTheme.bar.hasRoundedCorners
-                      ? BORDER_RADIUS.Top
-                      : BORDER_RADIUS.None
-                  }
                 />
               </g>
             )}

--- a/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
@@ -19,7 +19,6 @@ export function FunnelSegment({
   barHeight,
   drawableHeight,
   x,
-  borderRadius,
   ariaLabel,
   index = 0,
   color,
@@ -29,8 +28,11 @@ export function FunnelSegment({
   percentLabel,
   formattedYValue,
 }) {
+  const selectedTheme = useTheme();
   const mounted = useRef(false);
   const {shouldAnimate} = useChartContext();
+
+  const borderRadius = selectedTheme.bar.borderRadius;
 
   const {
     xAxis: {labelColor: axisLabelColor},
@@ -62,7 +64,11 @@ export function FunnelSegment({
           fill={color}
           width={barWidth}
           d={animatedHeight.to((value: number) =>
-            getRoundedRectPath({height: value, width: barWidth, borderRadius}),
+            getRoundedRectPath({
+              height: value,
+              width: barWidth,
+              borderRadius: `${borderRadius} ${borderRadius} 0 0`,
+            }),
           )}
           style={{
             transform: animatedHeight.to(

--- a/packages/polaris-viz/src/components/FunnelChart/stories/FunnelChart.stories.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/stories/FunnelChart.stories.tsx
@@ -59,7 +59,7 @@ const data = [
   },
 ];
 
-const DefaultTemplate: Story<FunnelChartProps> = (args: FunnelChartProps) => {
+const Template: Story<FunnelChartProps> = (args: FunnelChartProps) => {
   return (
     <div style={{height: 400}}>
       <FunnelChart {...args} />
@@ -67,7 +67,7 @@ const DefaultTemplate: Story<FunnelChartProps> = (args: FunnelChartProps) => {
   );
 };
 
-export const Default = DefaultTemplate.bind({});
+export const Default = Template.bind({});
 
 Default.args = {
   data,
@@ -79,7 +79,7 @@ Default.args = {
   },
 };
 
-export const Light = DefaultTemplate.bind({});
+export const Light = Template.bind({});
 
 Light.args = {
   theme: 'Light',

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -144,7 +144,7 @@ export function Chart({
             scale={100}
             key="empty-bar"
             color={selectedTheme.seriesColors.empty}
-            roundedCorners={selectedTheme.bar.hasRoundedCorners}
+            roundedCorners={selectedTheme.bar.borderRadius}
           />
         ) : (
           bars.map(({value, key}, index) => {
@@ -163,7 +163,7 @@ export function Chart({
                 scale={xScale(value)}
                 key={`${key}-${index}`}
                 color={colors[colorIndex]}
-                roundedCorners={selectedTheme.bar.hasRoundedCorners}
+                roundedCorners={selectedTheme.bar.borderRadius}
               />
             );
           })

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
@@ -27,7 +27,7 @@ interface Props {
   color: Color;
   size: Size;
   direction: Direction;
-  roundedCorners: boolean;
+  roundedCorners: number;
 }
 
 export function BarSegment({

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/SimpleNormalizedChart.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/SimpleNormalizedChart.stories.tsx
@@ -11,6 +11,7 @@ import {
   LEGEND_POSITION_ARGS,
   CHART_STATE_CONTROL_ARGS,
 } from '../../../storybook';
+import {PolarisVizProvider} from '../../../';
 import {PageWithSizingInfo} from '../../Docs/stories/components/PageWithSizingInfo';
 
 export default {
@@ -42,7 +43,19 @@ export default {
 const Template: Story<SimpleNormalizedChartProps> = (
   args: SimpleNormalizedChartProps,
 ) => {
-  return <SimpleNormalizedChart {...args} />;
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          bar: {
+            borderRadius: 2,
+          },
+        },
+      }}
+    >
+      <SimpleNormalizedChart {...args} />;
+    </PolarisVizProvider>
+  );
 };
 
 const defaultProps: SimpleNormalizedChartProps = {

--- a/packages/polaris-viz/src/components/SparkBarChart/stories/SparkBarChart.stories.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/stories/SparkBarChart.stories.tsx
@@ -6,6 +6,8 @@ import {THEME_CONTROL_ARGS, CHART_STATE_CONTROL_ARGS} from '../../../storybook';
 
 import {PageWithSizingInfo} from '../../Docs/stories/components/PageWithSizingInfo';
 
+import {PolarisVizProvider} from '../../../';
+
 export default {
   title: 'polaris-viz/Charts/SparkBarChart',
   parameters: {
@@ -45,7 +47,19 @@ export default {
 } as Meta;
 
 const Template: Story<SparkBarChartProps> = (args: SparkBarChartProps) => {
-  return <SparkBarChart {...args} />;
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          bar: {
+            borderRadius: 5,
+          },
+        },
+      }}
+    >
+      <SparkBarChart {...args} />
+    </PolarisVizProvider>
+  );
 };
 
 const comparisonValue = 2000;

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -8,7 +8,6 @@ import {
   COLOR_VISION_GROUP_ITEM,
   getColorVisionEventAttrs,
   clamp,
-  BORDER_RADIUS,
   useTheme,
   useChartContext,
 } from '@shopify/polaris-viz-core';
@@ -39,7 +38,6 @@ export interface BarGroupProps {
   data: (number | null)[];
   colors: Color[];
   barGroupIndex: number;
-  hasRoundedCorners: boolean;
   indexOffset: number;
   accessibilityData: AccessibilitySeries[];
   activeBarGroup: number;
@@ -58,7 +56,6 @@ export function BarGroup({
   drawableHeight,
   indexOffset,
   barGroupIndex,
-  hasRoundedCorners,
   accessibilityData,
   activeBarGroup,
   gapWidth,
@@ -151,9 +148,6 @@ export function BarGroup({
                 rawValue={rawValue}
                 width={barWidth}
                 index={index}
-                borderRadius={
-                  hasRoundedCorners ? BORDER_RADIUS.Top : BORDER_RADIUS.None
-                }
                 animationDelay={animationDelay}
                 areAllNegative={areAllNegative}
               />

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/tests/BarGroup.test.tsx
@@ -42,7 +42,6 @@ const MOCK_PROPS: BarGroupProps = {
   data: [10, 20, 0, 1],
   colors: ['purple', 'teal', 'red', 'orange'],
   barGroupIndex: 0,
-  hasRoundedCorners: false,
   gapWidth: 10,
   animationDelay: 0,
   indexOffset: 0,

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
@@ -1,9 +1,9 @@
 import React, {useMemo} from 'react';
 import {animated, useSpring} from '@react-spring/web';
 import {
-  BORDER_RADIUS,
   DataType,
   getRoundedRectPath,
+  useTheme,
 } from '@shopify/polaris-viz-core';
 
 import {ZeroValueLine} from '../../../shared/ZeroValueLine';
@@ -21,7 +21,6 @@ export interface VerticalBarProps {
   zeroPosition: number;
   animationDelay?: number;
   ariaLabel?: string;
-  borderRadius?: string;
   isAnimated?: boolean;
   role?: string;
   areAllNegative?: boolean;
@@ -30,7 +29,6 @@ export interface VerticalBarProps {
 export const VerticalBar = React.memo(function Bar({
   animationDelay = 0,
   ariaLabel,
-  borderRadius = BORDER_RADIUS.None,
   color,
   height,
   index,
@@ -42,6 +40,8 @@ export const VerticalBar = React.memo(function Bar({
   zeroPosition,
   areAllNegative,
 }: VerticalBarProps) {
+  const selectedTheme = useTheme();
+  const borderRadius = selectedTheme.bar.borderRadius;
   const treatAsNegative = rawValue < 0 || rawValue === 0;
   const zeroValue = rawValue === 0;
 
@@ -64,7 +64,7 @@ export const VerticalBar = React.memo(function Bar({
   }, [yPosition, treatAsNegative, x, width]);
 
   const path = getRoundedRectPath({
-    borderRadius,
+    borderRadius: `${borderRadius} ${borderRadius} 0 0`,
     height,
     width,
   });

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/tests/VerticalBar.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/tests/VerticalBar.test.tsx
@@ -45,15 +45,15 @@ describe('<VerticalBar/>', () => {
       expect(bar).toContainReactComponent('path', {
         // eslint-disable-next-line id-length
         d: `
-  M0,0
-  h100
-  a0,0 0 0 1 0,0
-  v1000
+  M3,0
+  h94
+  a3,3 0 0 1 3,3
+  v997
   a0,0 0 0 1 -0,0
   h-100
   a0,0 0 0 1 -0,-0
-  v-1000
-  a0,0 0 0 1 0,-0
+  v-997
+  a3,3 0 0 1 3,-3
   Z
 `,
       });

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
@@ -3,7 +3,6 @@ import {
   DataType,
   LOAD_ANIMATION_DURATION,
   useChartContext,
-  useTheme,
 } from '@shopify/polaris-viz-core';
 import type {
   StackedValues,
@@ -52,7 +51,6 @@ export function VerticalBarGroup({
   yAxisOptions,
   areAllNegative,
 }: VerticalBarGroupProps) {
-  const selectedTheme = useTheme();
   const {id: chartId, isPerformanceImpacted} = useChartContext();
 
   const [activeBarGroup, setActiveBarGroup] = useState<number>(-1);
@@ -134,7 +132,6 @@ export function VerticalBarGroup({
             colors={colors}
             data={item}
             gapWidth={gapWidth}
-            hasRoundedCorners={selectedTheme.bar.hasRoundedCorners}
             drawableHeight={drawableHeight}
             indexOffset={indexOffset}
             key={index}

--- a/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
+++ b/packages/polaris-viz/src/components/shared/Bar/Bar.tsx
@@ -1,12 +1,12 @@
 import React, {useCallback} from 'react';
 import {animated, useSpring} from '@react-spring/web';
 import {
-  BORDER_RADIUS,
   getRoundedRectPath,
   COLOR_VISION_ACTIVE_OPACITY,
   COLOR_VISION_FADED_OPACITY,
   BARS_TRANSITION_CONFIG,
   DataType,
+  useTheme,
 } from '@shopify/polaris-viz-core';
 import type {Direction} from '@shopify/polaris-viz-core';
 
@@ -22,7 +22,6 @@ export interface BarProps {
   y: number;
   animationDelay?: number;
   animationDirection?: Direction;
-  borderRadius?: string;
   index?: number;
   isActive?: boolean;
   isAnimated?: boolean;
@@ -34,7 +33,6 @@ export interface BarProps {
 export const Bar = React.memo(function Bar({
   animationDelay = 0,
   animationDirection = 'horizontal',
-  borderRadius = BORDER_RADIUS.None,
   color,
   height,
   index,
@@ -47,6 +45,9 @@ export const Bar = React.memo(function Bar({
   ariaLabel,
   areAllNegative,
 }: BarProps) {
+  const selectedTheme = useTheme();
+  const borderRadius = `0 ${selectedTheme.bar.borderRadius} ${selectedTheme.bar.borderRadius} 0`;
+
   const getPath = useCallback(
     (height = 0, width = 0) => {
       return getRoundedRectPath({height, width, borderRadius});

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -4,7 +4,6 @@ import {
   DataSeries,
   getColorVisionEventAttrs,
   LabelFormatter,
-  BORDER_RADIUS,
   estimateStringWidth,
   COLOR_VISION_SINGLE_ITEM,
   useChartContext,
@@ -115,7 +114,6 @@ export function HorizontalBars({
           <React.Fragment key={`series-${seriesIndex}-${id}-${name}`}>
             <Bar
               animationDelay={animationDelay}
-              borderRadius={BORDER_RADIUS.Right}
               color={`url(#${getGradientDefId(theme, seriesIndex, id)})`}
               height={barHeight}
               index={groupIndex}

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -35,7 +35,6 @@ export interface HorizontalGroupProps {
   groupHeight: number;
   id: string;
   index: number;
-
   isSimple: boolean;
   isStacked: boolean;
   name: string;

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -130,13 +130,13 @@ export function HorizontalStackedBars({
         const key = dataKeys[seriesIndex] ?? '';
         const ariaLabel = `${key} ${end}`;
 
-        const areAllValuesAreZero = stackedValues[groupIndex].every(
+        const areAllValuesZero = stackedValues[groupIndex].every(
           ([start, end]) => start + end === 0,
         );
 
         return (
           <React.Fragment key={`stackedBar ${barId}`}>
-            {areAllValuesAreZero ? (
+            {areAllValuesZero ? (
               <ZeroValueLine x={x} y={barHeight / 2} direction="horizontal" />
             ) : (
               <StackedBar


### PR DESCRIPTION
## What does this implement/fix?

Replaces `hasRoundedCorners` with `borderRadius` for  bar chart allowing consumers to choose how rounded the corners should be.

## Does this close any currently open issues?

Resolves #440 


## Storybook link

[Bar Chart](http://localhost:6006/?path=/story/polaris-viz-charts-barchart--default)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
