### PR TITLE
Use a single options object for useYScale

### DIFF
--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -128,12 +128,16 @@ export function Chart({
 
   const {minY, maxY} = yAxisMinMax(data);
 
-  const {yAxisLabelWidth} = useYScale({
-    drawableHeight: height,
+  const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
     max: maxY,
     min: minY,
+  };
+
+  const {yAxisLabelWidth} = useYScale({
+    ...yScaleOptions,
+    drawableHeight: height,
   });
 
   const {reversedSeries, longestSeriesLength, longestSeriesIndex} =
@@ -165,11 +169,8 @@ export function Chart({
   });
 
   const {ticks, yScale} = useYScale({
+    ...yScaleOptions,
     drawableHeight,
-    formatYAxisLabel: yAxisOptions.labelFormatter,
-    integersOnly: yAxisOptions.integersOnly,
-    max: maxY,
-    min: minY,
   });
 
   const annotationsDrawableHeight =

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -132,12 +132,16 @@ export function Chart({
 
   const {minY, maxY} = yAxisMinMax(stackedValues);
 
-  const {yAxisLabelWidth} = useYScale({
-    drawableHeight: height,
+  const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
     max: maxY,
     min: minY,
+  };
+
+  const {yAxisLabelWidth} = useYScale({
+    ...yScaleOptions,
+    drawableHeight: height,
   });
 
   const {
@@ -164,11 +168,8 @@ export function Chart({
   });
 
   const {ticks, yScale} = useYScale({
+    ...yScaleOptions,
     drawableHeight,
-    formatYAxisLabel: yAxisOptions.labelFormatter,
-    integersOnly: yAxisOptions.integersOnly,
-    max: maxY,
-    min: minY,
   });
 
   const annotationsDrawableHeight =

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -119,12 +119,16 @@ export function Chart({
     integersOnly: yAxisOptions.integersOnly,
   });
 
-  const {ticks: initialTicks} = useYScale({
-    drawableHeight: height,
+  const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
     max,
     min,
+  };
+
+  const {ticks: initialTicks} = useYScale({
+    ...yScaleOptions,
+    drawableHeight: height,
   });
 
   const yAxisLabelWidth = useMemo(() => {
@@ -171,11 +175,8 @@ export function Chart({
   });
 
   const {ticks, yScale} = useYScale({
+    ...yScaleOptions,
     drawableHeight,
-    formatYAxisLabel: yAxisOptions.labelFormatter,
-    integersOnly: yAxisOptions.integersOnly,
-    max,
-    min,
   });
 
   const barColors = data.map(({color}) => color!);


### PR DESCRIPTION
## What does this implement/fix?

In some charts, we have to call `useYScale` twice. Once to get initial values and then a second time once the chart has resized itself based on labels & legends.

We were passing the same data twice, which lends itself to bugs.