### PR TITLE
Fix points not rendering when no active line

### DIFF
--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -84,10 +84,11 @@ export function Points({
             ? false
             : singleData[activeIndex ?? -1]?.value != null;
 
+        const isLineActive =
+          activeLineIndex !== -1 && activeLineIndex !== unreversedIndex;
+
         const hidePoint =
-          !hasValidData ||
-          animatedCoordinates == null ||
-          activeLineIndex !== unreversedIndex;
+          !hasValidData || animatedCoordinates == null || isLineActive;
 
         const pointColor = isGradientType(color)
           ? `url(#${pointGradientId})`

--- a/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
@@ -38,10 +38,6 @@ export function useLineChartTooltipContent({
         : '';
 
       data.forEach(({name, data: seriesData, color, isComparison}, index) => {
-        if (hiddenIndexes.includes(index)) {
-          return null;
-        }
-
         if (!seriesData[activeIndex]) {
           return;
         }
@@ -52,6 +48,7 @@ export function useLineChartTooltipContent({
           value,
           color: color!,
           isComparison,
+          isHidden: hiddenIndexes.includes(index),
         });
       });
 

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -58,24 +58,27 @@ export function TooltipContent({
             {name != null && (
               <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
             )}
-            {series.map(({key, value, color, isComparison}, seriesIndex) => {
-              const indexOffset = data[dataIndex - 1]
-                ? data[dataIndex - 1].data.length
-                : 0;
+            {series.map(
+              ({key, value, color, isComparison, isHidden}, seriesIndex) => {
+                const indexOffset = data[dataIndex - 1]
+                  ? data[dataIndex - 1].data.length
+                  : 0;
 
-              return (
-                <TooltipRow
-                  key={`row-${seriesIndex}`}
-                  activeIndex={activeIndex}
-                  color={color}
-                  index={seriesIndex + indexOffset}
-                  isComparison={isComparison}
-                  label={key}
-                  shape={shape}
-                  value={value}
-                />
-              );
-            })}
+                return (
+                  <TooltipRow
+                    key={`row-${seriesIndex}`}
+                    activeIndex={activeIndex}
+                    color={color}
+                    index={seriesIndex + indexOffset}
+                    isComparison={isComparison}
+                    isHidden={isHidden}
+                    label={key}
+                    shape={shape}
+                    value={value}
+                  />
+                );
+              },
+            )}
           </div>
         );
       })}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -20,6 +20,7 @@ interface Props {
   value: string;
   color?: Color;
   isComparison?: boolean;
+  isHidden?: boolean;
   renderSeriesIcon?: () => React.ReactNode;
 }
 
@@ -28,12 +29,17 @@ export function TooltipRow({
   color,
   index,
   isComparison = false,
+  isHidden = false,
   label,
   renderSeriesIcon,
   shape,
   value,
 }: Props) {
   const selectedTheme = useTheme();
+
+  if (isHidden) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
@@ -1,10 +1,13 @@
 import {useEffect} from 'react';
 import {COLOR_VISION_EVENT, useChartContext} from '@shopify/polaris-viz-core';
 
+import {useExternalHideEvents} from '../ExternalEvents';
+
 import {getDataSetItem, getEventName} from './utilities';
 
 export function useColorVisionEvents(enabled = true) {
   const {id} = useChartContext();
+  const {hiddenIndexes} = useExternalHideEvents();
 
   useEffect(() => {
     if (!enabled) {
@@ -67,5 +70,5 @@ export function useColorVisionEvents(enabled = true) {
         item.removeEventListener('blur', onMouseLeave);
       });
     };
-  }, [id, enabled]);
+  }, [id, enabled, hiddenIndexes]);
 }

--- a/packages/polaris-viz/src/playground/ExternalEvents.stories.tsx
+++ b/packages/polaris-viz/src/playground/ExternalEvents.stories.tsx
@@ -3,7 +3,6 @@ import type {Story} from '@storybook/react';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 
 import {LineChartRelational} from '../components/LineChartRelational';
-import {PolarisVizProvider} from '../components/PolarisVizProvider';
 import {setSingleSeriesActive} from '../utilities';
 import {useWatchActiveSeries} from '../hooks';
 import {setHiddenItems} from '../hooks/ExternalEvents';
@@ -11,7 +10,7 @@ import {setHiddenItems} from '../hooks/ExternalEvents';
 export default {
   title: 'polaris-viz/Playground/ExternalEvents',
   parameters: {},
-  decorators: [(Story) => <div>{Story()}</div>],
+  decorators: [(Story) => <div style={{height: 500}}>{Story()}</div>],
   argTypes: {},
 };
 
@@ -90,17 +89,7 @@ const Template: Story = () => {
           <strong>{activeName}</strong>.
         </p>
       </div>
-      <PolarisVizProvider
-        themes={{
-          Default: {
-            chartContainer: {
-              padding: '20px',
-            },
-          },
-        }}
-      >
-        <LineChartRelational id={CHART_ID} data={DEFAULT_DATA} />
-      </PolarisVizProvider>
+      <LineChartRelational id={CHART_ID} data={DEFAULT_DATA} />
     </>
   );
 };
@@ -111,7 +100,7 @@ const style = {marginBottom: 10, gap: 10, display: 'flex'};
 
 const RELATIONAL_DATA: DataSeries[] = [
   {
-    name: 'Apr 1 – Apr 14, 2020',
+    name: 'Average',
     data: [
       {value: 333, key: '2020-04-01T12:00:00'},
       {value: 797, key: '2020-04-02T12:00:00'},
@@ -129,14 +118,9 @@ const RELATIONAL_DATA: DataSeries[] = [
       {value: 129, key: '2020-04-14T12:00:00'},
     ],
     color: [
-      {offset: 0, color: '#986BFF'},
-      {offset: 100, color: '#3AA4F6'},
+      {offset: 0, color: 'rgba(149, 101, 255, 1)'},
+      {offset: 100, color: 'rgba(75, 146, 229, 1)'},
     ],
-    styleOverride: {
-      line: {
-        width: 3,
-      },
-    },
   },
   {
     name: '75th Percentile',
@@ -156,15 +140,14 @@ const RELATIONAL_DATA: DataSeries[] = [
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: 'red',
+    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
-      areaColor: 'rgba(255,0,0,0.1)',
-      shape: 'Bar',
+      areaColor: 'rgba(103, 197, 228, 0.1)',
     },
   },
   {
-    name: 'Similar stores median',
+    name: 'Median',
     data: [
       {value: 759, key: '2020-03-02T12:00:00'},
       {value: 238, key: '2020-03-01T12:00:00'},
@@ -181,11 +164,14 @@ const RELATIONAL_DATA: DataSeries[] = [
       {value: 623, key: '2020-03-13T12:00:00'},
       {value: 21, key: '2020-03-14T12:00:00'},
     ],
-    color: '#286A7B',
+    color: 'rgba(40, 106, 123, 1)',
+    metadata: {
+      relatedIndex: 3,
+      areaColor: 'rgba(47, 175, 218, 0.2)',
+    },
     styleOverride: {
       line: {
         strokeDasharray: '3 6',
-        width: 3,
       },
     },
   },
@@ -207,12 +193,7 @@ const RELATIONAL_DATA: DataSeries[] = [
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: 'blue',
-    metadata: {
-      shape: 'Bar',
-      relatedIndex: 2,
-      areaColor: 'rgba(0,0,255,0.1)',
-    },
+    color: 'rgba(103, 197, 228, 1)',
   },
 ];
 
@@ -282,22 +263,13 @@ const HiddenTemplate: Story = () => {
           );
         })}
       </div>
-      <PolarisVizProvider
-        themes={{
-          Default: {
-            chartContainer: {
-              padding: '20px',
-            },
-          },
-        }}
-      >
-        <LineChartRelational
-          data={RELATIONAL_DATA}
-          id={CHART_ID}
-          showLegend={false}
-          theme="Light"
-        />
-      </PolarisVizProvider>
+      <LineChartRelational
+        isAnimated={true}
+        data={RELATIONAL_DATA}
+        id={CHART_ID}
+        // showLegend={false}
+        theme="Light"
+      />
     </>
   );
 };

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -72,6 +72,7 @@ export interface RenderTooltipDataPoint {
   isComparison?: boolean;
   key: number | string;
   value: number | string | null;
+  isHidden?: boolean;
 }
 
 export interface TooltipFormatters {
@@ -95,12 +96,7 @@ export interface RenderTooltipContentData {
 
 export interface TooltipData {
   shape: Shape;
-  data: {
-    key: string;
-    value: string;
-    color?: Color;
-    isComparison?: boolean;
-  }[];
+  data: RenderTooltipDataPoint[];
   name?: string;
 }
 

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -96,7 +96,13 @@ export interface RenderTooltipContentData {
 
 export interface TooltipData {
   shape: Shape;
-  data: RenderTooltipDataPoint[];
+  data: {
+    key: string;
+    value: string;
+    color?: Color;
+    isComparison?: boolean;
+    isHidden?: boolean;
+  }[];
   name?: string;
 }
 


### PR DESCRIPTION
## What does this implement/fix?

I introduced a bug where the points on a line chart wouldn't show up unless you were hovering over a line. The points should always show and then hide all inactive points when hovering a line.

Resolves https://github.com/Shopify/core-issues/issues/53198

- https://6062ad4a2d14cd0021539c1b-desuufdvxo.chromatic.com/?path=/story/polaris-viz-charts-linechart--default

### Tooltips

I also noticed an issue where tooltip items wouldn't highlight correctly if some of the lines had been hidden.

https://6062ad4a2d14cd0021539c1b-desuufdvxo.chromatic.com/?path=/story/polaris-viz-playground-externalevents--hide-lines

- Have at least 2 lines visible
  - Tooltip should show correct data AND highlight correctly when hovering lines.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/228029028-0a05ac84-0c97-4aa2-95ca-1cd852b50dbd.png)|![image](https://user-images.githubusercontent.com/149873/228029646-7665cc46-c331-4987-bc07-3c1f6bec3fb9.png)|