### PR TITLE
Allow MissingDataArea to render anywhere on the chart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Allow `<MissingDataArea />` to render wherever values are `null` instead of at the end of the chart.
+
 ### Fixed
 
 - Fixed issue with `<BarChart />` hover zones being too short.

--- a/packages/polaris-viz/src/components/LineChartRelational/components/MissingDataArea/tests/MissingDataArea.test.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/MissingDataArea/tests/MissingDataArea.test.tsx
@@ -10,35 +10,44 @@ const MOCK_PROPS: Props = {
       name: 'Apr 1 – Apr 14, 2020',
       data: [
         {value: 333, key: '2020-04-01T12:00:00'},
-        {value: 797, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-02T12:00:00'},
         {value: 234, key: '2020-04-03T12:00:00'},
-        {value: 534, key: '2020-04-04T12:00:00'},
+        {value: 333, key: '2020-04-04T12:00:00'},
+        {value: 333, key: '2020-04-05T12:00:00'},
       ],
     },
     {
       name: '75th Percentile',
       data: [
         {value: 333, key: '2020-04-01T12:00:00'},
-        {value: 797, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-03T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
       ],
     },
     {
       name: 'Similar stores median',
       data: [
         {value: 333, key: '2020-04-01T12:00:00'},
-        {value: 797, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-03T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
       ],
     },
     {
       name: '25th percentile',
       data: [
         {value: 333, key: '2020-04-01T12:00:00'},
-        {value: 797, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-02T12:00:00'},
+        {value: 333, key: '2020-04-03T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
       ],
     },
   ],
   drawableHeight: 200,
-  drawableWidth: 600,
   xScale: scaleLinear(),
 };
 
@@ -50,10 +59,13 @@ describe('<MissingDataArea />', () => {
       </svg>,
     );
 
-    expect(chart).toContainReactComponent('rect');
+    expect(chart).toContainReactComponent('rect', {
+      x: 2,
+      width: 2,
+    });
   });
 
-  it('renders nothing when data series have same length', () => {
+  it('renders nothing when data has no nulls', () => {
     const chart = mount(
       <svg>
         <MissingDataArea
@@ -63,20 +75,29 @@ describe('<MissingDataArea />', () => {
               name: 'Apr 1 – Apr 14, 2020',
               data: [
                 {value: 333, key: '2020-04-01T12:00:00'},
-                {value: 797, key: '2020-04-02T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
               ],
             },
             {
               name: '75th Percentile',
-              data: [],
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+              ],
             },
             {
               name: 'Similar stores median',
-              data: [],
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+              ],
             },
             {
               name: '25th percentile',
-              data: [],
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+              ],
             },
           ]}
         />
@@ -84,5 +105,129 @@ describe('<MissingDataArea />', () => {
     );
 
     expect(chart).not.toContainReactComponent('rect');
+  });
+
+  it('renders area at the start of the chart', () => {
+    const chart = mount(
+      <svg>
+        <MissingDataArea
+          {...MOCK_PROPS}
+          data={[
+            {
+              name: 'Apr 1 – Apr 14, 2020',
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+                {value: 333, key: '2020-04-03T12:00:00'},
+                {value: 333, key: '2020-04-04T12:00:00'},
+                {value: 333, key: '2020-04-05T12:00:00'},
+              ],
+            },
+            {
+              name: '75th Percentile',
+              data: [
+                {value: null, key: '2020-04-01T12:00:00'},
+                {value: null, key: '2020-04-02T12:00:00'},
+                {value: null, key: '2020-04-03T12:00:00'},
+                {value: 333, key: '2020-04-04T12:00:00'},
+                {value: 333, key: '2020-04-05T12:00:00'},
+              ],
+            },
+          ]}
+        />
+      </svg>,
+    );
+
+    expect(chart).toContainReactComponent('rect', {
+      x: 0,
+      width: 3,
+    });
+  });
+
+  it('renders areas in the middle of the chart', () => {
+    const chart = mount(
+      <svg>
+        <MissingDataArea
+          {...MOCK_PROPS}
+          data={[
+            {
+              name: 'Apr 1 – Apr 14, 2020',
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+                {value: 333, key: '2020-04-03T12:00:00'},
+                {value: 333, key: '2020-04-04T12:00:00'},
+                {value: 333, key: '2020-04-05T12:00:00'},
+                {value: 333, key: '2020-04-06T12:00:00'},
+                {value: 333, key: '2020-04-07T12:00:00'},
+                {value: 333, key: '2020-04-08T12:00:00'},
+                {value: 333, key: '2020-04-09T12:00:00'},
+              ],
+            },
+            {
+              name: '75th Percentile',
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+                {value: 333, key: '2020-04-03T12:00:00'},
+                {value: null, key: '2020-04-04T12:00:00'},
+                {value: null, key: '2020-04-05T12:00:00'},
+                {value: null, key: '2020-04-06T12:00:00'},
+                {value: 333, key: '2020-04-07T12:00:00'},
+                {value: 333, key: '2020-04-08T12:00:00'},
+                {value: 333, key: '2020-04-09T12:00:00'},
+              ],
+            },
+          ]}
+        />
+      </svg>,
+    );
+
+    expect(chart).toContainReactComponent('rect', {
+      x: 2,
+      width: 4,
+    });
+  });
+
+  it('renders areas at random areas', () => {
+    const chart = mount(
+      <svg>
+        <MissingDataArea
+          {...MOCK_PROPS}
+          data={[
+            {
+              name: 'Apr 1 – Apr 14, 2020',
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: 333, key: '2020-04-02T12:00:00'},
+                {value: 333, key: '2020-04-03T12:00:00'},
+                {value: 333, key: '2020-04-04T12:00:00'},
+                {value: 333, key: '2020-04-05T12:00:00'},
+                {value: 333, key: '2020-04-06T12:00:00'},
+                {value: 333, key: '2020-04-07T12:00:00'},
+                {value: 333, key: '2020-04-08T12:00:00'},
+                {value: 333, key: '2020-04-09T12:00:00'},
+              ],
+            },
+            {
+              name: '75th Percentile',
+              data: [
+                {value: 333, key: '2020-04-01T12:00:00'},
+                {value: null, key: '2020-04-02T12:00:00'},
+                {value: null, key: '2020-04-03T12:00:00'},
+                {value: 333, key: '2020-04-04T12:00:00'},
+                {value: 333, key: '2020-04-05T12:00:00'},
+                {value: 333, key: '2020-04-06T12:00:00'},
+                {value: null, key: '2020-04-07T12:00:00'},
+                {value: null, key: '2020-04-08T12:00:00'},
+                {value: 333, key: '2020-04-09T12:00:00'},
+              ],
+            },
+          ]}
+        />
+      </svg>,
+    );
+
+    expect(chart).toContainReactComponentTimes('rect', 2);
   });
 });

--- a/packages/polaris-viz/src/components/LineChartRelational/components/MissingDataArea/utilities/groupNumbersIntoRuns.ts
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/MissingDataArea/utilities/groupNumbersIntoRuns.ts
@@ -1,0 +1,17 @@
+export function groupNumbersIntoRuns(indexes) {
+  const runs: number[][] = [];
+  let current: number[] = [];
+
+  indexes.forEach((value, index) => {
+    if (index === 0 || value - indexes[index - 1] === 1) {
+      current.push(value);
+    } else {
+      runs.push(current);
+      current = [value];
+    }
+  });
+
+  runs.push(current);
+
+  return runs;
+}

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/MissingData.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/MissingData.chromatic.stories.tsx
@@ -1,0 +1,52 @@
+import type {Story} from '@storybook/react';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/LineChartRelational',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+import {DEFAULT_PROPS, Template} from '../data';
+import type {LineChartProps} from 'components/LineChart/LineChart';
+import {MISSING_END_DATA} from './data/missing-end-data';
+
+import {MISSING_START_DATA} from './data/missing-start-data';
+import {MISSING_MIDDLE_DATA} from './data/missing-middle-data';
+import {MISSING_RANDOM_DATA} from './data/missing-random-data';
+
+const PROPS = {
+  ...DEFAULT_PROPS,
+  isAnimated: false,
+};
+
+export const MissingEndData: Story<LineChartProps> = Template.bind({});
+
+MissingEndData.args = {
+  ...PROPS,
+  data: MISSING_END_DATA,
+};
+
+export const MissingStartData: Story<LineChartProps> = Template.bind({});
+
+MissingStartData.args = {
+  ...PROPS,
+  data: MISSING_START_DATA,
+};
+
+export const MissingMiddleData: Story<LineChartProps> = Template.bind({});
+
+MissingMiddleData.args = {
+  ...PROPS,
+  data: MISSING_MIDDLE_DATA,
+};
+
+export const MissingRandomData: Story<LineChartProps> = Template.bind({});
+
+MissingRandomData.args = {
+  ...PROPS,
+  data: MISSING_RANDOM_DATA,
+};

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-end-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-end-data.js
@@ -1,67 +1,4 @@
-import type {Story} from '@storybook/react';
-import type {RenderTooltipContentData} from 'types';
-import type {DataSeries} from '@shopify/polaris-viz-core';
-import type {LineChartProps} from 'components/LineChart/LineChart';
-
-import {LineChartRelational} from '../LineChartRelational';
-import {
-  formatLinearXAxisLabel,
-  formatLinearYAxisLabel,
-} from '../../../storybook/utilities';
-import {renderLinearTooltipContent} from '../../../utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${formatLinearYAxisLabel(
-            Number(value!),
-          )}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
-
-export const Template: Story<LineChartProps> = (args: LineChartProps) => {
-  return <LineChartRelational {...args} />;
-};
-
-export const DEFAULT_PROPS: Partial<LineChartProps> = {
-  xAxisOptions: {
-    labelFormatter: formatLinearXAxisLabel,
-  },
-  yAxisOptions: {labelFormatter: formatLinearYAxisLabel},
-  tooltipOptions: {
-    titleFormatter: (value) => new Date(value!).toLocaleDateString(),
-    valueFormatter: formatLinearYAxisLabel,
-    renderTooltipContent: (tooltipData) => {
-      return renderLinearTooltipContent(tooltipData, {
-        title: tooltipData.title,
-        groups: [
-          {title: 'Your store', indexes: [0]},
-          {title: 'Similar stores', indexes: [1, 2, 3]},
-        ],
-      });
-    },
-  },
-  showLegend: false,
-};
-
-export const DEFAULT_DATA: DataSeries[] = [
+export const MISSING_END_DATA = [
   {
     name: 'Average',
     data: [
@@ -98,10 +35,10 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 162, key: '2020-03-08T12:00:00'},
       {value: 540, key: '2020-03-09T12:00:00'},
       {value: 193, key: '2020-03-10T12:00:00'},
-      {value: 860, key: '2020-03-11T12:00:00'},
-      {value: 941, key: '2020-03-12T12:00:00'},
-      {value: 773, key: '2020-03-13T12:00:00'},
-      {value: 171, key: '2020-03-14T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-12T12:00:00'},
+      {value: null, key: '2020-03-13T12:00:00'},
+      {value: null, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(103, 197, 228, 1)',
     metadata: {
@@ -127,10 +64,10 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 12, key: '2020-03-08T12:00:00'},
       {value: 390, key: '2020-03-09T12:00:00'},
       {value: 43, key: '2020-03-10T12:00:00'},
-      {value: 710, key: '2020-03-11T12:00:00'},
-      {value: 791, key: '2020-03-12T12:00:00'},
-      {value: 623, key: '2020-03-13T12:00:00'},
-      {value: 21, key: '2020-03-14T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-12T12:00:00'},
+      {value: null, key: '2020-03-13T12:00:00'},
+      {value: null, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(40, 106, 123, 1)',
     metadata: {
@@ -157,10 +94,10 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 0, key: '2020-03-08T12:00:00'},
       {value: 240, key: '2020-03-09T12:00:00'},
       {value: 0, key: '2020-03-10T12:00:00'},
-      {value: 540, key: '2020-03-11T12:00:00'},
-      {value: 641, key: '2020-03-12T12:00:00'},
-      {value: 473, key: '2020-03-13T12:00:00'},
-      {value: 0, key: '2020-03-14T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-12T12:00:00'},
+      {value: null, key: '2020-03-13T12:00:00'},
+      {value: null, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(103, 197, 228, 1)',
     styleOverride: {

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-middle-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-middle-data.js
@@ -1,67 +1,4 @@
-import type {Story} from '@storybook/react';
-import type {RenderTooltipContentData} from 'types';
-import type {DataSeries} from '@shopify/polaris-viz-core';
-import type {LineChartProps} from 'components/LineChart/LineChart';
-
-import {LineChartRelational} from '../LineChartRelational';
-import {
-  formatLinearXAxisLabel,
-  formatLinearYAxisLabel,
-} from '../../../storybook/utilities';
-import {renderLinearTooltipContent} from '../../../utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${formatLinearYAxisLabel(
-            Number(value!),
-          )}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
-
-export const Template: Story<LineChartProps> = (args: LineChartProps) => {
-  return <LineChartRelational {...args} />;
-};
-
-export const DEFAULT_PROPS: Partial<LineChartProps> = {
-  xAxisOptions: {
-    labelFormatter: formatLinearXAxisLabel,
-  },
-  yAxisOptions: {labelFormatter: formatLinearYAxisLabel},
-  tooltipOptions: {
-    titleFormatter: (value) => new Date(value!).toLocaleDateString(),
-    valueFormatter: formatLinearYAxisLabel,
-    renderTooltipContent: (tooltipData) => {
-      return renderLinearTooltipContent(tooltipData, {
-        title: tooltipData.title,
-        groups: [
-          {title: 'Your store', indexes: [0]},
-          {title: 'Similar stores', indexes: [1, 2, 3]},
-        ],
-      });
-    },
-  },
-  showLegend: false,
-};
-
-export const DEFAULT_DATA: DataSeries[] = [
+export const MISSING_MIDDLE_DATA = [
   {
     name: 'Average',
     data: [
@@ -93,9 +30,9 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 340, key: '2020-03-03T12:00:00'},
       {value: 240, key: '2020-03-04T12:00:00'},
       {value: 387, key: '2020-03-05T12:00:00'},
-      {value: 760, key: '2020-03-07T12:00:00'},
-      {value: 122, key: '2020-03-06T12:00:00'},
-      {value: 162, key: '2020-03-08T12:00:00'},
+      {value: null, key: '2020-03-07T12:00:00'},
+      {value: null, key: '2020-03-06T12:00:00'},
+      {value: null, key: '2020-03-08T12:00:00'},
       {value: 540, key: '2020-03-09T12:00:00'},
       {value: 193, key: '2020-03-10T12:00:00'},
       {value: 860, key: '2020-03-11T12:00:00'},
@@ -122,9 +59,9 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 190, key: '2020-03-03T12:00:00'},
       {value: 90, key: '2020-03-04T12:00:00'},
       {value: 237, key: '2020-03-05T12:00:00'},
-      {value: 580, key: '2020-03-07T12:00:00'},
-      {value: 172, key: '2020-03-06T12:00:00'},
-      {value: 12, key: '2020-03-08T12:00:00'},
+      {value: null, key: '2020-03-07T12:00:00'},
+      {value: null, key: '2020-03-06T12:00:00'},
+      {value: null, key: '2020-03-08T12:00:00'},
       {value: 390, key: '2020-03-09T12:00:00'},
       {value: 43, key: '2020-03-10T12:00:00'},
       {value: 710, key: '2020-03-11T12:00:00'},
@@ -152,9 +89,9 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 40, key: '2020-03-03T12:00:00'},
       {value: 0, key: '2020-03-04T12:00:00'},
       {value: 87, key: '2020-03-05T12:00:00'},
-      {value: 430, key: '2020-03-07T12:00:00'},
-      {value: 22, key: '2020-03-06T12:00:00'},
-      {value: 0, key: '2020-03-08T12:00:00'},
+      {value: null, key: '2020-03-07T12:00:00'},
+      {value: null, key: '2020-03-06T12:00:00'},
+      {value: null, key: '2020-03-08T12:00:00'},
       {value: 240, key: '2020-03-09T12:00:00'},
       {value: 0, key: '2020-03-10T12:00:00'},
       {value: 540, key: '2020-03-11T12:00:00'},

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-random-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-random-data.js
@@ -1,67 +1,4 @@
-import type {Story} from '@storybook/react';
-import type {RenderTooltipContentData} from 'types';
-import type {DataSeries} from '@shopify/polaris-viz-core';
-import type {LineChartProps} from 'components/LineChart/LineChart';
-
-import {LineChartRelational} from '../LineChartRelational';
-import {
-  formatLinearXAxisLabel,
-  formatLinearYAxisLabel,
-} from '../../../storybook/utilities';
-import {renderLinearTooltipContent} from '../../../utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${formatLinearYAxisLabel(
-            Number(value!),
-          )}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
-
-export const Template: Story<LineChartProps> = (args: LineChartProps) => {
-  return <LineChartRelational {...args} />;
-};
-
-export const DEFAULT_PROPS: Partial<LineChartProps> = {
-  xAxisOptions: {
-    labelFormatter: formatLinearXAxisLabel,
-  },
-  yAxisOptions: {labelFormatter: formatLinearYAxisLabel},
-  tooltipOptions: {
-    titleFormatter: (value) => new Date(value!).toLocaleDateString(),
-    valueFormatter: formatLinearYAxisLabel,
-    renderTooltipContent: (tooltipData) => {
-      return renderLinearTooltipContent(tooltipData, {
-        title: tooltipData.title,
-        groups: [
-          {title: 'Your store', indexes: [0]},
-          {title: 'Similar stores', indexes: [1, 2, 3]},
-        ],
-      });
-    },
-  },
-  showLegend: false,
-};
-
-export const DEFAULT_DATA: DataSeries[] = [
+export const MISSING_RANDOM_DATA = [
   {
     name: 'Average',
     data: [
@@ -90,15 +27,15 @@ export const DEFAULT_DATA: DataSeries[] = [
     data: [
       {value: 859, key: '2020-03-02T12:00:00'},
       {value: 388, key: '2020-03-01T12:00:00'},
-      {value: 340, key: '2020-03-03T12:00:00'},
-      {value: 240, key: '2020-03-04T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-04T12:00:00'},
       {value: 387, key: '2020-03-05T12:00:00'},
       {value: 760, key: '2020-03-07T12:00:00'},
       {value: 122, key: '2020-03-06T12:00:00'},
       {value: 162, key: '2020-03-08T12:00:00'},
       {value: 540, key: '2020-03-09T12:00:00'},
       {value: 193, key: '2020-03-10T12:00:00'},
-      {value: 860, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
       {value: 941, key: '2020-03-12T12:00:00'},
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
@@ -119,15 +56,15 @@ export const DEFAULT_DATA: DataSeries[] = [
     data: [
       {value: 759, key: '2020-03-02T12:00:00'},
       {value: 238, key: '2020-03-01T12:00:00'},
-      {value: 190, key: '2020-03-03T12:00:00'},
-      {value: 90, key: '2020-03-04T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-04T12:00:00'},
       {value: 237, key: '2020-03-05T12:00:00'},
       {value: 580, key: '2020-03-07T12:00:00'},
       {value: 172, key: '2020-03-06T12:00:00'},
       {value: 12, key: '2020-03-08T12:00:00'},
       {value: 390, key: '2020-03-09T12:00:00'},
       {value: 43, key: '2020-03-10T12:00:00'},
-      {value: 710, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
       {value: 791, key: '2020-03-12T12:00:00'},
       {value: 623, key: '2020-03-13T12:00:00'},
       {value: 21, key: '2020-03-14T12:00:00'},
@@ -149,15 +86,15 @@ export const DEFAULT_DATA: DataSeries[] = [
     data: [
       {value: 559, key: '2020-03-02T12:00:00'},
       {value: 88, key: '2020-03-01T12:00:00'},
-      {value: 40, key: '2020-03-03T12:00:00'},
-      {value: 0, key: '2020-03-04T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-04T12:00:00'},
       {value: 87, key: '2020-03-05T12:00:00'},
       {value: 430, key: '2020-03-07T12:00:00'},
       {value: 22, key: '2020-03-06T12:00:00'},
       {value: 0, key: '2020-03-08T12:00:00'},
       {value: 240, key: '2020-03-09T12:00:00'},
       {value: 0, key: '2020-03-10T12:00:00'},
-      {value: 540, key: '2020-03-11T12:00:00'},
+      {value: null, key: '2020-03-11T12:00:00'},
       {value: 641, key: '2020-03-12T12:00:00'},
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-start-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-start-data.js
@@ -1,16 +1,6 @@
-import type {Story} from '@storybook/react';
-
-export {META as default} from './meta';
-
-import {DEFAULT_PROPS, Template} from './data';
-import type {LineChartProps} from 'components/LineChart/LineChart';
-import type {DataSeries} from '@shopify/polaris-viz-core';
-
-export const MissingData: Story<LineChartProps> = Template.bind({});
-
-const DATA: DataSeries[] = [
+export const MISSING_START_DATA = [
   {
-    name: 'Apr 1 – Apr 14, 2020',
+    name: 'Average',
     data: [
       {value: 333, key: '2020-04-01T12:00:00'},
       {value: 797, key: '2020-04-02T12:00:00'},
@@ -24,25 +14,20 @@ const DATA: DataSeries[] = [
       {value: 645, key: '2020-04-10T12:00:00'},
       {value: 543, key: '2020-04-11T12:00:00'},
       {value: 89, key: '2020-04-12T12:00:00'},
-      {value: 1000, key: '2020-04-13T12:00:00'},
+      {value: 849, key: '2020-04-13T12:00:00'},
       {value: 129, key: '2020-04-14T12:00:00'},
     ],
     color: [
-      {offset: 0, color: '#986BFF'},
-      {offset: 100, color: '#3AA4F6'},
+      {offset: 0, color: 'rgba(149, 101, 255, 1)'},
+      {offset: 100, color: 'rgba(75, 146, 229, 1)'},
     ],
-    styleOverride: {
-      line: {
-        width: 3,
-      },
-    },
   },
   {
     name: '75th Percentile',
     data: [
-      {value: 859, key: '2020-03-02T12:00:00'},
-      {value: 388, key: '2020-03-01T12:00:00'},
-      {value: 340, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-02T12:00:00'},
+      {value: null, key: '2020-03-01T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
       {value: 240, key: '2020-03-04T12:00:00'},
       {value: 387, key: '2020-03-05T12:00:00'},
       {value: 760, key: '2020-03-07T12:00:00'},
@@ -51,20 +36,27 @@ const DATA: DataSeries[] = [
       {value: 540, key: '2020-03-09T12:00:00'},
       {value: 193, key: '2020-03-10T12:00:00'},
       {value: 860, key: '2020-03-11T12:00:00'},
+      {value: 941, key: '2020-03-12T12:00:00'},
+      {value: 773, key: '2020-03-13T12:00:00'},
+      {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: '#9EDAEF',
+    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
-      areaColor: '#C8E7F4',
-      shape: 'Bar',
+      areaColor: 'rgba(103, 197, 228, 0.1)',
+    },
+    styleOverride: {
+      line: {
+        hasArea: false,
+      },
     },
   },
   {
-    name: 'Similar stores median',
+    name: 'Median',
     data: [
-      {value: 759, key: '2020-03-02T12:00:00'},
-      {value: 238, key: '2020-03-01T12:00:00'},
-      {value: 190, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-02T12:00:00'},
+      {value: null, key: '2020-03-01T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
       {value: 90, key: '2020-03-04T12:00:00'},
       {value: 237, key: '2020-03-05T12:00:00'},
       {value: 580, key: '2020-03-07T12:00:00'},
@@ -73,25 +65,28 @@ const DATA: DataSeries[] = [
       {value: 390, key: '2020-03-09T12:00:00'},
       {value: 43, key: '2020-03-10T12:00:00'},
       {value: 710, key: '2020-03-11T12:00:00'},
+      {value: 791, key: '2020-03-12T12:00:00'},
+      {value: 623, key: '2020-03-13T12:00:00'},
+      {value: 21, key: '2020-03-14T12:00:00'},
     ],
-    color: '#286A7B',
+    color: 'rgba(40, 106, 123, 1)',
     metadata: {
       relatedIndex: 3,
-      areaColor: '#F0F8FB',
+      areaColor: 'rgba(47, 175, 218, 0.2)',
     },
     styleOverride: {
       line: {
+        hasArea: false,
         strokeDasharray: '3 6',
-        width: 3,
       },
     },
   },
   {
     name: '25th percentile',
     data: [
-      {value: 559, key: '2020-03-02T12:00:00'},
-      {value: 88, key: '2020-03-01T12:00:00'},
-      {value: 40, key: '2020-03-03T12:00:00'},
+      {value: null, key: '2020-03-02T12:00:00'},
+      {value: null, key: '2020-03-01T12:00:00'},
+      {value: null, key: '2020-03-03T12:00:00'},
       {value: 0, key: '2020-03-04T12:00:00'},
       {value: 87, key: '2020-03-05T12:00:00'},
       {value: 430, key: '2020-03-07T12:00:00'},
@@ -100,16 +95,15 @@ const DATA: DataSeries[] = [
       {value: 240, key: '2020-03-09T12:00:00'},
       {value: 0, key: '2020-03-10T12:00:00'},
       {value: 540, key: '2020-03-11T12:00:00'},
+      {value: 641, key: '2020-03-12T12:00:00'},
+      {value: 473, key: '2020-03-13T12:00:00'},
+      {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: '#E0F1F8',
-    metadata: {
-      shape: 'Bar',
+    color: 'rgba(103, 197, 228, 1)',
+    styleOverride: {
+      line: {
+        hasArea: false,
+      },
     },
   },
 ];
-
-MissingData.args = {
-  ...DEFAULT_PROPS,
-  data: DATA,
-  isAnimated: false,
-};

--- a/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
@@ -83,7 +83,7 @@ export function renderLinearTooltipContent(
             ...tooltipData.dataSeries[groupIndex],
             color: rawDataSeries.color,
             groupIndex,
-            isHidden: rawDataSeries.isHidden,
+            isHidden: rawDataSeries.value == null || rawDataSeries.isHidden,
           };
         })
         .filter((series): series is TooltipDataSeries => Boolean(series));


### PR DESCRIPTION
## What does this implement/fix?

It was assumed that the missing data for benchmarks would always be at the end of the chart, but that was wrong.

We want t be able to render the diagonal lines wherever the data is actually missing, instead of assuming the end.

### Data change needed for web

Currently in web [we are stripping `null` values from benchmarks](https://github.com/Shopify/web/blob/93d1c4f64612b5c02447bc2c95624c7a8e32d98b/app/sections/Analytics/ReportViewer/components/ReportViewer/components/Chart/components/LineChartRelational/LineChartRelational.tsx#L43), which originally resulted in arrays with different lengths. We don't want to do this anymore because it's also positioning the benchmark lines always at the beginning of the chart.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/54090
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-kqtjsvzndv.chromatic.com/?path=/story/polaris-viz-chromatic-charts-linechartrelational--missing-end-data

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [x] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
