### PR TITLE
Add `legendFullWidth` prop to `<DonutChart />`

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -13,7 +13,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `arc` property to `PartialTheme` to allow override of the default theme option for `DonutChart`.
+- Added `arc` property to `PartialTheme` to allow override of the default theme option for `<DonutChart />`.
+- Added `legendFullWidth` prop to `<DonutChart />`
 
 ## [7.11.1] - 2022-12-05
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -42,6 +42,7 @@ export interface ChartProps {
   total?: number;
   dimensions?: Dimensions;
   labelFormatter: LabelFormatter;
+  legendFullWidth?: boolean;
   legendPosition: LegendPosition;
   state: ChartState;
   errorText?: string;
@@ -56,6 +57,7 @@ export function Chart({
   showLegend,
   dimensions = {height: 0, width: 0},
   labelFormatter,
+  legendFullWidth = false,
   legendPosition = 'right',
   state,
   errorText,
@@ -247,6 +249,7 @@ export function Chart({
       </div>
       {showLegend && (
         <LegendContainer
+          fullWidth={legendFullWidth}
           onDimensionChange={setLegendDimensions}
           colorVisionType={COLOR_VISION_SINGLE_ITEM}
           data={legend}

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -16,6 +16,7 @@ export type DonutChartProps = {
   comparisonMetric?: ComparisonMetricProps;
   showLegend?: boolean;
   labelFormatter?: LabelFormatter;
+  legendFullWidth?: boolean;
   legendPosition?: LegendPosition;
   renderLegendContent?: RenderLegendContent;
 } & ChartProps;
@@ -27,6 +28,7 @@ export function DonutChart(props: DonutChartProps) {
     comparisonMetric,
     showLegend,
     labelFormatter,
+    legendFullWidth,
     legendPosition,
     isAnimated,
     state,
@@ -54,6 +56,7 @@ export function DonutChart(props: DonutChartProps) {
         labelFormatter={labelFormatter}
         comparisonMetric={comparisonMetric}
         showLegend={showLegend}
+        legendFullWidth={legendFullWidth}
         legendPosition={legendPosition}
         renderLegendContent={renderLegendContent}
       />

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomArcWidth.stories.tsx
@@ -11,17 +11,19 @@ import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
 
 const CustomArcWidthTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
   return (
-    <PolarisVizProvider
-      themes={{
-        Default: {
-          arc: {
-            thickness: 50,
-          }
-        },
-      }}
-    >
-      <DonutChart {...args} />
-    </PolarisVizProvider>
+    <div style={{width: 550, height: 400}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            arc: {
+              thickness: 50,
+            }
+          },
+        }}
+      >
+        <DonutChart {...args} />
+      </PolarisVizProvider>
+    </div>
   );
 };
 

--- a/packages/polaris-viz/src/components/DonutChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/DynamicData.stories.tsx
@@ -26,7 +26,7 @@ export const DynamicData = () => {
   };
 
   return (
-    <>
+    <div style={{width: 550, height: 400}}>
       <DonutChart data={data} />
       <button
         style={{
@@ -38,6 +38,6 @@ export const DynamicData = () => {
       >
         Change Data
       </button>
-    </>
+    </div>
   );
 };

--- a/packages/polaris-viz/src/components/DonutChart/stories/LegendFullWidth.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/LegendFullWidth.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type {Story, StoryFn} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import {DonutChart} from '..';
+import type {DonutChartProps} from '..';
+
+import {DEFAULT_PROPS} from './data';
+
+const data = [
+  {
+    name: 'Shopify Pay',
+    data: [{key: 'april - march', value: 50000}],
+  },
+  {
+    name: 'Paypal',
+    data: [{key: 'april - march', value: 25000}],
+  },
+  {
+    name: 'Other',
+    data: [{key: 'april - march', value: 10000}],
+  },
+  {
+    name: 'This is an extremely long label that will span the remaining width of the chart container',
+    data: [{key: 'april - march', value: 4000}],
+  },
+];
+
+const Template: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
+  return (
+    <div style={{width: 900, height: 400}}>
+      <DonutChart {...args} />
+    </div>
+  );
+};
+
+export const LegendFullWidth: Story<DonutChartProps> = Template.bind({});
+
+LegendFullWidth.args = {
+  ...DEFAULT_PROPS,
+  data,
+  legendFullWidth: true,
+};

--- a/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/WithoutRoundedCorners.stories.tsx
@@ -11,17 +11,19 @@ import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
 
 const WithoutRoundedCornersTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
   return (
-    <PolarisVizProvider
-      themes={{
-        Default: {
-          arc: {
-            cornerRadius: 0,
-          }
-        },
-      }}
-    >
-      <DonutChart {...args} />
-    </PolarisVizProvider>
+    <div style={{width: 550, height: 400}}>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            arc: {
+              cornerRadius: 0,
+            }
+          },
+        }}
+      >
+        <DonutChart {...args} />
+      </PolarisVizProvider>
+    </div>
   );
 };
 

--- a/packages/polaris-viz/src/components/DonutChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/data.tsx
@@ -4,7 +4,11 @@ import type {StoryFn} from '@storybook/react';
 import {DonutChart, DonutChartProps} from '../DonutChart';
 
 export const Template: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
-  return <DonutChart {...args} />;
+  return (
+    <div style={{width: 550, height: 400}}>
+      <DonutChart {...args} />
+    </div>
+  );
 };
 
 export const DEFAULT_PROPS: Partial<DonutChartProps> = {

--- a/packages/polaris-viz/src/components/DonutChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/meta.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import type {Meta} from '@storybook/react';
 
 import {
   CHART_STATE_CONTROL_ARGS,
   CONTROLS_ARGS,
   DATA_SERIES_ARGS,
+  LEGEND_FULL_WIDTH_ARGS,
   LEGEND_POSITION_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
   THEME_CONTROL_ARGS,
@@ -26,12 +26,10 @@ export const META: Meta<DonutChartProps> = {
   },
   argTypes: {
     data: DATA_SERIES_ARGS,
+    legendFullWidth: LEGEND_FULL_WIDTH_ARGS,
     legendPosition: LEGEND_POSITION_ARGS,
     renderLegendContent: RENDER_LEGEND_CONTENT_ARGS,
     theme: THEME_CONTROL_ARGS,
     state: CHART_STATE_CONTROL_ARGS,
   },
-  decorators: [
-    (Story) => <div style={{width: 550, height: 400}}>{Story()}</div>,
-  ],
 };

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -33,6 +33,7 @@ export interface LegendContainerProps {
   data: LegendData[];
   onDimensionChange: Dispatch<SetStateAction<Dimensions>>;
   direction?: Direction;
+  fullWidth?: boolean;
   position?: LegendPosition;
   maxWidth?: number;
   renderLegendContent?: RenderLegendContent;
@@ -43,6 +44,7 @@ export function LegendContainer({
   data,
   onDimensionChange,
   direction = 'horizontal',
+  fullWidth = false,
   position = 'top-left',
   maxWidth,
   renderLegendContent,
@@ -65,7 +67,8 @@ export function LegendContainer({
       alignItems: 'flex-start',
       margin: `0 ${selectedTheme.grid.horizontalMargin}px 0`,
       flexDirection: 'column',
-      maxWidth,
+      maxWidth: fullWidth ? 'none' : maxWidth,
+      flex: fullWidth ? 1 : 'initial',
     },
     centerTiles: {
       justifyContent: 'center',

--- a/packages/polaris-viz/src/storybook/constants.ts
+++ b/packages/polaris-viz/src/storybook/constants.ts
@@ -34,6 +34,14 @@ export const LEGEND_CONTROL_ARGS: ArgType = {
   description: 'Renders a `<Legend />` component underneath the chart.',
 };
 
+export const LEGEND_FULL_WIDTH_ARGS = {
+  description:
+    'Allows the legend to take up the remaining width of the chart container.',
+  control: {
+    type: 'boolean',
+  },
+};
+
 export const RENDER_LEGEND_CONTENT_ARGS = {
   description:
     'This accepts a function that is called to render the legend content instead of the given legend. If `showLegend` is false, this prop will have no effect.',


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->

This PR adds a `legendFullWidth` property to `<DonutChart />` to allow users the ability to specify whether they want the legend to take up the full width of the chart container (or not). By default, if no value is provided, this prop will take on the value `false`.

This will allow users to make more customizable legends with the `renderLegendContent` prop (i.e., not limited by the `maxWidth` style that is currently being set).

## Does this close any currently open issues?
N/A

## What do the changes look like?

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/44531733/209022676-1c5fab26-dd02-4b97-9323-eb87b0af1b3a.png) | ![image](https://user-images.githubusercontent.com/44531733/209022712-c0d539af-f113-4987-89f8-928256e5d1e7.png) |

The `before` image shows what the text looks like with a container chart width of 550px, whereas the `after` image shows what the text looks like with a container chart width of 900px. 
 
## Storybook link
https://6062ad4a2d14cd0021539c1b-etvrxezokp.chromatic.com/?path=/story/polaris-viz-charts-donutchart--legend-full-width

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
