### PR TITLE
Remove tab-index 0 from TrendIndicator svg

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Set tab-index to `-1` to stop `<TrendIndicator />` from allowing it to be tabbed into.
 
 ## [9.3.4] - 2023-06-13
 

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -17,6 +17,7 @@ import {
 export interface TrendIndicatorProps {
   accessibilityLabel?: string;
   direction?: TrendDirection;
+  tabIndex?: number;
   theme?: string;
   trend?: Trend;
   value?: string;
@@ -25,6 +26,7 @@ export interface TrendIndicatorProps {
 export function TrendIndicator({
   accessibilityLabel,
   direction = 'upward',
+  tabIndex = -1,
   theme = 'Light',
   trend = 'neutral',
   value,
@@ -37,6 +39,7 @@ export function TrendIndicator({
         accessibilityLabel={accessibilityLabel}
         height={HEIGHT}
         width={NO_VALUE_WIDTH}
+        tabIndex={tabIndex}
       >
         <path
           d="M0.519531 1.79395H12.0039V0.249023H0.519531V1.79395Z"

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.tsx
@@ -7,9 +7,16 @@ interface Props {
   height: number;
   width: number;
   accessibilityLabel?: string;
+  tabIndex?: number;
 }
 
-export function Svg({accessibilityLabel, children, height, width}: Props) {
+export function Svg({
+  accessibilityLabel,
+  children,
+  height,
+  width,
+  tabIndex = 0,
+}: Props) {
   const hasLabel = accessibilityLabel != null;
 
   return (
@@ -19,7 +26,7 @@ export function Svg({accessibilityLabel, children, height, width}: Props) {
       width={width}
       role={hasLabel ? 'img' : undefined}
       className={styles.SVG}
-      tabIndex={0}
+      tabIndex={tabIndex}
     >
       {hasLabel && <title>{accessibilityLabel}</title>}
       {children}


### PR DESCRIPTION
## What does this implement/fix?

The `<SVG />` component sets the tab-index property to `0` which was causing the `<TrendIndicator />` component to enter the tab order, even though there's nothing to interact with.