### PR TITLE
Fix points moving away from mouse

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed bug where `<LineChart />` crosshair would be too far from current mouse position when hovering points.
 
 ## [7.4.1] - 2022-10-04
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -203,7 +203,9 @@ export function Chart({
 
       const {svgX, svgY} = point;
 
-      const closestIndex = Math.round(xScale.invert(svgX - chartXPosition));
+      const closestIndex = Math.round(
+        xScale.invert(svgX - (chartXPosition + halfXAxisLabelWidth)),
+      );
 
       const activeIndex = clamp({
         amount: closestIndex,

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -76,6 +76,7 @@ export function Points({
 
         const hidePoint =
           animatedCoordinates == null ||
+          activeLineIndex === index ||
           (activeIndex != null && activeIndex >= noNullSingleData.length);
 
         const pointColor = isGradientType(color)


### PR DESCRIPTION
## What does this implement/fix?

We had an issue where the mouse position wasn't being offset by the correct amount so the crosshair would always run away from the mouse.

We're also going to hide any points when another line is actively being hovered.

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/193896596-7b5998df-85ab-442a-9d4d-08af8ae977e4.mov

**After**

https://user-images.githubusercontent.com/149873/193896572-4153fada-b9d0-4ae9-8b70-bb7fbac139e7.mov

## Storybook link

https://6062ad4a2d14cd0021539c1b-jnmfwuntqf.chromatic.com/?path=/story/polaris-viz-charts-linechart--default

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
