### PR TITLE
Make LineSeries hit area smaller. Fade out RelatedAreas more

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -129,10 +129,12 @@ export function LineSeries({
     : data.width ?? selectedTheme.line.width;
   const strokeDasharray = data.strokeDasharray ?? 'none';
 
-  const PathHoverTargetSize = 40;
+  const PathHoverTargetSize = 15;
 
   const showPoint =
     -isSparkChart && !data.isComparison && lastLinePointCoordinates != null;
+  const showArea =
+    selectedTheme.line.hasArea && data?.styleOverride?.line?.hasArea !== false;
 
   const zeroLineY = yScale(0);
 
@@ -199,7 +201,7 @@ export function LineSeries({
           </Mask>
         </Defs>
 
-        {selectedTheme.line.hasArea &&
+        {showArea &&
           (dataIsValidForAnimation ? (
             <AnimatedArea
               areaGenerator={areaGenerator}

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -19,6 +19,7 @@ export interface DataSeries {
 
 interface StyleOverride {
   line?: {
+    hasArea?: boolean;
     width?: number;
     strokeDasharray?: string;
   };

--- a/packages/polaris-viz/src/components/LineChartRelational/components/Area/Area.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/Area/Area.tsx
@@ -55,7 +55,11 @@ export function Area({
       d={spring.pathD}
       fill={fill}
       style={{
-        ...getColorVisionStylesForActiveIndex({activeIndex, index}),
+        ...getColorVisionStylesForActiveIndex({
+          activeIndex,
+          index: -1,
+          fadedOpacity: 0.2,
+        }),
       }}
     />
   );

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
@@ -107,6 +107,11 @@ export const DEFAULT_DATA: DataSeries[] = [
       relatedIndex: 2,
       areaColor: 'rgba(103, 197, 228, 0.1)',
     },
+    styleOverride: {
+      line: {
+        hasArea: false,
+      },
+    },
   },
   {
     name: 'Median',
@@ -133,6 +138,7 @@ export const DEFAULT_DATA: DataSeries[] = [
     },
     styleOverride: {
       line: {
+        hasArea: false,
         strokeDasharray: '3 6',
       },
     },
@@ -156,5 +162,10 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(103, 197, 228, 1)',
+    styleOverride: {
+      line: {
+        hasArea: false,
+      },
+    },
   },
 ];


### PR DESCRIPTION
## What does this implement/fix?

We're making the hit area of lines a little smaller so they don't get jumbled up when lots of lines are close together.

We're also going to fade out all the related areas in `<LineChartRelational />` when hovering lines.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/53555
Resolves https://github.com/Shopify/core-issues/issues/53565

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/229833016-c8a27654-8a5e-4832-b2be-07857e8983bd.png)|![image](https://user-images.githubusercontent.com/149873/229833061-29893ef3-9f6b-40ca-8165-ff54cfd2c857.png)|
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-oiaxhtpomj.chromatic.com/?path=/story/polaris-viz-charts-linechartrelational--default&args=theme:Light

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
