### PR TITLE
Render annotations over crosshair

### DIFF
--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -246,20 +246,6 @@ export function Chart({
           />
         </g>
 
-        {hasXAxisAnnotations && (
-          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
-            <Annotations
-              annotationsLookupTable={annotationsLookupTable}
-              axisLabelWidth={labelWidth}
-              drawableHeight={annotationsDrawableHeight}
-              drawableWidth={drawableWidth}
-              labels={labels}
-              onHeightChange={setAnnotationsHeight}
-              xScale={xScale}
-            />
-          </g>
-        )}
-
         <g
           transform={`translate(${
             chartXPosition + drawableWidth / labels.length / 2
@@ -277,6 +263,20 @@ export function Chart({
             yScale={lineYScale}
           />
         </g>
+
+        {hasXAxisAnnotations && (
+          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
+            <Annotations
+              annotationsLookupTable={annotationsLookupTable}
+              axisLabelWidth={labelWidth}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              labels={labels}
+              onHeightChange={setAnnotationsHeight}
+              xScale={xScale}
+            />
+          </g>
+        )}
 
         {hasYAxisAnnotations && (
           <React.Fragment>

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -287,7 +287,6 @@ export function Chart({
             ariaHidden
           />
         )}
-
         {selectedTheme.grid.showHorizontalLines ? (
           <HorizontalGridLines
             ticks={ticks}
@@ -300,7 +299,6 @@ export function Chart({
             }
           />
         ) : null}
-
         <YAxis
           ticks={ticks}
           width={yAxisLabelWidth}
@@ -309,7 +307,6 @@ export function Chart({
           x={yAxisBounds.x}
           y={yAxisBounds.y}
         />
-
         {emptyState ? null : (
           <VisuallyHiddenRows
             data={data}
@@ -317,21 +314,6 @@ export function Chart({
             xAxisLabels={labels}
           />
         )}
-
-        {hasXAxisAnnotations && (
-          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
-            <Annotations
-              annotationsLookupTable={annotationsLookupTable}
-              axisLabelWidth={xAxisDetails.labelWidth}
-              drawableHeight={annotationsDrawableHeight}
-              drawableWidth={drawableWidth}
-              labels={labels}
-              onHeightChange={setAnnotationsHeight}
-              xScale={xScale}
-            />
-          </g>
-        )}
-
         <g
           transform={`translate(${
             chartXPosition + halfXAxisLabelWidth
@@ -365,6 +347,20 @@ export function Chart({
             yScale={yScale}
           />
         </g>
+
+        {hasXAxisAnnotations && (
+          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
+            <Annotations
+              annotationsLookupTable={annotationsLookupTable}
+              axisLabelWidth={xAxisDetails.labelWidth}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              labels={labels}
+              onHeightChange={setAnnotationsHeight}
+              xScale={xScale}
+            />
+          </g>
+        )}
 
         {hasYAxisAnnotations && (
           <g

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -320,20 +320,6 @@ export function Chart({
           <rect width={width} height={drawableHeight} fill="black" />
         </clipPath>
 
-        {hasXAxisAnnotations && (
-          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
-            <Annotations
-              annotationsLookupTable={annotationsLookupTable}
-              axisLabelWidth={xAxisDetails.labelWidth}
-              drawableHeight={annotationsDrawableHeight}
-              drawableWidth={drawableWidth}
-              labels={labels}
-              onHeightChange={setAnnotationsHeight}
-              xScale={xScale}
-            />
-          </g>
-        )}
-
         {activePointIndex == null ? null : (
           <g
             transform={`translate(${
@@ -365,6 +351,20 @@ export function Chart({
             yScale={yScale}
           />
         </g>
+
+        {hasXAxisAnnotations && (
+          <g transform={`translate(${chartXPosition},0)`} tabIndex={-1}>
+            <Annotations
+              annotationsLookupTable={annotationsLookupTable}
+              axisLabelWidth={xAxisDetails.labelWidth}
+              drawableHeight={annotationsDrawableHeight}
+              drawableWidth={drawableWidth}
+              labels={labels}
+              onHeightChange={setAnnotationsHeight}
+              xScale={xScale}
+            />
+          </g>
+        )}
 
         {hasYAxisAnnotations && (
           <g

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/utils.stories.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/utils.stories.ts
@@ -18,7 +18,7 @@ export const data = [
       {key: 'February', value: 7349},
       {key: 'March', value: 9795},
       {key: 'April', value: 7396},
-      {key: 'May', value: 7028},
+      {key: 'May', value: 14000},
       {key: 'June', value: 12484},
       {key: 'July', value: 4878},
     ],


### PR DESCRIPTION
## What does this implement/fix?

We were rendering the Crosshair over the annotations which was causing the Crosshair to render above annotations with content.

We're going to render the Annotations over all the chart components. This means that the annotation dotted line will be rendered over the crosshair and line series dots. It's not ideal but we don't have a solution right now. In the future we will try and fix properly.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1350

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="432" alt="image" src="https://user-images.githubusercontent.com/149873/183688435-e20aba6f-7d60-495d-8630-9d8752c7d0b5.png">|<img width="431" alt="image" src="https://user-images.githubusercontent.com/149873/183688346-e16acc7e-6c7e-41b3-b7d7-fd3640285d33.png">|
