### PR TITLE
Fixed dupe key issue

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where empty keys would be used when data had multiple empty data keys.
 
 ## [9.3.1] - 2023-05-23
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/Multiple.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/Multiple.stories.tsx
@@ -1,0 +1,104 @@
+import {SimpleBarChart} from '../../SimpleBarChart';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+const DATA1 = [
+  {
+    data: [
+      {
+        key: '["!!","!!! Single variant product","!!!123 (Copy)",", (Copy) (Copy)","00 - A car product with Drone that can do amazing things (Copy)","001 another drummer boy (Copy)","1 of the list","AGUA","Rude t-shirt"]',
+        value: 727.45,
+      },
+      {
+        key: '["Champagne","Cup"]',
+        value: 383.04,
+      },
+      {
+        key: '["Copy of A new product with bells and whistles"]',
+        value: 101.48,
+      },
+      {
+        key: '["01 - Test Weight Bug 23"]',
+        value: 58.78,
+      },
+      {
+        key: '["Hat","Socks"]',
+        value: 26.1,
+      },
+    ],
+  },
+];
+
+const DATA2 = [
+  {
+    data: [
+      {
+        key: 'Direct',
+        value: 819.04,
+      },
+      {
+        key: '',
+        value: null,
+      },
+      {
+        key: '',
+        value: null,
+      },
+      {
+        key: '',
+        value: null,
+      },
+      {
+        key: '',
+        value: null,
+      },
+    ],
+  },
+];
+
+const DATA3 = [
+  {
+    data: [
+      {
+        key: 'Draft Orders',
+        value: 383.04,
+      },
+      {
+        key: 'Shopify Mobile for iPhone',
+        value: 263.41,
+      },
+      {
+        key: 'Shopify Mobile for Android',
+        value: 172.59,
+      },
+      {
+        key: '',
+        value: null,
+      },
+      {
+        key: '',
+        value: null,
+      },
+    ],
+  },
+];
+
+export const Multiple = () => {
+  return (
+    <div style={{display: 'flex', gap: '20px'}}>
+      <div style={{height: 300, width: 300}}>
+        <SimpleBarChart data={DATA1} showLegend={false} />
+      </div>
+      <div style={{height: 300, width: 300}}>
+        <SimpleBarChart data={DATA2} showLegend={false} />
+      </div>
+      <div style={{height: 300, width: 300}}>
+        <SimpleBarChart data={DATA3} showLegend={false} />
+      </div>
+    </div>
+  );
+};

--- a/packages/polaris-viz/src/hooks/useHorizontalTransitions.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalTransitions.ts
@@ -27,7 +27,7 @@ export function useHorizontalTransitions({
   groupHeight,
   series,
 }: Props) {
-  const {shouldAnimate} = useChartContext();
+  const {shouldAnimate, id} = useChartContext();
   const seriesWithIndex = useMemo(() => {
     return series[0].data.map(({key}, index) => ({
       key: `${key}`,
@@ -44,7 +44,7 @@ export function useHorizontalTransitions({
 
   const transitions = useTransition(seriesWithIndex, {
     keys: (item) => {
-      return item.key ?? '';
+      return item.key === '' ? `${id}-${item.index}` : item.key;
     },
     initial: ({index}) => ({
       opacity: 1,


### PR DESCRIPTION
## What does this implement/fix?

I noticed in the cohort drilldown we were getting react duplicate key errors.

<img width="1480" alt="image" src="https://github.com/Shopify/polaris-viz/assets/149873/23a03acd-e612-4a94-b47c-e4218950e445">

The reason for this is because the drilldown pushes empty data in the `DataSeries` so that all the bars are the same size regardless of how many `DataSeries` the chart has.

## What do the changes look like?

The story should not have any console errors.
 
## Storybook link

/?path=/story/polaris-viz-charts-simplebarchart-playground--multiple


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
