### PR TITLE
Fixed wrong color being used for Point stroke

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -188,7 +188,7 @@ export const DEFAULT_THEME: Theme = {
     hasArea: true,
     hasSpline: true,
     width: 2,
-    pointStroke: 'variables.colorGray160',
+    pointStroke: variables.colorGray160,
   },
   arc: {
     cornerRadius: DONUT_CHART_CORNER_RADIUS,

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed bug where points in `<StackedAreaChart />` were in the wrong positions when `StackedAreaChart.isAnimated=false`.
+- Fixed missing stroke for `<LineChart />` & `<StackedAreaChart />` points in `Default` theme.
 
 ### Changed
 

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -13,7 +13,7 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
 
-import {useTheme, useWatchColorVisionEvents} from '../../../../hooks';
+import {useWatchColorVisionEvents} from '../../../../hooks';
 import {Point} from '../../../Point';
 import type {AnimatedCoordinate} from '../../../../types';
 
@@ -34,7 +34,6 @@ interface PointsProps {
           },
         number
       >;
-  theme: string;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
 }
@@ -46,14 +45,12 @@ export function Points({
   getXPosition,
   gradientId,
   longestSeriesIndex,
-  theme,
   tooltipId,
   xScale,
   yScale,
 }: PointsProps) {
   const {shouldAnimate} = useChartContext();
 
-  const selectedTheme = useTheme(theme);
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
 
   useWatchColorVisionEvents({
@@ -100,7 +97,6 @@ export function Points({
             {shouldAnimate ? (
               <Point
                 color={pointColor}
-                stroke={selectedTheme.line.pointStroke}
                 cx={getXPosition({isCrosshair: false})}
                 cy={animatedYPosition}
                 active={activeIndex != null}
@@ -128,7 +124,6 @@ export function Points({
                 >
                   <Point
                     dataType={DataType.Point}
-                    stroke={selectedTheme.line.pointStroke}
                     color={pointColor}
                     cx={xScale(dataIndex)}
                     cy={yScale(value)}

--- a/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
@@ -98,7 +98,6 @@ export function PointsAndCrosshair({
           getXPosition={getXPosition}
           gradientId={gradientId.current}
           longestSeriesIndex={longestSeriesIndex}
-          theme={theme}
           tooltipId={tooltipId}
           xScale={xScale}
           yScale={yScale}

--- a/packages/polaris-viz/src/components/Point/Point.tsx
+++ b/packages/polaris-viz/src/components/Point/Point.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type {ActiveTooltip, DataType} from '@shopify/polaris-viz-core';
+import {ActiveTooltip, DataType, useTheme} from '@shopify/polaris-viz-core';
 import {useSpring, animated, Interpolation} from '@react-spring/web';
 
 import {classNames} from '../../utilities';
@@ -7,20 +7,19 @@ import {BASE_ANIMATION_DURATION} from '../../constants';
 
 import styles from './Point.scss';
 
-interface Props {
+export interface PointProps {
   active: boolean;
   cx: number | Interpolation;
   cy: number | Interpolation;
   color: string;
   index: number;
   isAnimated: boolean;
+  ariaHidden?: boolean;
+  ariaLabelledby?: string;
+  dataType?: DataType;
   onFocus?: ({index, x, y}: ActiveTooltip) => void;
   tabIndex?: number;
-  ariaLabelledby?: string;
-  ariaHidden?: boolean;
   visuallyHidden?: boolean;
-  stroke: string;
-  dataType?: DataType;
 }
 
 const DEFAULT_RADIUS = 5;
@@ -38,8 +37,9 @@ export const Point = React.memo(function Point({
   isAnimated,
   ariaHidden = false,
   visuallyHidden = false,
-  stroke,
-}: Props) {
+}: PointProps) {
+  const selectedTheme = useTheme();
+
   const handleFocus = () => {
     if (onFocus != null) {
       return onFocus({
@@ -72,7 +72,7 @@ export const Point = React.memo(function Point({
       cy={cy}
       r={isAnimated ? animatedRadius : radius}
       fill={color}
-      stroke={stroke}
+      stroke={selectedTheme.line.pointStroke}
       strokeWidth={2}
       onFocus={handleFocus}
       className={classNames(

--- a/packages/polaris-viz/src/components/Point/tests/Point.test.tsx
+++ b/packages/polaris-viz/src/components/Point/tests/Point.test.tsx
@@ -1,23 +1,22 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 
-import {Point} from '../Point';
+import {Point, PointProps} from '../Point';
 
-const mockProps = {
+const MOCK_PROPS: PointProps = {
   cx: 100,
   cy: 100,
   active: false,
   color: '#00ff00',
   index: 0,
   isAnimated: false,
-  stroke: 'white',
 };
 
 describe('<Point />', () => {
   it('renders a circle at the given coordinates', () => {
     const point = mount(
       <svg>
-        <Point {...mockProps} />
+        <Point {...MOCK_PROPS} />
       </svg>,
     );
 
@@ -31,7 +30,7 @@ describe('<Point />', () => {
     it('renders with a radius of 5 when active', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} active />
+          <Point {...MOCK_PROPS} active />
         </svg>,
       );
 
@@ -44,7 +43,7 @@ describe('<Point />', () => {
     it('renders with a radius of 0 when not active', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} active={false} />
+          <Point {...MOCK_PROPS} active={false} />
         </svg>,
       );
 
@@ -59,7 +58,7 @@ describe('<Point />', () => {
     it('is not aria hidden if the prop is not set', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} />
+          <Point {...MOCK_PROPS} />
         </svg>,
       );
 
@@ -69,7 +68,7 @@ describe('<Point />', () => {
     it('is aria hidden if the prop is set to true', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} ariaHidden />
+          <Point {...MOCK_PROPS} ariaHidden />
         </svg>,
       );
 
@@ -81,7 +80,7 @@ describe('<Point />', () => {
     it('does not adds the visually hidden class if the prop is not set', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} />
+          <Point {...MOCK_PROPS} />
         </svg>,
       );
 
@@ -93,7 +92,7 @@ describe('<Point />', () => {
     it('adds the visually hidden class if the prop is set to true', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} visuallyHidden />
+          <Point {...MOCK_PROPS} visuallyHidden />
         </svg>,
       );
 
@@ -107,7 +106,7 @@ describe('<Point />', () => {
     it("has an initial radius of 5 if it's active and not animated", () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} active />
+          <Point {...MOCK_PROPS} active />
         </svg>,
       );
 
@@ -120,7 +119,7 @@ describe('<Point />', () => {
     it("has an initial radius of 0 if it's active and animated", () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} active isAnimated />
+          <Point {...MOCK_PROPS} active isAnimated />
         </svg>,
       );
 
@@ -135,26 +134,12 @@ describe('<Point />', () => {
     it('renders a circle with the given color', () => {
       const point = mount(
         <svg>
-          <Point {...mockProps} />
+          <Point {...MOCK_PROPS} />
         </svg>,
       );
 
       expect(point).toContainReactComponent('circle', {
         fill: '#00ff00',
-      });
-    });
-  });
-
-  describe('stroke', () => {
-    it('renders a circle with the given color', () => {
-      const point = mount(
-        <svg>
-          <Point {...mockProps} />
-        </svg>,
-      );
-
-      expect(point).toContainReactComponent('circle', {
-        stroke: 'white',
       });
     });
   });

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -344,7 +344,6 @@ export function Chart({
             colors={seriesColors}
             getXPosition={getXPosition}
             stackedValues={stackedValues}
-            theme={theme}
             tooltipId={tooltipId}
             xScale={xScale}
             yScale={yScale}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Points/Points.tsx
@@ -15,7 +15,7 @@ import type {ScaleLinear} from 'd3-scale';
 
 import {Point} from '../../../';
 import type {AnimatedCoordinate, GetXPosition} from '../../../../types';
-import {useTheme, useWatchColorVisionEvents} from '../../../../hooks';
+import {useWatchColorVisionEvents} from '../../../../hooks';
 import {colorWhite} from '../../../../constants';
 
 interface PointsProps {
@@ -33,7 +33,6 @@ interface PointsProps {
   tooltipId: string;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  theme: string;
 }
 
 export function Points({
@@ -42,14 +41,12 @@ export function Points({
   colors,
   getXPosition,
   stackedValues,
-  theme,
   tooltipId,
   xScale,
   yScale,
 }: PointsProps) {
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
 
-  const selectedTheme = useTheme(theme);
   const {shouldAnimate} = useChartContext();
 
   useWatchColorVisionEvents({
@@ -101,7 +98,6 @@ export function Points({
               </defs>
             )}
             <Point
-              stroke={selectedTheme.line.pointStroke}
               color={pointColor}
               cx={getXPosition({isCrosshair: false, index: stackIndex})}
               cy={animatedYPostion}
@@ -122,7 +118,6 @@ export function Points({
           <Point
             dataType={DataType.Point}
             key={`point-${dataIndex}-${x}}`}
-            stroke={selectedTheme.line.pointStroke}
             color={colorWhite}
             cx={xScale(dataIndex)}
             cy={yScale(y)}


### PR DESCRIPTION
## What does this implement/fix?

The color value being used for the `<Point />` stroke in the `Default` theme was wrapped in quotes, so the color being passed was invalid.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1158

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="99" alt="image" src="https://user-images.githubusercontent.com/149873/184419409-6d031a07-38a6-46ae-b1c6-4850e741fa3f.png">|<img width="124" alt="image" src="https://user-images.githubusercontent.com/149873/184419350-65c76a5b-b7fa-4288-82bf-54675aaa8e0d.png">|

## Storybook link

<!-- 🎩 Include links to help tophatting -->

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
