### PR TITLE
don't render empty tooltip

### DIFF
--- a/packages/polaris-viz/src/hooks/useRenderTooltipContent.tsx
+++ b/packages/polaris-viz/src/hooks/useRenderTooltipContent.tsx
@@ -27,6 +27,12 @@ export function useRenderTooltipContent({
       tooltipOptions,
     });
 
-    return <TooltipContent data={formattedData} theme={theme} title={title} />;
+    if (formattedData[0].data.length === 0) {
+      return null;
+    } else {
+      return (
+        <TooltipContent data={formattedData} theme={theme} title={title} />
+      );
+    }
   };
 }


### PR DESCRIPTION
## What does this implement/fix?

If a tooltip doesn't contain any data, we don't render it.


## Does this close any currently open issues?

Resolves #1400


## What do the changes look like?

Before:
<img width="518" alt="Screen Shot 2022-10-12 at 3 05 39 PM" src="https://user-images.githubusercontent.com/64446645/195456748-d690e969-43cf-4fef-a06a-e11dcb75f566.png">

After:

https://user-images.githubusercontent.com/64446645/195456764-b0ba47c4-a8ea-48af-94ee-66db0bb02618.mov


 
## Storybook link

[Storybook](http://localhost:6006/?path=/story/polaris-viz-charts-linechart-playground--cohort-comparison-data-set)


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
