### PR TITLE
Add load animation to vertical stacked bar charts

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added animations to vertical stacked `<BarChart />'.
 
 ## [7.3.0] - 2022-08-31
 

--- a/packages/polaris-viz/src/components/BarChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/meta.tsx
@@ -10,6 +10,12 @@ import {
   TYPE_CONTROL_ARGS,
   CHART_STATE_CONTROL_ARGS,
   ANNOTATIONS_ARGS,
+  X_AXIS_OPTIONS_ARGS,
+  Y_AXIS_OPTIONS_ARGS,
+  SKIP_LINK_ARGS,
+  IS_ANIMATED_ARGS,
+  DATA_SERIES_ARGS,
+  EMPTY_STATE_TEXT_ARGS,
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 
@@ -34,28 +40,12 @@ export const META: Meta = {
   decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
   argTypes: {
     annotations: ANNOTATIONS_ARGS,
-    data: {
-      description:
-        'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
-    },
-    emptyStateText: {
-      description:
-        'Used to indicate to screen readers that a chart with no series data has been rendered, in the case that an empty array is passed as the data. If the series prop could be an empty array, it is strongly recommended to include this prop.',
-    },
-    isAnimated: {
-      description:
-        'Whether to animate the bars when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences. Note: animations are currently only available for the non-stacked bar chart.',
-    },
-    skipLinkText: {
-      description:
-        'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
-    },
-    xAxisOptions: {
-      description: 'An object that defines the xAxis and its options.',
-    },
-    yAxisOptions: {
-      description: 'An object that defines the yAxis and its options.',
-    },
+    data: DATA_SERIES_ARGS,
+    emptyStateText: EMPTY_STATE_TEXT_ARGS,
+    isAnimated: IS_ANIMATED_ARGS,
+    skipLinkText: SKIP_LINK_ARGS,
+    xAxisOptions: X_AXIS_OPTIONS_ARGS,
+    yAxisOptions: Y_AXIS_OPTIONS_ARGS,
     renderTooltipContent: {
       options: Object.keys(TOOLTIP_CONTENT),
       mapping: TOOLTIP_CONTENT,

--- a/packages/polaris-viz/src/components/LineChart/constants.ts
+++ b/packages/polaris-viz/src/components/LineChart/constants.ts
@@ -1,1 +1,0 @@
-export const ANIMATION_DELAY = 200;

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/StackedBarGroups.tsx
@@ -9,6 +9,7 @@ import {
   BAR_SPACING,
 } from '@shopify/polaris-viz-core';
 
+import {getLoadAnimationDelay} from '../../../../utilities/getLoadAnimationDelay';
 import {formatAriaLabel} from '../../../VerticalBarChart/utilities';
 import type {AccessibilitySeries} from '../../../VerticalBarChart/types';
 import type {StackedSeries} from '../../../../types';
@@ -61,6 +62,10 @@ export function StackedBarGroups({
       {formattedStackedValues.map((item, groupIndex) => {
         const x = xScale(groupIndex.toString()) ?? 0;
         const groupAriaLabel = formatAriaLabel(accessibilityData[groupIndex]);
+        const animationDelay = getLoadAnimationDelay(
+          groupIndex,
+          formattedStackedValues.length,
+        );
 
         return (
           <g
@@ -89,6 +94,7 @@ export function StackedBarGroups({
             />
             <Stack
               activeBarGroup={activeBarGroup}
+              animationDelay={animationDelay}
               data={item}
               gaps={gaps}
               groupIndex={groupIndex}

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/StackedBarGroups/components/Stack/Stack.tsx
@@ -1,12 +1,14 @@
 import React, {useState} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import {
+  BARS_TRANSITION_CONFIG,
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionEventAttrs,
   getColorVisionStylesForActiveIndex,
   getRoundedRectPath,
   useChartContext,
 } from '@shopify/polaris-viz-core';
+import {useSpring, animated} from '@react-spring/web';
 
 import type {
   FormattedStackedSeries,
@@ -24,6 +26,7 @@ import styles from './Stack.scss';
 
 interface StackProps {
   activeBarGroup: number;
+  animationDelay: number;
   data: FormattedStackedSeries;
   gaps: {[key: number]: StackedBarGapDirections};
   groupIndex: number;
@@ -35,6 +38,7 @@ interface StackProps {
 
 export function Stack({
   activeBarGroup,
+  animationDelay,
   data,
   gaps,
   groupIndex,
@@ -44,7 +48,7 @@ export function Stack({
   yScale,
 }: StackProps) {
   const [activeBarIndex, setActiveBarIndex] = useState(-1);
-  const {theme} = useChartContext();
+  const {theme, shouldAnimate} = useChartContext();
 
   const keys = data[0] ? Object.keys(data[0].data) : [];
 
@@ -61,8 +65,20 @@ export function Stack({
     },
   });
 
+  const {transform} = useSpring({
+    from: {
+      transform: `scale(1, 0)`,
+    },
+    to: {
+      transform: `scale(1, 1)`,
+    },
+    config: BARS_TRANSITION_CONFIG,
+    delay: animationDelay,
+    default: {immediate: !shouldAnimate},
+  });
+
   return (
-    <React.Fragment>
+    <animated.g style={{transform, transformOrigin: `0px ${yScale(0)}px`}}>
       {data.map((data, index) => {
         const [start, end] = data;
 
@@ -114,6 +130,6 @@ export function Stack({
           </g>
         );
       })}
-    </React.Fragment>
+    </animated.g>
   );
 }

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBarGroup/VerticalBarGroup.tsx
@@ -1,7 +1,6 @@
 import {
   COLOR_VISION_GROUP_ITEM,
   DataType,
-  LOAD_ANIMATION_DURATION,
   useChartContext,
 } from '@shopify/polaris-viz-core';
 import type {
@@ -13,6 +12,7 @@ import type {
 import type {ScaleBand, ScaleLinear} from 'd3-scale';
 import React, {useMemo, useState} from 'react';
 
+import {getLoadAnimationDelay} from '../../../../utilities/getLoadAnimationDelay';
 import {getChartId} from '../../../../utilities/getChartId';
 import {applyColorVisionToDomElement} from '../../../../utilities/applyColorVisionToDomElement';
 import type {SortedBarChartData} from '../../../../types';
@@ -120,8 +120,7 @@ export function VerticalBarGroup({
     <React.Fragment>
       {sortedData.map((item, index) => {
         const xPosition = xScale(index.toString());
-        const animationDelay =
-          index * (LOAD_ANIMATION_DURATION / sortedData.length);
+        const animationDelay = getLoadAnimationDelay(index, sortedData.length);
 
         return (
           <BarGroup

--- a/packages/polaris-viz/src/storybook/constants.ts
+++ b/packages/polaris-viz/src/storybook/constants.ts
@@ -62,3 +62,23 @@ export const X_AXIS_OPTIONS_ARGS = {
 export const Y_AXIS_OPTIONS_ARGS = {
   description: 'An object that defines the yAxis and its options.',
 };
+
+export const SKIP_LINK_ARGS = {
+  description:
+    'If provided, renders a `<SkipLink/>` button with the string. Use this for charts with large data sets, so keyboard users can skip all the tabbable data points in the chart.',
+};
+
+export const IS_ANIMATED_ARGS = {
+  description:
+    'Whether to animate when the chart is initially rendered and its data is updated. Even if `isAnimated` is set to true, animations will not be displayed for users with reduced motion preferences.',
+};
+
+export const DATA_SERIES_ARGS = {
+  description:
+    'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',
+};
+
+export const EMPTY_STATE_TEXT_ARGS = {
+  description:
+    'Used to indicate to screen readers that a chart with no series data has been rendered, in the case that an empty array is passed as the data. If the series prop could be an empty array, it is strongly recommended to include this prop.',
+};

--- a/packages/polaris-viz/src/utilities/getLoadAnimationDelay.ts
+++ b/packages/polaris-viz/src/utilities/getLoadAnimationDelay.ts
@@ -1,0 +1,5 @@
+import {LOAD_ANIMATION_DURATION} from '@shopify/polaris-viz-core';
+
+export function getLoadAnimationDelay(index, dataLength) {
+  return index * (LOAD_ANIMATION_DURATION / dataLength);
+}


### PR DESCRIPTION
## What does this implement/fix?

Added load animations for stacked vertical bar charts.
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
