### PR TITLE
add homepage and repository urls

### DIFF
--- a/packages/polaris-viz/package.json
+++ b/packages/polaris-viz/package.json
@@ -5,6 +5,8 @@
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",
+  "homepage": "https://polaris-viz.shopify.com/",
+  "repository": "https://github.com/Shopify/polaris-viz",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## What does this implement/fix?

I added the homepage and repository urls in `package.json` in order to improve the package visibility on https://www.npmjs.com/package/@shopify/polaris-viz.

I based my changes on https://github.com/Shopify/polaris/blob/main/polaris-react/package.json#L8

## Does this close any currently open issues?

Nope

## What do the changes look like?

https://www.npmjs.com/package/@shopify/polaris-viz will have links in the sidebar like in https://www.npmjs.com/package/@shopify/polaris

## Storybook link

NA

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
