### PR TITLE
Remove focus states from annotation elements

### DIFF
--- a/packages/polaris-viz/src/components/Annotations/Annotations.scss
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.Group {
+  @include no-outline;
+}

--- a/packages/polaris-viz/src/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.tsx
@@ -14,6 +14,7 @@ import {
 } from './components';
 import {useAnnotationPositions} from './hooks/useAnnotationPositions';
 import {PILL_HEIGHT, SHOW_MORE_BUTTON_OFFSET} from './constants';
+import styles from './Annotations.scss';
 
 export interface AnnotationsProps {
   annotationsLookupTable: AnnotationLookupTable;
@@ -96,7 +97,7 @@ export function Annotations({
     : 0;
 
   return (
-    <g ref={setRef} tabIndex={-1}>
+    <g ref={setRef} tabIndex={-1} className={styles.Group}>
       {isShowMoreButtonVisible && (
         <ShowMoreAnnotationsButton
           annotationsCount={hiddenAnnotationsCount}

--- a/packages/polaris-viz/src/components/Annotations/YAxisAnnotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/YAxisAnnotations.tsx
@@ -16,6 +16,7 @@ import {
   AnnotationYAxisLabel,
 } from './components';
 import type {OptionalDualAxisYAxis} from './types';
+import styles from './Annotations.scss';
 
 export interface YAxisAnnotationsProps {
   annotationsLookupTable: AnnotationLookupTable;
@@ -85,7 +86,7 @@ export function YAxisAnnotations({
   });
 
   return (
-    <g ref={setRef} tabIndex={-1}>
+    <g ref={setRef} tabIndex={-1} className={styles.Group}>
       <g transform={`translate(0, ${0})`}>
         {positions.map((position) => {
           const index = position.index;


### PR DESCRIPTION
## What does this implement/fix?

Reported by @adamperron - annotation elements were still showing a focus state when clicking on the annotation content popover.

https://user-images.githubusercontent.com/149873/192368249-ca3a8fd1-f8c2-4bbf-8f4b-d421b48413e6.mov
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
