### PR TITLE
Fix line being cut off on right side

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed `<LinePreview />` right side being cut off.
 
 ## [8.2.0] - 2023-03-08
 

--- a/packages/polaris-viz/src/components/LinePreview/LinePreview.scss
+++ b/packages/polaris-viz/src/components/LinePreview/LinePreview.scss
@@ -4,4 +4,5 @@
 
 .SVG {
   display: block;
+  overflow: visible;
 }


### PR DESCRIPTION
## What does this implement/fix?

The SVG was cutting off the right side of the LinePreview icon.

## What do the changes look like?


| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/228295936-8986447e-74b7-4014-8c60-5e34b82a7886.png)|![image](https://user-images.githubusercontent.com/149873/228295382-662023de-651c-457e-a75d-36dcd8edd602.png)|
