### PR TITLE
Move donut inner value to the right by 10px

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -13,6 +13,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Use the `showLegend` and `size` properties in loading state for `<SimpleNormalizedChart />`
 - Fixed bug where hover events in `<LineChart />` were not working.
+- Fixed positioning issue in `<DonutChart />` where inner value content is not centered properly.
 
 ## [7.15.0] - 2023-01-26
 

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.tsx
@@ -8,7 +8,7 @@ import {useTheme} from '../../../../hooks';
 
 import styles from './DonutSkeleton.scss';
 
-const ERROR_ANIMATION_PADDING = 30;
+const ERROR_ANIMATION_PADDING = 40;
 const FULL_CIRCLE = Math.PI * 2;
 const INITIAL_DELAY = 700;
 const RADIUS_PADDING = 20;

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -35,7 +35,7 @@ import {ChartSkeleton} from '../../components/ChartSkeleton';
 import styles from './DonutChart.scss';
 import {InnerValue} from './components';
 
-const ERROR_ANIMATION_PADDING = 30;
+const ERROR_ANIMATION_PADDING = 40;
 const FULL_CIRCLE = Math.PI * 2;
 const MAX_LEGEND_WIDTH_PERCENTAGE = 0.35;
 const RADIUS_PADDING = 20;


### PR DESCRIPTION
## What does this implement/fix?

This PR fixes a minor positioning issue for the `<DonutChart />` component that was introduced in https://github.com/Shopify/polaris-viz/pull/1462. The inner value content was not centered properly, so this moves the donut to start 10px to the right within the SVG viewport.

## Does this close any currently open issues?
N/A

## What do the changes look like?

I tried my best to measure the distances between the inner side of the donut and the respective side of the inner value content. While not a perfect way to measure, this method revealed a ~20px difference between both sides beforehand.

Before:
![image](https://user-images.githubusercontent.com/44531733/214912221-fe9b49a1-41f9-4017-83d0-b9204f767e6d.png)
![image](https://user-images.githubusercontent.com/44531733/214916157-ce330fb4-839f-459b-9967-81803ff48244.png)

After:
![image](https://user-images.githubusercontent.com/44531733/214913323-93e9baa1-26f5-4fef-8aa2-159f0dfc1218.png)
![image](https://user-images.githubusercontent.com/44531733/214913101-e580b709-e8df-4ca8-bbd8-a9e7447b2633.png)


## Storybook link
https://6062ad4a2d14cd0021539c1b-inobfyuqfm.chromatic.com/?path=/story/polaris-viz-charts-donutchart--default

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
