### PR TITLE
Use correct width based on grid.horizontalOverflow value

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Use correct width for `<HorizontalGridLines />` in `<BarChart />` based on `grid.horizontalOverflow` value.
+
 ### Added
 
 - Added `arc` property to `PartialTheme` to allow override of the default theme option for `DonutChart`.

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -242,7 +242,9 @@ export function Chart({
               x: selectedTheme.grid.horizontalOverflow ? 0 : chartXPosition,
               y: chartYPosition,
             }}
-            width={width}
+            width={
+              selectedTheme.grid.horizontalOverflow ? width : drawableWidth
+            }
           />
         ) : null}
 


### PR DESCRIPTION
## What does this implement/fix?

We weren't using the correct with in `BarChart` when rendering the grid lines. This PR takes into account the `grid.horizontalOverflow` value.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1448

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/207643488-6f834f50-124f-41c3-9e98-d26118fff25c.png)|![image](https://user-images.githubusercontent.com/149873/207643651-d121d8ec-087b-44b3-8c8d-b23103a59d7e.png)|
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
