### PR TITLE
Clamp large rounded corners to bar dimensions

### DIFF
--- a/packages/polaris-viz-core/src/utilities/getRoundedRectPath.ts
+++ b/packages/polaris-viz-core/src/utilities/getRoundedRectPath.ts
@@ -16,17 +16,15 @@ export function getRoundedRectPath({borderRadius, height, width}: Props) {
     return '';
   }
 
-  const {topLeft, topRight, bottomRight, bottomLeft} =
+  let {topLeft, topRight, bottomRight, bottomLeft} =
     borderRadiusStringToObject(borderRadius);
 
-  const minWidth = Math.max(topLeft + topRight, bottomLeft + bottomRight);
-  const minHeight = Math.max(topLeft + bottomLeft, topRight + bottomRight);
+  const smallestSize = Math.min(height, width);
 
-  // Return a basic rect if the rounded arcs
-  // would make the rect bigger than the min size.
-  if (height < minHeight || width < minWidth) {
-    return `m 0 0 h ${width} v ${height} h -${width} z`;
-  }
+  topLeft = Math.min(topLeft, smallestSize / 2);
+  topRight = Math.min(topRight, smallestSize / 2);
+  bottomRight = Math.min(bottomRight, smallestSize / 2);
+  bottomLeft = Math.min(bottomLeft, smallestSize / 2);
 
   const top = topLeft + topRight;
   const right = topRight + bottomRight;

--- a/packages/polaris-viz-core/src/utilities/stories/getRoundedRectPath.chromatic.stories.tsx
+++ b/packages/polaris-viz-core/src/utilities/stories/getRoundedRectPath.chromatic.stories.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {getRoundedRectPath} from '../getRoundedRectPath';
+
+const DIMENSIONS = {
+  horizontal: [
+    {
+      height: 5,
+      width: 100,
+    },
+    {
+      height: 20,
+      width: 100,
+    },
+  ],
+  vertical: [
+    {
+      height: 100,
+      width: 5,
+    },
+    {
+      height: 100,
+      width: 10,
+    },
+  ],
+};
+
+const RADIUS_CASES = [
+  '0 0 0 0',
+  '2 0 0 0',
+  '2 2 0 0',
+  '2 2 2 0',
+  '2 2 2 2',
+  '0 0 0 2',
+  '0 0 2 2',
+  '0 2 2 2',
+  '0 2 0 2',
+  '2 0 2 0',
+  '0 2 2 0',
+];
+
+const BORDER_RADIUS = [2, 5, 100];
+
+const DIRECTIONS = ['horizontal', 'vertical'];
+
+DIRECTIONS.forEach((direction) => {
+  const stories = storiesOf(
+    `Chromatic/Utilities/getRoundedRectPath`,
+    module,
+  ).addParameters({chromatic: {disableSnapshot: false}});
+
+  stories.add(direction, () => {
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gap: '20px',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+        }}
+      >
+        {BORDER_RADIUS.map((borderRadius) => {
+          return RADIUS_CASES.map((radiusCase) => {
+            const borderRadiusString = radiusCase.replace(
+              /2/g,
+              `${borderRadius}`,
+            );
+
+            return (
+              <div>
+                <p>
+                  <strong>{borderRadiusString}</strong>
+                </p>
+                <div style={{display: 'flex', gap: 10}}>
+                  {Object.values(DIMENSIONS[direction]).map(
+                    ({height, width}) => {
+                      return (
+                        <svg height={height} width={width}>
+                          <path
+                            d={getRoundedRectPath({
+                              height,
+                              width,
+                              borderRadius: borderRadiusString,
+                            })}
+                            height={height}
+                            width={width}
+                            fill="red"
+                          />
+                        </svg>
+                      );
+                    },
+                  )}
+                </div>
+              </div>
+            );
+          });
+        })}
+      </div>
+    );
+  });
+});

--- a/packages/polaris-viz-core/src/utilities/tests/getRoundedRectPath.test.ts
+++ b/packages/polaris-viz-core/src/utilities/tests/getRoundedRectPath.test.ts
@@ -47,13 +47,27 @@ describe('getRoundedRectPath()', () => {
     expect(makeDSingleLine(result)).toStrictEqual(EXPECTED_RESULTS[test]);
   });
 
-  it('returns a non-rounded rect if arcs are smaller than overall size', () => {
+  it('clamps the radius if the borderRadius is larger than the height', () => {
     const result = getRoundedRectPath({
-      height: 1,
-      width: 1,
-      borderRadius: BORDER_RADIUS.Left,
+      height: 5,
+      width: 100,
+      borderRadius: '0 10 10 0',
     });
 
-    expect(result).toStrictEqual('m 0 0 h 1 v 1 h -1 z');
+    expect(makeDSingleLine(result)).toStrictEqual(
+      'M0,0 h97.5 a2.5,2.5 0 0 1 2.5,2.5 v0 a2.5,2.5 0 0 1 -2.5,2.5 h-97.5 a0,0 0 0 1 -0,-0 v-5 a0,0 0 0 1 0,-0 Z',
+    );
+  });
+
+  it('clamps the radius if the borderRadius is larger than the width', () => {
+    const result = getRoundedRectPath({
+      height: 100,
+      width: 5,
+      borderRadius: '10 0 0 10',
+    });
+
+    expect(makeDSingleLine(result)).toStrictEqual(
+      'M2.5,0 h2.5 a0,0 0 0 1 0,0 v100 a0,0 0 0 1 -0,0 h-2.5 a2.5,2.5 0 0 1 -2.5,-2.5 v-95 a2.5,2.5 0 0 1 2.5,-2.5 Z',
+    );
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

If the combined radius of the border was larger than either the height or width, a rect would draw all funky.

<img width="233" alt="image" src="https://user-images.githubusercontent.com/149873/184222982-f386ecb3-d6d7-4b40-ae4b-2bac2e1415aa.png">

Our previous fix was to just remove the rounded borders and draw a basic rectangle.

<img width="249" alt="image" src="https://user-images.githubusercontent.com/149873/184223617-d92c869d-b308-4e83-ab40-8fa997c661a2.png">

Now that we allow users to set their own border radius via the theme, I think it's better is we still render a rounded corner, but clamp it to the largest radius we can use without breaking the rect.

<img width="245" alt="image" src="https://user-images.githubusercontent.com/149873/184223348-95ccf3cc-05b2-4179-8ffd-7926db77bd90.png">
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-oginxkncbh.chromatic.com/?path=/story/chromatic-utilities-getroundedrectpath--horizontal

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
