### PR TITLE
fix bug - display negative values for stacked horizontal chart

### DIFF
--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -118,9 +118,9 @@ export function HorizontalStackedBars({
     >
       {stackedValues[groupIndex].map((item, seriesIndex) => {
         const [start, end] = item;
+
         const barId = getBarId(id, groupIndex, seriesIndex);
         const width = Math.abs(xScale(end) - xScale(start));
-
         const borderRadius = getBorderRadius({
           lastIndexes,
           seriesIndex,
@@ -130,18 +130,14 @@ export function HorizontalStackedBars({
         const key = dataKeys[seriesIndex] ?? '';
         const ariaLabel = `${key} ${end}`;
 
-        const areSomeGreaterThanZero = stackedValues[groupIndex].some(
-          ([start, end]) => start + end > 0,
+        const areAllValuesAreZero = stackedValues[groupIndex].every(
+          ([start, end]) => start + end === 0,
         );
 
         return (
           <React.Fragment key={`stackedBar ${barId}`}>
-            {!areSomeGreaterThanZero ? (
-              <ZeroValueLine
-                x={x}
-                y={x + barHeight / 2}
-                direction="horizontal"
-              />
+            {areAllValuesAreZero ? (
+              <ZeroValueLine x={x} y={barHeight / 2} direction="horizontal" />
             ) : (
               <StackedBar
                 activeBarIndex={activeBarIndex}


### PR DESCRIPTION
## What does this implement/fix?

Fixing a bug, horizontal stacked bar didn't display correctly when all values were negative.

## What do the changes look like?

Before:
<img width="1111" alt="Screen Shot 2022-08-08 at 2 23 27 PM" src="https://user-images.githubusercontent.com/64446645/183517165-e0e1be56-f654-4683-b2fe-dffbb67208b3.png">

After:
 
<img width="724" alt="Screen Shot 2022-08-08 at 2 28 40 PM" src="https://user-images.githubusercontent.com/64446645/183517949-9cc52f94-813f-49dd-bf6f-c32b2d54b64a.png">


## Storybook link

 🎩 [Stacked Horizontal](http://localhost:6006/?path=/story/polaris-viz-charts-barchart--stacked&args=data[0].data[1].value:0;direction:horizontal)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
