### PR TITLE
Fixed invalid DOM properties

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Changed invalid `fill-rule` and `clip-rule` DOM properties.
 
 ## [9.2.0] - 2023-04-17
 

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowDown.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowDown.tsx
@@ -9,9 +9,9 @@ export function ArrowDown() {
     >
       <path
         fill="currentColor"
-        fill-rule="evenodd"
+        fillRule="evenodd"
         d="M5.75 1a.75.75 0 0 0-1.5 0v2.19L1.655.594a.75.75 0 1 0-1.06 1.06L3.189 4.25H1a.75.75 0 0 0 0 1.5h4a.748.748 0 0 0 .529-.218l.001-.002.002-.001A.748.748 0 0 0 5.75 5V1Z"
-        clip-rule="evenodd"
+        clipRule="evenodd"
       />
     </svg>
   );

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowUp.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Arrows/ArrowUp.tsx
@@ -9,9 +9,9 @@ export function ArrowUp() {
     >
       <path
         fill="currentColor"
-        fill-rule="evenodd"
+        fillRule="evenodd"
         d="M1 .25a.75.75 0 1 0 0 1.5h2.19L.594 4.345a.75.75 0 0 0 1.06 1.06L4.25 2.811V5a.75.75 0 0 0 1.5 0V1A.748.748 0 0 0 5 .25H1Z"
-        clip-rule="evenodd"
+        clipRule="evenodd"
       />
     </svg>
   );


### PR DESCRIPTION
## What does this implement/fix?

Somehow I missed these 2 properties in the arrow icons for `TrendIndicators`.

## What do the changes look like?

<img width="665" alt="image" src="https://user-images.githubusercontent.com/149873/234038450-7bf45cbc-ccfa-4911-8c45-bb6e60568dcc.png">
 