### PR TITLE
Add new prop to funnel chart for helper tooltip

### DIFF
--- a/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/Chart.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../constants';
 
 import {FunnelChartXAxisLabels, FunnelSegment} from './components/';
+import type {LabelHelpers} from './FunnelChart';
 
 const X_LABEL_OFFSET = 16;
 const NEGATIVE_LABEL_OFFSET = -4;
@@ -35,6 +36,7 @@ export interface ChartProps {
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
   dimensions?: Dimensions;
+  labelHelpers?: LabelHelpers[];
 }
 
 export function Chart({
@@ -42,6 +44,7 @@ export function Chart({
   dimensions,
   xAxisOptions,
   yAxisOptions,
+  labelHelpers,
 }: ChartProps) {
   const {theme} = useChartContext();
   const selectedTheme = useTheme();
@@ -155,12 +158,17 @@ export function Chart({
         const percentLabel = handlePercentLabelFormatter(percentCalculation);
         const formattedYValue = yAxisOptions.labelFormatter(yAxisValue);
 
+        const labelHelper = labelHelpers?.find(
+          (helper) => helper.key === dataPoint.key,
+        );
+
         return (
           <Fragment key={dataPoint.key}>
             {maskRef && (
               <g key={dataPoint.key} role="listitem">
                 <FunnelSegment
                   percentLabel={percentLabel}
+                  labelHelper={labelHelper && labelHelper.value}
                   formattedYValue={formattedYValue}
                   isLast={index === dataSeries.length - 1}
                   connector={{
@@ -209,6 +217,9 @@ export function Chart({
         width={width}
         height={drawableHeight}
         fill={`url(#${gradientId})`}
+        style={{
+          pointerEvents: 'none',
+        }}
       />
     </ChartElements.Svg>
   );

--- a/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import type {
   XAxisOptions,
   YAxisOptions,
@@ -20,9 +21,15 @@ import {ChartSkeleton} from '../';
 
 import {Chart} from './Chart';
 
+export interface LabelHelpers {
+  key: number | string;
+  value: ReactNode | null;
+}
+
 export type FunnelChartProps = {
   xAxisOptions?: Omit<XAxisOptions, 'hide'>;
   yAxisOptions?: Omit<XAxisOptions, 'integersOnly'>;
+  labelHelpers?: LabelHelpers[];
 } & ChartProps;
 
 export function FunnelChart(props: FunnelChartProps) {
@@ -36,6 +43,7 @@ export function FunnelChart(props: FunnelChartProps) {
     isAnimated,
     state,
     errorText,
+    labelHelpers,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -66,6 +74,7 @@ export function FunnelChart(props: FunnelChartProps) {
       ) : (
         <Chart
           data={seriesWithDefaults}
+          labelHelpers={labelHelpers}
           xAxisOptions={xAxisOptionsForChart}
           yAxisOptions={yAxisOptionsForChart}
         />

--- a/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/FunnelSegment.tsx
@@ -27,6 +27,7 @@ export function FunnelSegment({
   portalTo,
   percentLabel,
   formattedYValue,
+  labelHelper,
 }) {
   const selectedTheme = useTheme();
   const mounted = useRef(false);
@@ -104,6 +105,7 @@ export function FunnelSegment({
         backgroundColor={backgroundColor}
         label={percentLabel}
         labelWidth={barWidth}
+        labelHelper={labelHelper}
         transform={animatedNextY.to(
           (value: number) =>
             `translate(${Number(x) + Number(barWidth)}px, ${

--- a/packages/polaris-viz/src/components/FunnelChart/components/Label.scss
+++ b/packages/polaris-viz/src/components/FunnelChart/components/Label.scss
@@ -1,14 +1,17 @@
 .Label {
   text-align: center;
   padding-top: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  span {
+  > span {
     padding: 0 4px;
     border-radius: '4px';
     border-radius: 4px;
   }
 
-  span:empty {
+  > span:empty {
     display: none;
   }
 }

--- a/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/components/Label.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {animated} from '@react-spring/web';
 import type {SpringValue} from '@react-spring/web';
 
@@ -21,6 +22,7 @@ const FONT_SIZES = {
 export interface LabelProps {
   label: string;
   labelWidth: number;
+  labelHelper?: ReactNode;
   size: Size;
   color?: string;
   backgroundColor?: string;
@@ -30,6 +32,7 @@ export interface LabelProps {
 export function Label({
   label,
   labelWidth,
+  labelHelper,
   size,
   color,
   backgroundColor,
@@ -58,16 +61,18 @@ export function Label({
             fontSize: `${fontSize}px`,
             color,
             lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-            height: HORIZONTAL_BAR_LABEL_HEIGHT,
           }}
         >
           <span
             style={{
               backgroundColor,
+              height: HORIZONTAL_BAR_LABEL_HEIGHT,
+              userSelect: 'none',
             }}
           >
             {label}
           </span>
+          {labelHelper}
         </div>
       </foreignObject>
     </animated.g>


### PR DESCRIPTION
## What does this implement/fix?
This adds the ability to render a Tooltip component from web into the FunnelChart. We pass in an array of objects and use the key from the `data` object to decide which data point Tooltip will render on

<img width="1020" alt="image" src="https://github.com/Shopify/polaris-viz/assets/10606336/77f77891-b1f3-46fd-83bd-5bcb6fa65b7c">


<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?
[Spin URL](https://admin.web.web-funnel-chart-popover.juwan-petty.us.spin.dev/store/shop1/marketing/reports/tactic?since=2023-06-06&until=2023-07-05&attributionModel=last_click_non_direct&utm_campaign_name=Welcome%20-%20Quiz%3A%20Email%201%20%28WLNMcW%29&utm_campaign_medium=email&referring_channel=klaviyo) where the Tooltip is rendered

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |    |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
