### PR TITLE
Render dot in correct position when non-numeric keys provided

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -119,7 +119,7 @@ export function LineSeries({
   const lastLinePointCoordinates =
     lastLinePoint?.value != null
       ? {
-          x: xScale(Number(lastLinePoint.key)),
+          x: xScale(data.data.indexOf(lastLinePoint)),
           y: yScale(lastLinePoint.value),
         }
       : null;

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -12,6 +12,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Added animations to vertical stacked `<BarChart />'.
 - Added data change animations to vertical `<BarChart />'.
 
+### Fixed
+
+- Fixed position of dot in SparkLineCharts when series use non-numeric data keys.
+
 ## [7.3.0] - 2022-08-31
 
 ### Fixed

--- a/packages/polaris-viz/src/components/SparkLineChart/stories/WithoutSpline.stories.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/stories/WithoutSpline.stories.tsx
@@ -4,11 +4,12 @@ export {META as default} from './meta';
 
 import type {SparkLineChartProps} from '../../../components';
 
-import {DEFAULT_PROPS, Template} from './data';
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 export const withoutSpline: Story<SparkLineChartProps> = Template.bind({});
 
 withoutSpline.args = {
   ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
   theme: 'NoSpline',
 };

--- a/packages/polaris-viz/src/components/SparkLineChart/stories/playground/NonNumeric.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/stories/playground/NonNumeric.chromatic.stories.tsx
@@ -1,0 +1,32 @@
+import type {Story} from '@storybook/react';
+
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+import type {SparkLineChartProps} from '../../../../components';
+
+import {DEFAULT_PROPS, Template} from '../data';
+
+export const NonNumericKeys: Story<SparkLineChartProps> = Template.bind({});
+
+NonNumericKeys.args = {
+  ...DEFAULT_PROPS,
+  data: [
+    {
+      name: 'Sales',
+      data: [
+        {value: 100, key: '2020-04-01T12:00:00'},
+        {value: 99, key: '2020-04-02T12:00:00'},
+        {value: 1000, key: '2020-04-03T12:00:00'},
+        {value: 2, key: '2020-04-04T12:00:00'},
+        {value: 22, key: '2020-04-05T12:00:00'},
+        {value: 6, key: '2020-04-06T12:00:00'},
+        {value: 5, key: '2020-04-07T12:00:00'},
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## What does this implement/fix?

It looks like something funky happened with the original PR that fixed this, so I'm re-adding the changes.

https://github.com/Shopify/polaris-viz/pull/1358

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="217" alt="image" src="https://user-images.githubusercontent.com/149873/191029566-f175be23-477d-46ca-ad81-b195d964ddc0.png">|<img width="232" alt="image" src="https://user-images.githubusercontent.com/149873/191029483-b8c54f1d-d739-41fb-89e8-b2f2f75e4beb.png">|

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
