### PR TITLE
Set `solid` value `none` for `LineSeries` in core

### DIFF
--- a/packages/polaris-viz-core/CHANGELOG.md
+++ b/packages/polaris-viz-core/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- `LineSeries` `strokeDasharray` value for `solid` lines is now `none` vs `unset`, avoiding a failure on Android
 
 ## [7.5.1] - 2022-10-18
 

--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -32,7 +32,7 @@ const SPARK_STROKE_WIDTH = 1;
 export const StrokeDasharray = {
   dotted: '0.1 8',
   dashed: '2 4',
-  solid: 'unset',
+  solid: 'none',
 };
 
 function getLineStyle({


### PR DESCRIPTION
## What does this implement/fix?

Fixes the following Android error when importing `SparkLineChart` on Android.

https://user-images.githubusercontent.com/4960217/196744064-d517105a-a01a-4f89-95b2-f9d40d59811f.png

## Does this close any currently open issues?

Closes: https://github.com/Shopify/polaris-viz/issues/1404


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
