### PR TITLE
Add linear comparison tooltip

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -61,6 +61,7 @@ export {
   AREAS_LOAD_ANIMATION_CONFIG,
   COLOR_VARIABLES,
   AREAS_TRANSITION_CONFIG,
+  STROKE_DOT_ARRAY_WIDTH,
 } from './constants';
 export {
   clamp,

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -24,7 +24,7 @@ export interface DataGroup {
 
 export type Shape = 'Line' | 'Bar';
 
-export type LineStyle = 'dashed' | 'solid' | 'dotted';
+export type LineStyle = 'solid' | 'dotted';
 
 export interface GradientStop {
   offset: number;

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -3,8 +3,12 @@ import type {Story} from '@storybook/react';
 
 import {LineChart, LineChartProps} from '../../LineChart';
 import {randomNumber} from '../../../Docs/utilities';
-import {formatLinearXAxisLabel} from '../../../../storybook/utilities';
+import {
+  formatLinearXAxisLabel,
+  formatLinearYAxisLabel,
+} from '../../../../storybook/utilities';
 import {META} from '../meta';
+import {renderLinearComparisonTooltip} from '../../../../utilities';
 
 export default {
   ...META,
@@ -883,6 +887,94 @@ MissingData.args = {
         {value: 21, key: '2020-03-14T12:00:00'},
       ],
       isComparison: true,
+    },
+  ],
+};
+
+export const LinearComparisonTooltip: Story<LineChartProps> = Template.bind({});
+
+LinearComparisonTooltip.args = {
+  tooltipOptions: {
+    renderTooltipContent: (tooltipData) => {
+      return renderLinearComparisonTooltip(tooltipData, {
+        groups: [
+          {title: 'Net sales', indexes: [0, 1]},
+          {title: 'Average order value', indexes: [2, 3, 18]},
+        ],
+      });
+    },
+    valueFormatter: formatLinearYAxisLabel,
+  },
+  data: [
+    {
+      name: 'Bfcm sales',
+      data: [
+        {
+          key: 'Nov 25, 2022',
+          value: 4597927.99,
+        },
+        {
+          key: 'Nov 26, 2022',
+          value: 4597927.99,
+        },
+        {
+          key: 'Nov 27, 2022',
+          value: 4597927.99,
+        },
+      ],
+    },
+    {
+      name: 'Bfcm sales bfcm2021',
+      isComparison: true,
+      data: [
+        {
+          key: 'Nov 26, 2021',
+          value: 1856721.98,
+        },
+        {
+          key: 'Nov 27, 2021',
+          value: 1856721.98,
+        },
+        {
+          key: 'Nov 28, 2021',
+          value: 1856721.98,
+        },
+      ],
+    },
+    {
+      name: 'AOV',
+      data: [
+        {
+          key: 'Nov 25, 2022',
+          value: 5597927.99,
+        },
+        {
+          key: 'Nov 26, 2022',
+          value: 5597927.99,
+        },
+        {
+          key: 'Nov 27, 2022',
+          value: 5597927.99,
+        },
+      ],
+    },
+    {
+      name: 'AOV bfcm2021',
+      isComparison: true,
+      data: [
+        {
+          key: 'Nov 26, 2021',
+          value: 1956721.98,
+        },
+        {
+          key: 'Nov 27, 2021',
+          value: 1956721.98,
+        },
+        {
+          key: 'Nov 28, 2021',
+          value: 1956721.98,
+        },
+      ],
     },
   ],
 };

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -27,7 +27,6 @@ import {Annotations, YAxisAnnotations} from '../../Annotations';
 import {normalizeData} from '../../../utilities';
 import characterWidths from '../../../data/character-widths.json';
 import characterWidthOffsets from '../../../data/character-width-offsets.json';
-import {TextLine} from '../../TextLine';
 
 const MOCK_DATA: Required<LineChartDataSeriesWithDefaults> = {
   name: 'Primary',
@@ -69,12 +68,20 @@ jest.mock('@shopify/polaris-viz-core/src/utilities/estimateStringWidth', () => {
   };
 });
 
-jest.mock('../../../utilities', () => {
+jest.mock('../../../utilities/getPathLength', () => {
   return {
-    ...jest.requireActual('../../../utilities'),
-    isLargeDataSet: jest.fn(() => true),
     getPathLength: () => 0,
+  };
+});
+
+jest.mock('../../../utilities/getPointAtLength', () => {
+  return {
     getPointAtLength: () => ({x: 0, y: 0}),
+  };
+});
+
+jest.mock('../../../utilities/eventPoint', () => {
+  return {
     eventPointNative: () => {
       return {clientX: 200, clientY: 200, svgX: 200, svgY: 200};
     },

--- a/packages/polaris-viz/src/components/LineChart/tests/LineChart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/LineChart.test.tsx
@@ -17,10 +17,14 @@ const primarySeries: DataSeries = {
   ],
 };
 
-jest.mock('../../../utilities', () => {
+jest.mock('../../../utilities/getPathLength', () => {
   return {
-    ...jest.requireActual('../../../utilities'),
     getPathLength: () => 0,
+  };
+});
+
+jest.mock('../../../utilities/getPointAtLength', () => {
+  return {
     getPointAtLength: () => ({x: 0, y: 0}),
   };
 });

--- a/packages/polaris-viz/src/components/LinePreview/LinePreview.scss
+++ b/packages/polaris-viz/src/components/LinePreview/LinePreview.scss
@@ -1,3 +1,7 @@
 .Container {
   display: flex;
 }
+
+.SVG {
+  display: block;
+}

--- a/packages/polaris-viz/src/components/LinePreview/LinePreview.tsx
+++ b/packages/polaris-viz/src/components/LinePreview/LinePreview.tsx
@@ -9,7 +9,6 @@ import {
 import {PREVIEW_ICON_SIZE, XMLNS} from '../../constants';
 
 import {
-  DASHED_STROKE_DASHARRAY,
   DOTTED_LINE_PREVIEW_CY,
   DOTTED_LINE_PREVIEW_RADIUS,
   DOT_SPACING,
@@ -31,11 +30,16 @@ export function LinePreview({color, lineStyle}: LinePreviewProps) {
     : color;
 
   return (
-    <span className={styles.Container} style={{height: HEIGHT}}>
+    <span
+      className={styles.Container}
+      style={{height: HEIGHT, width: PREVIEW_ICON_SIZE}}
+    >
       <svg
-        xmlns={XMLNS}
-        width={`${PREVIEW_ICON_SIZE}px`}
+        className={styles.SVG}
         height={`${HEIGHT}px`}
+        viewBox={`0 0 ${PREVIEW_ICON_SIZE} ${HEIGHT}`}
+        width={`${PREVIEW_ICON_SIZE}px`}
+        xmlns={XMLNS}
       >
         {isGradientType(color) ? (
           <defs>
@@ -57,46 +61,31 @@ export function LinePreview({color, lineStyle}: LinePreviewProps) {
 }
 
 function getLinePreview(color: string, lineStyle: LineStyle) {
-  const solidLine = (
-    <path
-      d="M1,1L13.5,1"
-      stroke={color}
-      strokeLinejoin="round"
-      strokeLinecap="round"
-      strokeWidth="2"
-    />
-  );
-
-  const dashedLine = (
-    <path
-      d="M0,1L15,1"
-      stroke={color}
-      strokeWidth="2"
-      strokeDasharray={DASHED_STROKE_DASHARRAY}
-    />
-  );
-
-  const dottedLine = (
-    <g fill={color}>
-      {[...Array(3)].map((_, index) => {
-        return (
-          <circle
-            key={index}
-            cx={1 + index * DOT_SPACING}
-            cy={DOTTED_LINE_PREVIEW_CY}
-            r={DOTTED_LINE_PREVIEW_RADIUS}
-          />
-        );
-      })}
-    </g>
-  );
-
   switch (lineStyle) {
-    case 'dashed':
-      return dashedLine;
     case 'dotted':
-      return dottedLine;
+      return (
+        <g fill={color}>
+          {[...Array(3)].map((_, index) => {
+            return (
+              <circle
+                key={index}
+                cx={DOTTED_LINE_PREVIEW_CY + index * DOT_SPACING}
+                cy={DOTTED_LINE_PREVIEW_CY}
+                r={DOTTED_LINE_PREVIEW_RADIUS}
+              />
+            );
+          })}
+        </g>
+      );
     default:
-      return solidLine;
+      return (
+        <path
+          d={`M1 1 H${PREVIEW_ICON_SIZE}`}
+          stroke={color}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          strokeWidth="2"
+        />
+      );
   }
 }

--- a/packages/polaris-viz/src/components/LinePreview/constants.ts
+++ b/packages/polaris-viz/src/components/LinePreview/constants.ts
@@ -1,4 +1,3 @@
-export const DASHED_STROKE_DASHARRAY = '3.5 2';
 export const DOTTED_LINE_PREVIEW_CY = 1;
 export const DOTTED_LINE_PREVIEW_RADIUS = 1;
 export const DOT_SPACING = 5;

--- a/packages/polaris-viz/src/components/LinePreview/tests/LinePreview.test.tsx
+++ b/packages/polaris-viz/src/components/LinePreview/tests/LinePreview.test.tsx
@@ -2,21 +2,12 @@ import React from 'react';
 import {mount} from '@shopify/react-testing';
 
 import {LinePreview} from '../LinePreview';
-import {DASHED_STROKE_DASHARRAY} from '../constants';
 
 describe('<LinePreview />', () => {
   it('renders a path with the given color', () => {
     const linePreview = mount(<LinePreview color="red" lineStyle="solid" />);
 
     expect(linePreview).toContainReactComponent('path', {stroke: 'red'});
-  });
-
-  it('renders a dashed path if lineStyle is dashed', () => {
-    const linePreview = mount(<LinePreview color="red" lineStyle="dashed" />);
-
-    expect(linePreview).toContainReactComponent('path', {
-      strokeDasharray: DASHED_STROKE_DASHARRAY,
-    });
   });
 
   it('renders a solid path if lineStyle is solid', () => {

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -25,11 +25,20 @@ jest.mock('@shopify/polaris-viz-core/src/utilities/estimateStringWidth', () => {
   };
 });
 
-jest.mock('../../../utilities', () => {
+jest.mock('../../../utilities/getPathLength', () => {
   return {
-    ...jest.requireActual('../../../utilities'),
     getPathLength: () => 0,
+  };
+});
+
+jest.mock('../../../utilities/getPointAtLength', () => {
+  return {
     getPointAtLength: jest.fn(() => ({x: 0, y: 0})),
+  };
+});
+
+jest.mock('../../../utilities/eventPoint', () => {
+  return {
     eventPointNative: () => {
       return {clientX: 100, clientY: 100, svgX: 100, svgY: 100};
     },

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.scss
@@ -1,25 +1,5 @@
 @import '../../styles/common';
 
-.Container {
-  padding: 8px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(5px);
-  border-radius: 8px;
-  min-width: 180px;
-}
-
-.Title {
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 20px;
-  margin: 0 0 10px;
-}
-
-.AxisTitle {
-  line-height: 16px;
-  margin: 0 0 8px;
-}
-
 .Series:not(:last-child) {
   margin: 0 0 13px;
 }

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -1,21 +1,21 @@
 import React, {useState} from 'react';
 import {
-  FONT_SIZE,
-  useTheme,
   COLOR_VISION_SINGLE_ITEM,
-  changeColorOpacity,
   DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
-import {useBrowserCheck} from '../../hooks/useBrowserCheck';
-import {TOOLTIP_BG_OPACITY} from '../../constants';
 import {useWatchColorVisionEvents} from '../../hooks';
 import type {TooltipData} from '../../types';
 
 import {useGetLongestLabelFromData} from './hooks/useGetLongestLabelFromData';
 import styles from './TooltipContent.scss';
 import {SPACE_BETWEEN_LABEL_AND_VALUE} from './constants';
-import {TooltipRow} from './components/';
+import {
+  TooltipContentContainer,
+  TooltipRow,
+  TooltipSeriesName,
+  TooltipTitle,
+} from './components/';
 
 export interface TooltipContentProps {
   data: TooltipData[];
@@ -32,9 +32,7 @@ export function TooltipContent({
   title,
 }: TooltipContentProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
-  const {isFirefox} = useBrowserCheck();
 
-  const selectedTheme = useTheme(theme);
   const {keyWidth, valueWidth} = useGetLongestLabelFromData(data);
 
   useWatchColorVisionEvents({
@@ -46,42 +44,19 @@ export function TooltipContent({
   const rightWidth = valueWidth * FONT_SIZE_OFFSET;
 
   return (
-    <div
-      className={styles.Container}
-      style={{
-        background: changeColorOpacity(
-          selectedTheme.tooltip.backgroundColor,
-          isFirefox ? 1 : TOOLTIP_BG_OPACITY,
-        ),
-        maxWidth:
-          PREVIEW_WIDTH +
-          leftWidth +
-          SPACE_BETWEEN_LABEL_AND_VALUE +
-          rightWidth,
-      }}
+    <TooltipContentContainer
+      maxWidth={
+        PREVIEW_WIDTH + leftWidth + SPACE_BETWEEN_LABEL_AND_VALUE + rightWidth
+      }
+      theme={theme}
     >
-      {title != null && (
-        <p
-          className={styles.Title}
-          style={{color: selectedTheme.tooltip.titleColor}}
-        >
-          {title}
-        </p>
-      )}
+      {title != null && <TooltipTitle theme={theme}>{title}</TooltipTitle>}
 
       {data.map(({data: series, name, shape}, dataIndex) => {
         return (
           <div className={styles.Series} key={dataIndex}>
             {name != null && (
-              <p
-                className={styles.AxisTitle}
-                style={{
-                  color: selectedTheme.tooltip.titleColor,
-                  fontSize: FONT_SIZE,
-                }}
-              >
-                {name}
-              </p>
+              <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
             )}
             {series.map(({key, value, color, isComparison}, seriesIndex) => {
               const indexOffset = data[dataIndex - 1]
@@ -104,6 +79,6 @@ export function TooltipContent({
           </div>
         );
       })}
-    </div>
+    </TooltipContentContainer>
   );
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.scss
@@ -1,0 +1,7 @@
+.Container {
+  padding: 8px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(5px);
+  border-radius: 8px;
+  min-width: 180px;
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
@@ -1,0 +1,28 @@
+import {changeColorOpacity, useTheme} from '@shopify/polaris-viz-core';
+import React from 'react';
+
+import {TOOLTIP_BG_OPACITY} from '../../../../constants';
+import {useBrowserCheck} from '../../../../hooks/useBrowserCheck';
+
+import styles from './TooltipContentContainer.scss';
+
+export function TooltipContentContainer({children, maxWidth, theme}) {
+  const {isFirefox} = useBrowserCheck();
+
+  const selectedTheme = useTheme(theme);
+
+  return (
+    <div
+      className={styles.Container}
+      style={{
+        background: changeColorOpacity(
+          selectedTheme.tooltip.backgroundColor,
+          isFirefox ? 1 : TOOLTIP_BG_OPACITY,
+        ),
+        maxWidth,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/index.ts
@@ -1,0 +1,1 @@
+export {TooltipContentContainer} from './TooltipContentContainer';

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
@@ -1,6 +1,7 @@
 .Row {
   line-height: 20px;
   font-size: 14px;
+  gap: 8px;
 
   &:not(:last-child) {
     margin: 0 0 10px;

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -6,6 +6,7 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {Shape} from '@shopify/polaris-viz-core';
 
+import {PREVIEW_ICON_SIZE} from '../../../../constants';
 import {SeriesIcon} from '../../../shared/SeriesIcon';
 import {classNames} from '../../../../utilities';
 import {TITLE_MARGIN} from '../../constants';
@@ -43,7 +44,7 @@ export function TooltipRow({
       })}
     >
       {color != null && (
-        <div style={{marginRight: 4}}>
+        <div className={styles.SeriesIcon} style={{width: PREVIEW_ICON_SIZE}}>
           <SeriesIcon
             color={color!}
             isComparison={isComparison}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/TooltipSeriesName.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/TooltipSeriesName.scss
@@ -1,0 +1,4 @@
+.AxisTitle {
+  line-height: 16px;
+  margin: 0 0 8px;
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/TooltipSeriesName.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/TooltipSeriesName.tsx
@@ -1,0 +1,26 @@
+import {FONT_SIZE, useTheme} from '@shopify/polaris-viz-core';
+import React, {ReactNode} from 'react';
+
+import styles from './TooltipSeriesName.scss';
+
+export function TooltipSeriesName({
+  children,
+  theme,
+}: {
+  children: ReactNode;
+  theme: string;
+}) {
+  const selectedTheme = useTheme(theme);
+
+  return (
+    <p
+      className={styles.AxisTitle}
+      style={{
+        color: selectedTheme.tooltip.titleColor,
+        fontSize: FONT_SIZE,
+      }}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeriesName/index.ts
@@ -1,0 +1,1 @@
+export {TooltipSeriesName} from './TooltipSeriesName';

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
@@ -1,0 +1,6 @@
+.Title {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  margin: 0 0 10px;
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.tsx
@@ -1,0 +1,23 @@
+import {useTheme} from '@shopify/polaris-viz-core';
+import React, {ReactNode} from 'react';
+
+import styles from './TooltipTitle.scss';
+
+export function TooltipTitle({
+  children,
+  theme,
+}: {
+  children: ReactNode;
+  theme: string;
+}) {
+  const selectedTheme = useTheme(theme);
+
+  return (
+    <p
+      className={styles.Title}
+      style={{color: selectedTheme.tooltip.titleColor}}
+    >
+      {children}
+    </p>
+  );
+}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/index.ts
@@ -1,0 +1,1 @@
+export {TooltipTitle} from './TooltipTitle';

--- a/packages/polaris-viz/src/components/TooltipContent/components/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/components/index.ts
@@ -1,1 +1,4 @@
 export {TooltipRow} from './TooltipRow';
+export {TooltipContentContainer} from './TooltipContentContainer';
+export {TooltipTitle} from './TooltipTitle';
+export {TooltipSeriesName} from './TooltipSeriesName';

--- a/packages/polaris-viz/src/components/TooltipContent/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/index.ts
@@ -1,2 +1,8 @@
 export {TooltipContent} from './TooltipContent';
 export type {TooltipContentProps} from './TooltipContent';
+export {
+  TooltipContentContainer,
+  TooltipTitle,
+  TooltipSeriesName,
+  TooltipRow,
+} from './components';

--- a/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.tsx
@@ -98,7 +98,7 @@ export function TooltipAnimatedContainer({
         top: 0,
         left: 0,
         opacity,
-        transform: `translate3d(${x}px, ${y}px, 0px)`,
+        transform: `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0px)`,
         transition: immediate
           ? 'none'
           : 'opacity 300ms ease, transform 300ms ease',

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -33,7 +33,13 @@ export type {SimpleBarChartProps} from './SimpleBarChart';
 export {Legend} from './Legend';
 export type {LegendProps} from './Legend';
 export {PolarisVizProvider} from './PolarisVizProvider';
-export {TooltipContent} from './TooltipContent';
+export {
+  TooltipContent,
+  TooltipContentContainer,
+  TooltipSeriesName,
+  TooltipTitle,
+  TooltipRow,
+} from './TooltipContent';
 export type {TooltipContentProps} from './TooltipContent';
 export {ConicGradientWithStops} from './ConicGradientWithStops';
 export {ChartSkeleton} from './ChartSkeleton';

--- a/packages/polaris-viz/src/hooks/tests/useLinearChartAnimations.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useLinearChartAnimations.test.tsx
@@ -2,18 +2,23 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
 import {line} from 'd3-shape';
-import {ChartContext} from '@shopify/polaris-viz-core';
+import {
+  ChartContext,
+  LineChartDataSeriesWithDefaults,
+} from '@shopify/polaris-viz-core';
 
-import type {LineChartDataWithDefaults} from '../../components';
 import {useLinearChartAnimations} from '../useLinearChartAnimations';
 import characterWidths from '../../data/character-widths.json';
 import characterWidthOffsets from '../../data/character-width-offsets.json';
 
-jest.mock('../../utilities', () => {
+jest.mock('../../utilities/getPathLength', () => {
   return {
-    ...jest.requireActual('../../utilities'),
-    isLargeDataSet: jest.fn(() => true),
     getPathLength: () => 0,
+  };
+});
+
+jest.mock('../../utilities/getPointAtLength', () => {
+  return {
     getPointAtLength: jest.fn(() => ({x: 0, y: 0})),
   };
 });
@@ -24,7 +29,7 @@ const lineGeneratorMock = jest.fn(
     .y(({value}) => value),
 ) as any;
 
-const data: LineChartDataWithDefaults[] = [
+const data: LineChartDataSeriesWithDefaults[] = [
   {
     name: 'Primary',
     color: 'primary',

--- a/packages/polaris-viz/src/hooks/useRenderTooltipContent.tsx
+++ b/packages/polaris-viz/src/hooks/useRenderTooltipContent.tsx
@@ -16,9 +16,12 @@ export function useRenderTooltipContent({
 }) {
   return function renderTooltipContent(tooltipData: RenderTooltipContentData) {
     if (tooltipOptions?.renderTooltipContent != null) {
-      return tooltipOptions.renderTooltipContent({
+      const {renderTooltipContent, ...formatters} = tooltipOptions;
+
+      return renderTooltipContent({
         ...tooltipData,
         dataSeries: data,
+        formatters,
       });
     }
 

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -64,3 +64,5 @@ export type {
   DataPoint,
   ChartState,
 } from '@shopify/polaris-viz-core';
+
+export {renderLinearComparisonTooltip} from './utilities';

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -72,6 +72,12 @@ export interface RenderTooltipDataPoint {
   value: number | string | null;
 }
 
+export interface TooltipFormatters {
+  valueFormatter?: LabelFormatter;
+  keyFormatter?: LabelFormatter;
+  titleFormatter?: LabelFormatter;
+}
+
 export interface RenderTooltipContentData {
   data: {
     shape: Shape;
@@ -81,6 +87,7 @@ export interface RenderTooltipContentData {
   activeIndex: number;
   dataSeries: DataSeries[];
   title?: string;
+  formatters?: TooltipFormatters;
 }
 
 export interface TooltipData {
@@ -94,11 +101,8 @@ export interface TooltipData {
   name?: string;
 }
 
-export interface TooltipOptions {
+export interface TooltipOptions extends TooltipFormatters {
   renderTooltipContent?: (data: RenderTooltipContentData) => React.ReactNode;
-  valueFormatter?: LabelFormatter;
-  keyFormatter?: LabelFormatter;
-  titleFormatter?: LabelFormatter;
 }
 
 export interface PreparedLabels {

--- a/packages/polaris-viz/src/utilities/index.ts
+++ b/packages/polaris-viz/src/utilities/index.ts
@@ -17,3 +17,4 @@ export {
   getXAxisOptionsWithDefaults,
 } from './getAxisOptions';
 export {getHoverZoneOffset} from './getHoverZoneOffset';
+export {renderLinearComparisonTooltip} from './renderLinearComparisonTooltip';

--- a/packages/polaris-viz/src/utilities/renderLinearComparisonTooltip.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearComparisonTooltip.tsx
@@ -1,0 +1,98 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
+import React, {ReactNode} from 'react';
+
+import {
+  TooltipContentContainer,
+  TooltipSeriesName,
+  TooltipTitle,
+  TooltipRow,
+} from '../components';
+import type {RenderTooltipContentData, TooltipFormatters} from '../types';
+
+interface Group {
+  title: string;
+  indexes: number[];
+}
+interface Options {
+  title?: string;
+  groups?: Group[];
+  formatters?: TooltipFormatters;
+}
+
+interface TooltipDataSeries extends Required<DataSeries> {
+  groupIndex: number;
+}
+
+export function renderLinearComparisonTooltip(
+  tooltipData: RenderTooltipContentData,
+  options: Options = {},
+): ReactNode {
+  const {
+    title,
+    groups = [
+      {
+        title: tooltipData.dataSeries[0].data[tooltipData.activeIndex].key,
+        indexes: tooltipData.dataSeries.map((_, index) => index),
+      },
+    ],
+  } = options;
+
+  const formatters = {
+    keyFormatter: (key) => `${key}`,
+    valueFormatter: (value) => `${value}`,
+    titleFormatter: (title) => `${title}`,
+    ...tooltipData.formatters,
+  };
+
+  const content = groups.map(({title: seriesName, indexes}) => {
+    const dataSeries = indexes
+      .map((groupIndex) => {
+        if (tooltipData.data[0].data[groupIndex] == null) {
+          return;
+        }
+
+        const rawDataSeries = tooltipData.data[0].data[groupIndex];
+
+        return {
+          ...tooltipData.dataSeries[groupIndex],
+          color: rawDataSeries.color,
+          groupIndex,
+          isComparison: rawDataSeries.isComparison,
+        };
+      })
+      .filter((series): series is TooltipDataSeries => Boolean(series));
+
+    return (
+      <React.Fragment key={seriesName}>
+        <TooltipSeriesName theme="Default">{seriesName}</TooltipSeriesName>
+        {dataSeries.map(({data, color, isComparison, groupIndex}) => {
+          const item = data[tooltipData.activeIndex];
+
+          return (
+            <TooltipRow
+              key={`row-${groupIndex}`}
+              activeIndex={-1}
+              color={color}
+              index={groupIndex}
+              isComparison={isComparison}
+              label={formatters.keyFormatter(item.key)}
+              shape={tooltipData.data[0].shape}
+              value={formatters.valueFormatter(item.value ?? 0)}
+            />
+          );
+        })}
+      </React.Fragment>
+    );
+  });
+
+  return (
+    <TooltipContentContainer maxWidth={300} theme="Default">
+      {title != null && (
+        <TooltipTitle theme="Default">
+          {formatters.titleFormatter(title)}
+        </TooltipTitle>
+      )}
+      {content}
+    </TooltipContentContainer>
+  );
+}


### PR DESCRIPTION
## What does this implement/fix?

Adds a new Linear Comparison tooltip that allows consumers to render their data differently than the default tooltip. The `renderLinearComparisonTooltip` can be imported from PV and then used to pass back to a chart as `tooltipOptions`.

```
import {LineChart, renderLinearComparisonTooltip} from '@shopify/polaris-viz';

<LineChart
  tooltipOptions={{
    renderTooltipContent: (tooltipData) => {
      return renderLinearComparisonTooltip(tooltipData, {
        groups: [
          {title: 'Net sales', indexes: [0, 1]},
          {title: 'Average order value', indexes: [2, 3, 18]},
        ],
      });
    },
    keyFormatter: formatLinearYAxisLabel,
    valueFormatter: formatLinearYAxisLabel,
  }}
/>
```

The main change here is using `groups` as a way to alter how the data is displayed in the tooltip.

`renderLinearComparisonTooltip()` without the `options.group` will render as a single group.
`renderLinearComparisonTooltip()` will also respect the `(key/value/title)Formatter` methods passed along with `tooltipOptions`.
 
## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/47401 & https://github.com/Shopify/core-issues/issues/48100

## What do the changes look like?

<img width="337" alt="image" src="https://user-images.githubusercontent.com/149873/204901634-930fa124-336a-4b98-9039-b22fe931d0eb.png">
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-pkcbctvayk.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--linear-comparison-tooltip

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
