### PR TITLE
Re-export ChartState from `@shopify/polaris-viz` as value instead of type

### DIFF
--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -51,6 +51,7 @@ export {
   getAverageColor,
   paddingStringToObject,
   removeFalsyValues,
+  ChartState,
   ColorScale,
 } from '@shopify/polaris-viz-core';
 
@@ -62,5 +63,4 @@ export type {
   PartialTheme,
   GradientStop,
   DataPoint,
-  ChartState,
 } from '@shopify/polaris-viz-core';


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->
This PR exports the enum `ChartState` as a value instead of a type. This will allow developers to use `ChartState` when passing in the `state` prop to various charts, without having to install and import it from `@shopify/polaris-viz-core`.

Currently, this error appears when trying to use any of `ChartState.Success`, `ChartState.Loading`, or `ChartState.Error` after importing it from `@shopify/polaris-viz`:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/44531733/204922557-287b48de-dfae-4e90-a26a-b9cb2d11f6b3.png">

Seeing as this is how `ChartState` is exported from [`polaris-viz-core`](https://github.com/Shopify/polaris-viz/blob/main/packages/polaris-viz-core/src/index.ts#L119), I think it would make sense to match that.

## Does this close any currently open issues?
N/A

## What do the changes look like?
N/A
 
## Storybook link
[Storybook](https://6062ad4a2d14cd0021539c1b-pxkqyjyvnk.chromatic.com/)

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
