### PR TITLE
Inline TrendIndicators

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added `metadata.trends[]` to `SimpleBarChartProps` to allow `<TrendIndicator />`'s to render inline.
+
 ### Fixed
 
 - Fix ErrorText positioning in ChartSkeleton.

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -6,7 +6,6 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {
   ChartType,
-  DataSeries,
   Dimensions,
   XAxisOptions,
   YAxisOptions,
@@ -28,8 +27,10 @@ import {
 } from '../../hooks';
 import type {RenderLegendContent} from '../../types';
 
+import type {SimpleBarChartDataSeries} from './types';
+
 export interface ChartProps {
-  data: DataSeries[];
+  data: SimpleBarChartDataSeries[];
   showLegend: boolean;
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -14,8 +14,10 @@ import {ChartSkeleton} from '../../components';
 import type {RenderLegendContent} from '../../types';
 
 import {Chart} from './Chart';
+import type {SimpleBarChartDataSeries} from './types';
 
 export type SimpleBarChartProps = {
+  data: SimpleBarChartDataSeries[];
   renderLegendContent?: RenderLegendContent;
   showLegend?: boolean;
   type?: ChartType;

--- a/packages/polaris-viz/src/components/SimpleBarChart/index.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/index.ts
@@ -1,2 +1,3 @@
 export {SimpleBarChart} from './SimpleBarChart';
 export type {SimpleBarChartProps} from './SimpleBarChart';
+export type {MetaDataTrendIndicator} from './types';

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/MultipleTrendIndicators.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/MultipleTrendIndicators.stories.tsx
@@ -1,0 +1,116 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleBarChartProps} from '../../../components';
+
+import {Template} from './data';
+
+export const MultipleTrendIndicators: Story<SimpleBarChartProps> =
+  Template.bind({});
+
+MultipleTrendIndicators.args = {
+  data: [
+    {
+      name: 'BCFM 2019',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: -3,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 0,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 4,
+        },
+        {
+          key: 'Socks',
+          value: -8,
+        },
+        {
+          key: 'Hats',
+          value: 48,
+        },
+        {
+          key: 'Ties',
+          value: 1,
+        },
+      ],
+      metadata: {
+        trends: {
+          '0': {
+            value: '10%',
+          },
+        },
+      },
+    },
+    {
+      name: 'BCFM 2020',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 4,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 0,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 5,
+        },
+        {
+          key: 'Socks',
+          value: 15,
+        },
+        {
+          key: 'Hats',
+          value: 8,
+        },
+        {
+          key: 'Ties',
+          value: 5,
+        },
+      ],
+      metadata: {
+        trends: {
+          '0': {
+            value: '20%',
+          },
+        },
+      },
+    },
+    {
+      name: 'BCFM 2021',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 7,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 0,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 6,
+        },
+        {
+          key: 'Socks',
+          value: 12,
+        },
+        {
+          key: 'Hats',
+          value: 50,
+        },
+        {
+          key: 'Ties',
+          value: 5,
+        },
+      ],
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
@@ -1,0 +1,36 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleBarChartProps} from '../../../components';
+
+import {SINGLE_SERIES, Template} from './data';
+
+export const WithTrendIndicators: Story<SimpleBarChartProps> = Template.bind(
+  {},
+);
+
+WithTrendIndicators.args = {
+  data: [
+    {
+      ...SINGLE_SERIES[0],
+      metadata: {
+        trends: {
+          2: {
+            value: '10%',
+          },
+          4: {
+            value: '10%',
+            direction: 'downward',
+            trend: 'negative',
+          },
+          5: {
+            value: '10%',
+            direction: 'upward',
+            trend: 'positive',
+          },
+        },
+      },
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/data.tsx
@@ -46,6 +46,13 @@ export function buildSeries(
     return {
       name,
       data: data.filter(Boolean) as DataPoint[],
+      metadata: {
+        trends: {
+          0: {
+            value: '10%',
+          },
+        },
+      },
     };
   });
 }

--- a/packages/polaris-viz/src/components/SimpleBarChart/types.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/types.ts
@@ -1,0 +1,13 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import type {TrendIndicatorProps} from '../TrendIndicator';
+
+export type MetaDataTrendIndicator = Omit<TrendIndicatorProps, 'theme'>;
+
+export interface MetaData {
+  trends?: {[key: number]: MetaDataTrendIndicator};
+}
+
+export interface SimpleBarChartDataSeries extends DataSeries {
+  metadata?: MetaData;
+}

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -1,9 +1,18 @@
 import {useTheme} from '@shopify/polaris-viz-core';
 
-import {estimateStringWidthWithOffset} from '../../utilities';
 import type {Trend, TrendDirection} from '../../types';
 
 import {ArrowDown, ArrowUp, Svg} from './components/';
+import {estimateTrendIndicatorWidth} from './utilities/estimateTrendIndicatorWidth';
+import {
+  NO_VALUE_WIDTH,
+  NO_VALUE_ICON_HEIGHT,
+  TEXT_ICON_SPACING,
+  ICON_SIZE,
+  FONT_SIZE,
+  HEIGHT,
+  Y_OFFSET,
+} from './constants';
 
 export interface TrendIndicatorProps {
   accessibilityLabel?: string;
@@ -12,19 +21,6 @@ export interface TrendIndicatorProps {
   trend?: Trend;
   value?: string;
 }
-
-const NO_VALUE_WIDTH = 11;
-const NO_VALUE_ICON_HEIGHT = 2;
-
-const TEXT_ICON_SPACING = 4;
-const ICON_SIZE = 5.5;
-
-const FONT_SIZE = 12;
-const FONT_WEIGHT = 600;
-
-const HEIGHT = 16;
-
-const Y_OFFSET = 3;
 
 export function TrendIndicator({
   accessibilityLabel,
@@ -53,12 +49,7 @@ export function TrendIndicator({
     );
   }
 
-  const textWidth = estimateStringWidthWithOffset(
-    value,
-    FONT_SIZE,
-    FONT_WEIGHT,
-  );
-  const totalWidth = Math.round(ICON_SIZE + TEXT_ICON_SPACING + textWidth);
+  const {textWidth, totalWidth} = estimateTrendIndicatorWidth(value);
 
   return (
     <Svg

--- a/packages/polaris-viz/src/components/TrendIndicator/constants.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/constants.ts
@@ -1,0 +1,12 @@
+export const NO_VALUE_WIDTH = 11;
+export const NO_VALUE_ICON_HEIGHT = 2;
+
+export const TEXT_ICON_SPACING = 4;
+export const ICON_SIZE = 5.5;
+
+export const FONT_SIZE = 12;
+export const FONT_WEIGHT = 600;
+
+export const HEIGHT = 16;
+
+export const Y_OFFSET = 3;

--- a/packages/polaris-viz/src/components/TrendIndicator/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/index.ts
@@ -1,2 +1,4 @@
 export {TrendIndicator} from './TrendIndicator';
 export type {TrendIndicatorProps} from './TrendIndicator';
+export {estimateTrendIndicatorWidth} from './utilities/estimateTrendIndicatorWidth';
+export {HEIGHT as TREND_INDICATOR_HEIGHT} from './constants';

--- a/packages/polaris-viz/src/components/TrendIndicator/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/stories/meta.tsx
@@ -1,10 +1,11 @@
 import type {Meta} from '@storybook/react';
 
+import type {TrendIndicatorProps} from '../';
 import {TrendIndicator} from '../';
 import {CONTROLS_ARGS, THEME_CONTROL_ARGS} from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 
-export const META: Meta = {
+export const META: Meta<TrendIndicatorProps> = {
   title: 'polaris-viz/Subcomponents/TrendIndicator',
   component: TrendIndicator,
   parameters: {
@@ -24,10 +25,6 @@ export const META: Meta = {
     direction: {
       description: 'Set the direction of the trend arrow.',
       options: ['upward', 'downward'],
-    },
-    size: {
-      description: 'Set the visual size of the component.',
-      options: ['default', 'small'],
     },
     theme: THEME_CONTROL_ARGS,
     trend: {

--- a/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
@@ -1,0 +1,18 @@
+import {estimateStringWidthWithOffset} from '../../../utilities';
+import {
+  FONT_SIZE,
+  FONT_WEIGHT,
+  ICON_SIZE,
+  TEXT_ICON_SPACING,
+} from '../constants';
+
+export function estimateTrendIndicatorWidth(value) {
+  const textWidth = estimateStringWidthWithOffset(
+    value,
+    FONT_SIZE,
+    FONT_WEIGHT,
+  );
+  const totalWidth = Math.round(ICON_SIZE + TEXT_ICON_SPACING + textWidth);
+
+  return {totalWidth, textWidth};
+}

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
@@ -1,6 +1,3 @@
-import {animated, useSpring} from '@react-spring/web';
-
-import {useBarSpringConfig} from '../../../../../hooks/useBarSpringConfig';
 import {HORIZONTAL_BAR_LABEL_HEIGHT, FONT_SIZE} from '../../../../../constants';
 
 export interface LabelProps {
@@ -8,56 +5,29 @@ export interface LabelProps {
   color: string;
   label: string;
   labelWidth: number;
-  x: number;
   y: number;
-  animationDelay?: number;
 }
 
-export function Label({
-  animationDelay,
-  barHeight,
-  color,
-  label,
-  labelWidth,
-  x,
-  y,
-}: LabelProps) {
+export function Label({barHeight, color, label, labelWidth, y}: LabelProps) {
   const labelYOffset = (barHeight - HORIZONTAL_BAR_LABEL_HEIGHT) / 2;
 
-  const springConfig = useBarSpringConfig({animationDelay});
-
-  const spring = useSpring({
-    from: {transform: 'translateX(0px)', opacity: 0},
-    to: {opacity: 1, transform: `translateX(${x}px)`},
-    ...springConfig,
-  });
-
   return (
-    // animating the foreignObject does not work on Safari,
-    // so we need to use a g instead
-    <animated.g
-      style={{
-        opacity: spring.opacity,
-        transform: spring.transform,
-      }}
+    <foreignObject
+      height={FONT_SIZE}
+      width={labelWidth}
+      aria-hidden="true"
+      y={y + labelYOffset}
     >
-      <foreignObject
-        height={FONT_SIZE}
-        width={labelWidth}
-        aria-hidden="true"
-        y={y + labelYOffset}
+      <div
+        style={{
+          fontSize: `${FONT_SIZE}px`,
+          color,
+          lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
+          height: HORIZONTAL_BAR_LABEL_HEIGHT,
+        }}
       >
-        <div
-          style={{
-            fontSize: `${FONT_SIZE}px`,
-            color,
-            lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-            height: HORIZONTAL_BAR_LABEL_HEIGHT,
-          }}
-        >
-          {label}
-        </div>
-      </foreignObject>
-    </animated.g>
+        {label}
+      </div>
+    </foreignObject>
   );
 }

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
@@ -12,7 +12,6 @@ const MOCK_PROPS: LabelProps = {
   color: 'red',
   label: 'Label Text',
   labelWidth: 100,
-  x: 10,
   y: 20,
 };
 

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/LabelWrapper/LabelWrapper.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/LabelWrapper/LabelWrapper.tsx
@@ -1,0 +1,33 @@
+import {animated, useSpring} from '@react-spring/web';
+import type {ReactNode} from 'react';
+
+import {useBarSpringConfig} from '../../../../../hooks/useBarSpringConfig';
+
+interface Props {
+  animationDelay: number;
+  children: ReactNode;
+  x: number;
+}
+
+export function LabelWrapper({animationDelay, children, x}: Props) {
+  const springConfig = useBarSpringConfig({animationDelay});
+
+  const spring = useSpring({
+    from: {transform: 'translateX(0px)', opacity: 0},
+    to: {opacity: 1, transform: `translateX(${x}px)`},
+    ...springConfig,
+  });
+
+  return (
+    // animating the foreignObject does not work on Safari,
+    // so we need to use a g instead
+    <animated.g
+      style={{
+        opacity: spring.opacity,
+        transform: spring.transform,
+      }}
+    >
+      {children}
+    </animated.g>
+  );
+}

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/LabelWrapper/index.ts
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/LabelWrapper/index.ts
@@ -1,0 +1,1 @@
+export {LabelWrapper} from './LabelWrapper';

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/index.ts
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/index.ts
@@ -1,2 +1,3 @@
 export {Label} from './Label';
 export {Bar} from '../../Bar';
+export {LabelWrapper} from './LabelWrapper';

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
@@ -5,7 +5,8 @@ import type {DataSeries} from '@shopify/polaris-viz-core';
 import type {HorizontalBarsProps} from '../HorizontalBars';
 import {HorizontalBars} from '../HorizontalBars';
 import {Bar} from '../../Bar';
-import {Label} from '../components';
+import {Label, LabelWrapper} from '../components';
+import {TrendIndicator} from '../../..';
 
 jest.mock('d3-scale', () => ({
   scaleLinear: jest.requireActual('d3-scale').scaleLinear,
@@ -29,6 +30,15 @@ const DATA: DataSeries[] = [
       {value: 10, key: 'Label 02'},
       {value: 12, key: 'Label 03'},
     ],
+    metadata: {
+      trends: {
+        0: {
+          value: '10%',
+          trend: 'positive',
+          direction: 'upwards',
+        },
+      },
+    },
   },
   {
     name: 'Group 2',
@@ -171,7 +181,7 @@ describe('<HorizontalBars />', () => {
         </svg>,
       );
 
-      const labels = chart.findAll(Label);
+      const labels = chart.findAll(LabelWrapper);
 
       expect(labels[0].props.x).toStrictEqual(15);
     });
@@ -187,9 +197,63 @@ describe('<HorizontalBars />', () => {
         </svg>,
       );
 
-      const labels = chart.findAll(Label);
+      const labels = chart.findAll(LabelWrapper);
 
       expect(labels[0].props.x).toStrictEqual(-115);
+    });
+  });
+
+  describe('<TrendIndicator />', () => {
+    it('renders when metadata is provided', () => {
+      const chart = mount(
+        <svg>
+          <HorizontalBars {...MOCK_PROPS} isSimple />
+        </svg>,
+      );
+
+      expect(chart).toContainReactComponent(TrendIndicator, {
+        value: '10%',
+        trend: 'positive',
+        direction: 'upwards',
+      });
+    });
+
+    it('does not render if isSimple=false', () => {
+      const chart = mount(
+        <svg>
+          <HorizontalBars {...MOCK_PROPS} />
+        </svg>,
+      );
+
+      expect(chart).not.toContainReactComponent(TrendIndicator);
+    });
+
+    it('does not render when metadata is empty', () => {
+      const chart = mount(
+        <svg>
+          <HorizontalBars
+            {...MOCK_PROPS}
+            isSimple
+            data={[{data: [{value: -5, key: 'Label 01'}]}]}
+          />
+        </svg>,
+      );
+
+      expect(chart).not.toContainReactComponent(TrendIndicator);
+    });
+
+    it('is positioned', () => {
+      const chart = mount(
+        <svg>
+          <HorizontalBars {...MOCK_PROPS} isSimple />
+        </svg>,
+      );
+
+      const wrapper = chart.find(LabelWrapper)?.findAll('g');
+
+      expect(wrapper && wrapper[1]?.prop('transform')).toStrictEqual(
+        'translate(110, 2)',
+      );
     });
   });
 });

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/utilities/getTrendIndicatorData.ts
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/utilities/getTrendIndicatorData.ts
@@ -1,0 +1,17 @@
+import type {MetaDataTrendIndicator} from '../../../SimpleBarChart';
+import {estimateTrendIndicatorWidth} from '../../../TrendIndicator';
+
+export function getTrendIndicatorData(
+  trendMetadata: MetaDataTrendIndicator | undefined,
+) {
+  if (trendMetadata != null) {
+    const {totalWidth} = estimateTrendIndicatorWidth(`${trendMetadata.value}`);
+
+    return {
+      trendIndicatorProps: trendMetadata,
+      trendIndicatorWidth: totalWidth,
+    };
+  }
+
+  return {trendIndicatorProps: undefined, trendIndicatorWidth: 0};
+}


### PR DESCRIPTION
## What does this implement/fix?

Prototyping out inline `<TrendIndicator />` components in `<SimpleBarChart />`/ 

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/149873/233721533-da60ce5a-794a-47b7-bf7e-03c7184a187e.png">
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-hcstxeqycw.chromatic.com/?path=/story/polaris-viz-charts-simplebarchart--with-trend-indicators

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
