### PR TITLE
Fix issue with size-limit node version mismatch

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -11,7 +11,11 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
       - uses: andresz1/size-limit-action@v1.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes an issue causing `size-limit` to fail because `graphql-typescript-definitions` depends on `@apollo/federation `which refuses to install on node 18.

```
yarn why @apollo/federation
Found existing alias for "yarn". You should use: "y"
yarn why v1.22.5
[1/4] 🤔  Why do we have the module "@apollo/federation"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@apollo/federation@0.27.0"
info Reasons this module exists
   - "_project_#@shopify#loom-plugin-build-library-extended#graphql-typescript-definitions#graphql-tool-utilities#apollo-codegen-core#apollo-language-server" depends on it
   - Hoisted from "_project_#@shopify#loom-plugin-build-library-extended#graphql-typescript-definitions#graphql-tool-utilities#apollo-codegen-core#apollo-language-server#@apollo#federation"
info Disk size without dependencies: "1.72MB"
info Disk size with unique dependencies: "16.07MB"
info Disk size with transitive dependencies: "26.25MB"
info Number of shared dependencies: 7
✨  Done in 0.76s.
```