### PR TITLE
Push active state to all tooltips

### DIFF
--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -1,10 +1,6 @@
-import {useState} from 'react';
-import {
-  COLOR_VISION_SINGLE_ITEM,
-  DEFAULT_THEME_NAME,
-} from '@shopify/polaris-viz-core';
+import {Fragment} from 'react';
+import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
-import {useWatchColorVisionEvents} from '../../hooks';
 import type {TooltipData} from '../../types';
 
 import {useGetLongestLabelFromData} from './hooks/useGetLongestLabelFromData';
@@ -31,14 +27,7 @@ export function TooltipContent({
   theme = DEFAULT_THEME_NAME,
   title,
 }: TooltipContentProps) {
-  const [activeIndex, setActiveIndex] = useState(-1);
-
   const {keyWidth, valueWidth} = useGetLongestLabelFromData(data);
-
-  useWatchColorVisionEvents({
-    type: COLOR_VISION_SINGLE_ITEM,
-    onIndexChange: ({detail}) => setActiveIndex(detail.index),
-  });
 
   const leftWidth = keyWidth * FONT_SIZE_OFFSET;
   const rightWidth = valueWidth * FONT_SIZE_OFFSET;
@@ -50,38 +39,45 @@ export function TooltipContent({
       }
       theme={theme}
     >
-      {title != null && <TooltipTitle theme={theme}>{title}</TooltipTitle>}
+      {({activeColorVisionIndex}) => (
+        <Fragment>
+          {title != null && <TooltipTitle theme={theme}>{title}</TooltipTitle>}
 
-      {data.map(({data: series, name, shape}, dataIndex) => {
-        return (
-          <div className={styles.Series} key={dataIndex}>
-            {name != null && (
-              <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
-            )}
-            {series.map(
-              ({key, value, color, isComparison, isHidden}, seriesIndex) => {
-                const indexOffset = data[dataIndex - 1]
-                  ? data[dataIndex - 1].data.length
-                  : 0;
+          {data.map(({data: series, name, shape}, dataIndex) => {
+            return (
+              <div className={styles.Series} key={dataIndex}>
+                {name != null && (
+                  <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
+                )}
+                {series.map(
+                  (
+                    {key, value, color, isComparison, isHidden},
+                    seriesIndex,
+                  ) => {
+                    const indexOffset = data[dataIndex - 1]
+                      ? data[dataIndex - 1].data.length
+                      : 0;
 
-                return (
-                  <TooltipRow
-                    key={`row-${seriesIndex}`}
-                    activeIndex={activeIndex}
-                    color={color}
-                    index={seriesIndex + indexOffset}
-                    isComparison={isComparison}
-                    isHidden={isHidden}
-                    label={key}
-                    shape={shape}
-                    value={value}
-                  />
-                );
-              },
-            )}
-          </div>
-        );
-      })}
+                    return (
+                      <TooltipRow
+                        key={`row-${seriesIndex}`}
+                        activeIndex={activeColorVisionIndex}
+                        color={color}
+                        index={seriesIndex + indexOffset}
+                        isComparison={isComparison}
+                        isHidden={isHidden}
+                        label={key}
+                        shape={shape}
+                        value={value}
+                      />
+                    );
+                  },
+                )}
+              </div>
+            );
+          })}
+        </Fragment>
+      )}
     </TooltipContentContainer>
   );
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
@@ -1,14 +1,38 @@
-import {changeColorOpacity, useTheme} from '@shopify/polaris-viz-core';
+import {
+  COLOR_VISION_SINGLE_ITEM,
+  changeColorOpacity,
+  useTheme,
+} from '@shopify/polaris-viz-core';
+import type {ReactNode} from 'react';
+import {useState} from 'react';
 
+import {useWatchColorVisionEvents} from '../../../../hooks';
 import {TOOLTIP_BG_OPACITY} from '../../../../constants';
 import {useBrowserCheck} from '../../../../hooks/useBrowserCheck';
 
 import styles from './TooltipContentContainer.scss';
 
-export function TooltipContentContainer({children, maxWidth, theme}) {
+interface Props {
+  children: ({
+    activeColorVisionIndex,
+  }: {
+    activeColorVisionIndex: number;
+  }) => ReactNode;
+  maxWidth: number;
+  theme: string;
+}
+
+export function TooltipContentContainer({children, maxWidth, theme}: Props) {
   const {isFirefox} = useBrowserCheck();
 
   const selectedTheme = useTheme(theme);
+
+  const [activeColorVisionIndex, setActiveIndex] = useState(-1);
+
+  useWatchColorVisionEvents({
+    type: COLOR_VISION_SINGLE_ITEM,
+    onIndexChange: ({detail}) => setActiveIndex(detail.index),
+  });
 
   return (
     <div
@@ -21,7 +45,7 @@ export function TooltipContentContainer({children, maxWidth, theme}) {
         maxWidth,
       }}
     >
-      {children}
+      {children({activeColorVisionIndex})}
     </div>
   );
 }

--- a/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
@@ -64,62 +64,74 @@ export function renderLinearTooltipContent(
     );
   }
 
-  const content = groups.map(({title: seriesName, indexes}) => {
-    const dataSeries = indexes
-      .map((groupIndex) => {
-        if (tooltipData.data[0].data[groupIndex] == null) {
-          return;
-        }
+  function renderContent({
+    activeColorVisionIndex,
+  }: {
+    activeColorVisionIndex: number;
+  }) {
+    return groups.map(({title: seriesName, indexes}) => {
+      const dataSeries = indexes
+        .map((groupIndex) => {
+          if (tooltipData.data[0].data[groupIndex] == null) {
+            return;
+          }
 
-        const rawDataSeries = tooltipData.data[0].data[groupIndex];
+          const rawDataSeries = tooltipData.data[0].data[groupIndex];
 
-        return {
-          ...tooltipData.dataSeries[groupIndex],
-          color: rawDataSeries.color,
-          groupIndex,
-          isHidden: rawDataSeries.isHidden,
-        };
-      })
-      .filter((series): series is TooltipDataSeries => Boolean(series));
+          return {
+            ...tooltipData.dataSeries[groupIndex],
+            color: rawDataSeries.color,
+            groupIndex,
+            isHidden: rawDataSeries.isHidden,
+          };
+        })
+        .filter((series): series is TooltipDataSeries => Boolean(series));
 
-    const hasTitle = dataSeries.some(({isHidden}) => isHidden !== true);
+      const hasTitle = dataSeries.some(({isHidden}) => isHidden !== true);
 
-    return (
-      <Fragment key={seriesName}>
-        {hasTitle && (
-          <TooltipSeriesName theme={theme}>{seriesName}</TooltipSeriesName>
-        )}
-        {dataSeries.map(
-          ({name, data, color, groupIndex, styleOverride, isHidden}) => {
-            const item = data[tooltipData.activeIndex];
+      return (
+        <Fragment key={seriesName}>
+          {hasTitle && (
+            <TooltipSeriesName theme={theme}>{seriesName}</TooltipSeriesName>
+          )}
+          {dataSeries.map(
+            ({name, data, color, groupIndex, styleOverride, isHidden}) => {
+              const item = data[tooltipData.activeIndex];
 
-            return (
-              <TooltipRow
-                activeIndex={-1}
-                color={color}
-                index={groupIndex}
-                isHidden={isHidden}
-                key={`row-${groupIndex}`}
-                label={name}
-                renderSeriesIcon={() => renderSeriesIcon(color, styleOverride)}
-                shape="Line"
-                value={formatters.valueFormatter(item.value ?? 0)}
-              />
-            );
-          },
-        )}
-      </Fragment>
-    );
-  });
+              return (
+                <TooltipRow
+                  activeIndex={activeColorVisionIndex}
+                  color={color}
+                  index={groupIndex}
+                  isHidden={isHidden}
+                  key={`row-${groupIndex}`}
+                  label={name}
+                  renderSeriesIcon={() =>
+                    renderSeriesIcon(color, styleOverride)
+                  }
+                  shape="Line"
+                  value={formatters.valueFormatter(item.value ?? 0)}
+                />
+              );
+            },
+          )}
+        </Fragment>
+      );
+    });
+  }
 
   return (
     <TooltipContentContainer maxWidth={300} theme={theme}>
-      {title != null && (
-        <TooltipTitle theme={theme}>
-          {formatters.titleFormatter(title)}
-        </TooltipTitle>
+      {({activeColorVisionIndex}) => (
+        <Fragment>
+          {title != null && (
+            <TooltipTitle theme={theme}>
+              {formatters.titleFormatter(title)}
+            </TooltipTitle>
+          )}
+          {renderContent({activeColorVisionIndex})}
+        </Fragment>
       )}
-      {content}
     </TooltipContentContainer>
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

The `renderLinearTooltipContent` component wasn't using the colorvision active states to highlight the different items. 

I've refactored the `<TooltipContentContainer />` to push the `activeIndex` so we only have to watch for events in a single place.

## What do the changes look like?

### Before

https://user-images.githubusercontent.com/149873/228330487-f5b382ae-b235-41ff-a78b-3f1fb04e5cac.mov

### After

https://user-images.githubusercontent.com/149873/228330531-28051f27-f6e3-49ab-be1c-e9e74cfdf124.mov
 
## Storybook link

### BarChart

https://6062ad4a2d14cd0021539c1b-lwydmnlqii.chromatic.com/?path=/story/polaris-viz-charts-barchart--default

### LineChart

https://6062ad4a2d14cd0021539c1b-lwydmnlqii.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--linear-comparison-tooltip

### LineChartRelational

https://6062ad4a2d14cd0021539c1b-lwydmnlqii.chromatic.com/?path=/story/polaris-viz-charts-linechartrelational--default
