### PR TITLE
Removed outline from TrendIndicator svg

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Removed
+
+- Removed outline from `<svg>` tag when focused.
 
 ## [9.8.0] - 2023-07-13
 

--- a/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.scss
+++ b/packages/polaris-viz/src/components/TrendIndicator/components/Svg/Svg.scss
@@ -1,4 +1,7 @@
+@import '../../../../styles/common';
+
 .SVG {
   display: block;
   font-feature-settings: normal;
+  @include no-outline;
 }


### PR DESCRIPTION
## What does this implement/fix?

Removing the outline when a `<TrendIndicator />` svg has focus.

## What do the changes look like?

This one is a little funky to test because storybook removes the outline itself for some reason, so I've attached a screenshot of the element with `focus` state forced on.

This change is only applied to `<TrendIndicator />` so we should be safe to merge into main to test in web.

![image](https://github.com/Shopify/polaris-viz/assets/149873/ee18dd4a-9a39-4f11-af77-859934125299)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
