### PR TITLE
Unify spring config logic

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/components/AnimatedArea/AnimatedArea.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/components/AnimatedArea/AnimatedArea.tsx
@@ -1,7 +1,11 @@
 import React, {useRef} from 'react';
 import {useSpring} from '@react-spring/core';
 
-import {LINES_LOAD_ANIMATION_CONFIG} from '../../../../';
+import {useSpringConfig} from '../../../../hooks/useSpringConfig';
+import {
+  LINES_TRANSITION_CONFIG,
+  LINES_LOAD_ANIMATION_CONFIG,
+} from '../../../../constants';
 import {Area} from '../Area';
 
 export function AnimatedArea({
@@ -15,6 +19,13 @@ export function AnimatedArea({
 }) {
   const mounted = useRef(false);
 
+  const springConfig = useSpringConfig({
+    shouldAnimate: !immediate,
+    animationDelay: delay,
+    mountedSpringConfig: LINES_TRANSITION_CONFIG,
+    unmountedSpringConfig: LINES_LOAD_ANIMATION_CONFIG,
+  });
+
   const {animatedLineShape} = useSpring({
     from: {
       animatedLineShape: areaGenerator(
@@ -24,10 +35,7 @@ export function AnimatedArea({
     to: {
       animatedLineShape: areaGenerator(toData.data),
     },
-    delay,
-    config: LINES_LOAD_ANIMATION_CONFIG,
-    default: {immediate},
-    onRest: () => (mounted.current = true),
+    ...springConfig,
   });
 
   return <Area areaPath={animatedLineShape} series={toData} type={type} />;

--- a/packages/polaris-viz-core/src/components/LineSeries/components/AnimatedLine/AnimatedLine.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/components/AnimatedLine/AnimatedLine.tsx
@@ -7,6 +7,8 @@ import {
   LINE_SERIES_POINT_RADIUS,
   getColorVisionStylesForActiveIndex,
 } from '../../../../';
+import {useSpringConfig} from '../../../../hooks/useSpringConfig';
+import {LINES_TRANSITION_CONFIG} from '../../../../constants';
 
 export function AnimatedLine({
   immediate,
@@ -31,6 +33,13 @@ export function AnimatedLine({
   const AnimatedPath = animated(Path);
   const AnimatedCircle = animated(Circle);
 
+  const springConfig = useSpringConfig({
+    shouldAnimate: !immediate,
+    animationDelay: delay,
+    mountedSpringConfig: LINES_TRANSITION_CONFIG,
+    unmountedSpringConfig: LINES_LOAD_ANIMATION_CONFIG,
+  });
+
   const mounted = useRef(false);
 
   const {animatedLineShape, cy} = useSpring({
@@ -44,10 +53,7 @@ export function AnimatedLine({
       cy: lastY,
       animatedLineShape: lineGenerator(toData.data),
     },
-    delay,
-    config: LINES_LOAD_ANIMATION_CONFIG,
-    default: {immediate},
-    onRest: () => (mounted.current = true),
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -1,4 +1,5 @@
 import {createElement} from 'react';
+import type {SpringConfig} from '@react-spring/core';
 
 import variables from './styles/shared/_variables.scss';
 import {createGradient} from './utilities/createGradient';
@@ -53,46 +54,58 @@ export enum ChartMargin {
   Right = 0,
 }
 
-export const BARS_TRANSITION_CONFIG = {
+export const BARS_TRANSITION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 190,
   friction: 26,
-  clamp: true,
 };
 
-export const BARS_SORT_TRANSITION_CONFIG = {
+export const BARS_SORT_TRANSITION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 150,
   friction: 20,
   restVelocity: 200,
 };
 
-export const AREAS_LOAD_ANIMATION_CONFIG = {
+export const BARS_LOAD_ANIMATION_CONFIG: SpringConfig = {
+  mass: 1,
+  tension: 140,
+  friction: 18,
+};
+
+export const AREAS_LOAD_ANIMATION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 120,
   friction: 20,
   clamp: true,
 };
 
-export const LINES_LOAD_ANIMATION_CONFIG = {
+export const AREAS_TRANSITION_CONFIG: SpringConfig = {
+  mass: 1,
+  tension: 190,
+  friction: 26,
+  clamp: true,
+};
+
+export const LINES_LOAD_ANIMATION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 140,
   friction: 18,
 };
 
-export const BARS_LOAD_ANIMATION_CONFIG = {
+export const LINES_TRANSITION_CONFIG: SpringConfig = {
   mass: 1,
-  tension: 140,
-  friction: 18,
+  tension: 190,
+  friction: 26,
 };
 
-export const ARC_LOAD_ANIMATION_CONFIG = {
+export const ARC_LOAD_ANIMATION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 150,
   friction: 10,
 };
 
-export const ARC_DATA_CHANGE_ANIMATION_CONFIG = {
+export const ARC_DATA_CHANGE_ANIMATION_CONFIG: SpringConfig = {
   mass: 1,
   tension: 150,
   friction: 20,

--- a/packages/polaris-viz-core/src/hooks/index.ts
+++ b/packages/polaris-viz-core/src/hooks/index.ts
@@ -9,3 +9,4 @@ export {useAriaLabel} from './useAriaLabel';
 export {useChartContext} from './useChartContext';
 export {usePrevious} from './usePrevious';
 export {useChartPositions} from './useChartPositions';
+export {useSpringConfig} from './useSpringConfig';

--- a/packages/polaris-viz-core/src/hooks/useSpringConfig.ts
+++ b/packages/polaris-viz-core/src/hooks/useSpringConfig.ts
@@ -1,0 +1,25 @@
+import {useRef} from 'react';
+import type {SpringConfig} from '@react-spring/web';
+
+interface Props {
+  animationDelay?: number;
+  shouldAnimate?: boolean;
+  mountedSpringConfig?: SpringConfig;
+  unmountedSpringConfig?: SpringConfig;
+}
+
+export function useSpringConfig({
+  animationDelay = 0,
+  shouldAnimate = true,
+  mountedSpringConfig,
+  unmountedSpringConfig,
+}: Props) {
+  const isMounted = useRef(false);
+
+  return {
+    config: isMounted.current ? mountedSpringConfig : unmountedSpringConfig,
+    default: {immediate: !shouldAnimate},
+    delay: isMounted.current ? 0 : animationDelay,
+    onRest: () => (isMounted.current = true),
+  };
+}

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -60,6 +60,7 @@ export {
   LINE_SERIES_POINT_RADIUS,
   AREAS_LOAD_ANIMATION_CONFIG,
   COLOR_VARIABLES,
+  AREAS_TRANSITION_CONFIG,
 } from './constants';
 export {
   clamp,
@@ -103,6 +104,7 @@ export {
   useChartContext,
   usePrevious,
   useChartPositions,
+  useSpringConfig,
 } from './hooks';
 export {
   Bar,

--- a/packages/polaris-viz/src/components/Arc/Arc.tsx
+++ b/packages/polaris-viz/src/components/Arc/Arc.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {useMemo} from 'react';
 import {arc} from 'd3-shape';
 import {
   ARC_LOAD_ANIMATION_CONFIG,
@@ -8,6 +8,7 @@ import {
   getColorVisionEventAttrs,
   getColorVisionStylesForActiveIndex,
   COLOR_VISION_SINGLE_ITEM,
+  useSpringConfig,
 } from '@shopify/polaris-viz-core';
 import type {Color} from '@shopify/polaris-viz-core';
 import {useSpring, animated, to} from '@react-spring/web';
@@ -46,17 +47,16 @@ export function Arc({
   isAnimated,
   activeIndex = 0,
 }: ArcProps) {
-  const [mounted, setMounted] = useState(false);
   const gradientId = useMemo(() => uniqueId('DonutChart'), []);
   const createArc = arc().cornerRadius(cornerRadius);
   const gradient = getGradientFromColor(color);
 
-  const getDelay = () => {
-    if (isAnimated) {
-      return mounted ? 0 : index * 100;
-    }
-    return 0;
-  };
+  const springConfig = useSpringConfig({
+    animationDelay: index * 100,
+    shouldAnimate: isAnimated,
+    mountedSpringConfig: ARC_DATA_CHANGE_ANIMATION_CONFIG,
+    unmountedSpringConfig: ARC_LOAD_ANIMATION_CONFIG,
+  });
 
   const {
     animatedInnerRadius,
@@ -79,14 +79,7 @@ export function Arc({
     from: {
       animatedOuterRadius: radius - thickness,
     },
-    config: mounted
-      ? ARC_DATA_CHANGE_ANIMATION_CONFIG
-      : ARC_LOAD_ANIMATION_CONFIG,
-    delay: getDelay(),
-    default: {
-      immediate: !isAnimated,
-    },
-    onRest: () => setMounted(true),
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz/src/components/BarChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/DynamicData.stories.tsx
@@ -1,0 +1,79 @@
+import React, {useState} from 'react';
+
+import {BarChart} from '../BarChart';
+
+export {META as default} from './meta';
+
+export const DynamicData = () => {
+  const [data, setData] = useState([
+    {
+      name: 'BCFM 2019',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 3,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 7,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 4,
+        },
+      ],
+    },
+    {
+      name: 'BCFM 2020',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 1,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 2,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 5,
+        },
+      ],
+    },
+  ]);
+
+  const onClick = () => {
+    const newData = data.map((series) => {
+      return {
+        ...series,
+        data: series.data.map(({key}) => {
+          const newValue = Math.floor(Math.random() * 200);
+          return {
+            key,
+            value: newValue,
+          };
+        }),
+      };
+    });
+
+    setData(newData);
+  };
+
+  return (
+    <>
+      <div style={{height: '500px', width: 800}}>
+        <BarChart data={data} showLegend={true} />
+      </div>
+      <button
+        style={{
+          position: 'absolute',
+          top: '10px',
+          left: '10px',
+        }}
+        onClick={onClick}
+      >
+        Change Data
+      </button>
+    </>
+  );
+};

--- a/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
@@ -3,11 +3,11 @@ import {createPortal} from 'react-dom';
 import {useSpring, animated, to} from '@react-spring/web';
 import {
   getRoundedRectPath,
-  BARS_LOAD_ANIMATION_CONFIG,
-  useChartContext,
   changeColorOpacity,
   useTheme,
 } from '@shopify/polaris-viz-core';
+
+import {useBarSpringConfig} from '../../../hooks/useBarSpringConfig';
 
 import {Label} from './Label';
 
@@ -30,7 +30,6 @@ export function FunnelSegment({
 }) {
   const selectedTheme = useTheme();
   const mounted = useRef(false);
-  const {shouldAnimate} = useChartContext();
 
   const borderRadius = selectedTheme.bar.borderRadius;
 
@@ -38,6 +37,8 @@ export function FunnelSegment({
     xAxis: {labelColor: axisLabelColor},
     chartContainer: {backgroundColor},
   } = useTheme();
+
+  const springConfig = useBarSpringConfig({animationDelay: index * 150});
 
   const {animatedHeight, animatedStartY, animatedNextY} = useSpring({
     from: {
@@ -50,10 +51,7 @@ export function FunnelSegment({
       animatedStartY: connector.startY,
       animatedNextY: connector.nextY,
     },
-    delay: mounted.current ? 0 : index * 150,
-    config: BARS_LOAD_ANIMATION_CONFIG,
-    default: {immediate: !shouldAnimate},
-    onRest: () => (mounted.current = true),
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarSegment/BarSegment.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React from 'react';
 import {animated, useSpring} from '@react-spring/web';
 import {
   COLOR_VISION_SINGLE_ITEM,
@@ -9,11 +9,8 @@ import {
 import type {Color, Direction} from '@shopify/polaris-viz-core';
 
 import {getCSSBackgroundFromColor} from '../../../../utilities/getCSSBackgroundFromColor';
-import {
-  BARS_TRANSITION_CONFIG,
-  BARS_LOAD_ANIMATION_CONFIG,
-} from '../../../../constants';
 import {classNames} from '../../../../utilities';
+import {useBarSpringConfig} from '../../../../hooks/useBarSpringConfig';
 import type {Size} from '../../types';
 
 import styles from './BarSegment.scss';
@@ -48,19 +45,14 @@ export function BarSegment({
   const angle = direction === 'horizontal' ? 90 : 180;
   const dimension = direction === 'horizontal' ? 'width' : 'height';
 
-  const isMounted = useRef(false);
-
   const backgroundColor = getCSSBackgroundFromColor(color, angle);
+
+  const springConfig = useBarSpringConfig({animationDelay: delay});
 
   const spring = useSpring({
     from: {[dimension]: `0%`},
     to: {[dimension]: `${safeScale}%`},
-    config: isMounted.current
-      ? BARS_TRANSITION_CONFIG
-      : BARS_LOAD_ANIMATION_CONFIG,
-    default: {immediate: !shouldAnimate},
-    delay: isMounted.current ? 0 : delay,
-    onRest: () => (isMounted.current = true),
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
@@ -10,6 +10,8 @@ import {
   useChartContext,
   AREAS_LOAD_ANIMATION_CONFIG,
   getGradientFromColor,
+  useSpringConfig,
+  AREAS_TRANSITION_CONFIG,
 } from '@shopify/polaris-viz-core';
 import type {Color, Theme, GradientStop} from '@shopify/polaris-viz-core';
 
@@ -45,10 +47,16 @@ export function Area({
   zeroLineValues,
 }: AreaProps) {
   const {shouldAnimate} = useChartContext();
-
   const delay = animationIndex * (duration / 2);
 
   const mounted = useRef(false);
+
+  const springConfig = useSpringConfig({
+    shouldAnimate,
+    animationDelay: delay,
+    mountedSpringConfig: AREAS_TRANSITION_CONFIG,
+    unmountedSpringConfig: AREAS_LOAD_ANIMATION_CONFIG,
+  });
 
   const {
     animatedAreaShape,
@@ -69,10 +77,7 @@ export function Area({
       animatedAreaShape: areaGenerator(data),
       animatedLineShape: lineGenerator(data),
     },
-    delay: mounted.current ? 0 : delay,
-    config: AREAS_LOAD_ANIMATION_CONFIG,
-    default: {immediate: !shouldAnimate},
-    onRest: () => (mounted.current = true),
+    ...springConfig,
   });
 
   if (animatedAreaShape == null || animatedLineShape == null) {

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/DynamicData.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {useState} from 'react';
+
+export {META as default} from './meta';
+
+import {StackedAreaChart} from '../../../components';
+
+export const DynamicData = () => {
+  const [data, setData] = useState({
+    name: 'Sales',
+    data: [
+      {value: 100, key: '2020-04-01T12:00:00'},
+      {value: 99, key: '2020-04-02T12:00:00'},
+      {value: 1000, key: '2020-04-03T12:00:00'},
+      {value: 2, key: '2020-04-04T12:00:00'},
+      {value: 22, key: '2020-04-05T12:00:00'},
+      {value: 6, key: '2020-04-06T12:00:00'},
+      {value: 5, key: '2020-04-07T12:00:00'},
+    ],
+  });
+
+  const onClick = () => {
+    const newData = data.data.map(({key}) => {
+      const newValue = Math.floor(Math.random() * 200);
+      return {
+        key,
+        value: newValue,
+      };
+    });
+    setData({
+      name: data.name,
+      data: newData,
+    });
+  };
+
+  return (
+    <>
+      <StackedAreaChart data={[data]} />
+      <button
+        style={{
+          position: 'absolute',
+          top: '10px',
+          left: '10px',
+        }}
+        onClick={onClick}
+      >
+        Change Data
+      </button>
+    </>
+  );
+};

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -64,7 +64,7 @@ export function BarGroup({
   areAllNegative,
 }: BarGroupProps) {
   const groupAriaLabel = formatAriaLabel(accessibilityData[barGroupIndex]);
-  const {id, shouldAnimate, isPerformanceImpacted} = useChartContext();
+  const {id, isPerformanceImpacted} = useChartContext();
 
   const selectedTheme = useTheme(theme);
 
@@ -142,7 +142,6 @@ export function BarGroup({
             >
               <VerticalBar
                 height={getBarHeight(rawValue)}
-                isAnimated={shouldAnimate}
                 color={MASK_HIGHLIGHT_COLOR}
                 x={x + (barWidth + BAR_SPACING) * index}
                 zeroPosition={yScale(0)}

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
@@ -6,8 +6,8 @@ import {
   useTheme,
 } from '@shopify/polaris-viz-core';
 
+import {useBarSpringConfig} from '../../../../hooks/useBarSpringConfig';
 import {ZeroValueLine} from '../../../shared/ZeroValueLine';
-import {BARS_TRANSITION_CONFIG} from '../../../../constants';
 
 import styles from './VerticalBar.scss';
 
@@ -21,7 +21,6 @@ export interface VerticalBarProps {
   zeroPosition: number;
   animationDelay?: number;
   ariaLabel?: string;
-  isAnimated?: boolean;
   role?: string;
   areAllNegative?: boolean;
 }
@@ -32,7 +31,6 @@ export const VerticalBar = React.memo(function Bar({
   color,
   height,
   index,
-  isAnimated = true,
   rawValue,
   role,
   width,
@@ -69,12 +67,12 @@ export const VerticalBar = React.memo(function Bar({
     width,
   });
 
+  const springConfig = useBarSpringConfig({animationDelay});
+
   const {transform} = useSpring({
     from: {transform: 'scaleY(0) translateZ(0)'},
     to: {transform: 'scaleY(1) translateZ(0)'},
-    delay: isAnimated ? animationDelay : 0,
-    config: BARS_TRANSITION_CONFIG,
-    default: {immediate: !isAnimated},
+    ...springConfig,
   });
 
   return (

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -1,6 +1,5 @@
 import React, {useMemo, useState} from 'react';
 import type {ScaleLinear} from 'd3-scale';
-import {animated, useSpring} from '@react-spring/web';
 import {
   COLOR_VISION_SINGLE_ITEM,
   BORDER_RADIUS,
@@ -9,10 +8,7 @@ import {
 
 import {useWatchColorVisionEvents} from '../../../hooks';
 import {getBarId} from '../../../utilities';
-import {
-  BARS_TRANSITION_CONFIG,
-  HORIZONTAL_GROUP_LABEL_HEIGHT,
-} from '../../../constants';
+import {HORIZONTAL_GROUP_LABEL_HEIGHT} from '../../../constants';
 import type {FormattedStackedSeries} from '../../../types';
 import {getGradientDefId} from '..';
 import {ZeroValueLine} from '../ZeroValueLine';
@@ -65,7 +61,7 @@ export function HorizontalStackedBars({
   stackedValues,
   xScale,
 }: HorizontalStackedBarsProps) {
-  const {shouldAnimate, theme} = useChartContext();
+  const {theme} = useChartContext();
   const [activeBarIndex, setActiveBarIndex] = useState(-1);
 
   useWatchColorVisionEvents({
@@ -75,18 +71,6 @@ export function HorizontalStackedBars({
         setActiveBarIndex(detail.index);
       }
     },
-  });
-
-  const {transform} = useSpring({
-    from: {
-      transform: `scale(0, 1) translate(0, ${HORIZONTAL_GROUP_LABEL_HEIGHT}px`,
-    },
-    to: {
-      transform: `scale(1, 1) translate(0, ${HORIZONTAL_GROUP_LABEL_HEIGHT}px`,
-    },
-    config: BARS_TRANSITION_CONFIG,
-    delay: animationDelay,
-    default: {immediate: !shouldAnimate},
   });
 
   const lastIndexes = useMemo(() => {
@@ -109,10 +93,9 @@ export function HorizontalStackedBars({
   const gaps = useStackedGaps({stackedValues, groupIndex});
 
   return (
-    <animated.g
+    <g
       style={{
-        transform,
-        transformOrigin: `${xScale(0)}px 0px`,
+        transform: `translate(0, ${HORIZONTAL_GROUP_LABEL_HEIGHT}px`,
       }}
       aria-hidden="true"
     >
@@ -140,6 +123,7 @@ export function HorizontalStackedBars({
               <ZeroValueLine x={x} y={barHeight / 2} direction="horizontal" />
             ) : (
               <StackedBar
+                animationDelay={animationDelay}
                 activeBarIndex={activeBarIndex}
                 ariaLabel={ariaLabel}
                 borderRadius={borderRadius}
@@ -150,11 +134,12 @@ export function HorizontalStackedBars({
                 setActiveBarIndex={setActiveBarIndex}
                 width={width}
                 x={x}
+                zeroPosition={xScale(0)}
               />
             )}
           </React.Fragment>
         );
       })}
-    </animated.g>
+    </g>
   );
 }

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/components/StackedBar/StackedBar.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/components/StackedBar/StackedBar.tsx
@@ -6,22 +6,26 @@ import {
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionStylesForActiveIndex,
   getRoundedRectPath,
-  useChartContext,
 } from '@shopify/polaris-viz-core';
 
+import {useBarSpringConfig} from '../../../../../hooks/useBarSpringConfig';
+
 export interface StackedBarProps {
-  activeBarIndex: number;
-  ariaLabel: string;
-  borderRadius: string;
-  color: string;
-  height: number;
-  seriesIndex: number;
-  setActiveBarIndex: Dispatch<SetStateAction<number>>;
-  width: number;
+  zeroPosition: number;
   x: number;
+  width: number;
+  setActiveBarIndex: Dispatch<SetStateAction<number>>;
+  seriesIndex: number;
+  height: number;
+  color: string;
+  borderRadius: string;
+  ariaLabel: string;
+  animationDelay: number;
+  activeBarIndex: number;
 }
 
 export function StackedBar({
+  animationDelay,
   activeBarIndex,
   ariaLabel,
   borderRadius,
@@ -31,13 +35,13 @@ export function StackedBar({
   setActiveBarIndex,
   width,
   x,
+  zeroPosition,
 }: StackedBarProps) {
-  const {shouldAnimate} = useChartContext();
-
+  const springConfig = useBarSpringConfig({animationDelay});
   const {transform} = useSpring({
-    from: {transform: `scale(0.5, 1)`},
+    from: {transform: `scale(0, 1)`},
     to: {transform: `scale(1, 1)`},
-    default: {immediate: !shouldAnimate},
+    ...springConfig,
   });
 
   const pathD = getRoundedRectPath({
@@ -47,7 +51,7 @@ export function StackedBar({
   });
 
   return (
-    <animated.g style={{transform}}>
+    <animated.g style={{transform, transformOrigin: `${zeroPosition}px 0px`}}>
       <path
         d={pathD}
         fill={`url(#${color})`}

--- a/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
+++ b/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
@@ -1,8 +1,8 @@
-import {useRef} from 'react';
 import {
   BARS_LOAD_ANIMATION_CONFIG,
   BARS_TRANSITION_CONFIG,
   useChartContext,
+  useSpringConfig,
 } from '@shopify/polaris-viz-core';
 
 interface Props {
@@ -10,15 +10,12 @@ interface Props {
 }
 
 export function useBarSpringConfig({animationDelay = 0}: Props) {
-  const isMounted = useRef(false);
   const {shouldAnimate} = useChartContext();
 
-  return {
-    config: isMounted.current
-      ? BARS_TRANSITION_CONFIG
-      : BARS_LOAD_ANIMATION_CONFIG,
-    default: {immediate: !shouldAnimate},
-    delay: isMounted.current ? 0 : animationDelay,
-    onRest: () => (isMounted.current = true),
-  };
+  return useSpringConfig({
+    animationDelay,
+    shouldAnimate,
+    unmountedSpringConfig: BARS_LOAD_ANIMATION_CONFIG,
+    mountedSpringConfig: BARS_TRANSITION_CONFIG,
+  });
 }


### PR DESCRIPTION
## What does this implement/fix?

We were using the same logic for setting mounted/unmounted state in `useSpring` config, so now we have a single hook that takes care of everything.

## What do the changes look like?

Nothing should look different.
 