### PR TITLE
Fix ErrorText positioning in ChartSkeleton

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fix ErrorText positioning in ChartSkeleton.
 
 ## [9.2.2] - 2023-04-25
 

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/ErrorText/ErrorText.tsx
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/ErrorText/ErrorText.tsx
@@ -25,7 +25,7 @@ export function ErrorText({errorText, width, height}: ErrorTextProps) {
   return (
     <g
       style={{
-        transform: `translateY(${height / 2 - FONT_SIZE * 2}px)`,
+        transform: `translateY(${Math.max(0, height / 2 - FONT_SIZE / 2)}px)`,
         filter: `
         drop-shadow( ${TEXT_DROP_SHADOW_SIZE}px 0px 1px ${backgroundColor})
         drop-shadow( -${TEXT_DROP_SHADOW_SIZE}px  0px 1px ${backgroundColor})

--- a/packages/polaris-viz/src/components/SparkLineChart/stories/ErrorState.stories.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/stories/ErrorState.stories.tsx
@@ -1,0 +1,16 @@
+import {ChartState} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SparkLineChartProps} from '../../../components';
+
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
+
+export const ErrorState: Story<SparkLineChartProps> = Template.bind({});
+
+ErrorState.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  state: ChartState.Error,
+};


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->

The ErrorText component was allowing a negative Y-axis translation that cut off the text when viewing on a very short SparkLineChart. It was also not really centering the text because it was multiplying the font size by 2 instead of dividing it by 2.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

## What do the changes look like?

| Before  | After  |
|---|---|
| <img width="1495" alt="image" src="https://user-images.githubusercontent.com/1236959/235499946-ff748949-1e17-4ef4-8012-b994892be759.png"> |  <img width="1472" alt="image" src="https://user-images.githubusercontent.com/1236959/235499802-498758d0-7d87-474c-9dd1-8a4f7a16e88d.png"> |
 
## Storybook link




### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
