### PR TITLE
Use dist versions of d3 when testing

### DIFF
--- a/packages/polaris-viz-core/loom.config.ts
+++ b/packages/polaris-viz-core/loom.config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import {buildLibraryExtended} from '@shopify/loom-plugin-build-library-extended';
 import {buildLibrary} from '@shopify/loom-plugin-build-library';
 import {
@@ -59,7 +61,13 @@ function jestAdjustments() {
         configure.jestConfig?.hook((config) => {
           return {
             ...config,
-            transformIgnorePatterns: ['<rootDir>/node_modules/(?!d3)'],
+            moduleNameMapper: {
+              ...config.moduleNameMapper,
+              '^d3-(.*)$': path.resolve(
+                __dirname,
+                '../../node_modules/d3-$1/dist/d3-$1',
+              ),
+            },
           };
         });
       });

--- a/packages/polaris-viz-native/loom.config.ts
+++ b/packages/polaris-viz-native/loom.config.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import {buildLibrary} from '@shopify/loom-plugin-build-library';
 import {createPackage, createProjectPlugin} from '@shopify/loom';
-
 // Needed so TS realises what configuration hooks are provided by Jest (in `jestAdjustments` below)
 import type {} from '@shopify/loom-plugin-jest';
 
@@ -33,8 +34,11 @@ function jestAdjustments() {
               '^@quilted/react-testing/matchers$':
                 '@quilted/react-testing/build/cjs/matchers/index.cjs',
               '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
+              '^d3-(.*)$': path.resolve(
+                __dirname,
+                '../../node_modules/d3-$1/dist/d3-$1',
+              ),
             },
-            transformIgnorePatterns: ['<rootDir>/node_modules/(?!d3)'],
           };
         });
       });

--- a/packages/polaris-viz/loom.config.ts
+++ b/packages/polaris-viz/loom.config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import {
   createPackage,
   createProjectBuildPlugin,
@@ -59,7 +61,13 @@ function jestAdjustments() {
         configure.jestConfig?.hook((config) => {
           return {
             ...config,
-            transformIgnorePatterns: ['<rootDir>/node_modules/(?!d3)'],
+            moduleNameMapper: {
+              ...config.moduleNameMapper,
+              '^d3-(.*)$': path.resolve(
+                __dirname,
+                '../../node_modules/d3-$1/dist/d3-$1',
+              ),
+            },
           };
         });
       });


### PR DESCRIPTION
## What does this implement/fix?

Moving from `transformIgnorePatterns` which requires d3 packages to be transpiled.

Transpiling has a speed hit so moving to the built versions of d3 in jest is faster.