### PR TITLE
Use Bar data for yScale

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue in `<ComboChart />` where wrong `yScale` could be used which rendered the `<Tooltip />` component outside the chart bounds.
 
 ## [7.7.1] - 2022-11-04
 

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -343,7 +343,7 @@ export function Chart({
     const highestValuePos = Math.max(...sortedDataPos);
 
     const x = xPosition + chartXPosition;
-    const y = yScale(highestValuePos) + (ChartMargin.Top as number);
+    const y = barYScale(highestValuePos) + (ChartMargin.Top as number);
 
     return {
       x,

--- a/packages/polaris-viz/src/components/ComboChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/stories/playground/Playground.stories.tsx
@@ -5,6 +5,7 @@ import {ComboChart, ComboChartProps} from '../../ComboChart';
 
 import type {DataGroup} from '@shopify/polaris-viz-core';
 import {META} from '../meta';
+import {Template as BasicTemplate} from '../data';
 
 export default {
   ...META,
@@ -507,3 +508,83 @@ const Template: Story<ComboChartProps> = ({
 export const Default: Story<ComboChartProps> = Template.bind({});
 
 Default.args = {};
+
+export const WebVitals: Story<ComboChartProps> = BasicTemplate.bind({});
+
+WebVitals.args = {
+  data: [
+    {
+      name: 'Web vitals',
+      series: [
+        {
+          data: [
+            {
+              key: 'June 25',
+              value: 4.1,
+            },
+            {
+              key: 'June 26',
+              value: 6.7,
+            },
+            {
+              key: 'June 27',
+              value: 7.4,
+            },
+            {
+              key: 'June 28',
+              value: 7.6,
+            },
+            {
+              key: 'June 29',
+              value: 6.7,
+            },
+            {
+              key: 'June 30',
+              value: 8.6,
+            },
+          ],
+          name: 'LCP',
+          color: '#5C6AC4',
+        },
+      ],
+      shape: 'Line',
+    },
+    {
+      name: 'Sessions measured',
+      series: [
+        {
+          isComparison: true,
+          data: [
+            {
+              key: 'June 25',
+              value: 4057,
+            },
+            {
+              key: 'June 26',
+              value: 21583,
+            },
+            {
+              key: 'June 27',
+              value: 18069,
+            },
+            {
+              key: 'June 28',
+              value: 19332,
+            },
+            {
+              key: 'June 29',
+              value: 20282,
+            },
+            {
+              key: 'June 30',
+              value: 23515,
+            },
+          ],
+          name: 'Sessions measured',
+          color: '#79CCE5',
+        },
+      ],
+      shape: 'Bar',
+    },
+  ],
+};


### PR DESCRIPTION
## What does this implement/fix?

When getting the position for the tooltip, the wrong `yScale` was being used which would sometimes render the `<Tooltip />` outside the chart bounds because the y value was huge.

We always want to use the bar chart data as the positioning for the tooltip.

**Video of the bug**

https://user-images.githubusercontent.com/149873/200875025-e979ce2d-44c4-460d-b6bc-11a7ab169c9b.mov
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-xfoasitseo.chromatic.com/?path=/story/polaris-viz-charts-combochart-playground--web-vitals

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
