### PR TITLE
Add TrendIndicator

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -225,9 +225,9 @@ export const DEFAULT_THEME: Theme = {
     labelColor: variables.colorGray30,
     backgroundColor: variables.colorGray150,
     trendIndicator: {
-      positive: '#03AB92',
-      negative: '#f24f62',
-      neutral: '#8C9196',
+      positive: variables.colorDarkPositive,
+      negative: variables.colorDarkNegative,
+      neutral: variables.colorDarkNeutral,
     },
   },
   annotations: {
@@ -238,6 +238,12 @@ export const DEFAULT_THEME: Theme = {
     axisLabelColor: variables.colorGray80,
     lineColor: variables.colorGray80,
     pillOpacity: 0.6,
+  },
+  trendIndicator: {
+    positive: variables.colorDarkPositive,
+    negative: variables.colorDarkNegative,
+    neutral: variables.colorDarkNeutral,
+    background: variables.colorGray150,
   },
 };
 
@@ -327,9 +333,9 @@ export const LIGHT_THEME: Theme = {
     labelColor: variables.colorGray100,
     backgroundColor: variables.colorGray10,
     trendIndicator: {
-      positive: '#119d7f',
-      negative: '#eb4c5e',
-      neutral: '#8C9196',
+      positive: variables.colorLightPositive,
+      negative: variables.colorLightNegative,
+      neutral: variables.colorLightNeutral,
     },
   },
   annotations: {
@@ -340,6 +346,12 @@ export const LIGHT_THEME: Theme = {
     axisLabelColor: variables.colorGray70,
     lineColor: variables.colorGray70,
     pillOpacity: 1,
+  },
+  trendIndicator: {
+    positive: variables.colorLightPositive,
+    negative: variables.colorLightNegative,
+    neutral: variables.colorLightNeutral,
+    background: variables.colorGray10,
   },
 };
 

--- a/packages/polaris-viz-core/src/styles/shared/_variables.scss
+++ b/packages/polaris-viz-core/src/styles/shared/_variables.scss
@@ -10,6 +10,14 @@ $color-purple-dark: rgb(80, 36, 143);
 $color-dark-comparison: rgba(144, 176, 223, 0.8);
 $color-light-comparison: rgba(103, 147, 204, 1);
 
+$color-light-positive: #119d7f;
+$color-light-negative: #eb4c5e;
+$color-light-neutral: #8c9196;
+
+$color-dark-positive: #039c86;
+$color-dark-negative: #f24f62;
+$color-dark-neutral: #8c9196;
+
 $color-gray-00: #ffffff;
 $color-gray-10: #f6f6f7;
 $color-gray-20: #eeeeef;
@@ -168,6 +176,14 @@ $font-stack-base: -apple-system, BlinkMacSystemFont, 'San Francisco', 'Segoe UI'
 
   colorDarkComparison: $color-dark-comparison;
   colorLightComparison: $color-light-comparison;
+
+  colorLightPositive: $color-light-positive;
+  colorLightNegative: $color-light-negative;
+  colorLightNeutral: $color-light-neutral;
+
+  colorDarkPositive: $color-dark-positive;
+  colorDarkNegative: $color-dark-negative;
+  colorDarkNeutral: $color-dark-neutral;
 
   colorGray00: $color-gray-00;
   colorGray10: $color-gray-10;

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -140,6 +140,13 @@ export interface LegendTheme {
   trendIndicator: {positive: string; negative: string; neutral: string};
 }
 
+export interface TrendIndicatorTheme {
+  positive: string;
+  negative: string;
+  neutral: string;
+  background: string;
+}
+
 export interface PartialTheme {
   arc?: Partial<ArcTheme>;
   chartContainer?: Partial<ChartContainerTheme>;
@@ -152,6 +159,7 @@ export interface PartialTheme {
   legend?: Partial<LegendTheme>;
   seriesColors?: Partial<SeriesColors>;
   tooltip?: Partial<TooltipTheme>;
+  trendIndicator?: Partial<TrendIndicatorTheme>;
 }
 
 export interface Theme {
@@ -167,6 +175,7 @@ export interface Theme {
   legend: LegendTheme;
   seriesColors: SeriesColors;
   tooltip: TooltipTheme;
+  trendIndicator: TrendIndicatorTheme;
 }
 
 export enum DataType {

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -1,0 +1,99 @@
+import {estimateStringWidth, useTheme} from '@shopify/polaris-viz-core';
+
+import type {Trend, TrendDirection, TrendSize} from '../../types';
+import characterWidths from '../../data/character-widths.json';
+import characterWidthOffsets from '../../data/character-width-offsets.json';
+
+import {ArrowDown, ArrowUp, Svg} from './components/';
+
+export interface TrendIndicatorProps {
+  accessibilityLabel?: string;
+  direction?: TrendDirection;
+  size?: TrendSize;
+  theme?: string;
+  trend?: Trend;
+  value?: string;
+}
+
+const HEIGHT = 20;
+const NO_VALUE_WIDTH = 29;
+
+const LEFT_PADDING = 8;
+const TEXT_X = 22;
+
+export function TrendIndicator({
+  accessibilityLabel,
+  direction = 'upward',
+  size = 'default',
+  theme = 'Light',
+  trend = 'neutral',
+  value,
+}: TrendIndicatorProps) {
+  const selectedTheme = useTheme(theme);
+
+  if (value == null) {
+    return (
+      <Svg
+        accessibilityLabel={accessibilityLabel}
+        height={HEIGHT}
+        width={NO_VALUE_WIDTH}
+      >
+        <rect
+          width={NO_VALUE_WIDTH}
+          height={HEIGHT}
+          fill="#F6F6F7"
+          rx={HEIGHT / 2}
+        />
+
+        <path
+          d="M0.519531 1.79395H12.0039V0.249023H0.519531V1.79395Z"
+          fill="#8C9196"
+          transform={`translate(${LEFT_PADDING}, 9)`}
+        />
+      </Svg>
+    );
+  }
+
+  const fontSize = size === 'small' ? 12 : 14;
+  const rightPadding = size === 'small' ? 8 : 10;
+
+  const textWidth =
+    estimateStringWidth(value, characterWidths) *
+    characterWidthOffsets[fontSize];
+
+  const totalWidth = Math.round(TEXT_X + textWidth + rightPadding);
+
+  return (
+    <Svg
+      accessibilityLabel={accessibilityLabel}
+      height={HEIGHT}
+      width={totalWidth}
+    >
+      <rect
+        width={totalWidth}
+        height={HEIGHT}
+        fill={selectedTheme.trendIndicator.background}
+        rx={HEIGHT / 2}
+      />
+
+      <g color={selectedTheme.trendIndicator[trend]}>
+        <g transform={`translate(${LEFT_PADDING}, 4)`}>
+          {direction === 'upward' ? <ArrowUp /> : <ArrowDown />}
+        </g>
+
+        <text
+          x={TEXT_X}
+          y="11.5"
+          fontSize={fontSize}
+          fill="currentColor"
+          fontWeight="600"
+          dominantBaseline="middle"
+          fontFamily="-apple-system, BlinkMacSystemFont, sans-serif"
+          textRendering="geometricPrecision"
+        >
+          {value}
+        </text>
+      </g>
+    </Svg>
+  );
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowDown.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowDown.tsx
@@ -1,0 +1,25 @@
+export function ArrowDown() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 3L9 9L3 9"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 9L3.1875 3.1875"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowUp.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowUp.tsx
@@ -1,0 +1,25 @@
+export function ArrowUp() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3 3H9V9"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 3L3.1875 8.8125"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+    </svg>
+  );
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/index.ts
@@ -1,0 +1,2 @@
+export {ArrowUp} from './ArrowUp';
+export {ArrowDown} from './ArrowDown';

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.scss
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.scss
@@ -1,0 +1,3 @@
+.SVG {
+  display: block;
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.tsx
@@ -1,0 +1,28 @@
+import type {ReactNode} from 'react';
+
+import styles from './Svg.scss';
+
+interface Props {
+  children: ReactNode;
+  height: number;
+  width: number;
+  accessibilityLabel?: string;
+}
+
+export function Svg({accessibilityLabel, children, height, width}: Props) {
+  const hasLabel = accessibilityLabel != null;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      height={height}
+      width={width}
+      role={hasLabel ? 'img' : undefined}
+      className={styles.SVG}
+      tabIndex={0}
+    >
+      {hasLabel && <title>{accessibilityLabel}</title>}
+      {children}
+    </svg>
+  );
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Svg/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Svg/index.ts
@@ -1,0 +1,1 @@
+export {Svg} from './Svg';

--- a/packages/polaris-viz/src/components/TrendIndicator/components/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/index.ts
@@ -1,0 +1,2 @@
+export {ArrowUp, ArrowDown} from './Arrows';
+export {Svg} from './Svg';

--- a/packages/polaris-viz/src/components/TrendIndicator/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/index.ts
@@ -1,0 +1,2 @@
+export {TrendIndicator} from './TrendIndicator';
+export type {TrendIndicatorProps} from './TrendIndicator';

--- a/packages/polaris-viz/src/components/TrendIndicator/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/stories/Default.stories.tsx
@@ -1,0 +1,15 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {TrendIndicatorProps} from '..';
+
+import {Template} from './data';
+
+export const Default: Story<TrendIndicatorProps> = Template.bind({});
+
+Default.args = {
+  accessibilityLabel: 'Increase of 10%',
+  theme: 'Light',
+  value: '10%',
+};

--- a/packages/polaris-viz/src/components/TrendIndicator/stories/TrendIndicator.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/stories/TrendIndicator.chromatic.stories.tsx
@@ -1,0 +1,41 @@
+import {storiesOf} from '@storybook/react';
+
+import {
+  addWithPropsCombinations,
+  renderCombinationSections,
+} from '../../../chromatic';
+import {TrendIndicator} from '../';
+import type {TrendIndicatorProps} from '../';
+
+const stories = storiesOf('Chromatic/Components', module).addParameters({
+  docs: {page: null},
+  chromatic: {disableSnapshot: false},
+});
+
+const combinations = renderCombinationSections([
+  [
+    'Data',
+    addWithPropsCombinations<TrendIndicatorProps>(TrendIndicator, {
+      value: [undefined, '10%', '1000000%'],
+      trend: ['positive', 'negative', 'neutral'],
+      direction: ['upward', 'downward'],
+    }),
+  ],
+  [
+    'Size & Theme',
+    addWithPropsCombinations(TrendIndicator, {
+      value: [undefined, '10'],
+      size: ['default', 'small'],
+    }),
+  ],
+  [
+    'Theme',
+    addWithPropsCombinations(TrendIndicator, {
+      value: ['10'],
+      trend: ['positive', 'negative', 'neutral'],
+      theme: ['Default', 'Light'],
+    }),
+  ],
+]);
+
+stories.add('TrendIndicator', combinations);

--- a/packages/polaris-viz/src/components/TrendIndicator/stories/data.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/stories/data.tsx
@@ -1,0 +1,10 @@
+import type {Story} from '@storybook/react';
+
+import type {TrendIndicatorProps} from '../TrendIndicator';
+import {TrendIndicator} from '../TrendIndicator';
+
+export const Template: Story<TrendIndicatorProps> = (
+  args: TrendIndicatorProps,
+) => {
+  return <TrendIndicator {...args} />;
+};

--- a/packages/polaris-viz/src/components/TrendIndicator/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/stories/meta.tsx
@@ -1,0 +1,38 @@
+import type {Meta} from '@storybook/react';
+
+import {TrendIndicator} from '../';
+import {CONTROLS_ARGS, THEME_CONTROL_ARGS} from '../../../storybook/constants';
+import {PageWithSizingInfo} from '../../Docs/stories';
+
+export const META: Meta = {
+  title: 'polaris-viz/Subcomponents/TrendIndicator',
+  component: TrendIndicator,
+  parameters: {
+    docs: {
+      page: PageWithSizingInfo,
+      description: {
+        component: 'Used to indicate a trend based on previous data.',
+      },
+    },
+    controls: CONTROLS_ARGS,
+  },
+  decorators: [(Story) => <div style={{height: '500px'}}>{Story()}</div>],
+  argTypes: {
+    accessibilityLabel: {
+      description: 'Visually hidden text for screen readers.',
+    },
+    direction: {
+      description: 'Set the direction of the trend arrow.',
+      options: ['upward', 'downward'],
+    },
+    size: {
+      description: 'Set the visual size of the component.',
+      options: ['default', 'small'],
+    },
+    theme: THEME_CONTROL_ARGS,
+    trend: {
+      description: 'Set the visual styling for the current trend.',
+      options: ['positive', 'negative', 'neutral'],
+    },
+  },
+};

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -46,3 +46,4 @@ export {ChartSkeleton} from './ChartSkeleton';
 export {ComboChart} from './ComboChart';
 export type {ComboChartProps} from './ComboChart';
 export {XAxis} from './XAxis';
+export {TrendIndicator} from './TrendIndicator';

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -15,6 +15,7 @@ export {
   ChartSkeleton,
   ComboChart,
   DonutChart,
+  TrendIndicator,
 } from './components';
 
 export type {
@@ -39,6 +40,9 @@ export type {
   InnerValueContents,
   RenderInnerValueContent,
   TooltipData,
+  Trend,
+  TrendSize,
+  TrendDirection,
 } from './types';
 
 export {

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -211,3 +211,7 @@ export interface InnerValueContents {
 }
 
 export type RenderInnerValueContent = (values: InnerValueContents) => ReactNode;
+
+export type Trend = 'positive' | 'negative' | 'neutral';
+export type TrendSize = 'default' | 'small';
+export type TrendDirection = 'upward' | 'downward';

--- a/scripts/character-widths/build-character-widths.html
+++ b/scripts/character-widths/build-character-widths.html
@@ -22,8 +22,6 @@
       const set = new Set([]);
       const workspace = document.querySelector('#workspace');
 
-      z;
-
       const characters = {};
 
       set.forEach((item) => {


### PR DESCRIPTION
## What does this implement/fix?

Initial exploration for a TrendIndicator component that can be used in `web`.

### Why an SVG?

There was an ask about adding these TrendIndicators in charts like Funnel and SimpleBarChart.

![image](https://user-images.githubusercontent.com/149873/217582624-d1a4a771-7a0d-4c78-8f36-e692892bd62f.png)

To allow the TrendIndicator to be an inline element in the chart, and be copyable/printable, it needs to be an svg element. 

Thoughts @pbojinov @LBWright @nickpresta @philschoefer? Is it worth supporting an SVG element instead of just plain ol' HTML?

## What do the changes look like?

![image](https://user-images.githubusercontent.com/149873/217582256-dd62320c-a058-49d7-aaf9-4bf53f2e3bb6.png)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-tneqaezlby.chromatic.com/?path=/story/polaris-viz-subcomponents-trendindicator--default

https://6062ad4a2d14cd0021539c1b-tneqaezlby.chromatic.com/?path=/story/chromatic-components--trendindicator

