### PR TITLE
Pass theme to ChartSkeleton

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Fixed horizontal bar charts not animating their bars in on mount.
 - Fixed links from `polaris-viz.shopify.io` to `polaris-viz.shopify.com` in documentation.
+- Fixed `theme` not being passed to `<ChartSkeleton />`.
 
 ## [7.0.0] - 2022-08-12
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -110,7 +110,7 @@ export function BarChart(props: BarChartProps) {
         type={InternalChartType.Bar}
       >
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           ChartByDirection
         )}

--- a/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
@@ -53,7 +53,12 @@ export function FunnelChart(props: FunnelChartProps) {
   return (
     <ChartContainer data={data} isAnimated={isAnimated} theme={theme}>
       {state !== ChartState.Success ? (
-        <ChartSkeleton type="Funnel" state={state} errorText={errorText} />
+        <ChartSkeleton
+          type="Funnel"
+          state={state}
+          errorText={errorText}
+          theme={theme}
+        />
       ) : (
         <Chart
           data={seriesWithDefaults}

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -83,7 +83,7 @@ export function LineChart(props: LineChartProps) {
         type={InternalChartType.Line}
       >
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
             annotationsLookupTable={annotationsLookupTable}

--- a/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
@@ -4,12 +4,13 @@ export {META as default} from './meta';
 
 import type {LineChartProps} from '../../../components';
 
-import {DEFAULT_PROPS, Template} from './data';
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 export const Annotations: Story<LineChartProps> = Template.bind({});
 
 Annotations.args = {
   ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
   annotations: [
     {
       startKey: '2020-04-02T12:00:00',

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -41,7 +41,12 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
   return (
     <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>
       {state !== ChartState.Success ? (
-        <ChartSkeleton type="SimpleBar" state={state} errorText={errorText} />
+        <ChartSkeleton
+          type="SimpleBar"
+          state={state}
+          errorText={errorText}
+          theme={theme}
+        />
       ) : (
         <Chart
           data={data}

--- a/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
@@ -38,7 +38,12 @@ export function SparkBarChart(props: SparkBarChartProps) {
       isAnimated={isAnimated}
     >
       {state !== ChartState.Success ? (
-        <ChartSkeleton type="Spark" state={state} errorText={errorText} />
+        <ChartSkeleton
+          type="Spark"
+          state={state}
+          errorText={errorText}
+          theme={theme}
+        />
       ) : (
         <Chart
           data={data}

--- a/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
@@ -39,7 +39,12 @@ export function SparkLineChart(props: SparkLineChartProps) {
       sparkChart
     >
       {state !== ChartState.Success ? (
-        <ChartSkeleton type="Spark" state={state} errorText={errorText} />
+        <ChartSkeleton
+          type="Spark"
+          state={state}
+          errorText={errorText}
+          theme={theme}
+        />
       ) : (
         <Chart
           data={data}

--- a/packages/polaris-viz/src/components/SparkLineChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/stories/meta.tsx
@@ -2,7 +2,10 @@ import type {Meta} from '@storybook/react';
 import React from 'react';
 
 import {PageWithSizingInfo} from '../../Docs/stories';
-import {THEME_CONTROL_ARGS} from '../../../storybook/constants';
+import {
+  CHART_STATE_CONTROL_ARGS,
+  THEME_CONTROL_ARGS,
+} from '../../../storybook/constants';
 import {SparkLineChart} from '../SparkLineChart';
 
 export const META: Meta = {
@@ -44,5 +47,6 @@ export const META: Meta = {
         'The amount of pixels to add as a right margin to the non-comparison line data.',
     },
     theme: THEME_CONTROL_ARGS,
+    state: CHART_STATE_CONTROL_ARGS,
   },
 };

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -68,7 +68,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
       )}
       <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>
         {state !== ChartState.Success ? (
-          <ChartSkeleton state={state} errorText={errorText} />
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (
           <Chart
             annotationsLookupTable={annotationsLookupTable}


### PR DESCRIPTION
## What does this implement/fix?

We weren't passing `theme` down to `<ChartSkeleton />` which was causing it to always render the `Default` theme.

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="263" alt="image" src="https://user-images.githubusercontent.com/149873/187237112-ffae53f1-5560-4a1a-887d-7a19fb088831.png">|<img width="260" alt="image" src="https://user-images.githubusercontent.com/149873/187237021-4bea98e4-e999-46ce-9a1b-05474c9db83a.png">|

 