### PR TITLE
Add yAxisOptions to SimpleBarChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `yAxisOptions` to `SimpleBarChartProps`.
 
 ## [9.3.0] - 2023-05-03
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -2,6 +2,7 @@ import type {
   ChartType,
   XAxisOptions,
   ChartProps,
+  YAxisOptions,
 } from '@shopify/polaris-viz-core';
 import {DEFAULT_CHART_PROPS, ChartState} from '@shopify/polaris-viz-core';
 
@@ -22,6 +23,7 @@ export type SimpleBarChartProps = {
   showLegend?: boolean;
   type?: ChartType;
   xAxisOptions?: XAxisOptions;
+  yAxisOptions?: YAxisOptions;
 } & ChartProps;
 
 export function SimpleBarChart(props: SimpleBarChartProps) {
@@ -33,6 +35,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
     theme,
     type = 'default',
     xAxisOptions,
+    yAxisOptions,
     state,
     errorText,
   }: SimpleBarChartProps = {
@@ -40,7 +43,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
     ...props,
   };
   const xAxisOptionsWithDefaults = getXAxisOptionsWithDefaults(xAxisOptions);
-  const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults();
+  const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
 
   return (
     <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/meta.tsx
@@ -9,6 +9,7 @@ import {
   THEME_CONTROL_ARGS,
   TYPE_CONTROL_ARGS,
   X_AXIS_OPTIONS_ARGS,
+  Y_AXIS_OPTIONS_ARGS,
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 import {SimpleBarChart} from '../SimpleBarChart';
@@ -34,5 +35,6 @@ export const META: Meta = {
     theme: THEME_CONTROL_ARGS,
     type: TYPE_CONTROL_ARGS,
     xAxisOptions: X_AXIS_OPTIONS_ARGS,
+    yAxisOptions: Y_AXIS_OPTIONS_ARGS,
   },
 };


### PR DESCRIPTION
## What does this implement/fix?

While doing some Cohort work I noticed that the `<SimpleBarChart />` didn't apply formatting to the yAxis/group labels
