### PR TITLE
Include SquareColorPreview when printing

### DIFF
--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.scss
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.scss
@@ -5,8 +5,7 @@
   font-size: 14px;
   display: flex;
   box-sizing: border-box;
-  -webkit-print-color-adjust: exact; /* stylelint-disable-line property-no-vendor-prefix */
-  print-color-adjust: exact; /* stylelint-disable-line property-no-unknown */
+  @include print-color;
 }
 
 .VerticalContainer {

--- a/packages/polaris-viz/src/components/SquareColorPreview/SquareColorPreview.scss
+++ b/packages/polaris-viz/src/components/SquareColorPreview/SquareColorPreview.scss
@@ -1,5 +1,8 @@
+@import '../../styles/common';
+
 .ColorPreview {
   border-radius: 2px;
   display: block;
   flex: none;
+  @include print-color;
 }

--- a/packages/polaris-viz/src/styles/_common.scss
+++ b/packages/polaris-viz/src/styles/_common.scss
@@ -8,3 +8,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+@mixin print-color {
+  -webkit-print-color-adjust: exact; /* stylelint-disable-line property-no-vendor-prefix */
+  print-color-adjust: exact; /* stylelint-disable-line property-no-unknown */
+}


### PR DESCRIPTION
## What does this implement/fix?

Add css class to force the browser to include the background color when printing.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1262

## What do the changes look like?

<img width="286" alt="image" src="https://user-images.githubusercontent.com/149873/184675096-16cc6319-2191-4cc6-b40b-b02349198bd2.png">
 