### PR TITLE
Change `RenderInnerValueContent` type

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Change `RenderInnerValueContent` type introduced in `7.12.0`.
 
 ## [7.16.1] - 2023-01-26
 

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
@@ -38,23 +38,21 @@ export function InnerValue({
     },
   });
 
-  const animatedTotalValue = animatedValue.to((value) =>
-    animatedValue.isPaused
-      ? labelFormatter(value)
-      : labelFormatter(Math.abs(Math.floor(value))),
+  const animatedTotalValue = (
+    <animated.span>
+      {animatedValue.to((value) =>
+        animatedValue.isPaused
+          ? labelFormatter(value)
+          : labelFormatter(Math.abs(Math.floor(value))),
+      )}
+    </animated.span>
   );
 
-  const getAnimatedTotalValue = (styles: React.CSSProperties) => (
-    <animated.span style={styles}>{animatedTotalValue}</animated.span>
-  );
-
-  const innerContent = renderInnerValueContent?.(
-    {
-      activeValue,
-      totalValue,
-    },
-    getAnimatedTotalValue,
-  ) ?? (
+  const innerContent = renderInnerValueContent?.({
+    activeValue,
+    animatedTotalValue,
+    totalValue,
+  }) ?? (
     <React.Fragment>
       <animated.p
         className={classNames(styles.ContentValue)}

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomInnerValueContent.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomInnerValueContent.stories.tsx
@@ -17,7 +17,7 @@ export const CustomInnerValueContent: Story<DonutChartProps> = Template.bind({})
 CustomInnerValueContent.args = {
   ...DEFAULT_PROPS,
   data: DEFAULT_DATA,
-  renderInnerValueContent: ({activeValue, totalValue}, getAnimatedTotalValue) => {
+  renderInnerValueContent: ({activeValue, animatedTotalValue, totalValue}) => {
     const activeValuePercentage = activeValue
       ? `${(activeValue / totalValue * 100).toFixed(1)}%`
       : null;
@@ -43,11 +43,15 @@ CustomInnerValueContent.args = {
           gap: 4,
           margin: '8px 0',
         }}>
-          <span>Total:</span>
-          {getAnimatedTotalValue({
-            fontSize: 20,
-            ...numberStyles
-          })}
+          Total:
+          <span
+            style={{
+              fontSize: 20,
+              ...numberStyles
+            }}
+          >
+            {animatedTotalValue}
+          </span>
         </p>
       </div>
     )

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -36,6 +36,7 @@ export {
 
 export type {
   ColorVisionInteractionMethods,
+  InnerValueContents,
   RenderInnerValueContent,
   TooltipData,
 } from './types';

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -204,10 +204,10 @@ export type RenderLegendContent = (
 
 export type SortedBarChartData = (number | null)[][];
 
-export type RenderInnerValueContent = (
-  values: {
-    activeValue: number | null;
-    totalValue: number;
-  },
-  getAnimatedTotalValue: (styles: React.CSSProperties) => ReactNode,
-) => ReactNode;
+export interface InnerValueContents {
+  activeValue: number | null;
+  animatedTotalValue: ReactNode;
+  totalValue: number;
+}
+
+export type RenderInnerValueContent = (values: InnerValueContents) => ReactNode;


### PR DESCRIPTION
## What does this implement/fix?

This PR changes the `RenderInnerValueContent` type to be simpler. Specifically, this means:
- Changing the parameter to the function to only take one object
- Removing `getAnimatedTotalValue: (styles: React.CSSProperties) => React.ReactNode` and replacing it with `animatedTotalValue: React.ReactNode`. The `styles` param in `getAnimatedTotalValue` is unnecessary because the consumer can just wrap the result of this function in an element and apply styles directly on that element instead.

I'm open to any other suggestions for this API.

## Does this close any currently open issues?
N/A

## What do the changes look like?
There should be no visual changes.

| Before  | After  |
|---|---|
| ![image](https://user-images.githubusercontent.com/44531733/214963958-13ec0f25-04d3-4d45-a8af-319e153cd791.png) | ![image](https://user-images.githubusercontent.com/44531733/214963825-8cd142d9-fd20-44ab-865e-14ba4de00be1.png) |

## Storybook link
https://6062ad4a2d14cd0021539c1b-tnmvrybdkf.chromatic.com/?path=/story/polaris-viz-charts-donutchart--custom-inner-value-content

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
