### PR TITLE
update line stroke width for spark line chart

### DIFF
--- a/packages/polaris-viz-core/CHANGELOG.md
+++ b/packages/polaris-viz-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Updated
+### Changed
 
 - Increased `<SparkLineChart />` stroke width from 1px to 1.5px
 

--- a/packages/polaris-viz-core/CHANGELOG.md
+++ b/packages/polaris-viz-core/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Updated
+
+- Increased `<SparkLineChart />` stroke width from 1px to 1.5px
 
 ## [7.8.0] - 2022-11-09
 

--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -26,7 +26,7 @@ import {
 import {Area, AnimatedLine, AnimatedArea} from './components';
 
 const ANIMATION_DELAY = 200;
-const SPARK_STROKE_WIDTH = 1;
+const SPARK_STROKE_WIDTH = 1.5;
 
 export const StrokeDasharray = {
   dotted: '0.1 4',


### PR DESCRIPTION
## What does this implement/fix?
Increases sparkline chart's stroke width

Before:
<img width="253" alt="Screenshot 2022-11-14 at 2 12 31 PM" src="https://user-images.githubusercontent.com/64446645/201780133-a4ee90e0-e02b-4733-b5f2-f76fa1edbd67.png">

After:
<img width="232" alt="Screenshot 2022-11-14 at 2 12 43 PM" src="https://user-images.githubusercontent.com/64446645/201780101-cb47ffa0-9d5c-4568-879a-e58429172cc3.png">


## Does this close any currently open issues?

Resolves [#1421](https://github.com/Shopify/polaris-viz/issues/1421)


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
