### PR TITLE
[Polaris-Viz] Fix Cut-Off Commas in Funnel Chart

### DIFF
--- a/packages/polaris-viz/src/components/FunnelChart/components/Label.scss
+++ b/packages/polaris-viz/src/components/FunnelChart/components/Label.scss
@@ -12,3 +12,6 @@
     display: none;
   }
 }
+.YAxis {
+  overflow: visible;
+}

--- a/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
@@ -50,6 +50,7 @@ export function Label({
         height={LABEL_HEIGHT}
         width={labelWidth}
         aria-hidden="true"
+        className={styles.YAxis}
       >
         <div
           className={styles.Label}


### PR DESCRIPTION
## What does this implement/fix?

Closes: https://github.com/Shopify/marketing-technology/issues/7235

Adds classname to prevent the `<ForeignObject />` from cutting off the bottoms of the commas in the y-axis labels of the Funnel Chart. This only happens when the labels have been formatted. There are no commas by default. 

Before: 
<img width="1011" alt="Screenshot 2023-04-14 at 1 07 45 PM" src="https://user-images.githubusercontent.com/43480700/233723481-b6f6515a-60c4-496b-92ff-4fa8cfe1caea.png">

After: 
<img width="979" alt="Screenshot 2023-04-25 at 9 57 56 AM" src="https://user-images.githubusercontent.com/43480700/234300071-37a5e530-146c-4840-98a1-f4bcc1aec7f2.png">

Spin link: https://admin.web.web-minimal-ekn7.claire-deboer.us.spin.dev/store/shop1/marketing/reports/marketing-activity-report-next

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
