### PR TITLE
LineChart changes for Cohort comparisons

### DIFF
--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -66,7 +66,9 @@ export function Points({
         const {data: singleData, name, color} = singleSeries;
         const isLongestLine = index === longestSeriesIndex;
         const pointGradientId = `${gradientId}-point-${index}`;
-
+        const noNullSingleData = singleData.filter((data) => {
+          return data.value != null;
+        });
         const animatedYPosition =
           animatedCoordinates == null || animatedCoordinates[index] == null
             ? 0
@@ -74,12 +76,11 @@ export function Points({
 
         const hidePoint =
           animatedCoordinates == null ||
-          (activeIndex != null && activeIndex >= singleData.length);
+          (activeIndex != null && activeIndex >= noNullSingleData.length);
 
         const pointColor = isGradientType(color)
           ? `url(#${pointGradientId})`
           : changeColorOpacity(color);
-
         return (
           <React.Fragment key={`${name}-${index}`}>
             {isGradientType(color) ? (
@@ -93,7 +94,6 @@ export function Points({
                 />
               </defs>
             ) : null}
-
             {shouldAnimate ? (
               <Point
                 color={pointColor}
@@ -108,11 +108,10 @@ export function Points({
               />
             ) : null}
 
-            {singleData.map(({value}, dataIndex) => {
+            {noNullSingleData.map(({value}, dataIndex) => {
               if (value == null) {
                 return null;
               }
-
               return (
                 <g
                   key={`${name}-${index}-${dataIndex}`}

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -5,6 +5,168 @@ import {LineChart, LineChartProps} from '../../LineChart';
 import {randomNumber} from '../../../Docs/utilities';
 import {formatLinearXAxisLabel} from '../../../../storybook/utilities';
 import {META} from '../meta';
+import type {DataSeries} from '@shopify/polaris-viz-core/src';
+
+const REPORTIFY_RESPONSE_AVG = [
+  {
+    result: {
+      columns: [
+        {
+          field: 'Average',
+          raw: '"Average"',
+          type: 'property',
+          format: 'string',
+        },
+        {
+          field: 'periods_since_first_purchase',
+          raw: 'periods_since_first_purchase',
+          type: 'property',
+          format: 'number',
+        },
+        {
+          field: 'average_customer_retention_rate',
+          raw: 'round((sum(total_customers) / sum(total_customers_in_cohort_period)), 4)',
+          type: 'measure',
+          format: 'float',
+        },
+        {
+          field: 'avg_total_customers',
+          raw: 'avg(total_customers)',
+          type: 'measure',
+          format: 'float',
+        },
+      ],
+      data: [
+        ['Average', 0, 1, 9719],
+        ['Average', 1, 0.1108, 1118.090909090909],
+        ['Average', 2, 0.0809, 847.3],
+        ['Average', 3, 0.0627, 681.8888888888889],
+        ['Average', 4, 0.0543, 620.5],
+        ['Average', 5, 0.0441, 528.7142857142857],
+        ['Average', 6, 0.0363, 438.8333333333333],
+        ['Average', 7, 0.0315, 359.8],
+        ['Average', 8, 0.0313, 267.25],
+        ['Average', 9, 0.032, 313],
+        ['Average', 10, 0.0273, 295.5],
+        ['Average', 11, 0.0227, 259],
+      ],
+    },
+  },
+];
+
+const REPORTIFY_RESPONSE_COHORT = [
+  {
+    result: {
+      columns: [
+        {
+          field: 'customer_cohort_period',
+          raw: 'customer_cohort_period',
+          type: 'property',
+          format: 'timestamp',
+          unit: 'second',
+        },
+        {
+          field: 'periods_since_first_purchase',
+          raw: 'periods_since_first_purchase',
+          type: 'property',
+          format: 'number',
+        },
+        {
+          field: 'customer_retention_rate',
+          raw: 'customer_retention_rate',
+          type: 'measure',
+          format: 'float',
+        },
+        {
+          field: 'total_customers',
+          raw: 'total_customers',
+          type: 'measure',
+          format: 'number',
+        },
+      ],
+      data: [
+        ['2021-09-01T00:00:00+02:00', 0, 1, 11395],
+        ['2021-09-01T00:00:00+02:00', 1, 0.1111, 1266],
+        ['2021-09-01T00:00:00+02:00', 2, 0.0756, 861],
+        ['2021-09-01T00:00:00+02:00', 3, 0.0307, 350],
+        ['2021-09-01T00:00:00+02:00', 4, 0.0729, 831],
+        ['2021-09-01T00:00:00+02:00', 5, 0.0519, 591],
+        ['2021-09-01T00:00:00+02:00', 6, 0.0461, 525],
+        ['2021-09-01T00:00:00+02:00', 7, 0.0315, 359],
+        ['2021-09-01T00:00:00+02:00', 8, 0.0291, 332],
+        ['2021-09-01T00:00:00+02:00', 9, 0.0367, 418],
+        ['2021-09-01T00:00:00+02:00', 10, 0.0249, 284],
+        ['2021-09-01T00:00:00+02:00', 11, 0.0227, 259],
+        ['2021-10-01T00:00:00+02:00', 0, 1, 10245],
+        ['2021-10-01T00:00:00+02:00', 1, 0.1082, 1108],
+        ['2021-10-01T00:00:00+02:00', 2, 0.0437, 448],
+        ['2021-10-01T00:00:00+02:00', 3, 0.0868, 889],
+        ['2021-10-01T00:00:00+02:00', 4, 0.0636, 652],
+        ['2021-10-01T00:00:00+02:00', 5, 0.0554, 568],
+        ['2021-10-01T00:00:00+02:00', 6, 0.0416, 426],
+        ['2021-10-01T00:00:00+02:00', 7, 0.039, 400],
+        ['2021-10-01T00:00:00+02:00', 8, 0.0391, 401],
+        ['2021-10-01T00:00:00+02:00', 9, 0.0317, 325],
+        ['2021-10-01T00:00:00+02:00', 10, 0.03, 307],
+        ['2021-11-01T00:00:00+01:00', 0, 1, 7706],
+        ['2021-11-01T00:00:00+01:00', 1, 0.0489, 377],
+        ['2021-11-01T00:00:00+01:00', 2, 0.093, 717],
+        ['2021-11-01T00:00:00+01:00', 3, 0.0658, 507],
+        ['2021-11-01T00:00:00+01:00', 4, 0.0531, 409],
+        ['2021-11-01T00:00:00+01:00', 5, 0.0414, 319],
+        ['2021-11-01T00:00:00+01:00', 6, 0.0376, 290],
+        ['2021-11-01T00:00:00+01:00', 7, 0.0384, 296],
+        ['2021-11-01T00:00:00+01:00', 8, 0.0289, 223],
+        ['2021-11-01T00:00:00+01:00', 9, 0.0254, 196],
+        ['2021-12-01T00:00:00+01:00', 0, 1, 4804],
+        ['2021-12-01T00:00:00+01:00', 1, 0.1301, 625],
+        ['2021-12-01T00:00:00+01:00', 2, 0.0895, 430],
+        ['2021-12-01T00:00:00+01:00', 3, 0.0724, 348],
+        ['2021-12-01T00:00:00+01:00', 4, 0.0485, 233],
+        ['2021-12-01T00:00:00+01:00', 5, 0.0466, 224],
+        ['2021-12-01T00:00:00+01:00', 6, 0.0441, 212],
+        ['2021-12-01T00:00:00+01:00', 7, 0.0327, 157],
+        ['2021-12-01T00:00:00+01:00', 8, 0.0235, 113],
+        ['2022-01-01T00:00:00+01:00', 0, 1, 22877],
+        ['2022-01-01T00:00:00+01:00', 1, 0.1294, 2960],
+        ['2022-01-01T00:00:00+01:00', 2, 0.0931, 2129],
+        ['2022-01-01T00:00:00+01:00', 3, 0.0608, 1391],
+        ['2022-01-01T00:00:00+01:00', 4, 0.0481, 1100],
+        ['2022-01-01T00:00:00+01:00', 5, 0.0445, 1019],
+        ['2022-01-01T00:00:00+01:00', 6, 0.0316, 723],
+        ['2022-01-01T00:00:00+01:00', 7, 0.0257, 587],
+        ['2022-02-01T00:00:00+01:00', 0, 1, 15413],
+        ['2022-02-01T00:00:00+01:00', 1, 0.1257, 1937],
+        ['2022-02-01T00:00:00+01:00', 2, 0.0777, 1198],
+        ['2022-02-01T00:00:00+01:00', 3, 0.0636, 981],
+        ['2022-02-01T00:00:00+01:00', 4, 0.0542, 836],
+        ['2022-02-01T00:00:00+01:00', 5, 0.0376, 580],
+        ['2022-02-01T00:00:00+01:00', 6, 0.0297, 457],
+        ['2022-03-01T00:00:00+01:00', 0, 1, 11405],
+        ['2022-03-01T00:00:00+01:00', 1, 0.1002, 1143],
+        ['2022-03-01T00:00:00+01:00', 2, 0.0843, 961],
+        ['2022-03-01T00:00:00+01:00', 3, 0.0723, 825],
+        ['2022-03-01T00:00:00+01:00', 4, 0.0456, 520],
+        ['2022-03-01T00:00:00+01:00', 5, 0.0351, 400],
+        ['2022-04-01T00:00:00+02:00', 0, 1, 7590],
+        ['2022-04-01T00:00:00+02:00', 1, 0.1128, 856],
+        ['2022-04-01T00:00:00+02:00', 2, 0.1005, 763],
+        ['2022-04-01T00:00:00+02:00', 3, 0.0677, 514],
+        ['2022-04-01T00:00:00+02:00', 4, 0.0505, 383],
+        ['2022-05-01T00:00:00+02:00', 0, 1, 6508],
+        ['2022-05-01T00:00:00+02:00', 1, 0.1182, 769],
+        ['2022-05-01T00:00:00+02:00', 2, 0.0742, 483],
+        ['2022-05-01T00:00:00+02:00', 3, 0.051, 332],
+        ['2022-06-01T00:00:00+02:00', 0, 1, 6735],
+        ['2022-06-01T00:00:00+02:00', 1, 0.0983, 662],
+        ['2022-06-01T00:00:00+02:00', 2, 0.0717, 483],
+        ['2022-07-01T00:00:00+02:00', 0, 1, 6325],
+        ['2022-07-01T00:00:00+02:00', 1, 0.0942, 596],
+        ['2022-08-01T00:00:00+02:00', 0, 1, 5625],
+      ],
+    },
+  },
+];
 
 export default {
   ...META,
@@ -14,6 +176,44 @@ export default {
 const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return <LineChart {...args} />;
 };
+
+const getName = (reportifyValue) => {
+  const nameTest = Date.parse(reportifyValue);
+  if (isNaN(nameTest)) {
+    return reportifyValue;
+  } else {
+    const parsedDate = new Date(reportifyValue);
+    return `${parsedDate.getFullYear()}-${String(
+      parsedDate.getMonth() + 1,
+    ).padStart(2, '0')}-${String(parsedDate.getDate()).padStart(2, '0')}`;
+  }
+};
+
+const parseReportify = (reportifyDataObj) => {
+  const parsedData: DataSeries[] = [];
+  const oganizedData: DataSeries[] = [];
+  const reportifyData = reportifyDataObj.result.data;
+  for (let index = 0; index < reportifyData.length; index++) {
+    const row = reportifyData[index];
+    if (row[0] in oganizedData) {
+      oganizedData[row[0]].data.push({key: row[1], value: row[2]});
+    } else {
+      const cleanName = getName(row[0]);
+      oganizedData[row[0]] = {
+        data: [{key: row[1], value: row[2]}],
+        name: cleanName,
+      };
+    }
+  }
+  for (const property in oganizedData) {
+    parsedData.push(oganizedData[property]);
+  }
+  return parsedData;
+};
+
+const COHORT_DATA = parseReportify(REPORTIFY_RESPONSE_AVG[0]).concat(
+  parseReportify(REPORTIFY_RESPONSE_COHORT[0]),
+);
 
 const HOURLY_DATA = [
   {
@@ -48,4 +248,10 @@ export const BadData: Story<LineChartProps> = (args: LineChartProps) => {
 
 BadData.args = {
   data: [{name: 'Empty', data: []}],
+};
+
+export const CohortDataSet: Story<LineChartProps> = Template.bind({});
+
+CohortDataSet.args = {
+  data: COHORT_DATA,
 };

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -194,13 +194,14 @@ const parseReportify = (reportifyDataObj) => {
   const oganizedData: DataSeries[] = [];
   const reportifyData = reportifyDataObj.result.data;
   for (let index = 0; index < reportifyData.length; index++) {
-    const row = reportifyData[index];
-    if (row[0] in oganizedData) {
-      oganizedData[row[0]].data.push({key: row[1], value: row[2]});
+    const [date, key, percentValue] = reportifyData[index];
+    const formattedValue = parseFloat((percentValue * 100).toFixed(3));
+    if (date in oganizedData) {
+      oganizedData[date].data.push({key: key, value: formattedValue});
     } else {
-      const cleanName = getName(row[0]);
-      oganizedData[row[0]] = {
-        data: [{key: row[1], value: row[2]}],
+      const cleanName = getName(date);
+      oganizedData[date] = {
+        data: [{key: key, value: formattedValue}],
         name: cleanName,
       };
     }

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -255,4 +255,9 @@ export const CohortDataSet: Story<LineChartProps> = Template.bind({});
 
 CohortDataSet.args = {
   data: COHORT_DATA,
+  yAxisOptions: {
+    labelFormatter: (y) => {
+      return `${y}%`;
+    },
+  },
 };

--- a/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
+++ b/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
@@ -9,11 +9,11 @@ interface Props {
   tooltipOptions: TooltipOptions;
 }
 
-export function formatDataForTooltip({data, tooltipOptions}: Props): {
+export function formatDataForTooltip({ data, tooltipOptions }: Props): {
   formattedData: TooltipData[];
   title: string | undefined;
 } {
-  const {keyFormatter, valueFormatter, titleFormatter} = {
+  const { keyFormatter, valueFormatter, titleFormatter } = {
     keyFormatter: (key) => `${key}`,
     valueFormatter: (value) => `${value}`,
     titleFormatter: (title) => `${title}`,
@@ -21,9 +21,11 @@ export function formatDataForTooltip({data, tooltipOptions}: Props): {
   };
 
   const formattedData = data.data.map((data) => {
+    const noNullData = data.data.filter((data) => {
+      return data.value !== null;
+    });
     return {
-      ...data,
-      data: data.data.map((values) => {
+      data: noNullData.map((values) => {
         return {
           ...values,
           key: keyFormatter(values.key),

--- a/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
+++ b/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
@@ -15,16 +15,19 @@ export function formatDataForTooltip({ data, tooltipOptions }: Props): {
 } {
   const { keyFormatter, valueFormatter, titleFormatter } = {
     keyFormatter: (key) => `${key}`,
-    valueFormatter: (value) => `${value}`,
+    // valueFormatter: (value) => `${value}`,
+    valueFormatter: (value) => value.toFixed(3),
     titleFormatter: (title) => `${title}`,
     ...tooltipOptions,
   };
 
   const formattedData = data.data.map((data) => {
+    const shape = data.shape;
     const noNullData = data.data.filter((data) => {
       return data.value !== null;
     });
     return {
+      shape,
       data: noNullData.map((values) => {
         return {
           ...values,
@@ -34,7 +37,6 @@ export function formatDataForTooltip({ data, tooltipOptions }: Props): {
       }),
     };
   });
-
   return {
     formattedData,
     title: data.title ? titleFormatter(data.title) : undefined,

--- a/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
+++ b/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
@@ -9,11 +9,11 @@ interface Props {
   tooltipOptions: TooltipOptions;
 }
 
-export function formatDataForTooltip({ data, tooltipOptions }: Props): {
+export function formatDataForTooltip({data, tooltipOptions}: Props): {
   formattedData: TooltipData[];
   title: string | undefined;
 } {
-  const { keyFormatter, valueFormatter, titleFormatter } = {
+  const {keyFormatter, valueFormatter, titleFormatter} = {
     keyFormatter: (key) => `${key}`,
     // valueFormatter: (value) => `${value}`,
     valueFormatter: (value) => value.toFixed(3),

--- a/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
+++ b/packages/polaris-viz/src/utilities/formatDataForTooltip.ts
@@ -15,8 +15,7 @@ export function formatDataForTooltip({data, tooltipOptions}: Props): {
 } {
   const {keyFormatter, valueFormatter, titleFormatter} = {
     keyFormatter: (key) => `${key}`,
-    // valueFormatter: (value) => `${value}`,
-    valueFormatter: (value) => value.toFixed(3),
+    valueFormatter: (value) => `${value}`,
     titleFormatter: (title) => `${title}`,
     ...tooltipOptions,
   };


### PR DESCRIPTION
## What does this implement/fix?

Some small modifications to the LineChart Chart to enable lines with an unequal number of data points to render. This is required for the Cohort Analysis Report (https://vault.shopify.io/gsd/projects/24301)

I have also added a new playground called 'Cohort Data Set' to the Playgrounds folder within the LineChart directory. This playground contains static data as it is received from Reportify, and parses it for use in the LineChart

UX Designs are available here - https://www.figma.com/file/oUEHbxrkt38DFp399hsyDg/Customer-Analytics?node-id=1710%3A25335

UX Design - line chart:
<img width="1399" alt="lineChartDesign" src="https://user-images.githubusercontent.com/5003768/193329356-2ddc904d-7a12-47b3-b973-373ee9fc8e08.png">

UX Design - Cohort Analysis Report:
<img width="1152" alt="reportDesign" src="https://user-images.githubusercontent.com/5003768/193329373-e50c1512-115b-4d43-a9a7-1c99a35da4e9.png">

LineChart as generated within the new Cohort Data Set Playground:
![proposed](https://user-images.githubusercontent.com/5003768/193329835-d9f2d1f0-af0f-4f72-84a8-c54b518755da.png)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
