### PR TITLE
Fix LineSeries being cut off at bottom of the chart

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -244,7 +244,9 @@ export function LineSeries({
           y={(strokeWidth + SHAPE_ANIMATION_HEIGHT_BUFFER) * -1}
           width={svgDimensions.width}
           height={
-            svgDimensions.height + strokeWidth + SHAPE_ANIMATION_HEIGHT_BUFFER
+            svgDimensions.height +
+            strokeWidth * 2 +
+            SHAPE_ANIMATION_HEIGHT_BUFFER
           }
           fill={
             data.isComparison

--- a/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
@@ -28,7 +28,6 @@ const defaultProps: LineSeriesProps = {
   xScale: someScale,
   yScale: someScale,
   data: mockData,
-  isAnimated: false,
   svgDimensions: {width: 100, height: 100},
   index: 0,
   theme: 'Default',
@@ -66,7 +65,7 @@ describe('<LineSeries />', () => {
         width: defaultProps.svgDimensions.width,
         height:
           defaultProps.svgDimensions.height +
-          10 +
+          20 +
           SHAPE_ANIMATION_HEIGHT_BUFFER,
       });
     });

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Fixed `<LineSeries />` path being cut off when data was along the bottom of the chart.
 
 ## [7.6.0] - 2022-10-25
 


### PR DESCRIPTION
## What does this implement/fix?

The mask wasn't tall enough for the stroke of the line. This was causing the line to get cut off at the 0 line.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/45442

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/198058678-a3b6c93e-f11c-42e1-8484-67349688899a.png)|![image](https://user-images.githubusercontent.com/149873/198058488-05100ee9-cad4-4e67-881a-c5dbc34c90f4.png)|

## Storybook link

https://6062ad4a2d14cd0021539c1b-bdssklfvha.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--cohort-comparison-data-set

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
