### PR TITLE
Fix BarChart hover zones being too short

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue with `<BarChart />` hover zones being too short.
 
 ## [9.1.1] - 2023-04-12
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/BarGroup/BarGroup.tsx
@@ -222,7 +222,6 @@ export function BarGroup({
             barSize: height,
             zeroPosition: yScale(0),
             max: drawableHeight,
-            isNegative,
             position: 'vertical',
           });
 

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -110,7 +110,6 @@ export function HorizontalBars({
           zeroPosition: xScale(0),
           max: containerWidth - x,
           position: 'horizontal',
-          isNegative: value < 0,
         });
 
         return (

--- a/packages/polaris-viz/src/utilities/getHoverZoneOffset.ts
+++ b/packages/polaris-viz/src/utilities/getHoverZoneOffset.ts
@@ -7,20 +7,17 @@ export interface Props {
   zeroPosition: number;
   max: number;
   position: 'vertical' | 'horizontal';
-  isNegative: boolean;
 }
 
 export function getHoverZoneOffset({
   barSize,
   zeroPosition,
   max,
-  isNegative,
   position,
 }: Props) {
   let offset = HOVER_TARGET_ZONE;
   const chartMaxSize = max - zeroPosition;
   const chartNegativeMaxSize = max - chartMaxSize;
-  let clampedSize;
 
   if (position === 'horizontal') {
     if (barSize + offset >= chartMaxSize) {
@@ -30,19 +27,11 @@ export function getHoverZoneOffset({
     offset = chartNegativeMaxSize - barSize;
   }
 
-  if (isNegative) {
-    clampedSize = clamp({
-      amount: barSize + offset,
-      min: barSize,
-      max,
-    });
-  } else {
-    clampedSize = clamp({
-      amount: barSize + offset,
-      min: barSize,
-      max: max - zeroPosition,
-    });
-  }
+  const clampedSize = clamp({
+    amount: barSize + offset,
+    min: barSize,
+    max,
+  });
 
   return {clampedSize, offset};
 }

--- a/packages/polaris-viz/src/utilities/tests/getHoverZoneOffset.test.ts
+++ b/packages/polaris-viz/src/utilities/tests/getHoverZoneOffset.test.ts
@@ -6,7 +6,6 @@ const mockProps: Props = {
   zeroPosition: 0,
   max: 100,
   position: 'vertical',
-  isNegative: false,
 };
 
 const mockPropsHorizontal: Props = {
@@ -14,7 +13,6 @@ const mockPropsHorizontal: Props = {
   zeroPosition: 0,
   max: 125,
   position: 'horizontal',
-  isNegative: true,
 };
 
 describe('getHoverZoneOffset', () => {


### PR DESCRIPTION
## What does this implement/fix?

I noticed that the hover zones for `<BarChart />` were ignoring events at certain spots and it looks like the issue was we weren't sizing the zones correctly.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://user-images.githubusercontent.com/149873/231867540-d7c0026e-12cf-489c-a730-1fb5217964d8.png)|![image](https://user-images.githubusercontent.com/149873/231867029-204212f6-291c-439f-a435-750169cb3c74.png)|

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
