### PR TITLE
Default `width` for GroupLabel to `100%`

### DIFF
--- a/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
+++ b/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
@@ -43,7 +43,7 @@ export function GroupLabel({
           color: selectedTheme.yAxis.labelColor,
           maxWidth,
           height: HORIZONTAL_GROUP_LABEL_HEIGHT,
-          width: labelWidth,
+          width: '100%',
         }}
       >
         {label}


### PR DESCRIPTION
## What does this implement/fix?

We ran into issues with labels on `SimpleBarChart` on the Cohort work where labels are getting cut-off prematurely. This approach might be a bit naive, but it seems to me that there doesn't need to be any calculation of label widths since the foreign object width is already 100%.

## Does this close any currently open issues?

Related: https://github.com/Shopify/core-issues/issues/45433#issuecomment-1268713877

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
