### PR TITLE
Stop the tooltip from covering the crosshair

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Stop the `<LineChart />` tooltip from covering the current active crosshair.
 
 ## [8.1.1] - 2023-02-17
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -64,7 +64,7 @@ import {ChartElements} from '../ChartElements';
 import {useLineChartTooltipContent} from './hooks/useLineChartTooltipContent';
 import {PointsAndCrosshair} from './components';
 import {useFormatData} from './hooks';
-import {yAxisMinMax} from './utilities';
+import {getAlteredLineChartPosition, yAxisMinMax} from './utilities';
 
 export interface ChartProps {
   renderTooltipContent: (data: RenderTooltipContentData) => React.ReactNode;
@@ -222,7 +222,10 @@ export function Chart({
       });
 
       return {
-        x: svgX,
+        x:
+          xScale(activeIndex) +
+          chartXPosition +
+          parseInt(selectedTheme.chartContainer.padding, 10),
         y: svgY,
         position: TOOLTIP_POSITION,
         activeIndex,
@@ -389,6 +392,7 @@ export function Chart({
           alwaysUpdatePosition
           chartBounds={chartBounds}
           focusElementDataType={DataType.Point}
+          getAlteredPosition={getAlteredLineChartPosition}
           getMarkup={getTooltipMarkup}
           getPosition={getTooltipPosition}
           id={tooltipId.current}

--- a/packages/polaris-viz/src/components/LineChart/utilities/getAlteredLineChartPosition.ts
+++ b/packages/polaris-viz/src/components/LineChart/utilities/getAlteredLineChartPosition.ts
@@ -1,0 +1,141 @@
+import type {BoundingRect, Dimensions} from '@shopify/polaris-viz-core';
+import {clamp} from '@shopify/polaris-viz-core';
+
+import type {TooltipPositionOffset} from '../../TooltipWrapper';
+import type {Margin} from '../../../types';
+import {TooltipHorizontalOffset} from '../../TooltipWrapper';
+
+// The space between the cursor and the tooltip
+export const TOOLTIP_MARGIN = 20;
+
+export interface AlteredPositionProps {
+  bandwidth: number;
+  chartBounds: BoundingRect;
+  currentX: number;
+  currentY: number;
+  isPerformanceImpacted: boolean;
+  margin: Margin;
+  position: TooltipPositionOffset;
+  tooltipDimensions: Dimensions;
+}
+
+export interface AlteredPositionReturn {
+  x: number;
+  y: number;
+}
+
+export type AlteredPosition = (
+  props: AlteredPositionProps,
+) => AlteredPositionReturn;
+
+export function getAlteredLineChartPosition(
+  props: AlteredPositionProps,
+): AlteredPositionReturn {
+  const {currentX, currentY, position, chartBounds} = props;
+
+  const newPosition = {...position};
+
+  let x = currentX;
+  let y = currentY;
+
+  //
+  // Y POSITIONING
+  //
+
+  if (props.isPerformanceImpacted) {
+    y = 0;
+  }
+
+  //
+  // X POSITIONING
+  //
+
+  const left = getLeftPosition(x, props);
+
+  if (left.wasOutsideBounds) {
+    newPosition.horizontal = TooltipHorizontalOffset.Right;
+  } else {
+    x = left.value;
+  }
+
+  if (newPosition.horizontal === TooltipHorizontalOffset.Right) {
+    const right = getRightPosition(x, props);
+    x = right.value;
+  }
+
+  return {
+    x: clamp({
+      amount: x,
+      min: chartBounds.x ?? 0,
+      max: chartBounds.width,
+    }),
+    y: clamp({
+      amount: y,
+      min: chartBounds.y ?? 0,
+      max: chartBounds.height - props.tooltipDimensions.height,
+    }),
+  };
+}
+
+interface IsOutsideBoundsData {
+  current: number;
+  alteredPosition: AlteredPositionProps;
+}
+
+function isOutsideBounds(data: IsOutsideBoundsData) {
+  const {current, alteredPosition} = data;
+
+  const isLeft =
+    current <
+    alteredPosition.margin.Left + alteredPosition.tooltipDimensions.width;
+  const isRight =
+    current + alteredPosition.tooltipDimensions.width >
+    alteredPosition.chartBounds.width - alteredPosition.margin.Right;
+
+  return {left: isLeft, right: isRight};
+}
+
+type getFunction = (
+  value: number,
+  props: AlteredPositionProps,
+) => {value: number; wasOutsideBounds: boolean};
+
+function getLeftPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let x = value - props.tooltipDimensions.width;
+  const wasOutsideBounds = isOutsideBounds({
+    current: x,
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds.left) {
+    x = props.currentX + props.margin.Left + props.bandwidth + TOOLTIP_MARGIN;
+  } else {
+    x -= TOOLTIP_MARGIN;
+  }
+
+  return {value: x, wasOutsideBounds: wasOutsideBounds.left};
+}
+
+function getRightPosition(
+  ...args: Parameters<getFunction>
+): ReturnType<getFunction> {
+  const [value, props] = args;
+
+  let x = value + props.bandwidth;
+  const wasOutsideBounds = isOutsideBounds({
+    current: x,
+    alteredPosition: props,
+  });
+
+  if (wasOutsideBounds.right) {
+    x -= props.tooltipDimensions.width + props.bandwidth + TOOLTIP_MARGIN;
+  } else {
+    x += TOOLTIP_MARGIN;
+  }
+
+  return {value: x, wasOutsideBounds: wasOutsideBounds.right};
+}

--- a/packages/polaris-viz/src/components/LineChart/utilities/index.ts
+++ b/packages/polaris-viz/src/components/LineChart/utilities/index.ts
@@ -1,1 +1,2 @@
 export {yAxisMinMax} from './yAxisMinMax';
+export {getAlteredLineChartPosition} from './getAlteredLineChartPosition';

--- a/packages/polaris-viz/src/components/LineChart/utilities/tests/getAlteredLineChartPosition.test.ts
+++ b/packages/polaris-viz/src/components/LineChart/utilities/tests/getAlteredLineChartPosition.test.ts
@@ -1,0 +1,46 @@
+import type {AlteredPositionProps} from '../../../TooltipWrapper';
+import {
+  TooltipVerticalOffset,
+  TooltipHorizontalOffset,
+} from '../../../TooltipWrapper';
+import {getAlteredLineChartPosition} from '../getAlteredLineChartPosition';
+
+const MARGIN = {Top: 0, Left: 0, Right: 0, Bottom: 0};
+
+const BASE_PROPS: AlteredPositionProps = {
+  isPerformanceImpacted: false,
+  chartBounds: {height: 100, width: 200, x: 0, y: 0},
+  tooltipDimensions: {height: 40, width: 60},
+  margin: MARGIN,
+  bandwidth: 40,
+  currentX: 0,
+  currentY: 0,
+  position: {
+    horizontal: TooltipHorizontalOffset.Left,
+    vertical: TooltipVerticalOffset.Center,
+  },
+};
+
+describe('getAlteredLineChartPosition', () => {
+  it.each([
+    ['y: 0', {x: 0, y: 0}, {x: 60, y: 0}],
+    ['y: 50', {x: 0, y: 50}, {x: 60, y: 50}],
+    ['y: 100', {x: 0, y: 100}, {x: 60, y: 60}],
+
+    ['x: 0', {x: 0, y: 0}, {x: 60, y: 0}],
+    ['x: 40', {x: 40, y: 0}, {x: 100, y: 0}],
+    ['x: 80', {x: 80, y: 0}, {x: 140, y: 0}],
+    ['x: 100', {x: 100, y: 0}, {x: 160, y: 0}],
+    ['x: 120', {x: 120, y: 0}, {x: 40, y: 0}],
+    ['x: 160', {x: 160, y: 0}, {x: 80, y: 0}],
+    ['x: 200', {x: 200, y: 0}, {x: 120, y: 0}],
+  ])(`alters position when cursor is %s`, (_, {x, y}, result) => {
+    expect(
+      getAlteredLineChartPosition({
+        ...BASE_PROPS,
+        currentX: x,
+        currentY: y,
+      }),
+    ).toStrictEqual(result);
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

The `<LineChart />` tooltip would try and follow the cursor around when interacting with the chart. This allowed the tooltip to get into a state where it was covering the crosshair for the active state, which covers the data.

Now, we're going to make the tooltip never cover the crosshair. It will always try and render on either side of the crosshair that keeps the tooltip within the bounds of the chart.

## What do the changes look like?

**Before**

https://user-images.githubusercontent.com/149873/223225806-da4465fa-f095-49fd-b0f7-cf32c8474a95.mov

**After**

https://user-images.githubusercontent.com/149873/223225878-fe9d4823-375d-40e1-8cb8-516b7d0da4e1.mov

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
