### PR TITLE
add focus removal class to combo line chart

### DIFF
--- a/packages/polaris-viz/src/components/ComboChart/Chart.scss
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.scss
@@ -1,0 +1,6 @@
+@import '../../styles/common';
+
+.Group * {
+  @include no-outline;
+  pointer-events: none;
+}

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -47,6 +47,7 @@ import {ComboBarChart, ComboLineChart, AxisLabel} from './components';
 import {useSplitDataForCharts} from './hooks/useSplitDataForCharts';
 import {useComboChartTooltipContent} from './hooks/useComboChartTooltipContent';
 import {useComboChartPositions} from './hooks/useComboChartPositions';
+import styles from './Chart.scss';
 
 export interface ChartProps {
   annotationsLookupTable: AnnotationLookupTable;
@@ -236,6 +237,7 @@ export function Chart({
           transform={`translate(${
             chartXPosition + drawableWidth / labels.length / 2
           },${chartYPosition})`}
+          className={styles.Group}
         >
           <ComboLineChart
             activeIndex={activeIndex}


### PR DESCRIPTION
## What does this implement/fix?

The Line Chart in the Combo Charts was staying in focus while hovering over the Bar Chart

## Does this close any currently open issues?

Resolves [#1430](https://github.com/Shopify/polaris-viz/issues/1430)

## What do the changes look like?

**Before:**

https://user-images.githubusercontent.com/64446645/203603418-c7d258c0-f77f-47bd-b6df-a22bc8ca1eb7.mov

**After:**

https://user-images.githubusercontent.com/64446645/203603461-5029b015-68ef-4a17-8bd7-5c82dcb90d51.mov

## Storybook link

🎩 http://localhost:6006/?path=/docs/polaris-viz-charts-combochart--default


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
