### PR TITLE
Only push never versions live when a new release is made

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this implement/fix?

We shouldn't update https://polaris-viz.shopify.com/ whenever we merge code to main because if we're between releases consumers could be seeing charts/features that aren't currently available to them.

