### PR TITLE
Allow ability to override `arc` in Theme

### DIFF
--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -140,6 +140,7 @@ export interface LegendTheme {
 }
 
 export interface PartialTheme {
+  arc?: Partial<ArcTheme>;
   chartContainer?: Partial<ChartContainerTheme>;
   bar?: Partial<BarTheme>;
   line?: Partial<LineTheme>;

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `arc` property to `PartialTheme` to allow override of the default theme option for `DonutChart`.
 
 ## [7.11.1] - 2022-12-05
 

--- a/packages/polaris-viz/src/components/Docs/stories/arc.stories.mdx
+++ b/packages/polaris-viz/src/components/Docs/stories/arc.stories.mdx
@@ -1,0 +1,81 @@
+import {Meta, Story, Canvas} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+
+import {PolarisVizProvider} from '../../../';
+import {
+  Divider,
+  ComponentContainer,
+  Title,
+  ExamplesGrid,
+  PropertyTable,
+  SampleDonutChart,
+} from './components';
+
+<Meta
+  title="Shared/Themes/Theme Definition/Chart Specific Properties/arc"
+  parameters={{
+    viewMode: 'docs',
+    docsOnly: true,
+  }}
+/>
+
+<Title>✍️ Theme Definition</Title>
+
+<Title type="h3">
+  <code>arc</code>
+</Title>
+
+<PropertyTable>
+  <PropertyTable.Row
+    property="arc.borderRadius"
+    type="number"
+    description="determines whether the arc should have sharp or round corners"
+    chartsAffected={['DonutChart']}
+  />
+  <PropertyTable.Row
+    property="arc.thickness"
+    type="number"
+    description="determines the width of each arc segment"
+    chartsAffected={['DonutChart']}
+  />
+</PropertyTable>
+
+<Title type="h4">Examples:</Title>
+
+<ExamplesGrid cols={2}>
+
+<ComponentContainer
+  codeSample={dedent`
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          arc: {
+            borderRadius: 0,
+            thickness: 10,
+          }
+        }
+      }}
+    >
+      <DonutChart data={data} />
+    </PolarisVizProvider>
+  `}
+  center
+  chart={
+    <div style={{width: '350px', height: '140px'}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            arc: {
+              cornerRadius: 0,
+              thickness: 10,
+            }
+          }
+        }}
+      >
+        <SampleDonutChart />
+      </PolarisVizProvider>
+    </div>
+  }
+/>
+
+</ExamplesGrid>

--- a/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
@@ -12,6 +12,7 @@ import {
   BarChart,
   StackedAreaChart,
   SimpleNormalizedChart,
+  DonutChart,
 } from '../../../../components';
 import {generateMultipleSeries} from '../../../Docs/utilities';
 
@@ -275,5 +276,31 @@ export const SampleLabelsBarChart = ({width = 760}: {width: number}) => {
         </div>
       </div>
     </SimpleContainer>
+  );
+};
+
+export const SampleDonutChart = ({theme} = {theme: 'Default'}) => {
+  return (
+    <DonutChart
+      theme={theme}
+      data={[
+        {
+          name: 'Shopify Payments',
+          data: [{key: 'april - march', value: 50000}],
+        },
+        {
+          name: 'Paypal',
+          data: [{key: 'april - march', value: 25000}],
+        },
+        {
+          name: 'Other',
+          data: [{key: 'april - march', value: 10000}],
+        },
+        {
+          name: 'Amazon Pay',
+          data: [{key: 'april - march', value: 4000}],
+        },
+      ]}
+    />
   );
 };

--- a/packages/polaris-viz/src/components/Docs/stories/components/index.ts
+++ b/packages/polaris-viz/src/components/Docs/stories/components/index.ts
@@ -13,6 +13,7 @@ export {
   SampleLegendContainer,
   SampleLegendChart,
   SampleLabelsBarChart,
+  SampleDonutChart,
 } from './SampleComponents';
 export {SimpleContainer} from './SimpleContainer';
 export {Banner} from './Banner';

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
@@ -7,6 +7,8 @@ import {PolarisVizProvider} from '../../PolarisVizProvider';
 import {DonutChart} from '../DonutChart';
 import type {DonutChartProps} from '../DonutChart';
 
+import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
+
 const CustomArcWidthTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
   return (
     <PolarisVizProvider
@@ -26,27 +28,6 @@ const CustomArcWidthTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps)
 export const CustomArcWidth: Story<DonutChartProps> = CustomArcWidthTemplate.bind({});
 
 CustomArcWidth.args = {
-  data: [
-    {
-      name: 'Shopify Payments',
-      data: [{key: 'april - march', value: 50000}],
-    },
-    {
-      name: 'Paypal',
-      data: [{key: 'april - march', value: 25000}],
-    },
-    {
-      name: 'Other',
-      data: [{key: 'april - march', value: 10000}],
-    },
-    {
-      name: 'Amazon Pay',
-      data: [{key: 'april - march', value: 4000}],
-    },
-  ],
-  comparisonMetric: {
-    metric: '10%',
-    trend: 'negative',
-    accessibilityLabel: 'trending down 10%',
-  },
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type {Story, StoryFn} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {DonutChart} from '../DonutChart';
+import type {DonutChartProps} from '../DonutChart';
+
+const CustomArcWidthTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          arc: {
+            thickness: 50,
+          }
+        },
+      }}
+    >
+      <DonutChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const CustomArcWidth: Story<DonutChartProps> = CustomArcWidthTemplate.bind({});
+
+CustomArcWidth.args = {
+  data: [
+    {
+      name: 'Shopify Payments',
+      data: [{key: 'april - march', value: 50000}],
+    },
+    {
+      name: 'Paypal',
+      data: [{key: 'april - march', value: 25000}],
+    },
+    {
+      name: 'Other',
+      data: [{key: 'april - march', value: 10000}],
+    },
+    {
+      name: 'Amazon Pay',
+      data: [{key: 'april - march', value: 4000}],
+    },
+  ],
+  comparisonMetric: {
+    metric: '10%',
+    trend: 'negative',
+    accessibilityLabel: 'trending down 10%',
+  },
+};

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomColors.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomColors.stories.tsx
@@ -4,11 +4,12 @@ export {META as default} from './meta';
 
 import type {DonutChartProps} from '../DonutChart';
 
-import {Template} from './data';
+import {DEFAULT_PROPS, Template} from './data';
 
 export const CustomColors: Story<DonutChartProps> = Template.bind({});
 
 CustomColors.args = {
+  ...DEFAULT_PROPS,
   data: [
     {
       name: 'Shopify Payments',
@@ -24,9 +25,4 @@ CustomColors.args = {
       data: [{key: 'april - march', value: 4000}],
     },
   ],
-  comparisonMetric: {
-    metric: '6%',
-    trend: 'positive',
-    accessibilityLabel: 'trending up 6%',
-  },
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/Default.stories.tsx
@@ -4,32 +4,11 @@ export {META as default} from './meta';
 
 import type {DonutChartProps} from '../DonutChart';
 
-import {Template} from './data';
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 export const Default: Story<DonutChartProps> = Template.bind({});
 
 Default.args = {
-  data: [
-    {
-      name: 'Shopify Payments',
-      data: [{key: 'april - march', value: 50000}],
-    },
-    {
-      name: 'Paypal',
-      data: [{key: 'april - march', value: 25000}],
-    },
-    {
-      name: 'Other',
-      data: [{key: 'april - march', value: 10000}],
-    },
-    {
-      name: 'Amazon Pay',
-      data: [{key: 'april - march', value: 4000}],
-    },
-  ],
-  comparisonMetric: {
-    metric: '10%',
-    trend: 'negative',
-    accessibilityLabel: 'trending down 10%',
-  },
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/DynamicData.stories.tsx
@@ -4,25 +4,10 @@ export {META as default} from './meta';
 
 import {DonutChart} from '../DonutChart';
 
+import {DEFAULT_DATA} from './data';
+
 export const DynamicData = () => {
-  const [data, setData] = useState([
-    {
-      name: 'Shopify Payments',
-      data: [{key: 'april - march', value: 50000}],
-    },
-    {
-      name: 'Paypal',
-      data: [{key: 'april - march', value: 25000}],
-    },
-    {
-      name: 'Amazon Pay',
-      data: [{key: 'april - march', value: 4000}],
-    },
-    {
-      name: 'Other',
-      data: [{key: 'april - march', value: 4000}],
-    },
-  ]);
+  const [data, setData] = useState(DEFAULT_DATA);
 
   const onClick = () => {
     const newData = data.map((item) => {

--- a/packages/polaris-viz/src/components/DonutChart/stories/ErrorState.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/ErrorState.stories.tsx
@@ -5,21 +5,17 @@ export {META as default} from './meta';
 
 import type {DonutChartProps} from '../DonutChart';
 
-import {Template} from './data';
+import {DEFAULT_PROPS, Template} from './data';
 
 export const ErrorState: Story<DonutChartProps> = Template.bind({});
 
 ErrorState.args = {
+  ...DEFAULT_PROPS,
   data: [
     {
       name: 'Engagement',
       data: [{key: 'april - march', value: 25000}],
     },
   ],
-  comparisonMetric: {
-    metric: '6%',
-    trend: 'positive',
-    accessibilityLabel: 'trending up 6%',
-  },
   state: ChartState.Error,
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/InteractiveCustomLegend.stories.tsx
@@ -7,26 +7,7 @@ import {DEFAULT_THEME} from '../../../constants';
 import type {DonutChartProps} from '../../DonutChart';
 import {SquareColorPreview} from '../../SquareColorPreview';
 
-import {Template} from './data';
-
-const DATA = [
-  {
-    name: 'Shopify Payments',
-    data: [{key: 'april - march', value: 50000}],
-  },
-  {
-    name: 'Paypal',
-    data: [{key: 'april - march', value: 25000}],
-  },
-  {
-    name: 'Other',
-    data: [{key: 'april - march', value: 10000}],
-  },
-  {
-    name: 'Amazon Pay',
-    data: [{key: 'april - march', value: 4000}],
-  },
-];
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
@@ -40,11 +21,11 @@ const liStyles = {
 export const InteractiveCustomLegend: Story<DonutChartProps> = Template.bind({});
 
 InteractiveCustomLegend.args = {
-  data: DATA,
-  legendPosition: 'left',
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
   renderLegendContent: ({getColorVisionStyles, getColorVisionEventAttrs}) => (
     <ul>
-      {DATA.map(({name}, index) => (
+      {DEFAULT_DATA.map(({name}, index) => (
         <li
           key={name}
           style={{

--- a/packages/polaris-viz/src/components/DonutChart/stories/SingleDataPoint.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/SingleDataPoint.stories.tsx
@@ -4,21 +4,16 @@ export {META as default} from './meta';
 
 import type {DonutChartProps} from '../DonutChart';
 
-import {Template} from './data';
+import {DEFAULT_PROPS, Template} from './data';
 
 export const SingleDataPoint: Story<DonutChartProps> = Template.bind({});
 
 SingleDataPoint.args = {
+  ...DEFAULT_PROPS,
   data: [
     {
       name: 'Engagement',
       data: [{key: 'april - march', value: 25000}],
     },
   ],
-  comparisonMetric: {
-    metric: '6%',
-    trend: 'positive',
-    accessibilityLabel: 'trending up 6%',
-  },
-  legendPosition: 'left',
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type {Story, StoryFn} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {DonutChart} from '../DonutChart';
+import type {DonutChartProps} from '../DonutChart';
+
+const WithoutRoundedCornersTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          arc: {
+            cornerRadius: 0,
+          }
+        },
+      }}
+    >
+      <DonutChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const WithoutRoundedCorners: Story<DonutChartProps> = WithoutRoundedCornersTemplate.bind({});
+
+WithoutRoundedCorners.args = {
+  data: [
+    {
+      name: 'Shopify Payments',
+      data: [{key: 'april - march', value: 50000}],
+    },
+    {
+      name: 'Paypal',
+      data: [{key: 'april - march', value: 25000}],
+    },
+    {
+      name: 'Other',
+      data: [{key: 'april - march', value: 10000}],
+    },
+    {
+      name: 'Amazon Pay',
+      data: [{key: 'april - march', value: 4000}],
+    },
+  ],
+  comparisonMetric: {
+    metric: '10%',
+    trend: 'negative',
+    accessibilityLabel: 'trending down 10%',
+  },
+};

--- a/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
@@ -7,6 +7,8 @@ import {PolarisVizProvider} from '../../PolarisVizProvider';
 import {DonutChart} from '../DonutChart';
 import type {DonutChartProps} from '../DonutChart';
 
+import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
+
 const WithoutRoundedCornersTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
   return (
     <PolarisVizProvider
@@ -26,27 +28,6 @@ const WithoutRoundedCornersTemplate: StoryFn<DonutChartProps> = (args: DonutChar
 export const WithoutRoundedCorners: Story<DonutChartProps> = WithoutRoundedCornersTemplate.bind({});
 
 WithoutRoundedCorners.args = {
-  data: [
-    {
-      name: 'Shopify Payments',
-      data: [{key: 'april - march', value: 50000}],
-    },
-    {
-      name: 'Paypal',
-      data: [{key: 'april - march', value: 25000}],
-    },
-    {
-      name: 'Other',
-      data: [{key: 'april - march', value: 10000}],
-    },
-    {
-      name: 'Amazon Pay',
-      data: [{key: 'april - march', value: 4000}],
-    },
-  ],
-  comparisonMetric: {
-    metric: '10%',
-    trend: 'negative',
-    accessibilityLabel: 'trending down 10%',
-  },
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/data.tsx
@@ -6,3 +6,31 @@ import {DonutChart, DonutChartProps} from '../DonutChart';
 export const Template: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
   return <DonutChart {...args} />;
 };
+
+export const DEFAULT_PROPS: Partial<DonutChartProps> = {
+  comparisonMetric: {
+    metric: '6%',
+    trend: 'positive',
+    accessibilityLabel: 'trending up 6%',
+  },
+  legendPosition: 'left',
+};
+
+export const DEFAULT_DATA = [
+  {
+    name: 'Shopify Payments',
+    data: [{key: 'april - march', value: 50000}],
+  },
+  {
+    name: 'Paypal',
+    data: [{key: 'april - march', value: 25000}],
+  },
+  {
+    name: 'Other',
+    data: [{key: 'april - march', value: 10000}],
+  },
+  {
+    name: 'Amazon Pay',
+    data: [{key: 'april - march', value: 4000}],
+  },
+];


### PR DESCRIPTION
## What does this implement/fix?
This PR adds the `arc` property to the `PartialTheme` type. This will allow developers to override the default value when instantiating a `DonutChart` component – through the usage of the `PolarisVizProvider.theme` prop.

Example usage:
```tsx
<PolarisVizProvider
  themes={{
    Default: {
      arc: {
        borderRadius: 0,
        thickness: 10,
      }
    }
  }}
>
  <DonutChart data={data} />
</PolarisVizProvider>
```

The `DonutChart` component already had the scaffolding in place to support this functionality, we just needed to add `arc: Partial<ArcTheme>` to the `PartialTheme` type to prevent type errors during usage.

Additionally, this PR includes documentation of the chart-specific property `arc` and some minor cleanup within the `DonutChart` stories.

## Does this close any currently open issues?
N/A

## What do the changes look like?
Docs example:
![image](https://user-images.githubusercontent.com/44531733/206598813-f27fb3ba-3048-41ed-95bc-889566295884.png)

`thickness: 50`
![image](https://user-images.githubusercontent.com/44531733/206598856-cfeeb7e2-7a49-4747-a297-bcc53f502e1d.png)

`cornerRadius: 0`
![image](https://user-images.githubusercontent.com/44531733/206598871-c429840c-3dcd-4d0a-aa8e-68fcef195995.png)

## Storybook link
- [Shared/Themes/Theme Definition/Chart Specific Properties/arc](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/shared-themes-theme-definition-chart-specific-properties-arc--page)
- [Polaris-viz/Charts/DonutChart/Custom Arc Width](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--custom-arc-width)
- [Polaris-viz/Charts/DonutChart/Without Rounded Corners](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--without-rounded-corners)

Check for regressions in:
- [Polaris-viz/Charts/DonutChart/Custom Colors](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--custom-colors)
- [Polaris-viz/Charts/DonutChart/Default](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--default)
- [Polaris-viz/Charts/DonutChart/Dynamic Data](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--dynamic-data)
- [Polaris-viz/Charts/DonutChart/Error State](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--error-state)
- [Polaris-viz/Charts/DonutChart/Interactive Custom Legend](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--interactive-custom-legend)
- [Polaris-viz/Charts/DonutChart/Single Data Point](https://6062ad4a2d14cd0021539c1b-gvpezrlkiz.chromatic.com/?path=/docs/polaris-viz-charts-donutchart--single-data-point)

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
