### PR TITLE
properly display spark bar chart in available charts

### DIFF
--- a/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/WebComponents/WebComponents.tsx
@@ -382,42 +382,10 @@ export function WebComponents() {
             <div style={{width: '250px', height: '140px'}}>
               <SparkBarChart
                 isAnimated
+                targetLine={{
+                  value: 2000,
+                }}
                 data={[
-                  {
-                    data: [
-                      {key: 0, value: 600},
-                      {key: 1, value: 600},
-                      {key: 2, value: 600},
-                      {key: 3, value: 600},
-                      {key: 4, value: 600},
-                      {key: 5, value: 600},
-                      {key: 6, value: 600},
-                      {key: 7, value: 600},
-                      {key: 8, value: 600},
-                      {key: 9, value: 600},
-                      {key: 10, value: 600},
-                      {key: 11, value: 600},
-                      {key: 12, value: 600},
-                      {key: 13, value: 600},
-                      {key: 14, value: 600},
-                      {key: 15, value: 600},
-                      {key: 16, value: 600},
-                      {key: 17, value: 600},
-                      {key: 18, value: 600},
-                      {key: 19, value: 600},
-                      {key: 20, value: 600},
-                      {key: 21, value: 600},
-                      {key: 22, value: 600},
-                      {key: 23, value: 600},
-                      {key: 24, value: 600},
-                      {key: 25, value: 600},
-                      {key: 26, value: 600},
-                      {key: 27, value: 600},
-                      {key: 28, value: 600},
-                      {key: 29, value: 600},
-                    ],
-                    isComparison: true,
-                  },
                   {
                     data: [
                       {key: 1, value: 100},


### PR DESCRIPTION
## What does this implement/fix?

Fixing a bug, spark bar chart was not displaying properly in all available charts.


## What do the changes look like?

Before:
<img width="1146" alt="Screen Shot 2022-08-09 at 8 54 42 AM" src="https://user-images.githubusercontent.com/64446645/183711131-5077d181-c0dd-4d1b-a597-2f3348345380.png">

After:
<img width="1127" alt="Screen Shot 2022-08-09 at 9 48 21 AM" src="https://user-images.githubusercontent.com/64446645/183711159-f2a9ff6f-192c-46bf-b636-a7e6c7134297.png">


 
## Storybook link

 🎩 [Available Charts](http://localhost:6006/?path=/docs/polaris-viz-available-charts--page)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
