### PR TITLE
Remove `hi` from `target_languages`

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -7,7 +7,6 @@ target_languages:
     es,
     fi,
     fr,
-    hi,
     it,
     ja,
     ko,


### PR DESCRIPTION
## This PR:
Removes Hindi (hi) from the `target_languages` in the component for  this repo. 
That language is no longer being used for any components that do not have the "audience" of `buyer`. See more here: https://github.com/Shopify/intl-languages/issues/190

Translation Platform is not requesting translations for that locale anyway, so it is unnecessary and misleading to have that in the `target_languages` list.