### PR TITLE
Add gradient helper methods for similar logic

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -12,10 +12,10 @@ import {
   useTheme,
   curveStepRounded,
   uniqueId,
-  isGradientType,
   getColorVisionEventAttrs,
   getColorVisionStylesForActiveIndex,
   useChartContext,
+  getGradientFromColor,
 } from '../../';
 import {
   COLOR_VISION_SINGLE_ITEM,
@@ -129,14 +129,7 @@ export function LineSeries({
   const id = useMemo(() => uniqueId('line-series'), []);
   const immediate = !shouldAnimate;
 
-  const lineGradientColor = isGradientType(color!)
-    ? color
-    : [
-        {
-          color,
-          offset: 0,
-        },
-      ];
+  const lineGradientColor = getGradientFromColor(color);
 
   const isSolidLine = data.isComparison !== true;
   const solidLineDelay = isSolidLine ? index * ANIMATION_DELAY : 0;

--- a/packages/polaris-viz-core/src/components/LineSeries/components/SparkArea/SparkArea.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/components/SparkArea/SparkArea.tsx
@@ -4,21 +4,14 @@ import type {SpringValue} from '@react-spring/core';
 import {usePolarisVizContext} from '../../../../hooks';
 import type {Color} from '../../../../types';
 import {LinearGradientWithStops} from '../../../../components';
-import {isGradientType, uniqueId} from '../../../../utilities';
+import {getGradientFromColor, uniqueId} from '../../../../utilities';
 
 function getGradientFill(color: Color | null) {
   if (color == null) {
     return null;
   }
 
-  return isGradientType(color)
-    ? color
-    : [
-        {
-          color,
-          offset: 0,
-        },
-      ];
+  return getGradientFromColor(color);
 }
 
 const MASK_GRADIENT = [

--- a/packages/polaris-viz-core/src/hooks/useSparkBar.ts
+++ b/packages/polaris-viz-core/src/hooks/useSparkBar.ts
@@ -1,7 +1,7 @@
 import {scaleBand, scaleLinear} from 'd3-scale';
 import {useCallback, useMemo} from 'react';
 
-import {isGradientType} from '../utilities';
+import {getGradientFromColor} from '../utilities';
 import type {Color, DataPoint, DataSeries, TargetLine} from '../types';
 
 const STROKE_WIDTH = 1.5;
@@ -105,15 +105,7 @@ export function useSparkBar({
     : [];
 
   const colorToUse = defaultData?.color ?? seriesColor;
-
-  const color = isGradientType(colorToUse)
-    ? colorToUse
-    : [
-        {
-          color: colorToUse,
-          offset: 0,
-        },
-      ];
+  const color = getGradientFromColor(colorToUse);
 
   return {
     dataWithIndex,

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -89,6 +89,7 @@ export {
   isLargeDataSet,
   ColorScale,
   isDataGroupArray,
+  getGradientFromColor,
 } from './utilities';
 export {
   useSparkBar,

--- a/packages/polaris-viz-core/src/utilities/getGradientFromColor.ts
+++ b/packages/polaris-viz-core/src/utilities/getGradientFromColor.ts
@@ -1,0 +1,12 @@
+import type {Color, GradientStop} from '../types';
+
+import {isGradientType} from './isGradientType';
+
+export function getGradientFromColor(color: Color): GradientStop[] {
+  return isGradientType(color)
+    ? color
+    : [
+        {color, offset: 0},
+        {color, offset: 1},
+      ];
+}

--- a/packages/polaris-viz-core/src/utilities/index.ts
+++ b/packages/polaris-viz-core/src/utilities/index.ts
@@ -24,3 +24,4 @@ export {roundToDecimals} from './roundToDecimals';
 export {isLargeDataSet} from './isLargeDataSet';
 export {ColorScale} from './ColorScale/ColorScale';
 export {isDataGroupArray} from './isDataGroup';
+export {getGradientFromColor} from './getGradientFromColor';

--- a/packages/polaris-viz-core/src/utilities/stories/isGradientType.stories.mdx
+++ b/packages/polaris-viz-core/src/utilities/stories/isGradientType.stories.mdx
@@ -37,3 +37,32 @@ isGradientType('red');
 
 // false
 ```
+
+<Title type="h3">
+  <code>getGradientFromColor()</code>
+</Title>
+
+<p>
+  Returns a valid `GradientStop[]` based on the `Color` provided. If the `Color`
+  provided is a `string`, it will return a gradient otherwise it will return the
+  provided gradient.
+</p>
+
+```tsx
+getGradientFromColor([
+  {offset: 0, color: 'red'},
+  {offset: 100, color: 'green'},
+]);
+
+// [
+//   {offset: 0, color: 'red'},
+//   {offset: 100, color: 'green'},
+// ]
+
+getGradientFromColor('red');
+
+// [
+//   {offset: 0, color: 'red'},
+//   {offset: 1, color: 'red'},
+// ]
+```

--- a/packages/polaris-viz-core/src/utilities/tests/getGradientFromColor.test.ts
+++ b/packages/polaris-viz-core/src/utilities/tests/getGradientFromColor.test.ts
@@ -1,0 +1,24 @@
+import {getGradientFromColor} from '../';
+
+describe('getGradientFromColor()', () => {
+  it('returns a gradient when gradient is provided', () => {
+    const gradient = getGradientFromColor([
+      {color: 'red', offset: 0},
+      {color: 'green', offset: 100},
+    ]);
+
+    expect(gradient).toStrictEqual([
+      {color: 'red', offset: 0},
+      {color: 'green', offset: 100},
+    ]);
+  });
+
+  it('returns a gradient when a string is provided', () => {
+    const gradient = getGradientFromColor('red');
+
+    expect(gradient).toStrictEqual([
+      {color: 'red', offset: 0},
+      {color: 'red', offset: 1},
+    ]);
+  });
+});

--- a/packages/polaris-viz/src/components/Arc/Arc.tsx
+++ b/packages/polaris-viz/src/components/Arc/Arc.tsx
@@ -3,7 +3,7 @@ import {arc} from 'd3-shape';
 import {
   ARC_LOAD_ANIMATION_CONFIG,
   ARC_DATA_CHANGE_ANIMATION_CONFIG,
-  isGradientType,
+  getGradientFromColor,
   uniqueId,
   getColorVisionEventAttrs,
   getColorVisionStylesForActiveIndex,
@@ -49,12 +49,7 @@ export function Arc({
   const [mounted, setMounted] = useState(false);
   const gradientId = useMemo(() => uniqueId('DonutChart'), []);
   const createArc = arc().cornerRadius(cornerRadius);
-  const gradient = isGradientType(color)
-    ? color
-    : [
-        {color, offset: 0},
-        {color, offset: 1},
-      ];
+  const gradient = getGradientFromColor(color);
 
   const getDelay = () => {
     if (isAnimated) {

--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -6,14 +6,13 @@ import {
   XAxisOptions,
   YAxisOptions,
   uniqueId,
-  isGradientType,
   LinearGradientWithStops,
-  GradientStop,
   useTheme,
   getAverageColor,
   changeColorOpacity,
   useChartContext,
   LINE_HEIGHT,
+  getGradientFromColor,
 } from '@shopify/polaris-viz-core';
 
 import {ChartElements} from '../ChartElements';
@@ -94,9 +93,7 @@ export function Chart({
   });
 
   const color = colorOverride || selectedTheme.seriesColors.single;
-  const barsGradient = isGradientType(color!)
-    ? color
-    : ([{color, offset: 0}] as GradientStop[]);
+  const barsGradient = getGradientFromColor(color);
 
   const averageColor = getAverageColor(
     barsGradient[0].color,

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
   getColorVisionEventAttrs,
-  isGradientType,
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionStylesForActiveIndex,
   useTheme,
 } from '@shopify/polaris-viz-core';
 import type {Color, Direction} from '@shopify/polaris-viz-core';
 
-import {createCSSGradient, classNames} from '../../../../utilities';
+import {getCSSBackgroundFromColor} from '../../../../utilities/getCSSBackgroundFromColor';
+import {classNames} from '../../../../utilities';
 import {
   ComparisonMetric,
   ComparisonMetricProps,
@@ -47,9 +47,7 @@ export function BarLabel({
 
   const angle = direction === 'horizontal' ? 90 : 180;
 
-  const formattedColor = isGradientType(color)
-    ? createCSSGradient(color, angle)
-    : color;
+  const backgroundColor = getCSSBackgroundFromColor(color, angle);
 
   return (
     <li
@@ -65,7 +63,10 @@ export function BarLabel({
         index,
       })}
     >
-      <div style={{background: formattedColor}} className={styles.LabelColor} />
+      <div
+        style={{background: backgroundColor}}
+        className={styles.LabelColor}
+      />
       <div className={styles.Label}>
         <strong style={{color: labelColor}}>{label}</strong>
         <div style={{color: valueColor}} className={styles.ValueContainer}>

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
@@ -3,17 +3,17 @@ import {animated, useSpring} from '@react-spring/web';
 import {
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionEventAttrs,
-  isGradientType,
   getColorVisionStylesForActiveIndex,
   useChartContext,
 } from '@shopify/polaris-viz-core';
 import type {Color, Direction} from '@shopify/polaris-viz-core';
 
+import {getCSSBackgroundFromColor} from '../../../../utilities/getCSSBackgroundFromColor';
 import {
   BARS_TRANSITION_CONFIG,
   BARS_LOAD_ANIMATION_CONFIG,
 } from '../../../../constants';
-import {createCSSGradient, classNames} from '../../../../utilities';
+import {classNames} from '../../../../utilities';
 import type {Size} from '../../types';
 
 import styles from './BarSegment.scss';
@@ -50,9 +50,7 @@ export function BarSegment({
 
   const isMounted = useRef(false);
 
-  const formattedColor = isGradientType(color)
-    ? createCSSGradient(color, angle)
-    : color;
+  const backgroundColor = getCSSBackgroundFromColor(color, angle);
 
   const spring = useSpring({
     from: {[dimension]: `0%`},
@@ -75,7 +73,7 @@ export function BarSegment({
       )}
       style={{
         [dimension]: shouldAnimate ? spring[dimension] : `${safeScale}%`,
-        background: formattedColor,
+        background: backgroundColor,
         ...getColorVisionStylesForActiveIndex({activeIndex, index}),
       }}
       {...getColorVisionEventAttrs({

--- a/packages/polaris-viz/src/components/SquareColorPreview/SquareColorPreview.tsx
+++ b/packages/polaris-viz/src/components/SquareColorPreview/SquareColorPreview.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import type {Color} from '@shopify/polaris-viz-core';
-import {isGradientType} from '@shopify/polaris-viz-core';
 
+import {getCSSBackgroundFromColor} from '../../utilities/getCSSBackgroundFromColor';
 import {PREVIEW_ICON_SIZE} from '../../constants';
-import {createCSSGradient} from '../../utilities';
 
 import styles from './SquareColorPreview.scss';
+
+const ANGLE = 305;
 
 export interface SquareColorPreviewProps {
   color: Color;
 }
 
 export function SquareColorPreview({color}: SquareColorPreviewProps) {
-  const background = isGradientType(color)
-    ? createCSSGradient(color, 305)
-    : color;
+  const background = getCSSBackgroundFromColor(color, ANGLE);
 
   return (
     <span

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
@@ -4,12 +4,12 @@ import type {SpringValue} from '@react-spring/web';
 import type {Area as D3Area, Line} from 'd3-shape';
 import {
   LinearGradientWithStops,
-  isGradientType,
   getColorVisionEventAttrs,
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionStylesForActiveIndex,
   useChartContext,
   AREAS_LOAD_ANIMATION_CONFIG,
+  getGradientFromColor,
 } from '@shopify/polaris-viz-core';
 import type {Color, Theme, GradientStop} from '@shopify/polaris-viz-core';
 
@@ -79,12 +79,7 @@ export function Area({
     return null;
   }
 
-  const currentColor = colors[index];
-  const isGradient = isGradientType(currentColor);
-
-  const gradient = isGradient
-    ? currentColor
-    : [{offset: 0, color: currentColor}];
+  const gradient = getGradientFromColor(colors[index]);
 
   return (
     <g

--- a/packages/polaris-viz/src/components/shared/GradientDefs/GradientDefs.tsx
+++ b/packages/polaris-viz/src/components/shared/GradientDefs/GradientDefs.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {
   LinearGradientWithStops,
-  isGradientType,
   useChartContext,
+  getGradientFromColor,
 } from '@shopify/polaris-viz-core';
-import type {Color, GradientStop, Direction} from '@shopify/polaris-viz-core';
+import type {Color, Direction} from '@shopify/polaris-viz-core';
 
 import type {GradientUnits} from '../../../types';
 
@@ -59,15 +59,7 @@ function Gradient({
   size: string;
   gradientUnits?: GradientUnits;
 }) {
-  const gradient: GradientStop[] = isGradientType(color)
-    ? color
-    : [
-        {
-          color,
-          offset: 0,
-        },
-      ];
-
+  const gradient = getGradientFromColor(color);
   const position = direction === 'vertical' ? {y1: size} : {x2: size};
 
   return (

--- a/packages/polaris-viz/src/utilities/getCSSBackgroundFromColor.ts
+++ b/packages/polaris-viz/src/utilities/getCSSBackgroundFromColor.ts
@@ -1,0 +1,7 @@
+import {Color, isGradientType} from '@shopify/polaris-viz-core';
+
+import {createCSSGradient} from './createCssGradient';
+
+export function getCSSBackgroundFromColor(color: Color, angle = 90): string {
+  return isGradientType(color) ? createCSSGradient(color, angle) : color;
+}

--- a/packages/polaris-viz/src/utilities/tests/getCSSBackgroundFromColor.test.ts
+++ b/packages/polaris-viz/src/utilities/tests/getCSSBackgroundFromColor.test.ts
@@ -1,0 +1,28 @@
+import {getCSSBackgroundFromColor} from '../getCSSBackgroundFromColor';
+
+describe('getCSSBackgroundFromColor', () => {
+  it('returns solid color', () => {
+    expect(getCSSBackgroundFromColor('red')).toStrictEqual('red');
+  });
+
+  it('returns css gradient', () => {
+    expect(
+      getCSSBackgroundFromColor([
+        {color: 'red', offset: 0},
+        {color: 'green', offset: 100},
+      ]),
+    ).toStrictEqual('linear-gradient(90deg, red 0%,green 100%)');
+  });
+
+  it('uses provided angle', () => {
+    expect(
+      getCSSBackgroundFromColor(
+        [
+          {color: 'red', offset: 0},
+          {color: 'green', offset: 100},
+        ],
+        180,
+      ),
+    ).toStrictEqual('linear-gradient(180deg, red 0%,green 100%)');
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

Unify the logic around returning a gradient, or CSS background that was used in multiple places.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/476
