### PR TITLE
Fixes accessibility issues in the line chart

### DIFF
--- a/packages/polaris-viz-core/CHANGELOG.md
+++ b/packages/polaris-viz-core/CHANGELOG.md
@@ -11,6 +11,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `LineSeries` comparison colors have been updated to meet accessibility standards
+
 - `LineSeries` `strokeDasharray` value for `solid` lines is now `none` vs `unset`, avoiding a failure on Android
 
 ## [7.5.1] - 2022-10-18

--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -30,7 +30,7 @@ const ANIMATION_DELAY = 200;
 const SPARK_STROKE_WIDTH = 1;
 
 export const StrokeDasharray = {
-  dotted: '0.1 8',
+  dotted: '0.1 4',
   dashed: '2 4',
   solid: 'none',
 };

--- a/packages/polaris-viz-core/src/styles/shared/_variables.scss
+++ b/packages/polaris-viz-core/src/styles/shared/_variables.scss
@@ -7,8 +7,8 @@ $color-purple-dark: rgb(80, 36, 143);
 // Colors are named non-sequencial numbers
 // so it matches the UX Color Matrix
 // stylelint-disable color-no-hex
-$color-dark-comparison: rgba(144, 176, 223, 0.6);
-$color-light-comparison: rgba(103, 147, 204, 0.6);
+$color-dark-comparison: rgba(144, 176, 223, 0.8);
+$color-light-comparison: rgba(103, 147, 204, 1);
 
 $color-gray-00: #ffffff;
 $color-gray-10: #f6f6f7;

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Fixed the case where the `LineChart` was not properly inheriting the theme theme passed to the chart.
+
 - Fixed `<LineSeries />` path being cut off when data was along the bottom of the chart.
 
 ## [7.6.0] - 2022-10-25

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -93,6 +93,7 @@ export function LineChart(props: LineChartProps) {
             renderTooltipContent={renderTooltip}
             showLegend={showLegend}
             emptyStateText={emptyStateText}
+            theme={theme}
           />
         )}
       </ChartContainer>


### PR DESCRIPTION
## What does this implement/fix?

Changes the contrast levels for the comparison dots in the line chart.

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?
closes #1413 

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?


| Before  | After  |
|---|---|
|  <img width="840" alt="Screen Shot 2022-10-28 at 12 41 41 PM" src="https://user-images.githubusercontent.com/36030324/198702025-2d57d179-1ebd-4a70-ba1c-5f5ddfc55284.png"> |  
<img width="806" alt="Screen Shot 2022-10-28 at 2 06 30 PM" src="https://user-images.githubusercontent.com/36030324/198713392-fbf440eb-0e5e-4442-904c-491ab3a320cf.png">

 |


 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
