### PR TITLE
Fixed issue with labels bleeding outside of the chart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where negative values in `SimpleBarChart` with `TrendIndicators` would bleed outside the chart.
 
 ## [9.3.2] - 2023-05-25
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
@@ -4,7 +4,7 @@ export {META as default} from './meta';
 
 import type {SimpleBarChartProps} from '../../../components';
 
-import {SINGLE_SERIES, Template} from './data';
+import {Template} from './data';
 
 export const WithTrendIndicators: Story<SimpleBarChartProps> = Template.bind(
   {},
@@ -13,7 +13,32 @@ export const WithTrendIndicators: Story<SimpleBarChartProps> = Template.bind(
 WithTrendIndicators.args = {
   data: [
     {
-      ...SINGLE_SERIES[0],
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 3000,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 0,
+        },
+        {
+          key: 'Mens Shorts',
+          value: -4000,
+        },
+        {
+          key: 'Socks',
+          value: 800,
+        },
+        {
+          key: 'Hats',
+          value: 48,
+        },
+        {
+          key: 'Ties',
+          value: 1,
+        },
+      ],
       metadata: {
         trends: {
           2: {

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -100,9 +100,10 @@ export function HorizontalBars({
           );
 
         const labelWidth = estimateStringWidth(`${label}`, characterWidths);
-        const width = Math.abs(xScale(value ?? 0) - xScale(0));
 
-        function getXPosition() {
+        function getWidthAndXPosition() {
+          const width = Math.abs(xScale(value ?? 0) - xScale(0));
+
           if (isNegative) {
             const itemSpacing =
               trendIndicatorProps == null
@@ -113,13 +114,19 @@ export function HorizontalBars({
               ? labelWidth + itemSpacing + trendIndicatorWidth
               : 0;
 
-            return (width + leftLabelOffset) * -1;
+            return {
+              x: width * -1,
+              width: width - leftLabelOffset,
+            };
           }
 
-          return width + HORIZONTAL_BAR_LABEL_OFFSET;
+          return {
+            x: width + HORIZONTAL_BAR_LABEL_OFFSET,
+            width,
+          };
         }
 
-        const x = getXPosition();
+        const {x, width} = getWidthAndXPosition();
 
         const y =
           barHeight * seriesIndex +

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
@@ -192,7 +192,7 @@ describe('<HorizontalBars />', () => {
           <HorizontalBars
             {...MOCK_PROPS}
             isSimple
-            data={[{data: [{value: -5, key: 'Label 01'}]}]}
+            data={[{data: [{value: -115, key: 'Label 01'}]}]}
           />
         </svg>,
       );


### PR DESCRIPTION
## What does this implement/fix?

Fixed the negative position logic to stop the labels from rendering outside of the chart bounds.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/Shopify/polaris-viz/assets/149873/c2ffc695-5fe3-4b96-80eb-2a568d7c21a9)|![image](https://github.com/Shopify/polaris-viz/assets/149873/b5361777-2ee8-4e32-ae53-02d19997a71e)|

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
