### PR TITLE
Fix scale issues with labels and trend indicators in SimpleBarChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed an issue where the label width was getting subtracted from the available space twice in `<SimpleBarChart>`.
+- Fixed an issue where horizontal bars with trend indicators would not be rendered to scale in `<SimpleBarChart>`.
 
 ## [9.4.0] - 2023-06-21
 

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the label width was getting subtracted from the available space twice in `<SimpleBarChart>`.
 
 ## [9.4.0] - 2023-06-21
 

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -143,6 +143,7 @@ export function Chart({
       isStacked,
       maxWidth: width - longestLabel.negative - longestLabel.positive,
       labelFormatter: xAxisOptions.labelFormatter,
+      longestLabel,
     });
 
   const {barHeight, chartHeight, groupBarsAreaHeight, groupHeight} =

--- a/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
@@ -207,10 +207,6 @@ describe('<Chart />', () => {
 
       expect(chart).not.toContainReactComponent(HorizontalBarChartXAnnotations);
       expect(chart).not.toContainReactComponent(HorizontalBarChartYAnnotations);
-
-      expect(group?.props.transform).toStrictEqual(
-        'translate(23.076923076923077, 5)',
-      );
     });
 
     it('renders <HorizontalBarChartXAnnotations /> when provided', () => {
@@ -235,10 +231,6 @@ describe('<Chart />', () => {
 
       expect(chart).toContainReactComponent(HorizontalBarChartXAnnotations);
       expect(chart).not.toContainReactComponent(HorizontalBarChartYAnnotations);
-
-      expect(group?.props.transform).toStrictEqual(
-        'translate(23.076923076923077, 33)',
-      );
     });
 
     it('renders <HorizontalBarChartYAnnotations /> when provided', () => {

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -29,6 +29,7 @@ import {getContainerAlignmentForLegend} from '../../utilities';
 import type {LegendPosition, RenderLegendContent} from '../../types';
 
 import type {SimpleBarChartDataSeries} from './types';
+import {getLongestTrendIndicator} from './utilities';
 
 export interface ChartProps {
   data: SimpleBarChartDataSeries[];
@@ -72,7 +73,13 @@ export function Chart({
     showLegend,
   });
 
-  const {allNumbers, longestLabel, areAllNegative} = useDataForHorizontalChart({
+  const {
+    allNumbers,
+    longestLabel,
+    highestPositive,
+    lowestNegative,
+    areAllNegative,
+  } = useDataForHorizontalChart({
     data,
     isSimple: true,
     isStacked,
@@ -84,13 +91,23 @@ export function Chart({
     data,
   });
 
+  const longestTrendIndicator = getLongestTrendIndicator(
+    data,
+    highestPositive,
+    lowestNegative,
+  );
+
+  const trendIndicatorOffset =
+    longestTrendIndicator.positive + longestTrendIndicator.negative;
+
   const {xScale} = useHorizontalXScale({
     allNumbers,
     isStacked,
     labelFormatter,
-    maxWidth: width,
+    maxWidth: width - trendIndicatorOffset,
     stackedMax,
     stackedMin,
+    longestLabel,
   });
 
   const {barHeight, groupHeight} = useHorizontalBarSizes({
@@ -108,7 +125,9 @@ export function Chart({
     chartXPosition: 0,
   });
 
-  const zeroPosition = xScale(0) - 0.5 * longestLabel.negative;
+  const zeroPosition =
+    xScale(0) + longestLabel.negative + longestTrendIndicator.negative;
+
   const getAriaLabel = useAriaLabel(data, {
     xAxisLabelFormatter: labelFormatter,
   });

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -88,7 +88,7 @@ export function Chart({
     allNumbers,
     isStacked,
     labelFormatter,
-    maxWidth: width - longestLabel.negative - longestLabel.positive,
+    maxWidth: width,
     stackedMax,
     stackedMin,
   });
@@ -108,7 +108,7 @@ export function Chart({
     chartXPosition: 0,
   });
 
-  const zeroPosition = longestLabel.negative + xScale(0);
+  const zeroPosition = xScale(0) - 0.5 * longestLabel.negative;
   const getAriaLabel = useAriaLabel(data, {
     xAxisLabelFormatter: labelFormatter,
   });

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/LongLabels.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/LongLabels.stories.tsx
@@ -1,0 +1,16 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleBarChartProps} from '../../../components';
+
+import {LONG_LABEL_SERIES, Template} from './data';
+
+export const LongLabels: Story<SimpleBarChartProps> = Template.bind({});
+
+LongLabels.args = {
+  data: LONG_LABEL_SERIES,
+  xAxisOptions: {
+    labelFormatter: (value) => `${value} products sold with a very long label`,
+  },
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/data.tsx
@@ -70,3 +70,8 @@ export const SINGLE_SERIES = buildSeries(
   [[3], [0], [4], [8], [48], [1]],
   [LABELS[0]],
 );
+
+export const LONG_LABEL_SERIES = buildSeries(
+  [[1000], [6000]],
+  ['Series label'],
+);

--- a/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
@@ -1,0 +1,150 @@
+import type {SimpleBarChartDataSeries} from '../types';
+import {getLongestTrendIndicator} from '../utilities';
+
+const positiveValues = [
+  {value: 1, key: 'Label 01'},
+  {value: 2, key: 'Label 02'},
+  {value: 3, key: 'Label 03'},
+];
+
+const negativeValues = [
+  {value: -1, key: 'Label 01'},
+  {value: -2, key: 'Label 02'},
+  {value: -3, key: 'Label 03'},
+];
+
+const highestPositive = 3;
+const lowestNegative = -3;
+
+const trends = {
+  '0': {
+    value: '77%',
+    trend: 'positive',
+    direction: 'upward',
+  },
+  '2': {
+    value: '907%',
+    trend: 'negative',
+    direction: 'downward',
+  },
+};
+
+const positiveSeries = {
+  name: 'Test',
+  data: positiveValues,
+  metadata: {
+    trends,
+  },
+} as SimpleBarChartDataSeries;
+
+const negativeSeries = {
+  ...positiveSeries,
+  data: negativeValues,
+};
+
+describe('getLongestTrendIndicator()', () => {
+  it('returns a value for positive when the highest positive value has a trend indicator', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [positiveSeries],
+      highestPositive,
+      0,
+    );
+
+    expect(positive).toBeGreaterThan(0);
+    expect(negative).toBe(0);
+  });
+
+  it('returns a value for negative when the lowest negative value has a trend indicator', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [negativeSeries],
+      0,
+      lowestNegative,
+    );
+
+    expect(positive).toBe(0);
+    expect(negative).toBeGreaterThan(0);
+  });
+
+  it('returns values for both positive and negative when both the highest positive and lowest negative values have trend indicators', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [positiveSeries, negativeSeries],
+      highestPositive,
+      lowestNegative,
+    );
+
+    expect(positive).toBeGreaterThan(0);
+    expect(negative).toBeGreaterThan(0);
+  });
+
+  it('returns 0 for positive when a lower value has a trend indicator but the highest positive value does not', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [
+        {
+          ...positiveSeries,
+          metadata: {
+            trends: {
+              '0': trends['0'],
+            },
+          },
+        } as SimpleBarChartDataSeries,
+      ],
+      highestPositive,
+      0,
+    );
+
+    expect(positive).toBe(0);
+    expect(negative).toBe(0);
+  });
+
+  it('returns 0 for negative when a higher value has a trend indicator but the lowest negative value does not', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [
+        {
+          ...negativeSeries,
+          metadata: {
+            trends: {
+              '0': trends['0'],
+            },
+          },
+        } as SimpleBarChartDataSeries,
+      ],
+      0,
+      lowestNegative,
+    );
+
+    expect(positive).toBe(0);
+    expect(negative).toBe(0);
+  });
+
+  it('returns 0 for both values if there are no trend indicators', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [
+        {
+          ...positiveSeries,
+          metadata: {},
+        },
+      ],
+      highestPositive,
+      0,
+    );
+
+    expect(positive).toBe(0);
+    expect(negative).toBe(0);
+  });
+
+  it('returns 0 for both values if metadata property is not present', () => {
+    const {positive, negative} = getLongestTrendIndicator(
+      [
+        {
+          ...positiveSeries,
+          metadata: undefined,
+        },
+      ],
+      highestPositive,
+      0,
+    );
+
+    expect(positive).toBe(0);
+    expect(negative).toBe(0);
+  });
+});

--- a/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
@@ -1,0 +1,48 @@
+import {HORIZONTAL_BAR_LABEL_OFFSET} from '@shopify/polaris-viz-core';
+
+import {estimateTrendIndicatorWidth} from '../TrendIndicator';
+
+import type {SimpleBarChartDataSeries} from './types';
+
+/**
+ * Returns the widths of the trend indicators associated with the highest positive value and the lowest negative value in the dataset, or 0 if the value doesn't have a trend indicator.
+ */
+export function getLongestTrendIndicator(
+  data: SimpleBarChartDataSeries[],
+  highestPositive: number,
+  lowestNegative: number,
+) {
+  const longestTrendIndicator = data.reduce(
+    (longestTrendIndicator, series) => {
+      const {data: seriesData, metadata} = series;
+      const trends = metadata?.trends ?? {};
+
+      const trendEntries = Object.entries(trends);
+      for (const [index, trend] of trendEntries) {
+        const dataPoint = seriesData[index];
+        if (dataPoint?.value === highestPositive) {
+          longestTrendIndicator.positive = estimateTrendIndicatorWidth(
+            trend.value,
+          ).totalWidth;
+        } else if (dataPoint?.value === lowestNegative) {
+          longestTrendIndicator.negative = estimateTrendIndicatorWidth(
+            trend.value,
+          ).totalWidth;
+        }
+      }
+
+      return longestTrendIndicator;
+    },
+    {positive: 0, negative: 0},
+  );
+
+  if (longestTrendIndicator.positive > 0) {
+    longestTrendIndicator.positive += HORIZONTAL_BAR_LABEL_OFFSET;
+  }
+
+  if (longestTrendIndicator.negative > 0) {
+    longestTrendIndicator.negative += HORIZONTAL_BAR_LABEL_OFFSET;
+  }
+
+  return longestTrendIndicator;
+}

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -114,24 +114,18 @@ export function HorizontalBars({
             ? labelWidth + itemSpacing + trendIndicatorWidth
             : 0;
 
-          if (isNegative) {
-            const clampedWidth = clamp({
-              amount: width - leftLabelOffset,
-              min: 1,
-              max: Infinity,
-            });
+          const clampedWidth = clamp({
+            amount: width,
+            min: 1,
+            max: Infinity,
+          });
 
+          if (isNegative) {
             return {
               x: -(clampedWidth + leftLabelOffset),
               width: clampedWidth,
             };
           }
-
-          const clampedWidth = clamp({
-            amount: width - leftLabelOffset,
-            min: 1,
-            max: Infinity,
-          });
 
           return {
             x: clampedWidth + HORIZONTAL_BAR_LABEL_OFFSET,

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
@@ -183,7 +183,7 @@ describe('<HorizontalBars />', () => {
 
       const labels = chart.findAll(LabelWrapper);
 
-      expect(labels[0].props.x).toStrictEqual(11);
+      expect(labels[0].props.x).toStrictEqual(15);
     });
 
     it('is positioned for negative values', () => {
@@ -199,7 +199,7 @@ describe('<HorizontalBars />', () => {
 
       const labels = chart.findAll(LabelWrapper);
 
-      expect(labels[0].props.x).toStrictEqual(-115);
+      expect(labels[0].props.x).toStrictEqual(-225);
     });
   });
 

--- a/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
@@ -91,7 +91,7 @@ describe('useDataForHorizontalChart()', () => {
     expect(data).toStrictEqual({
       allNumbers: [-5, -10, -12, -1, -2, -3],
       areAllNegative: true,
-      highestPositive: -1,
+      highestPositive: 0,
       longestLabel: {negative: 0, positive: 0},
       lowestNegative: -12,
     });

--- a/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
+++ b/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
@@ -28,8 +28,14 @@ export function useDataForHorizontalChart({
     }, []);
   }, [data]);
 
-  const lowestNegative = useMemo(() => Math.min(...allNumbers), [allNumbers]);
-  const highestPositive = useMemo(() => Math.max(...allNumbers), [allNumbers]);
+  const lowestNegative = useMemo(
+    () => Math.min(0, ...allNumbers),
+    [allNumbers],
+  );
+  const highestPositive = useMemo(
+    () => Math.max(0, ...allNumbers),
+    [allNumbers],
+  );
 
   const longestLabel = useMemo(() => {
     if (!isSimple || isStacked) {
@@ -37,7 +43,7 @@ export function useDataForHorizontalChart({
     }
 
     const negativeTextSize =
-      lowestNegative >= 0
+      lowestNegative === 0
         ? 0
         : estimateStringWidth(
             `${labelFormatter(lowestNegative)}`,
@@ -45,7 +51,7 @@ export function useDataForHorizontalChart({
           ) + HORIZONTAL_BAR_LABEL_OFFSET;
 
     const positiveTextSize =
-      highestPositive < 0
+      highestPositive === 0
         ? 0
         : estimateStringWidth(
             `${labelFormatter(highestPositive)}`,

--- a/packages/polaris-viz/src/hooks/useHorizontalXScale.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalXScale.ts
@@ -1,12 +1,4 @@
 import type {LabelFormatter} from '@shopify/polaris-viz-core';
-import {
-  clamp,
-  estimateStringWidth,
-  useChartContext,
-} from '@shopify/polaris-viz-core';
-import {useMemo} from 'react';
-
-import {HORIZONTAL_LABEL_MIN_WIDTH} from '../constants';
 
 import {useHorizontalTicksAndScale} from './useHorizontalTicksAndScale';
 
@@ -17,6 +9,7 @@ interface Props {
   stackedMax: number;
   stackedMin: number;
   labelFormatter: LabelFormatter;
+  longestLabel: {positive: number; negative: number};
 }
 
 export function useHorizontalXScale({
@@ -26,41 +19,12 @@ export function useHorizontalXScale({
   maxWidth,
   stackedMax = 0,
   stackedMin = 0,
+  longestLabel,
 }: Props) {
-  const {characterWidths} = useChartContext();
-
   let drawableWidth = maxWidth;
   let chartXPosition = 0;
 
-  const {ticksFormatted: initialTicksFormatted} = useHorizontalTicksAndScale({
-    maxWidth,
-    allNumbers,
-    labelFormatter,
-    isStacked,
-    stackedMin,
-    stackedMax,
-  });
-
-  const labelWidth = useMemo(() => {
-    const longestLabelWidth = initialTicksFormatted.reduce((prev, cur) => {
-      const width = estimateStringWidth(cur, characterWidths);
-
-      if (width > prev) {
-        return width;
-      }
-
-      return prev;
-    }, HORIZONTAL_LABEL_MIN_WIDTH);
-
-    return clamp({
-      amount: Math.min(
-        maxWidth / initialTicksFormatted.length,
-        longestLabelWidth,
-      ),
-      min: 0,
-      max: maxWidth,
-    });
-  }, [maxWidth, characterWidths, initialTicksFormatted]);
+  const labelWidth = longestLabel.positive + longestLabel.negative;
 
   drawableWidth -= labelWidth;
   chartXPosition += labelWidth / 2;


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

Fixes the following issues with `<SimpleBarChart>`:

- Label width is subtracted twice from the maximum available chart width, with the effect that horizontal bars didn't take up as much space as they could have (#1544)
- Trend indicators can truncate horizontal bars and make different values display the same width (#1552)
- Trend indicators are not taken into account when calculating the horizontal scale and can overflow the chart bounds (#1553)

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

See this [sandbox](https://codesandbox.io/s/shopify-polaris-viz-react-typescript-playground-forked-q9g3st?file=/src/index.tsx) for an example (also linked from the original issue). The issue is especially apparent for bars with long labels, where the double subtraction can make the bar lengths extremely small despite the relatively large amount of available space.

### Available width:

<img width="533" alt="Screenshot 2023-06-27 at 10 18 00" src="https://github.com/Shopify/polaris-viz/assets/4888172/c345d8ff-d4d4-464a-9967-c0d93d6a6bde">

### Bar + label doesn't use all available space:

<img width="532" alt="Screenshot 2023-06-27 at 10 18 07" src="https://github.com/Shopify/polaris-viz/assets/4888172/6cbce23b-0765-4f9c-9b79-35154216309a">

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

Fixes #1544, #1552, #1553

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

### Before:

<img width="878" alt="Screenshot 2023-06-27 at 13 43 04" src="https://github.com/Shopify/polaris-viz/assets/4888172/7c26b7a7-05c2-41e5-bac9-f4667d65b165">

### After:

<img width="876" alt="Screenshot 2023-06-27 at 13 43 21" src="https://github.com/Shopify/polaris-viz/assets/4888172/2f136844-7287-47dc-80ee-f85521d20698">
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

https://6062ad4a2d14cd0021539c1b-qxmjknhics.chromatic.com/?path=/docs/polaris-viz-charts-simplebarchart--long-labels

Check each of the `SimpleBarChart` stories to confirm that this change doesn't adversely impact other use cases for this chart type.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

<!-- - [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package -->
