### PR TITLE
Account for empty tooltip data

### DIFF
--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -760,3 +760,90 @@ export const CohortDataSet: Story<LineChartProps> = Template.bind({});
 CohortDataSet.args = {
   data: COHORT_DATA,
 };
+
+export const CohortComparisonDataSet: Story<LineChartProps> = Template.bind({});
+
+CohortComparisonDataSet.args = {
+  data: [
+    {
+      data: [
+        {
+          key: 0,
+          value: 1,
+        },
+        {
+          key: 1,
+          value: 0.113,
+        },
+        {
+          key: 2,
+          value: 0.06,
+        },
+        {
+          key: 3,
+          value: 0.0511,
+        },
+        {
+          key: 4,
+          value: 0.0459,
+        },
+        {
+          key: 5,
+          value: null,
+        },
+        {
+          key: 6,
+          value: null,
+        },
+        {
+          key: 7,
+          value: null,
+        },
+        {
+          key: 8,
+          value: null,
+        },
+        {
+          key: 9,
+          value: null,
+        },
+        {
+          key: 10,
+          value: null,
+        },
+        {
+          key: 11,
+          value: null,
+        },
+      ],
+      color: '#4282cd',
+      name: '2022-04-01T00:00:00-07:00',
+    },
+    {
+      data: [
+        {
+          key: 0,
+          value: 1,
+        },
+        {
+          key: 1,
+          value: 0,
+        },
+        {
+          key: 2,
+          value: 0,
+        },
+        {
+          key: 3,
+          value: 0,
+        },
+        {
+          key: 4,
+          value: 0,
+        },
+      ],
+      color: '#997afc',
+      name: '2022-05-01T00:00:00-07:00',
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/TooltipContent/hooks/tests/useGetLongestLabelFromData.test.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/hooks/tests/useGetLongestLabelFromData.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount, Root} from '@shopify/react-testing';
 
 import {useGetLongestLabelFromData} from '../useGetLongestLabelFromData';
-import {TooltipData} from '../../types';
+import {TooltipData} from '../../../../types';
 
 jest.mock('react', () => {
   return {
@@ -55,5 +55,24 @@ describe('useGetLongestLabelFromData()', () => {
     const data = parseData(result);
 
     expect(data).toStrictEqual({keyWidth: 1, valueWidth: 4});
+  });
+
+  it('does not throw error when data is missing', () => {
+    function TestComponent() {
+      const data = useGetLongestLabelFromData([
+        {
+          shape: 'Line',
+          data: [],
+        },
+      ]);
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const data = parseData(result);
+
+    expect(data).toStrictEqual({keyWidth: 0, valueWidth: 0});
   });
 });

--- a/packages/polaris-viz/src/components/TooltipContent/hooks/useGetLongestLabelFromData.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/hooks/useGetLongestLabelFromData.ts
@@ -21,16 +21,24 @@ export function useGetLongestLabelFromData(tooltipData: TooltipData[] = []) {
   }
 
   tooltipData.forEach(({data}) => {
-    data.forEach(({key, value}) => {
-      const keyWidth = estimateStringWidth(key, characterWidths);
-      const valueWidth = estimateStringWidth(value, characterWidths);
-
+    if (!data.length) {
       sizes.push({
-        width: keyWidth + valueWidth,
-        keyWidth,
-        valueWidth,
+        width: 0,
+        keyWidth: 0,
+        valueWidth: 0,
       });
-    });
+    } else {
+      data.forEach(({key, value}) => {
+        const keyWidth = estimateStringWidth(key, characterWidths);
+        const valueWidth = estimateStringWidth(value, characterWidths);
+
+        sizes.push({
+          width: keyWidth + valueWidth,
+          keyWidth,
+          valueWidth,
+        });
+      });
+    }
   });
 
   const {keyWidth, valueWidth} = sizes.reduce((prev, cur) => {


### PR DESCRIPTION
## What does this implement/fix?
Sometimes the data passed into tooltip is empty:

![image](https://user-images.githubusercontent.com/21347228/195134697-6fedf60d-fe66-4a1b-adad-abdc5be04a4c.png)

This is causing the LineChart component to break when mousing further right than the existing data. This PR ensures that the data exists before referencing it.

## Does this close any currently open issues?

Closes https://github.com/Shopify/core-issues/issues/45475

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
