### PR TITLE
Add onError prop to ErrorBoundary

### DIFF
--- a/packages/polaris-viz-core/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/packages/polaris-viz-core/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,7 +1,11 @@
 import type {ForwardRefExoticComponent, ReactNode} from 'react';
 import {useMemo} from 'react';
 
-import type {PartialTheme, SvgComponents} from '../../types';
+import type {
+  ErrorBoundaryResponse,
+  PartialTheme,
+  SvgComponents,
+} from '../../types';
 import {
   DEFAULT_THEME as Default,
   LIGHT_THEME as Light,
@@ -19,6 +23,7 @@ export interface PolarisVizProviderProps {
   components?: SvgComponents;
   defaultTheme?: string;
   animated: <T>(Component: any) => ForwardRefExoticComponent<T>;
+  onError?: ErrorBoundaryResponse;
 }
 
 export function PolarisVizProvider({
@@ -27,6 +32,7 @@ export function PolarisVizProvider({
   themes,
   components,
   animated,
+  onError,
 }: PolarisVizProviderProps) {
   const value = useMemo(() => {
     return {
@@ -43,8 +49,9 @@ export function PolarisVizProvider({
       }),
       animated,
       defaultTheme,
+      onError,
     };
-  }, [themes, components, animated, defaultTheme]);
+  }, [themes, components, animated, defaultTheme, onError]);
 
   return (
     <PolarisVizContext.Provider value={value}>

--- a/packages/polaris-viz-core/src/contexts/PolarisVizContext.ts
+++ b/packages/polaris-viz-core/src/contexts/PolarisVizContext.ts
@@ -1,7 +1,7 @@
 import {createContext} from 'react';
 import {createHost} from '@react-spring/animated';
 
-import type {SvgComponents, Theme} from '../types';
+import type {ErrorBoundaryResponse, SvgComponents, Theme} from '../types';
 import {
   DEFAULT_THEME as Default,
   LIGHT_THEME as Light,
@@ -20,6 +20,7 @@ export const PolarisVizContext = createContext<{
   components: SvgComponents;
   animated: typeof host.animated;
   defaultTheme: string;
+  onError?: ErrorBoundaryResponse;
 }>({
   themes: {
     Default,

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -149,4 +149,5 @@ export type {
   StackedValues,
   DataGroup,
   TargetLine,
+  ErrorBoundaryResponse,
 } from './types';

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -1,5 +1,5 @@
 import type {Series, SeriesPoint} from 'd3-shape';
-import type {SVGProps} from 'react';
+import type {ErrorInfo, SVGProps} from 'react';
 
 export type LabelFormatter = (value: string | number | null) => string;
 
@@ -284,6 +284,7 @@ export interface ChartProps<T = DataSeries[]> {
   isAnimated?: boolean;
   state?: ChartState;
   errorText?: string;
+  onError?: ErrorBoundaryResponse;
 }
 
 export type WithRequired<T, K extends keyof T> = T & {[P in K]-?: T[P]};
@@ -316,3 +317,8 @@ export interface TargetLine {
   offsetRight?: number;
   offsetLeft?: number;
 }
+
+export type ErrorBoundaryResponse = (
+  error: Error,
+  errorInfo: ErrorInfo,
+) => void;

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `onError` prop to all charts that consume `<ErrorBoundary />`.
 
 ## [9.7.0] - 2023-07-13
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -65,6 +65,7 @@ export function BarChart(props: BarChartProps) {
     type = 'default',
     xAxisOptions,
     yAxisOptions,
+    onError,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -116,6 +117,7 @@ export function BarChart(props: BarChartProps) {
       <ChartContainer
         isAnimated={isAnimated}
         data={data}
+        onError={onError}
         theme={theme}
         type={InternalChartType.Bar}
       >

--- a/packages/polaris-viz/src/components/BarChart/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/Default.stories.tsx
@@ -10,4 +10,7 @@ export const Default: Story<BarChartProps> = Template.bind({});
 
 Default.args = {
   data: DEFAULT_DATA,
+  onError: (a, b) => {
+    console.log({a, b});
+  },
 };

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -4,6 +4,7 @@ import type {
   DataGroup,
   DataSeries,
   InternalChartType,
+  ErrorBoundaryResponse,
 } from '@shopify/polaris-viz-core';
 import {
   uniqueId,
@@ -26,6 +27,7 @@ interface Props {
   isAnimated: boolean;
   theme: string;
   id?: string;
+  onError?: ErrorBoundaryResponse;
   sparkChart?: boolean;
   skeletonType?: SkeletonType;
   type?: InternalChartType;
@@ -84,6 +86,7 @@ export const ChartContainer = (props: Props) => {
       >
         <ChartDimensions
           data={props.data}
+          onError={props.onError}
           onIsPrintingChange={setIsPrinting}
           skeletonType={props.skeletonType}
           sparkChart={props.sparkChart}

--- a/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
@@ -4,8 +4,13 @@ import type {
   DataGroup,
   DataSeries,
   Dimensions,
+  ErrorBoundaryResponse,
 } from '@shopify/polaris-viz-core';
-import {usePrevious, useTheme} from '@shopify/polaris-viz-core';
+import {
+  usePolarisVizContext,
+  usePrevious,
+  useTheme,
+} from '@shopify/polaris-viz-core';
 import {useDebouncedCallback} from 'use-debounce';
 import type {SkeletonType} from 'components/ChartSkeleton';
 
@@ -20,6 +25,7 @@ interface ChartDimensionsProps {
   onIsPrintingChange: Dispatch<SetStateAction<boolean>>;
   sparkChart?: boolean;
   skeletonType?: SkeletonType;
+  onError?: ErrorBoundaryResponse;
 }
 
 export function ChartDimensions({
@@ -28,8 +34,10 @@ export function ChartDimensions({
   onIsPrintingChange,
   sparkChart = false,
   skeletonType = 'Default',
+  onError,
 }: ChartDimensionsProps) {
   const {chartContainer} = useTheme();
+  const {onError: onErrorProvider} = usePolarisVizContext();
 
   const [chartDimensions, setChartDimensions] =
     useState<Dimensions | null>(null);
@@ -109,6 +117,7 @@ export function ChartDimensions({
           type={skeletonType ?? 'Default'}
           dimensions={chartDimensions!}
           data={data}
+          onError={onError ?? onErrorProvider}
         >
           <div
             className={styles.Chart}

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/ChartErrorBoundary.tsx
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/ChartErrorBoundary.tsx
@@ -2,6 +2,7 @@ import type {
   DataGroup,
   DataSeries,
   Dimensions,
+  ErrorBoundaryResponse,
 } from '@shopify/polaris-viz-core';
 import {ChartState} from '@shopify/polaris-viz-core';
 import type {ErrorInfo, ReactNode} from 'react';
@@ -17,7 +18,7 @@ interface ErrorBoundaryProps {
   dimensions: Dimensions;
   type: SkeletonType;
   children?: ReactNode;
-  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  onError?: ErrorBoundaryResponse;
 }
 
 interface ErrorBoundaryState {

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/tests/ChartErrorBoundary.test.tsx
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/tests/ChartErrorBoundary.test.tsx
@@ -4,6 +4,7 @@ import type {DataGroup, DataSeries} from '@shopify/polaris-viz-core';
 import {ChartSkeleton} from '../../ChartSkeleton';
 import {ChartErrorBoundary} from '../ChartErrorBoundary';
 import {mountWithProvider} from '../../../test-utilities/mountWithProvider';
+import {BarChart} from '../../BarChart';
 
 const MOCK_PROPS = {
   data: [],
@@ -128,6 +129,19 @@ describe('<ChartErrorBoundary />', () => {
       expect(warnMock.mock.calls[0][0]).toStrictEqual(
         'The DataGroup[] provided does not have equal series values.',
       );
+    });
+  });
+
+  describe('onError', () => {
+    it('calls onError when provided', () => {
+      const onErrorSpy = jest.fn();
+
+      mountWithProvider(
+        <ChartErrorBoundary type="Default" {...MOCK_PROPS} onError={onErrorSpy}>
+          <Child />
+        </ChartErrorBoundary>,
+      );
+      expect(onErrorSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
+++ b/packages/polaris-viz/src/components/ChartErrorBoundary/utilities/checkForMismatchedData.ts
@@ -14,6 +14,10 @@ export function checkForMismatchedData(data: DataSeries[] | DataGroup[]) {
 }
 
 function checkDataSeries(data: DataSeries[], type = 'DataSeries') {
+  if (data[0].data == null) {
+    return false;
+  }
+
   const firstSetLength = data[0].data.length;
 
   const hasMismatchedData = data.some(

--- a/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
@@ -38,6 +38,7 @@ export function ComboChart(props: ComboChartProps) {
   const {
     data,
     annotations = [],
+    onError,
     isAnimated,
     renderTooltipContent,
     showLegend = true,
@@ -72,6 +73,7 @@ export function ComboChart(props: ComboChartProps) {
   return (
     <ChartContainer
       data={data}
+      onError={onError}
       isAnimated={isAnimated}
       theme={theme}
       type={InternalChartType.Combo}

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -35,6 +35,7 @@ export function DonutChart(props: DonutChartProps) {
     labelFormatter = (value) => `${value}`,
     legendFullWidth,
     legendPosition = 'left',
+    onError,
     isAnimated,
     state,
     errorText,
@@ -49,6 +50,7 @@ export function DonutChart(props: DonutChartProps) {
     <ChartContainer
       skeletonType="Donut"
       data={data}
+      onError={onError}
       theme={theme}
       isAnimated={isAnimated}
     >

--- a/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
@@ -44,6 +44,7 @@ export function FunnelChart(props: FunnelChartProps) {
     state,
     errorText,
     labelHelpers,
+    onError,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -63,7 +64,12 @@ export function FunnelChart(props: FunnelChartProps) {
     getYAxisOptionsWithDefaults(yAxisOptions);
 
   return (
-    <ChartContainer data={data} isAnimated={isAnimated} theme={theme}>
+    <ChartContainer
+      data={data}
+      isAnimated={isAnimated}
+      onError={onError}
+      theme={theme}
+    >
       {state !== ChartState.Success ? (
         <ChartSkeleton
           type="Funnel"

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -57,6 +57,7 @@ export function LineChart(props: LineChartProps) {
     errorText,
     id,
     isAnimated,
+    onError,
     renderLegendContent,
     showLegend = true,
     skipLinkText,
@@ -96,6 +97,7 @@ export function LineChart(props: LineChartProps) {
         theme={theme}
         isAnimated={isAnimated}
         type={InternalChartType.Line}
+        onError={onError}
       >
         {state !== ChartState.Success ? (
           <ChartSkeleton state={state} errorText={errorText} theme={theme} />

--- a/packages/polaris-viz/src/components/PolarisVizProvider/PolarisVizProvider.tsx
+++ b/packages/polaris-viz/src/components/PolarisVizProvider/PolarisVizProvider.tsx
@@ -1,22 +1,28 @@
 import {PolarisVizProvider as OriginalPolarisVizProvider} from '@shopify/polaris-viz-core';
 import {animated} from '@react-spring/web';
-import type {PartialTheme} from '@shopify/polaris-viz-core';
+import type {
+  ErrorBoundaryResponse,
+  PartialTheme,
+} from '@shopify/polaris-viz-core';
 import type {ReactNode} from 'react';
 
 export const PolarisVizProvider = ({
   themes,
   children,
   defaultTheme,
+  onError,
 }: {
   children: ReactNode;
   themes?: {[key: string]: PartialTheme};
   defaultTheme?: string;
+  onError?: ErrorBoundaryResponse;
 }) => {
   return (
     <OriginalPolarisVizProvider
       themes={themes}
       animated={animated}
       defaultTheme={defaultTheme}
+      onError={onError}
     >
       {children}
     </OriginalPolarisVizProvider>

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -39,6 +39,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
     data,
     renderLegendContent,
     legendPosition = 'bottom-right',
+    onError,
     showLegend = true,
     theme = defaultTheme,
     type = 'default',
@@ -54,7 +55,12 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
   const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
 
   return (
-    <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>
+    <ChartContainer
+      data={data}
+      theme={theme}
+      isAnimated={isAnimated}
+      onError={onError}
+    >
       {state !== ChartState.Success ? (
         <ChartSkeleton
           type="SimpleBar"

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -43,13 +43,19 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
     state,
     errorText,
     renderLegendContent,
+    onError,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
   };
 
   return (
-    <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>
+    <ChartContainer
+      data={data}
+      theme={theme}
+      isAnimated={isAnimated}
+      onError={onError}
+    >
       {state !== ChartState.Success ? (
         <ChartSkeleton
           type="SimpleNormalized"

--- a/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
@@ -27,6 +27,7 @@ export function SparkBarChart(props: SparkBarChartProps) {
     data,
     accessibilityLabel,
     isAnimated,
+    onError,
     targetLine,
     theme = defaultTheme,
     state,
@@ -41,6 +42,7 @@ export function SparkBarChart(props: SparkBarChartProps) {
       theme={theme}
       sparkChart
       isAnimated={isAnimated}
+      onError={onError}
     >
       {state !== ChartState.Success ? (
         <ChartSkeleton

--- a/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
@@ -25,6 +25,7 @@ export function SparkLineChart(props: SparkLineChartProps) {
     isAnimated,
     offsetLeft = 0,
     offsetRight = 0,
+    onError,
     theme = defaultTheme,
     state,
     errorText,
@@ -39,6 +40,7 @@ export function SparkLineChart(props: SparkLineChartProps) {
       data={data}
       theme={theme}
       sparkChart
+      onError={onError}
     >
       {state !== ChartState.Success ? (
         <ChartSkeleton

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -51,6 +51,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     data,
     state,
     errorText,
+    onError,
     tooltipOptions,
     isAnimated,
     renderLegendContent,
@@ -78,7 +79,12 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
       {skipLinkText == null || skipLinkText.length === 0 ? null : (
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
-      <ChartContainer data={data} theme={theme} isAnimated={isAnimated}>
+      <ChartContainer
+        data={data}
+        theme={theme}
+        isAnimated={isAnimated}
+        onError={onError}
+      >
         {state !== ChartState.Success ? (
           <ChartSkeleton state={state} errorText={errorText} theme={theme} />
         ) : (

--- a/packages/polaris-viz/src/playground/ErrorBoundary.stories.tsx
+++ b/packages/polaris-viz/src/playground/ErrorBoundary.stories.tsx
@@ -1,0 +1,68 @@
+import type {Story} from '@storybook/react';
+import {BarChart, PolarisVizProvider} from '../components';
+
+export default {
+  title: 'polaris-viz/Playground/ErrorBoundary',
+  parameters: {},
+  decorators: [(Story) => <div style={{height: 500}}>{Story()}</div>],
+  argTypes: {},
+};
+
+const ComponentPropTemplate: Story = () => {
+  return (
+    <BarChart
+      // @ts-ignore
+      data={[{notData: []}]}
+      onError={(error, errorInfo) => {
+        console.log('From component', {error, errorInfo});
+      }}
+    />
+  );
+};
+
+export const ComponentProp: Story = ComponentPropTemplate.bind({});
+
+const ProviderPropTemplate: Story = () => {
+  return (
+    <PolarisVizProvider
+      onError={(error, errorInfo) => {
+        console.log('From context', {error, errorInfo});
+      }}
+    >
+      <BarChart
+        data={[
+          {
+            // @ts-ignore
+            notData: [],
+          },
+        ]}
+      />
+    </PolarisVizProvider>
+  );
+};
+
+export const ProviderProp: Story = ProviderPropTemplate.bind({});
+
+const BothPropsTemplate: Story = () => {
+  return (
+    <PolarisVizProvider
+      onError={(error, errorInfo) => {
+        console.log('From context', {error, errorInfo});
+      }}
+    >
+      <BarChart
+        data={[
+          {
+            // @ts-ignore
+            notData: [],
+          },
+        ]}
+        onError={(error, errorInfo) => {
+          console.log('From component', {error, errorInfo});
+        }}
+      />
+    </PolarisVizProvider>
+  );
+};
+
+export const BothProps: Story = BothPropsTemplate.bind({});


### PR DESCRIPTION
## What does this implement/fix?

Allow consumers to respond to chart errors.

`<PolarisVizProvider />` accepts an `onError` prop. Individual components also have an `onError` prop that will override the context one.

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
