### PR TITLE
Change polaris-viz.shopify.io -> .com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
 ## Code of conduct
 
-We expect all participants to read our [code of conduct](https://polaris-viz.shopify.io/?path=/docs/contributing-code-of-conduct--page) to understand which actions are and aren’t tolerated.
+We expect all participants to read our [code of conduct](https://polaris-viz.shopify.com/?path=/docs/contributing-code-of-conduct--page) to understand which actions are and aren’t tolerated.
 
 <br/>
 <hr/>
@@ -16,7 +16,7 @@ We expect all participants to read our [code of conduct](https://polaris-viz.sho
 ## Development
 <!-- TODO UPDATE LINK -->
 
-👩🏾‍💻 For local development instructions, head to the [Contributing/Local Development](http://polaris-viz.shopify.io/?path=/story/contributing-local-development--page) section
+👩🏾‍💻 For local development instructions, head to the [Contributing/Local Development](http://polaris-viz.shopify.com/?path=/story/contributing-local-development--page) section
 
 <br/>
 <hr/>

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -25,7 +25,7 @@ Will type check all packages
 Will start the jest test runner
 
 - **`yarn dev`:**
-Builds all libraries and automatically rebuilds on code change. This can be combined with the [Sandbox](http://polaris-viz.shopify.io/?path=/docs/contributing-sandbox--page) to get near live updates.
+Builds all libraries and automatically rebuilds on code change. This can be combined with the [Sandbox](http://polaris-viz.shopify.com/?path=/docs/contributing-sandbox--page) to get near live updates.
 
 - **`yarn storybook`:**
 Runs storybook locally
@@ -48,7 +48,7 @@ The root `package.json` merely contains `devDependencies` that are needed to bui
 
 ### Developing in React Native
 
-To test `@shopify/polaris-viz-native` code please use our [Sandbox](http://polaris-viz.shopify.io/?path=/docs/contributing-sandbox--page).
+To test `@shopify/polaris-viz-native` code please use our [Sandbox](http://polaris-viz.shopify.com/?path=/docs/contributing-sandbox--page).
 
 <br>
 
@@ -66,7 +66,7 @@ In the packages folder you'll find the source code of the libraries that get pub
 
 `@shopify/polaris-viz-core` contains platform agnostic code shared by both `@shopify/polaris-viz` and `@shopify/polaris-viz-native`
 
-This monorepo is managed with Shopify's [Loom](https://www.npmjs.com/package/@shopify/loom) for building and testing and [Lerna](https://github.com/lerna/lerna) for the publishing workflow. To learn more about how to create releases please see our [Creating Releases page](http://polaris-viz.shopify.io/?path=/docs/contributing-creating-releases--page).
+This monorepo is managed with Shopify's [Loom](https://www.npmjs.com/package/@shopify/loom) for building and testing and [Lerna](https://github.com/lerna/lerna) for the publishing workflow. To learn more about how to create releases please see our [Creating Releases page](http://polaris-viz.shopify.com/?path=/docs/contributing-creating-releases--page).
 
 
 <br>
@@ -84,4 +84,4 @@ For complex props, like callback functions, consider adding a select to stories 
 
 ### `/sandbox`
 
-The sandbox folder contains an [Expo](https://docs.expo.dev/) app pre-configured so you can test the build of each library in a web browser, an iOS simulator or an Android simulator. Read more about how to use it on the [Sandbox page](http://polaris-viz.shopify.io/?path=/docs/contributing-sandbox--page).
+The sandbox folder contains an [Expo](https://docs.expo.dev/) app pre-configured so you can test the build of each library in a web browser, an iOS simulator or an Android simulator. Read more about how to use it on the [Sandbox page](http://polaris-viz.shopify.com/?path=/docs/contributing-sandbox--page).

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed horizontal bar charts not animating their bars in on mount.
+- Fixed links from `polaris-viz.shopify.io` to `polaris-viz.shopify.com` in documentation.
 
 ## [7.0.0] - 2022-08-12
 

--- a/packages/polaris-viz/src/storybook/index.ts
+++ b/packages/polaris-viz/src/storybook/index.ts
@@ -43,7 +43,7 @@ export const LEGEND_CONTROL_ARGS = {
 };
 
 export const RENDER_TOOLTIP_DESCRIPTION =
-  'This accepts a function that is called to render the tooltip content. When necessary it calls `formatXAxisLabel` and/or `formatYAxisLabel` to format the `DataSeries[]` values and passes them to `<TooltipContent />`. [RenderTooltipContentData type definition.](https://polaris-viz.shopify.io/?path=/docs/polaris-viz-subcomponents-tooltipcontent-rendertooltipcontent--page)';
+  'This accepts a function that is called to render the tooltip content. When necessary it calls `formatXAxisLabel` and/or `formatYAxisLabel` to format the `DataSeries[]` values and passes them to `<TooltipContent />`. [RenderTooltipContentData type definition.](https://polaris-viz.shopify.com/?path=/docs/polaris-viz-subcomponents-tooltipcontent-rendertooltipcontent--page)';
 
 export const DATA_ARGS = {
   description:

--- a/scripts/character-widths/README.md
+++ b/scripts/character-widths/README.md
@@ -1,6 +1,6 @@
 # 📏 Character Widths
 
-To speed up the truncation logic for [Labels](https://polaris-viz.shopify.io/?path=/docs/shared-labels--page) we use a pre-built `json` file that includes the width of each available character the browser provides. This includes multiple languages.
+To speed up the truncation logic for [Labels](https://polaris-viz.shopify.com/?path=/docs/shared-labels--page) we use a pre-built `json` file that includes the width of each available character the browser provides. This includes multiple languages.
 
 Currently this process is manual, but it only needs to be re-ran if the font size, or family changes.
 


### PR DESCRIPTION
## What does this implement/fix?

`polaris-viz.shopify.io` does not seem to exist. `polaris-viz.shopify.com` is interspersed throughout the code. Change all references from `.io` to `.com` in the READMEs, etc

Did not change the `CHANGELOG` as it's historical

Finally, change the storybook definition in `RENDER_TOOLTIP_DESCRIPTION` because it's used in the site to link back, and that link was broken.

![image](https://user-images.githubusercontent.com/430293/185699894-5e5d9cb7-2b0c-4187-b216-8f38789c61c8.png)


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [x] Update the Changelog's Unreleased section with your changes.
- [x] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
