### PR TITLE
Fix undefined value crashing SimpleBarChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where passing a value of `undefined` to `TrendIndicator.value` would cause `<SimpleBarChart />` to crash.
 
 ## [9.6.1] - 2023-07-06
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/WithTrendIndicators.stories.tsx
@@ -54,6 +54,10 @@ WithTrendIndicators.args = {
             direction: 'upward',
             trend: 'positive',
           },
+          3: {
+            direction: 'upward',
+            trend: 'positive',
+          },
         },
       },
     },

--- a/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
@@ -20,6 +20,11 @@ export function getLongestTrendIndicator(
       const trendEntries = Object.entries(trends);
       for (const [index, trend] of trendEntries) {
         const dataPoint = seriesData[index];
+
+        if (trend.value == null) {
+          continue;
+        }
+
         if (dataPoint?.value === highestPositive) {
           longestTrendIndicator.positive = estimateTrendIndicatorWidth(
             trend.value,

--- a/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
@@ -6,7 +6,7 @@ import {
   TEXT_ICON_SPACING,
 } from '../constants';
 
-export function estimateTrendIndicatorWidth(value) {
+export function estimateTrendIndicatorWidth(value: string) {
   const textWidth = estimateStringWidthWithOffset(
     value,
     FONT_SIZE,


### PR DESCRIPTION
## What does this implement/fix?

We were checking the length of `trend.value` even though it can be `undefined`.

https://6062ad4a2d14cd0021539c1b-mjpmjeklzw.chromatic.com/?path=/story/polaris-viz-charts-simplebarchart--with-trend-indicators

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [x] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
