### PR TITLE
Use unique values for stack() keys

### DIFF
--- a/packages/polaris-viz/src/components/BarChart/stories/BarChart.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/BarChart.chromatic.stories.tsx
@@ -1,0 +1,57 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {BarChartProps} from '../../../components';
+
+import {Template} from './data';
+
+export default {
+  ...META,
+  title: `${META.title}/Chromatic`,
+};
+
+export const UniqueStackedValues: Story<BarChartProps> = Template.bind({});
+
+UniqueStackedValues.args = {
+  isAnimated: false,
+  type: 'stacked',
+  data: [
+    {
+      name: 'Breakfast',
+      data: [
+        {key: 'Monday', value: 3},
+        {key: 'Tuesday', value: -7},
+        {key: 'Wednesday', value: -7},
+        {key: 'Thursday', value: -8},
+        {key: 'Friday', value: 50},
+        {key: 'Saturday', value: 0},
+        {key: 'Sunday', value: 0.1},
+      ],
+    },
+    {
+      name: 'Breakfast',
+      data: [
+        {key: 'Monday', value: 4},
+        {key: 'Tuesday', value: 0},
+        {key: 'Wednesday', value: -10},
+        {key: 'Thursday', value: 15},
+        {key: 'Friday', value: 8},
+        {key: 'Saturday', value: 50},
+        {key: 'Sunday', value: 0.1},
+      ],
+    },
+    {
+      name: 'Breakfast',
+      data: [
+        {key: 'Monday', value: 7},
+        {key: 'Tuesday', value: 0},
+        {key: 'Wednesday', value: -15},
+        {key: 'Thursday', value: -12},
+        {key: 'Friday', value: 50},
+        {key: 'Saturday', value: 5},
+        {key: 'Sunday', value: 0.1},
+      ],
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
@@ -1,7 +1,8 @@
 import {useMemo} from 'react';
-import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
 import type {DataSeries, XAxisOptions} from '@shopify/polaris-viz-core';
+import {stackOffsetNone, stackOrderReverse} from 'd3-shape';
 
+import {getStackedValues} from '../../../utilities/getStackedValues';
 import {useFormattedLabels} from '../../../hooks/useFormattedLabels';
 
 interface Props {
@@ -10,37 +11,17 @@ interface Props {
 }
 
 export function useStackedData({data, xAxisOptions}: Props) {
-  const areaStack = useMemo(
-    () =>
-      stack()
-        .keys(data.map(({name}) => name ?? ''))
-        .order(stackOrderReverse)
-        .offset(stackOffsetNone),
-    [data],
-  );
-
   const labels = useFormattedLabels({
     data,
     labelFormatter: xAxisOptions.labelFormatter,
   });
 
-  const formattedData = useMemo(
-    () =>
-      labels.map((_, labelIndex) =>
-        data.reduce((acc, {name, data}) => {
-          const {value} = data[labelIndex];
-
-          const dataPoint = {[name ?? '']: value};
-          return Object.assign(acc, dataPoint);
-        }, {}),
-      ),
-    [labels, data],
-  );
-
-  const stackedValues = useMemo(
-    () => areaStack(formattedData),
-    [areaStack, formattedData],
-  );
+  const stackedValues = getStackedValues({
+    series: data,
+    labels,
+    order: stackOrderReverse,
+    offset: stackOffsetNone,
+  });
 
   const longestSeriesLength = useMemo(() => {
     return Math.max(...stackedValues.map((stack) => stack.length)) - 1;

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -17,6 +17,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
+import {stackOffsetDiverging, stackOrderNone} from 'd3-shape';
 
 import {ChartElements} from '../ChartElements';
 import {
@@ -107,7 +108,14 @@ export function Chart({
   });
 
   const isStacked = type === 'stacked';
-  const stackedValues = isStacked ? getStackedValues(data, labels) : null;
+  const stackedValues = isStacked
+    ? getStackedValues({
+        series: data,
+        labels,
+        order: stackOrderNone,
+        offset: stackOffsetDiverging,
+      })
+    : null;
 
   const reducedLabelIndexes = useReducedLabelIndexes({
     dataLength: data[0] ? data[0].data.length : 0,

--- a/packages/polaris-viz/src/hooks/useHorizontalStackedValues.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalStackedValues.ts
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import type {DataSeries} from '@shopify/polaris-viz-core';
+import {stackOffsetDiverging, stackOrderNone} from 'd3-shape';
 
 import {getStackedMinMax, getStackedValues} from '../utilities';
 
@@ -22,7 +23,12 @@ export function useHorizontalStackedValues({data, isStacked}: Props) {
     }, data[0]);
 
     const labels = longestSeries.data.map(({key}) => `${key}`);
-    const stackedValues = getStackedValues(data, labels);
+    const stackedValues = getStackedValues({
+      series: data,
+      labels,
+      order: stackOrderNone,
+      offset: stackOffsetDiverging,
+    });
 
     const {min, max} = getStackedMinMax({
       stackedValues,

--- a/packages/polaris-viz/src/utilities/getStackedValues.ts
+++ b/packages/polaris-viz/src/utilities/getStackedValues.ts
@@ -1,23 +1,33 @@
-import {stack, stackOffsetDiverging} from 'd3-shape';
+import {stack} from 'd3-shape';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 
-export function getStackedValues(series: DataSeries[], labels: string[]) {
-  const barStack = stack()
-    .offset(stackOffsetDiverging)
-    .keys(series.map(({name}) => name ?? ''));
+function getKey(index: number, name?: string) {
+  return `${name ?? 'stack'}-${index}`;
+}
+
+interface Options {
+  series: DataSeries[];
+  labels: string[];
+  order;
+  offset;
+}
+
+export function getStackedValues({series, labels, order, offset}: Options) {
+  const stackedValues = stack()
+    .offset(offset)
+    .order(order)
+    .keys(series.map(({name}, index) => getKey(index, name)));
 
   const formattedData = labels.map((_, labelIndex) =>
-    series.reduce((acc, {name, data}) => {
+    series.reduce((acc, {name, data}, index) => {
       const indexData = data[labelIndex];
       const namedData = {
-        [name ?? '']: indexData.value == null ? 0 : indexData.value,
+        [getKey(index, name)]: indexData.value == null ? 0 : indexData.value,
       };
 
       return Object.assign(acc, namedData);
     }, {}),
   );
 
-  const stackedValues = barStack(formattedData);
-
-  return stackedValues;
+  return stackedValues(formattedData);
 }

--- a/packages/polaris-viz/src/utilities/tests/getStackedValues.test.tsx
+++ b/packages/polaris-viz/src/utilities/tests/getStackedValues.test.tsx
@@ -1,4 +1,4 @@
-import {stack} from 'd3-shape';
+import {stack, stackOffsetNone, stackOrderReverse} from 'd3-shape';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 
 import {getStackedValues} from '../getStackedValues';
@@ -39,6 +39,7 @@ jest.mock('d3-shape', () => ({
     const generator = (value: any) => value;
     generator.offset = () => generator;
     generator.keys = () => generator;
+    generator.order = () => generator;
     return generator;
   }),
 }));
@@ -49,10 +50,16 @@ describe('get-stacked-values', () => {
       const stack = () => (value: any) => value;
       stack.offset = () => stack;
       stack.keys = () => stack;
+      stack.order = () => stack;
       return stack;
     });
 
-    getStackedValues(mockData, labels);
+    getStackedValues({
+      series: mockData,
+      labels,
+      order: stackOrderReverse,
+      offset: stackOffsetNone,
+    });
 
     expect(stack).toHaveBeenCalledTimes(1);
   });
@@ -65,10 +72,16 @@ describe('get-stacked-values', () => {
       offsetSpy = jest.fn((offset: any) => (offset ? offset : stack));
       stack.offset = offsetSpy;
       stack.keys = (keys: any) => (keys ? stack : keys);
+      stack.order = () => stack;
       return stack;
     });
 
-    getStackedValues(mockData, labels);
+    getStackedValues({
+      series: mockData,
+      labels,
+      order: stackOrderReverse,
+      offset: stackOffsetNone,
+    });
 
     expect(offsetSpy).toHaveBeenCalledTimes(1);
   });
@@ -79,13 +92,19 @@ describe('get-stacked-values', () => {
     (stack as jest.Mock).mockImplementation(() => {
       const stack = () => (value: any) => value;
       stack.offset = (offset: any) => (offset ? offset : stack);
+      stack.order = () => stack;
 
       keySpy = jest.fn(() => stack);
       stack.keys = () => keySpy;
       return stack;
     });
 
-    getStackedValues(mockData, labels);
+    getStackedValues({
+      series: mockData,
+      labels,
+      order: stackOrderReverse,
+      offset: stackOffsetNone,
+    });
 
     expect(keySpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## What does this implement/fix?

Use a unique key for stacked values in case the consumer doesn't use a unique name for each data series.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/153

## What do the changes look like?

Nothing would crash the charts, but the logic for figuring out which stack needed rounded corners would be wrong.

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/188935096-465fadcd-a77a-4713-9e9e-e7f52aad0dd4.png)|![image](https://user-images.githubusercontent.com/149873/188935032-27206b62-18e4-4b74-af2e-08e35125a696.png)|
