### PR TITLE
Don't inset LineSeries when labels are hidden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ packages/*/build
 yalc.lock
 build
 storybook-static-chromatic
+docs-build

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Don't inset `<LineSeries />` when labels are hidden.
+
 ### Fixed
 
 - Fixed horizontal bar charts not animating their bars in on mount.

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -154,9 +154,12 @@ export function Chart({
     yAxisWidth: yAxisLabelWidth,
   });
 
+  const hideXAxis = xAxisOptions.hide || selectedTheme.xAxis.hide;
+
   const {xAxisDetails, xScale, labels} = useLinearLabelsAndDimensions({
     data,
     drawableWidth,
+    hideXAxis,
     labels: formattedLabels,
     longestSeriesLength,
   });
@@ -224,8 +227,6 @@ export function Chart({
       };
     }
   }
-
-  const hideXAxis = xAxisOptions.hide || selectedTheme.xAxis.hide;
 
   function moveCrosshair(index: number | null) {
     setActiveIndex(0);

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -157,6 +157,7 @@ export function Chart({
   const {xAxisDetails, xScale, labels} = useLinearLabelsAndDimensions({
     data,
     drawableWidth,
+    hideXAxis,
     labels: formattedLabels,
     longestSeriesLength,
   });

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -15,6 +15,7 @@ import {useReducedLabelIndexes} from './useReducedLabelIndexes';
 interface Props {
   data: DataSeries[];
   drawableWidth: number;
+  hideXAxis: boolean;
   labels: string[];
   longestSeriesLength: number;
 }
@@ -22,6 +23,7 @@ interface Props {
 export function useLinearLabelsAndDimensions({
   data,
   drawableWidth: initialDrawableWidth,
+  hideXAxis,
   labels,
   longestSeriesLength,
 }: Props) {
@@ -69,7 +71,7 @@ export function useLinearLabelsAndDimensions({
     reducedLabelIndexes.length > 0 ? reducedLabelIndexes.length : labels.length;
 
   const labelWidth = useMemo(() => {
-    if (visibleLabelsCount === 0) {
+    if (visibleLabelsCount === 0 || hideXAxis) {
       return 0;
     }
 
@@ -81,7 +83,7 @@ export function useLinearLabelsAndDimensions({
       min: 0,
       max: initialDrawableWidth,
     });
-  }, [initialDrawableWidth, visibleLabelsCount, longestLabelWidth]);
+  }, [initialDrawableWidth, visibleLabelsCount, hideXAxis, longestLabelWidth]);
 
   const drawableWidth = initialDrawableWidth - labelWidth;
 


### PR DESCRIPTION
## What does this implement/fix?

In order to center points over the labels on linear charts, we inset the `<LineSeries />` by half of the label width.

When the labels are hidden, we don't need to inset the series anymore. 

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1368

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/187709675-b9720889-3cd2-443f-8b23-40a0a542c359.png)|![image](https://user-images.githubusercontent.com/149873/187709604-d35c65d3-cd21-456e-8372-8cb85dacee01.png)|
 
## Storybook link

- [ ]  [LineChart w/ Labels](https://6062ad4a2d14cd0021539c1b-gphhsvqrqu.chromatic.com/?path=/story/polaris-viz-charts-linechart--default)
- [ ]  [LineChart w/o Labels](https://6062ad4a2d14cd0021539c1b-gphhsvqrqu.chromatic.com/?path=/story/polaris-viz-charts-linechart--hide-x-axis)
- [ ]  [StackedAreaChart w/ Labels](https://6062ad4a2d14cd0021539c1b-gphhsvqrqu.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart--default)
- [ ]  [StackedAreaChart w/o Labels](https://6062ad4a2d14cd0021539c1b-gphhsvqrqu.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart--hide-x-axis-labels)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
