### PR TITLE
Swallow Tooltip errors instead of crashing the chart

### DIFF
--- a/packages/polaris-viz/src/components/SwallowErrors/SwallowErrors.tsx
+++ b/packages/polaris-viz/src/components/SwallowErrors/SwallowErrors.tsx
@@ -1,0 +1,31 @@
+import {Component} from 'react';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class SwallowErrors extends Component<Props, State> {
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+
+  state: State = {
+    hasError: false,
+  };
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/polaris-viz/src/components/SwallowErrors/index.ts
+++ b/packages/polaris-viz/src/components/SwallowErrors/index.ts
@@ -1,0 +1,1 @@
+export {SwallowErrors} from './SwallowErrors';

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -9,6 +9,7 @@ import React, {
 import type {DataType, BoundingRect} from '@shopify/polaris-viz-core';
 
 import type {Margin} from '../../types';
+import {SwallowErrors} from '../SwallowErrors';
 
 import {shouldBlockTooltipEvents} from './utilities/shouldBlockTooltipEvents';
 import type {TooltipPosition, TooltipPositionParams} from './types';
@@ -30,7 +31,7 @@ interface TooltipWrapperProps {
   onIndexChange?: (index: number | null) => void;
 }
 
-export function TooltipWrapper(props: TooltipWrapperProps) {
+function TooltipWrapperRaw(props: TooltipWrapperProps) {
   const {
     alwaysUpdatePosition = false,
     bandwidth = 0,
@@ -183,5 +184,13 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     >
       {props.getMarkup(position.activeIndex)}
     </TooltipAnimatedContainer>
+  );
+}
+
+export function TooltipWrapper(props) {
+  return (
+    <SwallowErrors>
+      <TooltipWrapperRaw {...props} />
+    </SwallowErrors>
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

We've had an issue where if the data in a tooltip is accessed incorrectly, or not available at all, the Tooltip will crash the entire chart.

Would it make sense to swallow those errors and not render the Tooltip at all? Does this change make sense at all/is it necessary?

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/213560416-7fb1749b-2c29-40e4-ac6e-0efcca19c7d2.mov

**After**

https://user-images.githubusercontent.com/149873/213560602-ea4d959b-67c2-4601-b79b-fd6a8006ed76.mov
 