### PR TITLE
Add showLegend prop to SimpleNormalizedChart

### DIFF
--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -26,6 +26,7 @@ export interface ChartProps {
   legendPosition?: LegendPosition;
   direction?: Direction;
   size?: Size;
+  showLegend?: boolean;
 }
 
 export function Chart({
@@ -35,6 +36,7 @@ export function Chart({
   legendPosition = 'top-left',
   direction = 'horizontal',
   size = 'small',
+  showLegend = true,
 }: ChartProps) {
   const flattenedData = data.map(({data}) => data).flat();
 
@@ -83,6 +85,43 @@ export function Chart({
   const isHorizontalAndRightLabel = !isVertical && isRightLabel;
   const isHorizontalAndBottomLabel = !isVertical && isBottomLabel;
 
+  const legend = showLegend && (
+    <ul
+      className={classNames(
+        isVertical
+          ? styles.VerticalLabelContainer
+          : styles.HorizontalLabelContainer,
+        (isVerticalAndBottomLabel || isHorizontalAndRightLabel) &&
+          styles.LabelContainerEndJustify,
+      )}
+    >
+      {slicedData.map(({key, value}, index) => {
+        if (value == null) {
+          return null;
+        }
+
+        const comparisonMetric = comparisonMetrics.find(
+          ({dataIndex}) => index === dataIndex,
+        );
+
+        const formattedValue = labelFormatter(value);
+        return (
+          <BarLabel
+            activeIndex={activeIndex}
+            index={index}
+            key={`${key}-${formattedValue}-${index}`}
+            label={`${data[index].name}`}
+            value={formattedValue}
+            color={colors[index]}
+            comparisonMetric={comparisonMetric}
+            direction={direction}
+            legendPosition={legendPosition}
+          />
+        );
+      })}
+    </ul>
+  );
+
   return (
     <div
       className={classNames(
@@ -92,41 +131,7 @@ export function Chart({
         isHorizontalAndBottomLabel && styles.HorizontalContainerBottomLabel,
       )}
     >
-      <ul
-        className={classNames(
-          isVertical
-            ? styles.VerticalLabelContainer
-            : styles.HorizontalLabelContainer,
-          (isVerticalAndBottomLabel || isHorizontalAndRightLabel) &&
-            styles.LabelContainerEndJustify,
-        )}
-      >
-        {slicedData.map(({key, value}, index) => {
-          if (value == null) {
-            return null;
-          }
-
-          const comparisonMetric = comparisonMetrics.find(
-            ({dataIndex}) => index === dataIndex,
-          );
-
-          const formattedValue = labelFormatter(value);
-          return (
-            <BarLabel
-              activeIndex={activeIndex}
-              index={index}
-              key={`${key}-${formattedValue}-${index}`}
-              label={`${data[index].name}`}
-              value={formattedValue}
-              color={colors[index]}
-              comparisonMetric={comparisonMetric}
-              direction={direction}
-              legendPosition={legendPosition}
-            />
-          );
-        })}
-      </ul>
-
+      {legend}
       <div
         className={classNames(
           styles.BarContainer,

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -22,6 +22,7 @@ export type SimpleNormalizedChartProps = {
   legendPosition?: LegendPosition;
   direction?: Direction;
   size?: Size;
+  showLegend?: boolean;
 } & ChartProps;
 
 export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
@@ -32,6 +33,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
     legendPosition = 'top-left',
     direction = 'horizontal',
     size = 'small',
+    showLegend = true,
     theme,
     isAnimated,
     state,
@@ -55,6 +57,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
           data={data}
           labelFormatter={labelFormatter}
           legendPosition={legendPosition}
+          showLegend={showLegend}
           direction={direction}
           size={size}
         />

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/HiddenLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/HiddenLegend.stories.tsx
@@ -1,0 +1,15 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../..';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const HiddenLegend: Story<SimpleNormalizedChartProps> = Template.bind({});
+
+HiddenLegend.args = {
+  ...DEFAULT_PROPS,
+  showLegend: false,
+  data: DEFAULT_DATA,
+};

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/meta.tsx
@@ -31,6 +31,9 @@ export const META: Meta = {
         'Determines the width or height of the bar segments depending on `direction`.',
     },
     legendPosition: LEGEND_POSITION_ARGS,
+    showLegend: {
+      description: 'Shows the legend for the chart.',
+    },
     theme: THEME_CONTROL_ARGS,
     state: CHART_STATE_CONTROL_ARGS,
   },

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/tests/Chart.test.tsx
@@ -296,6 +296,14 @@ describe('<Chart />', () => {
 
       expect(barChart.findAll(BarLabel)).toHaveLength(2);
     });
+
+    it('renders no labels if showLegend is false', () => {
+      const barChart = mount(
+        <SimpleNormalizedChart {...mockProps} showLegend={false} />,
+      );
+
+      expect(barChart.findAll(BarLabel)).toHaveLength(0);
+    });
   });
 
   describe('Colors', () => {


### PR DESCRIPTION
## What does this implement/fix?

Done in a pairing session with @mbalamou

This PR adds the ability to show/hide the labels for the SimpleNormalizedChart through a prop named `showLegend`. The prop name was chosen to be consistent with other charts which offer the same functionality: namely `BarChart`, `LineChart`, and `StackedAreaChart`.

## Does this close any currently open issues?
- Solves https://github.com/Shopify/polaris-viz/issues/1433 

## What do the changes look like?

| Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/44531733/200907358-633f2b59-409f-4260-97a3-9f421d0703f3.png) | ![image](https://user-images.githubusercontent.com/44531733/200907425-072553d5-6f86-441e-9616-d4fb3afc1301.png)|
 
## Storybook link
[Storybook - Polaris-viz/Charts/SimpleNormalizedChart/Hidden Legend](https://6062ad4a2d14cd0021539c1b-khceubkhwp.chromatic.com/?path=/story/polaris-viz-charts-simplenormalizedchart--hidden-legend)

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
