### PR TITLE
Fix bug where points with null data threw all points off

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `<LineChart />` points not animating correctly.
+- Fixed `<LineChart />` points displaying incorrecly if `DataSeries` had `null` values.
 
 ## [8.0.2] - 2023-02-08
 

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -66,22 +66,25 @@ export function Points({
         const {data: singleData, name, color} = singleSeries;
         const isLongestLine = index === longestSeriesIndex;
         const pointGradientId = `${gradientId}-point-${index}`;
-        const noNullSingleData = singleData.filter((data) => {
-          return data.value != null;
-        });
         const animatedYPosition =
           animatedCoordinates == null || animatedCoordinates[index] == null
             ? 0
             : animatedCoordinates[index].to((coord) => coord.y);
 
+        const hasValidData =
+          activeIndex == null
+            ? false
+            : singleData[activeIndex ?? -1]?.value != null;
+
         const hidePoint =
+          !hasValidData ||
           animatedCoordinates == null ||
-          activeLineIndex === index ||
-          (activeIndex != null && activeIndex >= noNullSingleData.length);
+          activeLineIndex === index;
 
         const pointColor = isGradientType(color)
           ? `url(#${pointGradientId})`
           : changeColorOpacity(color);
+
         return (
           <Fragment key={`${name}-${index}`}>
             {isGradientType(color) ? (
@@ -100,7 +103,7 @@ export function Points({
                 color={pointColor}
                 cx={getXPosition({isCrosshair: false})}
                 cy={animatedYPosition}
-                active={activeIndex != null}
+                active={hasValidData && activeIndex != null}
                 index={index}
                 tabIndex={-1}
                 isAnimated={shouldAnimate}
@@ -109,10 +112,11 @@ export function Points({
               />
             ) : null}
 
-            {noNullSingleData.map(({value}, dataIndex) => {
+            {singleData.map(({value}, dataIndex) => {
               if (value == null) {
                 return null;
               }
+
               return (
                 <g
                   key={`${name}-${index}-${dataIndex}`}

--- a/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
@@ -48,8 +48,7 @@ export function PointsAndCrosshair({
   const lineGenerator = useMemo(() => {
     const generator = line<DataPoint>()
       .x((_, index) => (xScale == null ? 0 : xScale(index)))
-      .y(({value}) => yScale(value ?? 0))
-      .defined(({value}) => value != null);
+      .y(({value}) => yScale(value ?? 0));
 
     if (selectedTheme.line.hasSpline) {
       generator.curve(curveStepRounded);
@@ -72,8 +71,7 @@ export function PointsAndCrosshair({
     if (
       animatedCoordinates != null &&
       animatedCoordinates[longestSeriesIndex] != null &&
-      shouldAnimate &&
-      longestSeriesIndex !== 0
+      shouldAnimate
     ) {
       return animatedCoordinates[longestSeriesIndex].to(
         (coord) => coord.x - offset,

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -890,6 +890,52 @@ MissingData.args = {
   ],
 };
 
+export const PatchyData: Story<LineChartProps> = Template.bind({});
+
+PatchyData.args = {
+  tooltipOptions: {
+    renderTooltipContent: () => null,
+  },
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 333, key: '2020-04-01T12:00:00'},
+        {value: 797, key: '2020-04-02T12:00:00'},
+        {value: 234, key: '2020-04-03T12:00:00'},
+        {value: 534, key: '2020-04-04T12:00:00'},
+        {value: null, key: '2020-04-05T12:00:00'},
+        {value: 159, key: '2020-04-06T12:00:00'},
+        {value: 239, key: '2020-04-07T12:00:00'},
+        {value: 333, key: '2020-04-01T12:00:00'},
+        {value: null, key: '2020-04-02T12:00:00'},
+        {value: 234, key: '2020-04-03T12:00:00'},
+        {value: 534, key: '2020-04-04T12:00:00'},
+        {value: 132, key: '2020-04-05T12:00:00'},
+        {value: 159, key: '2020-04-06T12:00:00'},
+        {value: 24, key: '2020-04-07T12:00:00'},
+      ],
+    },
+    {
+      name: 'Previous month',
+      data: [
+        {value: 709, key: '2020-03-02T12:00:00'},
+        {value: 238, key: '2020-03-01T12:00:00'},
+        {value: 34, key: '2020-03-03T12:00:00'},
+        {value: 90, key: '2020-03-04T12:00:00'},
+        {value: 237, key: '2020-03-05T12:00:00'},
+        {value: 580, key: '2020-03-07T12:00:00'},
+        {value: 35, key: '2020-03-06T12:00:00'},
+        {value: 12, key: '2020-03-08T12:00:00'},
+        {value: 390, key: '2020-03-09T12:00:00'},
+        {value: 43, key: '2020-03-10T12:00:00'},
+        {value: 710, key: '2020-03-11T12:00:00'},
+      ],
+      isComparison: true,
+    },
+  ],
+};
+
 export const LinearComparisonTooltip: Story<LineChartProps> = Template.bind({});
 
 LinearComparisonTooltip.args = {


### PR DESCRIPTION
## What does this implement/fix?

Fixed a bug where data will null values would throw the calculations for all points after it off. Now the points will animate in/out when the value is null or not.

Also fixes a bug where point animations were not animating the x value. The video below poorly explains the issue.

https://user-images.githubusercontent.com/149873/217663052-363cf9d0-dab2-44c4-bead-9c2da447544b.mov

## Does this close any currently open issues?

Resolves https://github.com/Shopify/polaris-viz/issues/1439 

## What do the changes look like?

https://user-images.githubusercontent.com/149873/217663123-41da1639-7158-41c9-b8ea-0b04248c3db0.mov
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-jaltxmiiji.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--patchy-data

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
