### PR TITLE
Fix line series hover events not firing

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `<LineSeries />` single line hover events not firing.
 
 ## [7.13.1] - 2023-01-18
 

--- a/packages/polaris-viz/src/components/ComboChart/Chart.scss
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.scss
@@ -1,6 +1,10 @@
 @import '../../styles/common';
 
-.Group * {
+.Group *:not([data-color-vision-event-watch='true']) {
   @include no-outline;
   pointer-events: none;
+}
+
+[data-color-vision-event-watch='true'] {
+  pointer-events: auto;
 }

--- a/packages/polaris-viz/src/components/LineChart/Chart.scss
+++ b/packages/polaris-viz/src/components/LineChart/Chart.scss
@@ -1,6 +1,10 @@
 @import '../../styles/common';
 
-.Group * {
+.Group *:not([data-color-vision-event-watch='true']) {
   @include no-outline;
+  pointer-events: none;
+}
+
+[data-color-vision-event-watch='true'] {
   pointer-events: none;
 }


### PR DESCRIPTION
## What does this implement/fix?

Our css `*` selector was disabling color vision events from firing when hovering over single lines in a `LineChart`.

😢 

https://user-images.githubusercontent.com/149873/213788388-a5fb5a03-a6fb-453f-a522-7920b73d4445.mov

😄 

https://user-images.githubusercontent.com/149873/213788423-a88388fb-149e-47d3-a8d6-a21b95ae58f1.mov

## Storybook link

https://6062ad4a2d14cd0021539c1b-kdducsxitn.chromatic.com/?path=/story/polaris-viz-charts-linechart--default
