### PR TITLE
Fix LineChart tooltip being offset from mouse

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `<LineChart />` tooltip being offset from the mouse/pointer position.
 
 ## [7.8.0] - 2022-11-09
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -220,9 +220,7 @@ export function Chart({
 
       const {svgX, svgY} = point;
 
-      const closestIndex = Math.round(
-        xScale.invert(svgX - (chartXPosition + halfXAxisLabelWidth)),
-      );
+      const closestIndex = Math.round(xScale.invert(svgX - chartXPosition));
 
       const activeIndex = clamp({
         amount: closestIndex,


### PR DESCRIPTION
## What does this implement/fix?

The logic to position the tooltip was still being positioned as if the lines were offset from the labels. With the recent changes (https://github.com/Shopify/polaris-viz/pull/1411) to not offset the labels, this was missed.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1435
Resolves https://github.com/Shopify/core-issues/issues/47488

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/201779284-8d192f8e-83cf-47a8-8684-60b8f02f7fe6.mov

**After**

https://user-images.githubusercontent.com/149873/201779172-6bb62bc4-a3ac-4b13-8ed0-6df6a8d3c727.mov
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
