### PR TITLE
Fix jumping labels again

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed diagonal labels jumping around in cases where the threshold was too close.
 
 ## [7.1.0] - 2022-08-31
 

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
@@ -486,3 +486,60 @@ export const JumpyLabels = () => {
 };
 
 JumpyLabels.args = {};
+
+export const JumpyLabelsFromNotebooks = () => {
+  return (
+    <BarChart
+      data={[
+        {
+          name: 'Total Sales',
+          data: [
+            {
+              key: 'Persistent Cart + Custom Checkout App',
+              value: 1899932.26,
+            },
+            {
+              key: 'Feedonomics-Walmart',
+              value: 183214.61,
+            },
+            {
+              key: 'Feedonomics-Target',
+              value: 84626.41,
+            },
+            {
+              key: 'Online Store',
+              value: 17653.79,
+            },
+            {
+              key: 'Draft Orders',
+              value: 16524.72,
+            },
+            {
+              key: 'Feedonomics-Amazon',
+              value: 8854.52,
+            },
+            {
+              key: 'Gorgias ‑ Live Chat & Helpdesk',
+              value: 2195.97,
+            },
+            {
+              key: 'Wholesale',
+              value: 389.8,
+            },
+            {
+              key: 'Return & Exchange Portal',
+              value: 0,
+            },
+            {
+              key: 'Feedonomics',
+              value: -185.69,
+            },
+          ],
+        },
+      ]}
+      showLegend={false}
+    />
+  );
+};
+
+JumpyLabelsFromNotebooks.args = {};

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/ErrorText/ErrorText.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/ErrorText/ErrorText.tsx
@@ -6,7 +6,13 @@ import {TextLine} from '../../../TextLine';
 
 const TEXT_DROP_SHADOW_SIZE = 3;
 
-export function ErrorText({errorText, width, height}) {
+interface ErrorTextProps {
+  width: number;
+  height: number;
+  errorText: string;
+}
+
+export function ErrorText({errorText, width, height}: ErrorTextProps) {
   const {
     chartContainer: {backgroundColor},
   } = useTheme();
@@ -15,7 +21,6 @@ export function ErrorText({errorText, width, height}) {
     allowLineWrap: true,
     labels: [errorText],
     targetWidth: width,
-    chartHeight: height,
   });
 
   return (

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -206,7 +206,6 @@ export function Chart({
         {hideXAxis ? null : (
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
-            chartHeight={height}
             labels={labels}
             labelWidth={labelWidth}
             onHeightChange={setXAxisHeight}

--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -193,7 +193,6 @@ export function Chart({
       <g aria-hidden="true">
         <FunnelChartXAxisLabels
           allowLineWrap={xAxisOptions.allowLineWrap}
-          chartHeight={height}
           chartX={barWidth / NEGATIVE_LABEL_OFFSET}
           chartY={drawableHeight + X_LABEL_OFFSET}
           labels={labels}

--- a/packages/polaris-viz/src/components/FunnelChart/components/FunnelChartXAxisArrows.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/FunnelChartXAxisArrows.tsx
@@ -7,7 +7,6 @@ const ARROW_WIDTH = 11;
 const ARROW_HEIGHT = 9;
 
 export interface FunnelChartXAxisArrowsProps {
-  chartHeight: number;
   onHeightChange: Dispatch<SetStateAction<number>>;
   x: number;
   index: number;
@@ -17,7 +16,6 @@ export interface FunnelChartXAxisArrowsProps {
 }
 
 export function FunnelChartXAxisArrows({
-  chartHeight,
   onHeightChange,
   x,
   index,
@@ -30,7 +28,6 @@ export function FunnelChartXAxisArrows({
     labels: ['→'],
     targetWidth: labelWidth,
     onHeightChange,
-    chartHeight,
   });
   const firstLine = lines[0];
   const firstLabel = firstLine[0];

--- a/packages/polaris-viz/src/components/FunnelChart/components/FunnelChartXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/FunnelChartXAxisLabels.tsx
@@ -10,7 +10,6 @@ export interface FunnelChartXAxisLabelsProps {
   allowLineWrap: boolean;
   chartX: number;
   chartY: number;
-  chartHeight: number;
   labels: string[];
   labelWidth: number;
   onHeightChange: Dispatch<SetStateAction<number>>;
@@ -20,7 +19,6 @@ export interface FunnelChartXAxisLabelsProps {
 
 export function FunnelChartXAxisLabels({
   allowLineWrap,
-  chartHeight,
   chartX,
   chartY,
   labels,
@@ -34,7 +32,6 @@ export function FunnelChartXAxisLabels({
     labels,
     targetWidth: labelWidth,
     onHeightChange,
-    chartHeight,
   });
 
   return (
@@ -50,7 +47,6 @@ export function FunnelChartXAxisLabels({
           <g key={`label-group-${index}`}>
             {index === 0 ? null : (
               <FunnelChartXAxisArrows
-                chartHeight={chartHeight}
                 onHeightChange={onHeightChange}
                 x={x}
                 index={index}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -212,7 +212,6 @@ export function Chart({
             />
             <HorizontalBarChartXAxisLabels
               allowLineWrap={xAxisOptions.allowLineWrap}
-              chartHeight={height}
               chartX={-labelWidth / 2}
               chartY={drawableHeight}
               labels={ticksFormatted}

--- a/packages/polaris-viz/src/components/HorizontalBarChartXAxisLabels/HorizontalBarChartXAxisLabels.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChartXAxisLabels/HorizontalBarChartXAxisLabels.tsx
@@ -6,7 +6,6 @@ import {TextLine} from '../TextLine';
 
 interface HorizontalBarChartXAxisLabelsProps {
   allowLineWrap: boolean;
-  chartHeight: number;
   chartX: number;
   chartY: number;
   labels: string[];
@@ -18,7 +17,6 @@ interface HorizontalBarChartXAxisLabelsProps {
 
 export function HorizontalBarChartXAxisLabels({
   allowLineWrap,
-  chartHeight,
   chartX,
   chartY,
   labels,
@@ -29,7 +27,6 @@ export function HorizontalBarChartXAxisLabels({
 }: HorizontalBarChartXAxisLabelsProps) {
   const {lines} = useLabels({
     allowLineWrap,
-    chartHeight,
     labels,
     onHeightChange,
     targetWidth: labelWidth,

--- a/packages/polaris-viz/src/components/Labels/Labels.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/Labels/Labels.chromatic.stories.tsx
@@ -37,7 +37,6 @@ const stories = storiesOf(
               <XAxis
                 allowLineWrap={allowLineWrap}
                 ariaHidden={false}
-                chartHeight={CHART_HEIGHT}
                 labels={LABELS}
                 labelWidth={labelWidth}
                 onHeightChange={() => {}}
@@ -66,7 +65,6 @@ stories.add(`reducedLabelIndexes`, () => {
             <XAxis
               allowLineWrap={true}
               ariaHidden={false}
-              chartHeight={CHART_HEIGHT}
               labels={LABELS}
               labelWidth={labelWidth}
               onHeightChange={() => {}}

--- a/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
+++ b/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
@@ -12,11 +12,8 @@ import {getDiagonalLabels} from '../utilities/getDiagonalLabels';
 import {getHorizontalLabels} from '../utilities/getHorizontalLabels';
 import {getVerticalLabels} from '../utilities/getVerticalLabels';
 
-const LABEL_CONTAINER_MAX_PERCENTAGE = 0.25;
-
 interface Props {
   allowLineWrap: boolean;
-  chartHeight: number;
   labels: string[];
   targetWidth: number;
   onHeightChange?: Dispatch<SetStateAction<number>> | (() => void);
@@ -24,7 +21,6 @@ interface Props {
 
 export function useLabels({
   allowLineWrap,
-  chartHeight,
   labels,
   onHeightChange = () => {},
   targetWidth,
@@ -55,8 +51,6 @@ export function useLabels({
     }, 0);
   }, [labels, characterWidths]);
 
-  const maxWidth = Math.floor(chartHeight * LABEL_CONTAINER_MAX_PERCENTAGE);
-
   const {lines, containerHeight} = useMemo(() => {
     const shouldDrawHorizontal = checkIfShouldDrawHorizontal({
       allowLineWrap,
@@ -79,7 +73,7 @@ export function useLabels({
         return getDiagonalLabels({
           characterWidths,
           labels: preparedLabels,
-          maxWidth,
+          longestLabelWidth,
           targetHeight: LINE_HEIGHT,
           targetWidth,
         });
@@ -88,7 +82,7 @@ export function useLabels({
         return getVerticalLabels({
           characterWidths,
           labels: preparedLabels,
-          maxWidth,
+          longestLabelWidth,
           targetWidth,
         });
       }
@@ -101,7 +95,6 @@ export function useLabels({
     }
   }, [
     allowLineWrap,
-    maxWidth,
     targetWidth,
     characterWidths,
     preparedLabels,

--- a/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
@@ -12,7 +12,7 @@ import {truncateLabels} from './truncateLabels';
 
 interface Props {
   labels: PreparedLabels[];
-  maxWidth: number;
+  longestLabelWidth: number;
   targetHeight: number;
   targetWidth: number;
   characterWidths: CharacterWidths;
@@ -21,13 +21,13 @@ interface Props {
 export function getDiagonalLabels({
   characterWidths,
   labels,
-  maxWidth,
+  longestLabelWidth,
   targetHeight,
   targetWidth,
 }: Props) {
   const clampedTargetWidth = clamp({
-    amount: targetWidth,
-    min: maxWidth,
+    amount: longestLabelWidth,
+    min: targetWidth,
     max: MAX_DIAGONAL_LABEL_WIDTH,
   });
 

--- a/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
@@ -8,21 +8,21 @@ import {truncateLabels} from './truncateLabels';
 const QUARTER = 4;
 
 interface Props {
+  targetWidth: number;
+  longestLabelWidth: number;
   labels: PreparedLabels[];
   characterWidths: CharacterWidths;
-  maxWidth: number;
-  targetWidth: number;
 }
 
 export function getVerticalLabels({
   labels,
   characterWidths,
-  maxWidth,
+  longestLabelWidth,
   targetWidth,
 }: Props) {
   const clampedTargetWidth = clamp({
-    amount: maxWidth,
-    min: maxWidth,
+    amount: longestLabelWidth,
+    min: targetWidth,
     max: VERTICAL_LABEL_TARGET_WIDTH,
   });
   const truncatedLabels = truncateLabels({

--- a/packages/polaris-viz/src/components/Labels/utilities/truncateSingleLine.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/truncateSingleLine.ts
@@ -18,7 +18,7 @@ export function truncateSingleLine({
 }: Props) {
   const estimatedWidth = estimateStringWidth(label, characterWidths);
 
-  if (estimatedWidth < targetWidth) {
+  if (estimatedWidth <= targetWidth) {
     return label;
   }
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -276,7 +276,6 @@ export function Chart({
         {hideXAxis ? null : (
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
-            chartHeight={height}
             x={xAxisBounds.x}
             y={xAxisBounds.y}
             labels={labels}

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -261,7 +261,6 @@ export function Chart({
         {hideXAxis ? null : (
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
-            chartHeight={height}
             labels={labels}
             labelWidth={xAxisDetails.labelWidth}
             onHeightChange={setXAxisHeight}

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -205,7 +205,6 @@ export function Chart({
         {hideXAxis ? null : (
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
-            chartHeight={drawableHeight}
             labels={labels}
             labelWidth={xScale.bandwidth()}
             onHeightChange={setXAxisHeight}

--- a/packages/polaris-viz/src/components/XAxis/XAxis.tsx
+++ b/packages/polaris-viz/src/components/XAxis/XAxis.tsx
@@ -6,7 +6,6 @@ import {TextLine} from '../TextLine';
 
 interface XAxisProps {
   allowLineWrap: boolean;
-  chartHeight: number;
   x: number;
   y: number;
   labels: string[];
@@ -20,7 +19,6 @@ interface XAxisProps {
 export function XAxis({
   ariaHidden = false,
   allowLineWrap,
-  chartHeight,
   x,
   y,
   labels,
@@ -30,7 +28,6 @@ export function XAxis({
   xScale,
 }: XAxisProps) {
   const {lines} = useLabels({
-    chartHeight,
     labels,
     onHeightChange,
     targetWidth: labelWidth,


### PR DESCRIPTION
## What does this implement/fix?

The notebooks team reported a case where labels were jumping around again at certain chart sizes.

Diagonal and Horizontal labels don't really need to take the chart height into account because they have a set maximum size, so by using the chart height we would get into a condition where the truncation was flipping back and forth because the chart height was changing too often.

## What do the changes look like?

**Original Issue**

https://user-images.githubusercontent.com/149873/187736243-09b2fadb-78bb-4cd4-b0a3-6e2e19d04639.mp4

**Fix**

https://user-images.githubusercontent.com/149873/187736618-5123fdbc-1cc2-4bb2-824a-e9fe69d990eb.mov

## Storybook link

https://6062ad4a2d14cd0021539c1b-jokmkybbaz.chromatic.com/iframe.html?args=&id=polaris-viz-charts-barchart-playground--jumpy-labels-from-notebooks&viewMode=story

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
