### PR TITLE
Don't render TooltipWrapper when data could be bad

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -105,6 +105,7 @@ export {
   roundToDecimals,
   isLargeDataSet,
   ColorScale,
+  isDataGroupArray,
 } from './utilities';
 export {
   useSparkBar,

--- a/packages/polaris-viz-core/src/utilities/index.ts
+++ b/packages/polaris-viz-core/src/utilities/index.ts
@@ -23,3 +23,4 @@ export {getClosestDivisibleNumber} from './getClosestDivisibleNumber';
 export {roundToDecimals} from './roundToDecimals';
 export {isLargeDataSet} from './isLargeDataSet';
 export {ColorScale} from './ColorScale/ColorScale';
+export {isDataGroupArray} from './isDataGroup';

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where charts would crash when empty `DataSeries.data` array was empty.
 
 ## [7.2.0] - 2022-08-31
 

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
@@ -543,3 +543,15 @@ export const JumpyLabelsFromNotebooks = () => {
 };
 
 JumpyLabelsFromNotebooks.args = {};
+
+export const BadData: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <div style={{width: 600, height: 400}}>
+      <BarChart {...args} />
+    </div>
+  );
+};
+
+BadData.args = {
+  data: [{name: 'Empty', data: []}],
+};

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -73,6 +73,7 @@ export const ChartContainer = (props: Props) => {
         id={getChartId(value.id)}
       >
         <ChartDimensions
+          data={props.data}
           onIsPrintingChange={setIsPrinting}
           skeletonType={props.skeletonType}
           sparkChart={props.sparkChart}

--- a/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
@@ -7,7 +7,13 @@ import React, {
   useLayoutEffect,
   useState,
 } from 'react';
-import {Dimensions, usePrevious, useTheme} from '@shopify/polaris-viz-core';
+import {
+  DataGroup,
+  DataSeries,
+  Dimensions,
+  usePrevious,
+  useTheme,
+} from '@shopify/polaris-viz-core';
 import {useDebouncedCallback} from 'use-debounce/lib';
 import type {SkeletonType} from 'components/ChartSkeleton';
 
@@ -18,6 +24,7 @@ import styles from './ChartDimensions.scss';
 
 interface ChartDimensionsProps {
   children: ReactElement;
+  data: DataSeries[] | DataGroup[];
   onIsPrintingChange: Dispatch<SetStateAction<boolean>>;
   sparkChart?: boolean;
   skeletonType?: SkeletonType;
@@ -25,6 +32,7 @@ interface ChartDimensionsProps {
 
 export function ChartDimensions({
   children,
+  data,
   onIsPrintingChange,
   sparkChart = false,
   skeletonType = 'Default',
@@ -108,6 +116,7 @@ export function ChartDimensions({
         <ChartErrorBoundary
           type={skeletonType ?? 'Default'}
           dimensions={chartDimensions!}
+          data={data}
         >
           <div
             className={styles.Chart}

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/ChartErrorBoundary.tsx
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/ChartErrorBoundary.tsx
@@ -1,11 +1,19 @@
-import {ChartState, Dimensions} from '@shopify/polaris-viz-core';
+import {
+  ChartState,
+  DataGroup,
+  DataSeries,
+  Dimensions,
+} from '@shopify/polaris-viz-core';
 import React, {ErrorInfo} from 'react';
 
 import {ChartSkeleton} from '../ChartSkeleton';
 import type {SkeletonType} from '../ChartSkeleton';
 
+import {checkForMismatchedData} from './utilities/checkForMismatchedData';
+
 interface ErrorBoundaryProps {
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  data: DataSeries[] | DataGroup[];
   dimensions: Dimensions;
   type: SkeletonType;
 }
@@ -29,6 +37,8 @@ export class ChartErrorBoundary extends React.Component<
   }
 
   onError = (error, errorInfo) => {
+    checkForMismatchedData(this.props.data);
+
     if (this.props.onError) {
       this.props.onError(error, errorInfo);
     } else {

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
@@ -1,5 +1,5 @@
 import type {DataGroup, DataSeries} from '@shopify/polaris-viz-core';
-import {isDataGroupArray} from '@shopify/polaris-viz-core/src/utilities/isDataGroup';
+import {isDataGroupArray} from '@shopify/polaris-viz-core';
 
 export function checkForMismatchedData(data: DataSeries[] | DataGroup[]) {
   if (data == null || data.length === 0) {

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
@@ -1,0 +1,36 @@
+import type {DataGroup, DataSeries} from '@shopify/polaris-viz-core';
+import {isDataGroupArray} from '@shopify/polaris-viz-core/src/utilities/isDataGroup';
+
+export function checkForMismatchedData(data: DataSeries[] | DataGroup[]) {
+  if (data == null || data.length === 0) {
+    return;
+  }
+
+  if (isDataGroupArray(data)) {
+    checkDataGroup(data as DataGroup[]);
+  } else {
+    checkDataSeries(data as DataSeries[]);
+  }
+}
+
+function checkDataSeries(data: DataSeries[], type = 'DataSeries') {
+  const firstSetLength = data[0].data.length;
+
+  const hasMismatchedData = data.some(
+    (series) => series.data.length !== firstSetLength,
+  );
+
+  if (hasMismatchedData) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `The ${type}[] provided does not have equal series values.`,
+      data,
+    );
+
+    return true;
+  }
+}
+
+function checkDataGroup(group: DataGroup[]) {
+  group.some(({series}) => checkDataSeries(series, 'DataGroup'));
+}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -290,16 +290,18 @@ export function Chart({
         )}
       </svg>
 
-      <TooltipWrapper
-        bandwidth={groupBarsAreaHeight}
-        chartBounds={chartBounds}
-        focusElementDataType={DataType.BarGroup}
-        getAlteredPosition={getAlteredHorizontalBarPosition}
-        getMarkup={getTooltipMarkup}
-        getPosition={getTooltipPosition}
-        margin={ChartMargin}
-        parentRef={svgRef}
-      />
+      {highestValueForSeries.length !== 0 && (
+        <TooltipWrapper
+          bandwidth={groupBarsAreaHeight}
+          chartBounds={chartBounds}
+          focusElementDataType={DataType.BarGroup}
+          getAlteredPosition={getAlteredHorizontalBarPosition}
+          getMarkup={getTooltipMarkup}
+          getPosition={getTooltipPosition}
+          margin={ChartMargin}
+          parentRef={svgRef}
+        />
+      )}
 
       {showLegend && (
         <LegendContainer

--- a/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
@@ -17,6 +17,7 @@ import {
   VerticalGridLines,
 } from '../components';
 import {normalizeData} from '../../../utilities';
+import {TooltipWrapper} from '../../TooltipWrapper';
 
 jest.mock('../../Labels/utilities/getWidestLabel', () => {
   return {
@@ -306,6 +307,22 @@ describe('<Chart />', () => {
 
       expect(chart).toContainReactComponent(HorizontalBarChartYAnnotations);
       expect(chart).toContainReactComponent(HorizontalBarChartXAnnotations);
+    });
+  });
+
+  describe('<TooltipWrapper />', () => {
+    it('does not render <TooltipWrapper /> data series is empty', () => {
+      const chart = mount(
+        <Chart {...MOCK_PROPS} data={[{name: 'Empty', data: []}]} />,
+      );
+
+      expect(chart).not.toContainReactComponent(TooltipWrapper);
+    });
+
+    it('renders <TooltipWrapper /> data series has data', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      expect(chart).toContainReactComponent(TooltipWrapper);
     });
   });
 });

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -377,23 +377,25 @@ export function Chart({
         )}
       </svg>
 
-      <TooltipWrapper
-        alwaysUpdatePosition
-        chartBounds={chartBounds}
-        focusElementDataType={DataType.Point}
-        getMarkup={getTooltipMarkup}
-        getPosition={getTooltipPosition}
-        id={tooltipId.current}
-        margin={ChartMargin}
-        onIndexChange={(index) => {
-          if (index != null && isPerformanceImpacted) {
-            moveCrosshair(index);
-          } else {
-            setActiveIndex(index);
-          }
-        }}
-        parentRef={svgRef}
-      />
+      {longestSeriesLength !== -1 && (
+        <TooltipWrapper
+          alwaysUpdatePosition
+          chartBounds={chartBounds}
+          focusElementDataType={DataType.Point}
+          getMarkup={getTooltipMarkup}
+          getPosition={getTooltipPosition}
+          id={tooltipId.current}
+          margin={ChartMargin}
+          onIndexChange={(index) => {
+            if (index != null && isPerformanceImpacted) {
+              moveCrosshair(index);
+            } else {
+              setActiveIndex(index);
+            }
+          }}
+          parentRef={svgRef}
+        />
+      )}
 
       {showLegend && (
         <LegendContainer

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -37,3 +37,15 @@ LargeDataSet.args = {
     labelFormatter: formatLinearXAxisLabel,
   },
 };
+
+export const BadData: Story<LineChartProps> = (args: LineChartProps) => {
+  return (
+    <div style={{width: 600, height: 400}}>
+      <LineChart {...args} />
+    </div>
+  );
+};
+
+BadData.args = {
+  data: [{name: 'Empty', data: []}],
+};

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -17,7 +17,10 @@ import {Point} from '../../../components/Point';
 import {mountWithProvider, triggerSVGMouseMove} from '../../../test-utilities';
 import {HorizontalGridLines} from '../../../components/HorizontalGridLines';
 import {mockDefaultTheme} from '../../../test-utilities/mountWithProvider';
-import {TooltipAnimatedContainer} from '../../../components/TooltipWrapper';
+import {
+  TooltipAnimatedContainer,
+  TooltipWrapper,
+} from '../../../components/TooltipWrapper';
 import {Chart, ChartProps} from '../Chart';
 import {YAxis} from '../../YAxis';
 import {Annotations, YAxisAnnotations} from '../../Annotations';
@@ -475,6 +478,22 @@ describe('<Chart />', () => {
 
       expect(chart).toContainReactComponent(YAxisAnnotations);
       expect(chart).toContainReactComponent(Annotations);
+    });
+  });
+
+  describe('<TooltipWrapper />', () => {
+    it('does not render <TooltipWrapper /> data series is empty', () => {
+      const chart = mount(
+        <Chart {...MOCK_PROPS} data={[{name: 'Empty', color: [], data: []}]} />,
+      );
+
+      expect(chart).not.toContainReactComponent(TooltipWrapper);
+    });
+
+    it('renders <TooltipWrapper /> data series has data', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      expect(chart).toContainReactComponent(TooltipWrapper);
     });
   });
 });

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -380,17 +380,19 @@ export function Chart({
         )}
       </svg>
 
-      <TooltipWrapper
-        alwaysUpdatePosition
-        chartBounds={chartBounds}
-        focusElementDataType={DataType.Point}
-        getMarkup={getTooltipMarkup}
-        getPosition={getTooltipPosition}
-        id={tooltipId}
-        margin={ChartMargin}
-        onIndexChange={(index) => setActivePointIndex(index)}
-        parentRef={svgRef}
-      />
+      {longestSeriesLength !== -1 && (
+        <TooltipWrapper
+          alwaysUpdatePosition
+          chartBounds={chartBounds}
+          focusElementDataType={DataType.Point}
+          getMarkup={getTooltipMarkup}
+          getPosition={getTooltipPosition}
+          id={tooltipId}
+          margin={ChartMargin}
+          onIndexChange={(index) => setActivePointIndex(index)}
+          parentRef={svgRef}
+        />
+      )}
 
       {showLegend && (
         <LegendContainer

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/Playground.stories.tsx
@@ -256,3 +256,17 @@ NonAnimatedSmallData.args = {
   ],
   isAnimated: false,
 };
+
+export const BadData: Story<StackedAreaChartProps> = (
+  args: StackedAreaChartProps,
+) => {
+  return (
+    <div style={{width: 600, height: 400}}>
+      <StackedAreaChart {...args} />
+    </div>
+  );
+};
+
+BadData.args = {
+  data: [{name: 'Empty', data: []}],
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -322,4 +322,20 @@ describe('<Chart />', () => {
       expect(chart).toContainReactComponent(Annotations);
     });
   });
+
+  describe('<TooltipWrapper />', () => {
+    it('does not render <TooltipWrapper /> data series is empty', () => {
+      const chart = mount(
+        <Chart {...MOCK_PROPS} data={[{name: 'Empty', data: []}]} />,
+      );
+
+      expect(chart).not.toContainReactComponent(TooltipWrapper);
+    });
+
+    it('renders <TooltipWrapper /> data series has data', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      expect(chart).toContainReactComponent(TooltipWrapper);
+    });
+  });
 });

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -289,15 +289,17 @@ export function Chart({
         )}
       </svg>
 
-      <TooltipWrapper
-        bandwidth={xScale.bandwidth()}
-        chartBounds={chartBounds}
-        focusElementDataType={DataType.BarGroup}
-        getMarkup={getTooltipMarkup}
-        getPosition={getTooltipPosition}
-        margin={{...ChartMargin, Top: chartYPosition}}
-        parentRef={svgRef}
-      />
+      {sortedData.length > 0 && (
+        <TooltipWrapper
+          bandwidth={xScale.bandwidth()}
+          chartBounds={chartBounds}
+          focusElementDataType={DataType.BarGroup}
+          getMarkup={getTooltipMarkup}
+          getPosition={getTooltipPosition}
+          margin={{...ChartMargin, Top: chartYPosition}}
+          parentRef={svgRef}
+        />
+      )}
 
       {showLegend && (
         <LegendContainer

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -5,7 +5,10 @@ import {YAxis, XAxis} from '../../../components';
 import {mountWithProvider, triggerSVGMouseMove} from '../../../test-utilities';
 import {HorizontalGridLines} from '../../../components/HorizontalGridLines';
 import {mockDefaultTheme} from '../../../test-utilities/mountWithProvider';
-import {TooltipAnimatedContainer} from '../../../components/TooltipWrapper';
+import {
+  TooltipAnimatedContainer,
+  TooltipWrapper,
+} from '../../../components/TooltipWrapper';
 import {Chart, Props} from '../Chart';
 import {StackedBarGroups} from '../components';
 import {LegendContainer} from '../../LegendContainer';
@@ -271,6 +274,22 @@ describe('Chart />', () => {
 
       expect(chart).toContainReactComponent(YAxisAnnotations);
       expect(chart).toContainReactComponent(Annotations);
+    });
+  });
+
+  describe('<TooltipWrapper />', () => {
+    it('does not render <TooltipWrapper /> data series is empty', () => {
+      const chart = mount(
+        <Chart {...MOCK_PROPS} data={[{name: 'Empty', data: []}]} />,
+      );
+
+      expect(chart).not.toContainReactComponent(TooltipWrapper);
+    });
+
+    it('renders <TooltipWrapper /> data series has data', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      expect(chart).toContainReactComponent(TooltipWrapper);
     });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

When a data series has an empty data array, some of the charts will error because the tooltips expect valid data.

```
[{name: 'Empty', data: []}]
```

Instead of checking for bad data, we can not render the `<TooltipWrapper />`.

I also added a warning in the console if the user passes mismatched data series. Currently the chart goes into an error state, but the consumer may not know why.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1328

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
