### PR TITLE
Clean up `<SimpleNormalizedChart />` loading state [remake]

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Use the `showLegend` and `size` properties in loading state for `<SimpleNormalizedChart />`
 
 ## [7.14.1] - 2023-01-25
 

--- a/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/ChartSkeleton.tsx
@@ -6,6 +6,8 @@ import {
   DEFAULT_THEME_NAME,
 } from '@shopify/polaris-viz-core';
 
+import type {Size} from '../SimpleNormalizedChart';
+
 import {
   GridSkeleton,
   DonutSkeleton,
@@ -25,21 +27,56 @@ export type SkeletonType =
   | 'Spark'
   | 'SimpleNormalized';
 
-export interface ChartSkeletonProps {
+interface ChartSkeletonProps {
   dimensions?: Dimensions;
-  state?: ChartState;
   errorText?: string;
+  state?: ChartState;
   theme?: string;
-  type?: SkeletonType;
 }
 
-export function ChartSkeleton({
-  dimensions,
-  state = ChartState.Loading,
-  errorText = 'Could not load the chart',
-  theme = DEFAULT_THEME_NAME,
-  type = 'Default',
-}: ChartSkeletonProps) {
+interface DefaultSkeletonProps extends ChartSkeletonProps {
+  type?: 'Default';
+}
+
+export interface DonutSkeletonProps extends ChartSkeletonProps {
+  type: 'Donut';
+}
+
+export interface FunnelSkeletonProps extends ChartSkeletonProps {
+  type: 'Funnel';
+}
+
+export interface SimpleBarSkeletonProps extends ChartSkeletonProps {
+  type: 'SimpleBar';
+}
+
+export interface SparkSkeletonProps extends ChartSkeletonProps {
+  type: 'Spark';
+}
+
+export interface SimpleNormalizedSkeletonProps extends ChartSkeletonProps {
+  type: 'SimpleNormalized';
+  showLegend?: boolean;
+  size?: Size;
+}
+
+type Props =
+  | DefaultSkeletonProps
+  | DonutSkeletonProps
+  | FunnelSkeletonProps
+  | SimpleBarSkeletonProps
+  | SimpleNormalizedSkeletonProps
+  | SparkSkeletonProps;
+
+export function ChartSkeleton(props: Props) {
+  const {
+    dimensions,
+    errorText = 'Could not load the chart',
+    state = ChartState.Loading,
+    theme = DEFAULT_THEME_NAME,
+    type,
+  } = props;
+
   const {
     chartContainer: {backgroundColor},
   } = useTheme(theme);
@@ -81,7 +118,8 @@ export function ChartSkeleton({
             errorText={errorText}
           />
         );
-      case 'SimpleNormalized':
+      case 'SimpleNormalized': {
+        const {showLegend = true, size = 'small'} = props;
         return (
           <SimpleNormalizedSkeleton
             dimensions={{
@@ -90,8 +128,11 @@ export function ChartSkeleton({
             }}
             state={state}
             errorText={errorText}
+            showLegend={showLegend}
+            size={size}
           />
         );
+      }
       case 'Spark':
         return (
           <SparkSkeleton

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable node/callback-return */
 import React, {useEffect} from 'react';
-import {ChartState} from '@shopify/polaris-viz-core';
-import type {Dimensions} from '@shopify/polaris-viz-core';
+import {ChartState, Dimensions} from '@shopify/polaris-viz-core';
 import {useSprings, animated, config, easings} from '@react-spring/web';
 
 import {Arc} from '../../../Arc/';
@@ -15,15 +14,17 @@ const INITIAL_DELAY = 700;
 const RADIUS_PADDING = 20;
 const SECONDARY_DELAY = 200;
 
+interface Props {
+  dimensions: Dimensions;
+  state: ChartState;
+  errorText: string;
+}
+
 export function DonutSkeleton({
   dimensions: {height, width},
   state,
   errorText,
-}: {
-  dimensions: Dimensions;
-  state: ChartState;
-  errorText: string;
-}) {
+}: Props) {
   const diameter = Math.min(width, height);
   const radius = diameter / 2;
 

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/FunnelSkeleton/FunnelSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/FunnelSkeleton/FunnelSkeleton.tsx
@@ -4,17 +4,19 @@ import {
   useUniqueId,
   changeColorOpacity,
   ChartState,
+  Dimensions,
 } from '@shopify/polaris-viz-core';
 
-import type {ChartSkeletonProps} from '../../ChartSkeleton';
 import {Bar} from '../../../shared';
 import {ErrorText} from '../ErrorText';
 
-export function FunnelSkeleton({
-  dimensions,
-  state,
-  errorText,
-}: Omit<Required<ChartSkeletonProps>, 'type' | 'theme'>) {
+interface Props {
+  dimensions: Dimensions;
+  state: ChartState;
+  errorText: string;
+}
+
+export function FunnelSkeleton({dimensions, state, errorText}: Props) {
   const {width, height} = dimensions;
 
   const {

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/GridSkeleton/GridSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/GridSkeleton/GridSkeleton.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable node/callback-return */
 import React, {useEffect} from 'react';
 import {
-  Dimensions,
-  useTheme,
   paddingStringToObject,
+  useTheme,
   ChartState,
+  Dimensions,
 } from '@shopify/polaris-viz-core';
 import {useSprings, animated} from '@react-spring/web';
 
@@ -15,17 +15,13 @@ const BRICK_WIDTH = 32;
 const INITIAL_DELAY = 200;
 const NUMBER_OF_BRICKS = 5;
 
-export interface ChartSkeletonProps {
-  dimensions?: Dimensions;
-  state?: ChartState;
-  errorText?: string;
+interface Props {
+  dimensions: Dimensions;
+  state: ChartState;
+  errorText: string;
 }
 
-export function GridSkeleton({
-  dimensions,
-  state,
-  errorText,
-}: Required<ChartSkeletonProps>) {
+export function GridSkeleton({dimensions, state, errorText}: Props) {
   const {width, height} = dimensions;
 
   const {

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleBarSkeleton/SimpleBarSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleBarSkeleton/SimpleBarSkeleton.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
-import {useTheme, ChartState, useUniqueId} from '@shopify/polaris-viz-core';
+import {
+  useTheme,
+  useUniqueId,
+  ChartState,
+  Dimensions,
+} from '@shopify/polaris-viz-core';
 
-import type {ChartSkeletonProps} from '../../ChartSkeleton';
 import {ErrorText} from '../ErrorText';
 
 import styles from './SimpleBarSkeleton.scss';
 
-export function SimpleBarSkeleton({
-  dimensions,
-  state,
-  errorText,
-}: Omit<Required<ChartSkeletonProps>, 'type' | 'theme'>) {
+interface Props {
+  dimensions: Dimensions;
+  state: ChartState;
+  errorText: string;
+}
+
+export function SimpleBarSkeleton({dimensions, state, errorText}: Props) {
   const {width, height} = dimensions;
 
   const {

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.scss
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.scss
@@ -1,16 +1,9 @@
-.SimpleNormalizedSkeleton {
-  > span {
-    width: 100%;
-    height: 16px;
-    display: block;
-  }
-}
-
 .Legend {
-  height: 100px;
+  height: 50px;
   display: flex;
   gap: 5%;
   max-width: 60%;
+  margin: 14px 0;
 }
 
 .LegendItem {
@@ -33,4 +26,10 @@
     height: 16px;
     width: 80%;
   }
+}
+
+.LegendItemComponent {
+  border-radius: 2px;
+  height: 16px;
+  width: 100%;
 }

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SimpleNormalizedSkeleton/SimpleNormalizedSkeleton.tsx
@@ -1,16 +1,33 @@
 import React from 'react';
-import {useTheme, ChartState, useUniqueId} from '@shopify/polaris-viz-core';
+import {useTheme, useUniqueId, ChartState} from '@shopify/polaris-viz-core';
+import type {Dimensions} from '@shopify/polaris-viz-core';
 
-import type {ChartSkeletonProps} from '../../ChartSkeleton';
+import type {Size} from '../../../SimpleNormalizedChart';
 import {ErrorText} from '../ErrorText';
 
 import styles from './SimpleNormalizedSkeleton.scss';
 
+const SIZE_TO_PX = {
+  small: 16,
+  medium: 36,
+  large: 56,
+};
+
+interface Props {
+  dimensions: Dimensions;
+  errorText: string;
+  showLegend: boolean;
+  size: Size;
+  state: ChartState;
+}
+
 export function SimpleNormalizedSkeleton({
   dimensions,
-  state,
   errorText,
-}: Omit<Required<ChartSkeletonProps>, 'type' | 'theme'>) {
+  showLegend,
+  size,
+  state,
+}: Props) {
   const {width, height} = dimensions;
 
   const {
@@ -21,29 +38,32 @@ export function SimpleNormalizedSkeleton({
 
   const id = useUniqueId('simple-bar-skeleton');
 
-  const BarMarkup = () => (
-    <span
-      style={{
-        background: gridColor,
-        borderRadius,
-      }}
-    />
-  );
-
   return (
-    <div className={styles.SimpleNormalizedSkeleton} style={{padding}}>
+    <div style={{padding}}>
       {state === ChartState.Loading && (
         <React.Fragment>
-          <div className={styles.Legend}>
-            {new Array(3).fill(0).map((_, index) => (
-              <div key={`${id}${index}`} className={styles.LegendItem}>
-                {new Array(3).fill(0).map((_, innerIndex) => (
-                  <BarMarkup key={`${id}${index}${innerIndex}`} />
-                ))}
-              </div>
-            ))}
-          </div>
-          <BarMarkup />
+          {showLegend && (
+            <div className={styles.Legend}>
+              {new Array(3).fill(0).map((_, index) => (
+                <div key={`${id}${index}`} className={styles.LegendItem}>
+                  {new Array(3).fill(0).map((_, innerIndex) => (
+                    <div
+                      key={`${id}${index}${innerIndex}`}
+                      className={styles.LegendItemComponent}
+                      style={{background: gridColor}}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+          <div
+            style={{
+              background: gridColor,
+              borderRadius,
+              height: SIZE_TO_PX[size],
+            }}
+          />
         </React.Fragment>
       )}
       {state === ChartState.Error && (

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/SparkSkeleton/SparkSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/SparkSkeleton/SparkSkeleton.tsx
@@ -2,17 +2,19 @@ import React from 'react';
 import {
   useTheme,
   ChartState,
+  Dimensions,
   DEFAULT_BORDER_RADIUS,
 } from '@shopify/polaris-viz-core';
 
-import type {ChartSkeletonProps} from '../../ChartSkeleton';
 import {ErrorText} from '../ErrorText';
 
-export function SparkSkeleton({
-  dimensions,
-  state,
-  errorText,
-}: Omit<Required<ChartSkeletonProps>, 'type' | 'theme'>) {
+interface Props {
+  dimensions: Dimensions;
+  state: ChartState;
+  errorText: string;
+}
+
+export function SparkSkeleton({dimensions, state, errorText}: Props) {
   const {width, height} = dimensions;
 
   const {

--- a/packages/polaris-viz/src/components/ChartSkeleton/index.ts
+++ b/packages/polaris-viz/src/components/ChartSkeleton/index.ts
@@ -1,3 +1,9 @@
 export {ChartSkeleton} from './ChartSkeleton';
-export type {ChartSkeletonProps} from './ChartSkeleton';
+export type {
+  DonutSkeletonProps,
+  FunnelSkeletonProps,
+  SimpleBarSkeletonProps,
+  SparkSkeletonProps,
+  SimpleNormalizedSkeletonProps,
+} from './ChartSkeleton';
 export type {SkeletonType} from './ChartSkeleton';

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -52,6 +52,9 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
           type="SimpleNormalized"
           state={state}
           errorText={errorText}
+          theme={theme}
+          showLegend={showLegend && !renderLegendContent}
+          size={size}
         />
       ) : (
         <Chart

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/ErrorState.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/ErrorState.stories.tsx
@@ -1,0 +1,19 @@
+import {ChartState} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../..';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const ErrorState: Story<SimpleNormalizedChartProps> = Template.bind({});
+
+ErrorState.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA.map(({name}) => ({
+    name,
+    data: [],
+  })),
+  state: ChartState.Error,
+};

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingState.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingState.stories.tsx
@@ -1,0 +1,19 @@
+import {ChartState} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../..';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const LoadingState: Story<SimpleNormalizedChartProps> = Template.bind({});
+
+LoadingState.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA.map(({name}) => ({
+    name,
+    data: [],
+  })),
+  state: ChartState.Loading,
+};

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingStateWithMediumSize.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingStateWithMediumSize.stories.tsx
@@ -1,0 +1,20 @@
+import {ChartState} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../..';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const LoadingStateWithMediumSize: Story<SimpleNormalizedChartProps> = Template.bind({});
+
+LoadingStateWithMediumSize.args = {
+  ...DEFAULT_PROPS,
+  size: 'medium',
+  data: DEFAULT_DATA.map(({name}) => ({
+    name,
+    data: [],
+  })),
+  state: ChartState.Loading,
+};

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingStateWithoutLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/LoadingStateWithoutLegend.stories.tsx
@@ -1,0 +1,20 @@
+import {ChartState} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../..';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const LoadingStateWithoutLegend: Story<SimpleNormalizedChartProps> = Template.bind({});
+
+LoadingStateWithoutLegend.args = {
+  ...DEFAULT_PROPS,
+  showLegend: false,
+  data: DEFAULT_DATA.map(({name}) => ({
+    name,
+    data: [],
+  })),
+  state: ChartState.Loading,
+};


### PR DESCRIPTION
## What does this implement/fix?

This is a remake of https://github.com/Shopify/polaris-viz/pull/1463, which was already approved – however I didn't realize the base branch wasn't automatically updated to `main` before I merged. I've rebased this branch onto main here so it can be merged correctly.

## Does this close any currently open issues?
N/A

## What do the changes look like?
N/A

 
## Storybook link
https://6062ad4a2d14cd0021539c1b-iqwujydnfj.chromatic.com/?path=/story/intro--page

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
