### PR TITLE
Allow consumers to trigger and listen to active events

### DIFF
--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -249,6 +249,7 @@ export enum ChartState {
 export interface ChartProps<T = DataSeries[]> {
   data: T;
   theme?: string;
+  id?: string;
   isAnimated?: boolean;
   state?: ChartState;
   errorText?: string;

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -22,13 +22,14 @@ interface Props {
   data: DataSeries[] | DataGroup[];
   isAnimated: boolean;
   theme: string;
+  id?: string;
   sparkChart?: boolean;
   skeletonType?: SkeletonType;
   type?: InternalChartType;
 }
 
 export const ChartContainer = (props: Props) => {
-  const id = uniqueId('chart');
+  const id = props.id ?? uniqueId('chart');
 
   const {prefersReducedMotion} = usePrefersReducedMotion();
   const [isPrinting, setIsPrinting] = useState(false);

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -45,8 +45,9 @@ export function LineChart(props: LineChartProps) {
   const {
     annotations = [],
     data,
-    errorText,
     emptyStateText,
+    errorText,
+    id,
     isAnimated,
     renderLegendContent,
     showLegend = true,
@@ -82,6 +83,7 @@ export function LineChart(props: LineChartProps) {
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
       <ChartContainer
+        id={id}
         data={data}
         theme={theme}
         isAnimated={isAnimated}

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/index.ts
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/index.ts
@@ -1,2 +1,3 @@
 export {useColorVisionEvents} from './useColorVisionEvents';
 export {useWatchColorVisionEvents} from './useWatchColorVisionEvents';
+export {getEventName} from './utilities';

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/useWatchColorVisionEvents.tsx
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/useWatchColorVisionEvents.tsx
@@ -1,18 +1,14 @@
 import {useEffect} from 'react';
 import {useChartContext} from '@shopify/polaris-viz-core';
+import type {CustomEventReturn} from 'types';
 
 import {useCallbackRef} from '..';
 
 import {getEventName} from './utilities';
 
-interface EventReturn extends CustomEvent {
-  detail: {
-    index: number;
-  };
-}
 interface Props {
   type: string;
-  onIndexChange: (event: EventReturn) => void;
+  onIndexChange: (event: CustomEventReturn) => void;
 }
 
 export function useWatchColorVisionEvents({type, onIndexChange}: Props) {

--- a/packages/polaris-viz/src/hooks/index.ts
+++ b/packages/polaris-viz/src/hooks/index.ts
@@ -29,3 +29,4 @@ export {
   getSeriesColors,
   usePrevious,
 } from '@shopify/polaris-viz-core';
+export {useWatchActiveSeries} from './useWatchActiveSeries';

--- a/packages/polaris-viz/src/hooks/useWatchActiveSeries.ts
+++ b/packages/polaris-viz/src/hooks/useWatchActiveSeries.ts
@@ -1,0 +1,24 @@
+import {COLOR_VISION_SINGLE_ITEM} from '@shopify/polaris-viz-core';
+import {useEffect} from 'react';
+
+import type {CustomEventReturn} from '../types';
+
+import {getEventName} from './ColorVisionA11y';
+import {useCallbackRef} from './useCallbackRef';
+
+export function useWatchActiveSeries(
+  id: string,
+  onIndexChange: (event: CustomEventReturn) => void,
+) {
+  const onIndexChangeCallback = useCallbackRef(onIndexChange);
+
+  useEffect(() => {
+    const eventName = getEventName(id, COLOR_VISION_SINGLE_ITEM);
+
+    window.addEventListener(eventName, onIndexChangeCallback);
+
+    return () => {
+      window.removeEventListener(eventName, onIndexChangeCallback);
+    };
+  }, [id, onIndexChangeCallback]);
+}

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -69,4 +69,9 @@ export type {
   ChartState,
 } from '@shopify/polaris-viz-core';
 
-export {renderLinearComparisonTooltip} from './utilities';
+export {
+  renderLinearComparisonTooltip,
+  setSingleSeriesActive,
+} from './utilities';
+
+export {useWatchActiveSeries} from './hooks';

--- a/packages/polaris-viz/src/playground/ExternalEvents.stories.tsx
+++ b/packages/polaris-viz/src/playground/ExternalEvents.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type {Story} from '@storybook/react';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import {LineChart} from '../components/LineChart';
+import {PolarisVizProvider} from '../components/PolarisVizProvider';
+import {setSingleSeriesActive} from '../utilities';
+import {useWatchActiveSeries} from '../hooks';
+
+export default {
+  title: 'polaris-viz/Playground/ExternalEvents',
+  parameters: {},
+  decorators: [(Story) => <div>{Story()}</div>],
+  argTypes: {},
+};
+
+const DEFAULT_DATA: DataSeries[] = [
+  {
+    name: 'Breakfast',
+    data: [
+      {key: 'Monday', value: 3},
+      {key: 'Tuesday', value: -7},
+      {key: 'Wednesday', value: -7},
+      {key: 'Thursday', value: -8},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 0},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Lunch',
+    data: [
+      {key: 'Monday', value: 4},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -10},
+      {key: 'Thursday', value: 15},
+      {key: 'Friday', value: 8},
+      {key: 'Saturday', value: 50},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+  {
+    name: 'Dinner',
+    data: [
+      {key: 'Monday', value: 7},
+      {key: 'Tuesday', value: 0},
+      {key: 'Wednesday', value: -15},
+      {key: 'Thursday', value: -12},
+      {key: 'Friday', value: 50},
+      {key: 'Saturday', value: 5},
+      {key: 'Sunday', value: 0.1},
+    ],
+  },
+];
+
+const CHART_ID = 'chart_01';
+
+const Template: Story = () => {
+  const [activeName, setActiveName] = React.useState('none');
+
+  useWatchActiveSeries(CHART_ID, ({detail: {index}}) => {
+    if (index === -1) {
+      setActiveName('none');
+    } else {
+      setActiveName(DEFAULT_DATA[index].name ?? 'none');
+    }
+  });
+
+  return (
+    <>
+      <div style={{marginBottom: 40}}>
+        <p>This button interacts with the chart in one-direction.</p>
+        <button
+          onMouseOver={() => {
+            setSingleSeriesActive(CHART_ID, 2);
+          }}
+          onMouseLeave={() => {
+            setSingleSeriesActive(CHART_ID, -1);
+          }}
+          onClick={() => {
+            setSingleSeriesActive(CHART_ID, 1);
+          }}
+        >
+          Hover: Dinner, Click: Lunch
+        </button>
+
+        <p>
+          This only responds to events from the chart. Active series:{' '}
+          <strong>{activeName}</strong>.
+        </p>
+      </div>
+      <PolarisVizProvider
+        themes={{
+          Default: {
+            chartContainer: {
+              padding: '20px',
+            },
+          },
+        }}
+      >
+        <LineChart id={CHART_ID} data={DEFAULT_DATA} />
+      </PolarisVizProvider>
+    </>
+  );
+};
+
+export const Default: Story = Template.bind({});

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -211,3 +211,10 @@ export type RenderInnerValueContent = (
   },
   getAnimatedTotalValue: (styles: React.CSSProperties) => ReactNode,
 ) => ReactNode;
+
+export interface CustomEventReturn extends CustomEvent {
+  detail: {
+    index: number;
+    data?: DataSeries[];
+  };
+}

--- a/packages/polaris-viz/src/utilities/index.ts
+++ b/packages/polaris-viz/src/utilities/index.ts
@@ -18,3 +18,4 @@ export {
 } from './getAxisOptions';
 export {getHoverZoneOffset} from './getHoverZoneOffset';
 export {renderLinearComparisonTooltip} from './renderLinearComparisonTooltip';
+export {setSingleSeriesActive} from './setSingleSeriesActive';

--- a/packages/polaris-viz/src/utilities/setSingleSeriesActive.ts
+++ b/packages/polaris-viz/src/utilities/setSingleSeriesActive.ts
@@ -1,0 +1,13 @@
+import {COLOR_VISION_SINGLE_ITEM} from '@shopify/polaris-viz-core';
+
+import {getEventName} from '../hooks/ColorVisionA11y';
+
+export function setSingleSeriesActive(id: string, index: number) {
+  const custom = new CustomEvent(getEventName(id, COLOR_VISION_SINGLE_ITEM), {
+    detail: {
+      index,
+    },
+  });
+
+  window.dispatchEvent(custom);
+}


### PR DESCRIPTION
## What does this implement/fix?

We want users to be able to trigger, and respond to, active series changes.

This is an initial draft to support the Benchmarks project: https://vault.shopify.io/gsd/projects/30453 which is why were only supporting `LineChart` for this version.

If we find that there's a genuine need for this in other charts, we'll add the functionality later.
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-tsnlqfbano.chromatic.com/?path=/story/polaris-viz-playground-externalevents--default
