### PR TITLE
Use longest matching index for bar and line charts

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- When determining which `DataSeries[].data` to use for labels, use either the first item in the data array when lengths match or the array with the longest length.
 
 ## [7.9.0] - 2022-11-18
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useMemo} from 'react';
+import React, {useState, useRef} from 'react';
 import {
   uniqueId,
   DataType,
@@ -19,6 +19,7 @@ import type {
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
 
+import {useIndexForLabels} from '../../hooks/useIndexForLabels';
 import {
   Annotations,
   checkAvailableAnnotations,
@@ -116,20 +117,7 @@ export function Chart({
     onIndexChange: ({detail}) => setActiveLineIndex(detail.index),
   });
 
-  const indexForLabels = useMemo(() => {
-    return data.reduce((longestIndex, currentSeries, index, array) => {
-      const previousSeries = array[index - 1];
-
-      if (
-        previousSeries &&
-        previousSeries.data.length < currentSeries.data.length
-      ) {
-        return index;
-      }
-
-      return longestIndex;
-    }, 0);
-  }, [data]);
+  const indexForLabels = useIndexForLabels(data);
 
   const formattedLabels = useFormattedLabels({
     data: [data[indexForLabels]],

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
@@ -2,6 +2,7 @@ import {useMemo} from 'react';
 import type {DataSeries, XAxisOptions} from '@shopify/polaris-viz-core';
 import {stackOffsetNone, stackOrderReverse} from 'd3-shape';
 
+import {useIndexForLabels} from '../../../hooks/useIndexForLabels';
 import {getStackedValues} from '../../../utilities/getStackedValues';
 import {useFormattedLabels} from '../../../hooks/useFormattedLabels';
 
@@ -11,8 +12,10 @@ interface Props {
 }
 
 export function useStackedData({data, xAxisOptions}: Props) {
+  const indexForLabels = useIndexForLabels(data);
+
   const labels = useFormattedLabels({
-    data,
+    data: [data[indexForLabels]],
     labelFormatter: xAxisOptions.labelFormatter,
   });
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@shopify/polaris-viz-core';
 import {stackOffsetDiverging, stackOrderNone} from 'd3-shape';
 
+import {useIndexForLabels} from '../../hooks/useIndexForLabels';
 import {ChartElements} from '../ChartElements';
 import {
   YAxisAnnotations,
@@ -102,8 +103,10 @@ export function Chart({
 
   const emptyState = data.length === 0;
 
-  const labels = useFormattedLabels({
-    data,
+  const indexForLabels = useIndexForLabels(data);
+
+  const formattedLabels = useFormattedLabels({
+    data: [data[indexForLabels]],
     labelFormatter: xAxisOptions.labelFormatter,
   });
 
@@ -111,7 +114,7 @@ export function Chart({
   const stackedValues = isStacked
     ? getStackedValues({
         series: data,
-        labels,
+        labels: formattedLabels,
         order: stackOrderNone,
         offset: stackOffsetDiverging,
       })
@@ -179,7 +182,7 @@ export function Chart({
   const {sortedData, areAllNegative, xScale, gapWidth} = useVerticalBarChart({
     data,
     drawableWidth,
-    labels,
+    labels: formattedLabels,
   });
 
   const {ticks, yScale} = useYScale({
@@ -211,7 +214,7 @@ export function Chart({
         {hideXAxis ? null : (
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
-            labels={labels}
+            labels={formattedLabels}
             labelWidth={xScale.bandwidth()}
             onHeightChange={setXAxisHeight}
             reducedLabelIndexes={reducedLabelIndexes}
@@ -255,7 +258,7 @@ export function Chart({
             drawableHeight={drawableHeight}
             gapWidth={gapWidth}
             id={id}
-            labels={labels}
+            labels={formattedLabels}
             sortedData={sortedData}
             stackedValues={stackedValues}
             xScale={xScale}
@@ -272,7 +275,7 @@ export function Chart({
               axisLabelWidth={xScale.bandwidth()}
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
-              labels={labels}
+              labels={formattedLabels}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
             />

--- a/packages/polaris-viz/src/hooks/tests/useIndexForLabels.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useIndexForLabels.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {mount, Root} from '@shopify/react-testing';
+
+import {useIndexForLabels} from '../useIndexForLabels';
+
+function parseData(result: Root<any>) {
+  return JSON.parse(result.domNode?.dataset.data ?? '');
+}
+
+describe('useIndexForLabels', () => {
+  it('returns the first index when series.data[] length matches', () => {
+    0;
+    function TestComponent() {
+      const data = useIndexForLabels([
+        {
+          name: 'Bfcm sales',
+          data: [
+            {
+              key: 'Nov 25, 2022',
+              value: 4597927.99,
+            },
+            {
+              key: 'Nov 26, 2022',
+              value: 1771353.08,
+            },
+            {
+              key: 'Nov 27, 2022',
+              value: 1013047.84,
+            },
+            {
+              key: 'Nov 28, 2022',
+              value: 0,
+            },
+          ],
+        },
+        {
+          name: 'Bfcm sales bfcm2021',
+          data: [
+            {
+              key: 'Nov 26, 2021',
+              value: 1856721.98,
+            },
+            {
+              key: 'Nov 27, 2021',
+              value: 1029153.21,
+            },
+            {
+              key: 'Nov 28, 2021',
+              value: 1235163.58,
+            },
+            {
+              key: 'Nov 29, 2021',
+              value: 4393912.58,
+            },
+          ],
+        },
+      ]);
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const indexForLabels = parseData(result);
+
+    expect(indexForLabels).toStrictEqual(0);
+  });
+
+  it('returns the index of the first longest series.data[] when length does not match', () => {
+    0;
+    function TestComponent() {
+      const data = useIndexForLabels([
+        {
+          name: 'Bfcm sales',
+          data: [
+            {
+              key: 'Nov 25, 2022',
+              value: 4597927.99,
+            },
+            {
+              key: 'Nov 26, 2022',
+              value: 1771353.08,
+            },
+            {
+              key: 'Nov 27, 2022',
+              value: 1013047.84,
+            },
+          ],
+        },
+        {
+          name: 'Bfcm sales bfcm2021',
+          data: [
+            {
+              key: 'Nov 26, 2021',
+              value: 1856721.98,
+            },
+            {
+              key: 'Nov 27, 2021',
+              value: 1029153.21,
+            },
+            {
+              key: 'Nov 28, 2021',
+              value: 1235163.58,
+            },
+            {
+              key: 'Nov 29, 2021',
+              value: 4393912.58,
+            },
+          ],
+        },
+        {
+          name: 'Bfcm sales bfcm2021',
+          data: [
+            {
+              key: 'Nov 26, 2021',
+              value: 1856721.98,
+            },
+            {
+              key: 'Nov 27, 2021',
+              value: 1029153.21,
+            },
+            {
+              key: 'Nov 28, 2021',
+              value: 1235163.58,
+            },
+            {
+              key: 'Nov 29, 2021',
+              value: 4393912.58,
+            },
+          ],
+        },
+      ]);
+
+      return <span data-data={`${JSON.stringify(data)}`} />;
+    }
+
+    const result = mount(<TestComponent />);
+
+    const indexForLabels = parseData(result);
+
+    expect(indexForLabels).toStrictEqual(1);
+  });
+});

--- a/packages/polaris-viz/src/hooks/useIndexForLabels.ts
+++ b/packages/polaris-viz/src/hooks/useIndexForLabels.ts
@@ -1,0 +1,19 @@
+import {useMemo} from 'react';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+export function useIndexForLabels(data: DataSeries[]) {
+  return useMemo(() => {
+    return data.reduce((longestIndex, currentSeries, index, array) => {
+      const previousSeries = array[index - 1];
+
+      if (
+        previousSeries &&
+        previousSeries.data.length < currentSeries.data.length
+      ) {
+        return index;
+      }
+
+      return longestIndex;
+    }, 0);
+  }, [data]);
+}


### PR DESCRIPTION
## What does this implement/fix?

Based on some feedback from @susiekims the logic we used to determine which `DataSeries` we used for labels was different between `LineChart` and `BarChart`.

The original change was introduce to `LineChart` as part of https://github.com/Shopify/polaris-viz/pull/1411.

In `BarChart` we would loop through each `DataSeries` and overwrite the array of labels on each pass. This means that in most cases we used the labels from the last item in the array. This was to make sure we always displayed the correct amount of labels for `DataSeries` that don't contain matching lengths.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/204326285-bd119562-9dc0-4923-bad9-cc149bb92d62.png)|![image](https://user-images.githubusercontent.com/149873/204326121-53799fa9-dcda-48ca-aec3-3cc3a52da369.png)|

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
