### PR TITLE
Position points correctly when not animated

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed bug where points in `<StackedAreaChart />` were in the wrong positions when `StackedAreaChart.isAnimated=false`.
 
 ## [6.6.1] - 2022-08-10
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -220,13 +220,13 @@ export function Chart({
     if (
       index != null &&
       animatedCoordinates != null &&
-      activePointIndex != null &&
+      animatedCoordinates[index] != null &&
       animatedCoordinates[index]
     ) {
       return animatedCoordinates[index].to((coord) => coord.x - offset);
     }
 
-    return xScale(index == null ? 0 : index) - offset;
+    return xScale(activePointIndex == null ? 0 : activePointIndex) - offset;
   };
 
   if (xScale == null || drawableWidth == null || yAxisLabelWidth == null) {

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
@@ -61,17 +61,19 @@ export function Points({
 
   return (
     <React.Fragment>
-      {stackedValues.map((_, stackIndex) => {
+      {stackedValues.map((stack, stackIndex) => {
         if (activePointIndex == null) {
           return null;
         }
+
+        const [_, y] = stack[activePointIndex];
 
         const id = `${tooltipId}-point-${stackIndex}`;
         const color = colors[stackIndex];
 
         const animatedYPostion =
           animatedCoordinates == null || animatedCoordinates[stackIndex] == null
-            ? 0
+            ? yScale(y)
             : animatedCoordinates[stackIndex].to((coord) => coord.y);
 
         const pointColor = isGradientType(color)

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/Playground.stories.tsx
@@ -14,7 +14,11 @@ export default {
 const Template: Story<StackedAreaChartProps> = (
   args: StackedAreaChartProps,
 ) => {
-  return <StackedAreaChart {...args} />;
+  return (
+    <div style={{height: 400}}>
+      <StackedAreaChart {...args} />
+    </div>
+  );
 };
 
 export const WebData = Template.bind({});
@@ -227,4 +231,29 @@ WebData.args = {
       name: 'Returning',
     },
   ],
+};
+
+export const NonAnimatedSmallData: Story<StackedAreaChartProps> = Template.bind(
+  {},
+);
+NonAnimatedSmallData.args = {
+  data: [
+    {
+      name: 'Impressions',
+      data: [
+        {key: '2022-07-10', value: 1},
+        {key: '2022-07-11', value: 0},
+        {key: '2022-07-12', value: 0},
+      ],
+    },
+    {
+      name: 'Conversions',
+      data: [
+        {key: '2022-07-10', value: 0},
+        {key: '2022-07-11', value: 0},
+        {key: '2022-07-12', value: 0},
+      ],
+    },
+  ],
+  isAnimated: false,
 };


### PR DESCRIPTION
## What does this implement/fix?

When `<StackedAreaChart />` was not animated we were not returning the correct x/y values when hovering over different points.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1355

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/184239062-8ba3b4f3-d6a5-4ef3-95b7-b51c1b394070.mov

**After**

https://user-images.githubusercontent.com/149873/184238879-02e2c17c-e8bf-4d18-8286-a8433bbc4af7.mov
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
