### PR TITLE
Clamp negative widths to stop bars from rendering broken

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Clamp negative widths in `SimpleBarChart` to a min of `1px`.
 
 ## [9.3.3] - 2023-06-08
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/SimpleBarChart.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/SimpleBarChart.chromatic.stories.tsx
@@ -1,0 +1,173 @@
+import {META} from './meta';
+import type {ReactNode} from 'react';
+import type {MetaData} from '../types';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/SimpleBarChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+import {SimpleBarChart} from '../../../components';
+import {SINGLE_SERIES} from './data';
+
+const METADATA: MetaData = {
+  trends: {
+    '0': {
+      value: '77%',
+      trend: 'positive',
+      direction: 'upward',
+    },
+    '2': {
+      value: '907%',
+      trend: 'negative',
+      direction: 'downward',
+    },
+  },
+};
+
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <div
+      style={{
+        height: 250,
+        width: 250,
+        background: 'rgba(255,255,255,0.5)',
+        padding: 10,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const Default = () => {
+  return (
+    <Wrapper>
+      <SimpleBarChart showLegend={false} data={SINGLE_SERIES} />
+    </Wrapper>
+  );
+};
+
+export const TrendWithAllPositive = () => {
+  return (
+    <Wrapper>
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Unknown',
+                value: 248.14,
+              },
+              {
+                key: 'Social',
+                value: 256.45,
+              },
+              {
+                key: 'Direct',
+                value: 1863.96,
+              },
+            ],
+            name: 'Sales by traffic source',
+            metadata: METADATA,
+          },
+        ]}
+      />
+    </Wrapper>
+  );
+};
+
+export const TrendWithAllNegative = () => {
+  return (
+    <Wrapper>
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Unknown',
+                value: -248.14,
+              },
+              {
+                key: 'Social',
+                value: -256.45,
+              },
+              {
+                key: 'Direct',
+                value: -1863.96,
+              },
+            ],
+            name: 'Sales by traffic source',
+            metadata: METADATA,
+          },
+        ]}
+      />
+    </Wrapper>
+  );
+};
+
+export const TrendWithMixedValues = () => {
+  return (
+    <Wrapper>
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Unknown',
+                value: 248.14,
+              },
+              {
+                key: 'Social',
+                value: -256.45,
+              },
+              {
+                key: 'Direct',
+                value: -1863.96,
+              },
+            ],
+            name: 'Sales by traffic source',
+            metadata: METADATA,
+          },
+        ]}
+      />
+    </Wrapper>
+  );
+};
+
+export const TrendWithSimilarValues = () => {
+  return (
+    <Wrapper>
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Unknown',
+                value: 48.14,
+              },
+              {
+                key: 'Social',
+                value: -56.45,
+              },
+              {
+                key: 'Direct',
+                value: -63.96,
+              },
+            ],
+            name: 'Sales by traffic source',
+            metadata: METADATA,
+          },
+        ]}
+      />
+    </Wrapper>
+  );
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/SkinnyTrend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/SkinnyTrend.stories.tsx
@@ -1,0 +1,133 @@
+import {SimpleBarChart} from '../../SimpleBarChart';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+export const SkinnyTrend = () => {
+  return (
+    <div
+      style={{
+        height: 250,
+        width: 250,
+        background: 'rgba(255,255,255,0.5)',
+        padding: 10,
+      }}
+    >
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Unknown',
+                value: 248.14,
+              },
+              {
+                key: 'Social',
+                value: -256.45,
+              },
+              {
+                key: 'Direct',
+                value: -1863.96,
+              },
+              {
+                key: '',
+                value: null,
+              },
+              {
+                key: '',
+                value: null,
+              },
+            ],
+            name: 'Sales by traffic source',
+            metadata: {
+              trends: {
+                '0': {
+                  value: '77%',
+                  trend: 'positive',
+                  direction: 'upward',
+                },
+                '2': {
+                  value: '907%',
+                  trend: 'negative',
+                  direction: 'downward',
+                },
+              },
+            },
+          },
+        ]}
+      />
+    </div>
+  );
+};
+
+export const PositiveTrendOverflow = () => {
+  return (
+    <div
+      style={{
+        height: 250,
+        width: 250,
+        background: 'rgba(255,255,255,0.5)',
+        padding: 10,
+      }}
+    >
+      <SimpleBarChart
+        showLegend={false}
+        data={[
+          {
+            data: [
+              {
+                key: 'Droëwors',
+                value: 7,
+              },
+              {
+                key: 'Grass Fed Biltong',
+                value: 4,
+              },
+              {
+                key: 'Garlic & Herb Biltong',
+                value: 1,
+              },
+              {
+                key: 'Garlic & Herb Biltong Slab 8oz',
+                value: 1,
+              },
+              {
+                key: 'Traditional Biltong Slab 8oz',
+                value: 1,
+              },
+            ],
+            name: 'Top selling products',
+            metadata: {
+              trends: {
+                '0': {
+                  value: '75%',
+                  trend: 'positive',
+                  direction: 'upward',
+                },
+                '1': {
+                  value: '300%',
+                  trend: 'positive',
+                  direction: 'upward',
+                },
+                '2': {
+                  value: '75%',
+                  trend: 'negative',
+                  direction: 'downward',
+                },
+                '4': {
+                  value: '50%',
+                  trend: 'negative',
+                  direction: 'downward',
+                },
+              },
+            },
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -6,6 +6,7 @@ import {
   estimateStringWidth,
   COLOR_VISION_SINGLE_ITEM,
   useChartContext,
+  clamp,
 } from '@shopify/polaris-viz-core';
 
 import {TREND_INDICATOR_HEIGHT, TrendIndicator} from '../../TrendIndicator';
@@ -104,25 +105,37 @@ export function HorizontalBars({
         function getWidthAndXPosition() {
           const width = Math.abs(xScale(value ?? 0) - xScale(0));
 
-          if (isNegative) {
-            const itemSpacing =
-              trendIndicatorProps == null
-                ? HORIZONTAL_BAR_LABEL_OFFSET
-                : HORIZONTAL_BAR_LABEL_OFFSET * 2;
+          const itemSpacing =
+            trendIndicatorProps == null
+              ? HORIZONTAL_BAR_LABEL_OFFSET
+              : HORIZONTAL_BAR_LABEL_OFFSET * 2;
 
-            const leftLabelOffset = isSimple
-              ? labelWidth + itemSpacing + trendIndicatorWidth
-              : 0;
+          const leftLabelOffset = isSimple
+            ? labelWidth + itemSpacing + trendIndicatorWidth
+            : 0;
+
+          if (isNegative) {
+            const clampedWidth = clamp({
+              amount: width - leftLabelOffset,
+              min: 1,
+              max: Infinity,
+            });
 
             return {
-              x: width * -1,
-              width: width - leftLabelOffset,
+              x: -(clampedWidth + leftLabelOffset),
+              width: clampedWidth,
             };
           }
 
+          const clampedWidth = clamp({
+            amount: width - leftLabelOffset,
+            min: 1,
+            max: Infinity,
+          });
+
           return {
-            x: width + HORIZONTAL_BAR_LABEL_OFFSET,
-            width,
+            x: clampedWidth + HORIZONTAL_BAR_LABEL_OFFSET,
+            width: clampedWidth,
           };
         }
 

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
@@ -183,7 +183,7 @@ describe('<HorizontalBars />', () => {
 
       const labels = chart.findAll(LabelWrapper);
 
-      expect(labels[0].props.x).toStrictEqual(15);
+      expect(labels[0].props.x).toStrictEqual(11);
     });
 
     it('is positioned for negative values', () => {


### PR DESCRIPTION
## What does this implement/fix?

When creating a new negative width to account for the left offset of labels, sometimes the bar would get a negative width.

This would cause the bar to rendering in a broken state.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/Shopify/polaris-viz/assets/149873/0e4d42c6-e0ee-4866-b444-5b1f4167661b)|![image](https://github.com/Shopify/polaris-viz/assets/149873/3e8906ad-3f9d-4a9f-9c66-fc0efb202d5b)|
 
## Storybook link

- [Negative Values](https://6062ad4a2d14cd0021539c1b-kurslvbzpf.chromatic.com/?path=/story/polaris-viz-charts-simplebarchart-playground--skinny-trend)
- [Positive Values](https://6062ad4a2d14cd0021539c1b-ribxtinwbm.chromatic.com/?path=/story/polaris-viz-charts-simplebarchart-playground--positive-trend-overflow)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
