### PR TITLE
yAxis Fixed Width

### DIFF
--- a/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
+++ b/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
@@ -4,7 +4,7 @@ import {scaleLinear} from 'd3-scale';
 import {DEFAULT_MAX_Y} from '../../constants';
 import type {DataSeries} from '../../types';
 import type {Props} from '../useYScale';
-import {useYScale} from '../useYScale';
+import {getLabelWidth, useYScale} from '../useYScale';
 import {shouldRoundScaleUp} from '../../utilities/shouldRoundScaleUp';
 
 jest.mock('d3-scale', () => ({
@@ -362,5 +362,21 @@ describe('useYScale()', () => {
 
       expect(domainSpy).toHaveBeenCalledWith([0, 1]);
     });
+  });
+
+  describe('getLabelWidth()', () => {
+    it.each([
+      {fixedWidth: undefined, yAxisLabelWidth: 100, expected: 100},
+      {fixedWidth: null, yAxisLabelWidth: 100, expected: 100},
+      {fixedWidth: false, yAxisLabelWidth: 100, expected: 100},
+      {fixedWidth: 200, yAxisLabelWidth: 100, expected: 200},
+    ])(
+      'returns $expected when fixedWidth: $fixedWidth',
+      ({fixedWidth, yAxisLabelWidth, expected}) => {
+        expect(getLabelWidth(yAxisLabelWidth, fixedWidth as any)).toBe(
+          expected,
+        );
+      },
+    );
   });
 });

--- a/packages/polaris-viz-core/src/hooks/useYScale.ts
+++ b/packages/polaris-viz-core/src/hooks/useYScale.ts
@@ -18,6 +18,7 @@ export interface Props {
   integersOnly?: boolean;
   shouldRoundUp?: boolean;
   verticalOverflow?: boolean;
+  fixedWidth?: number | false;
 }
 
 export function useYScale({
@@ -28,6 +29,7 @@ export function useYScale({
   min,
   shouldRoundUp = true,
   verticalOverflow = true,
+  fixedWidth,
 }: Props) {
   const {characterWidths} = useChartContext();
 
@@ -99,5 +101,20 @@ export function useYScale({
     minY,
   ]);
 
-  return {yScale, ticks, yAxisLabelWidth};
+  return {
+    yScale,
+    ticks,
+    yAxisLabelWidth: getLabelWidth(yAxisLabelWidth, fixedWidth),
+  };
+}
+
+export function getLabelWidth(
+  yAxisLabelWidth: number,
+  fixedWidth?: number | false,
+): number {
+  if (fixedWidth === false || fixedWidth == null) {
+    return yAxisLabelWidth;
+  }
+
+  return fixedWidth;
 }

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -69,6 +69,7 @@ export interface XAxisOptions {
 export interface YAxisOptions {
   labelFormatter?: LabelFormatter;
   integersOnly?: boolean;
+  fixedWidth?: number | false;
 }
 
 // === Theme types === //

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Fixed issue where hover effects would not be triggered for the entire bar in `<BarChart />` and `<SimpleBarChart />`.
 
+### Added
+
+- Added ability to set a fixed width for `<LineChart />` `<YAxis />` labels.
+
 ## [9.8.1] - 2023-07-20
 
 ### Removed

--- a/packages/polaris-viz/src/components/Labels/SingleTextLine.tsx
+++ b/packages/polaris-viz/src/components/Labels/SingleTextLine.tsx
@@ -12,13 +12,17 @@ interface SingleTextLineProps {
   x: number;
   y: number;
   ariaHidden?: boolean;
+  dominantBaseline?: 'middle' | 'hanging';
+  textAnchor?: 'left' | 'center' | 'right';
 }
 
 export function SingleTextLine({
   ariaHidden = false,
   color,
+  dominantBaseline = 'hanging',
   targetWidth,
   text,
+  textAnchor = 'center',
   y,
   x,
 }: SingleTextLineProps) {
@@ -35,8 +39,8 @@ export function SingleTextLine({
     <Fragment>
       <text
         aria-hidden={ariaHidden}
-        textAnchor="center"
-        dominantBaseline="hanging"
+        textAnchor={textAnchor}
+        dominantBaseline={dominantBaseline}
         height={LINE_HEIGHT}
         width={targetWidth}
         fill={color}

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -148,6 +148,7 @@ export function Chart({
   const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
+    fixedWidth: yAxisOptions.fixedWidth,
     max: maxY,
     min: minY,
   };

--- a/packages/polaris-viz/src/components/LineChart/stories/FixedYScaleWidth.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/FixedYScaleWidth.stories.tsx
@@ -1,0 +1,17 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {LineChartProps} from '../../../components';
+
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
+
+export const FixedYScaleWidth: Story<LineChartProps> = Template.bind({});
+
+FixedYScaleWidth.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  yAxisOptions: {
+    fixedWidth: 130,
+  },
+};

--- a/packages/polaris-viz/src/components/LineChart/stories/chromatic/FixedYScaleWidth.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/chromatic/FixedYScaleWidth.chromatic.stories.tsx
@@ -1,0 +1,32 @@
+import type {Story} from '@storybook/react';
+
+import type {LineChartProps} from '../../../../components';
+
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from '../data';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/LineChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const DefaultYScaleWidth: Story<LineChartProps> = Template.bind({});
+
+DefaultYScaleWidth.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+};
+
+export const FixedYScaleWidth: Story<LineChartProps> = Template.bind({});
+
+FixedYScaleWidth.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  yAxisOptions: {
+    fixedWidth: 100,
+  },
+};

--- a/packages/polaris-viz/src/components/YAxis/YAxis.tsx
+++ b/packages/polaris-viz/src/components/YAxis/YAxis.tsx
@@ -1,7 +1,12 @@
-import {estimateStringWidth, useChartContext} from '@shopify/polaris-viz-core';
+import {
+  clamp,
+  estimateStringWidth,
+  useChartContext,
+} from '@shopify/polaris-viz-core';
 
+import {SingleTextLine} from '../Labels';
 import {useTheme} from '../../hooks';
-import {LINE_HEIGHT, FONT_SIZE} from '../../constants';
+import {LINE_HEIGHT} from '../../constants';
 import type {YAxisTick} from '../../types';
 
 interface Props {
@@ -34,30 +39,33 @@ export function YAxis({
           characterWidths,
         );
 
-        const x = textAlign === 'right' ? width - stringWidth : 0;
+        const clampedWidth = clamp({
+          amount: width,
+          min: width + PADDING_SIZE,
+          max: stringWidth,
+        });
+
+        const x = textAlign === 'right' ? width - clampedWidth : 0;
 
         return (
           <g key={value} transform={`translate(${x},${yOffset})`}>
             <rect
               height={LINE_HEIGHT}
-              width={stringWidth + PADDING_SIZE * 2}
+              width={clampedWidth + PADDING_SIZE}
               fill={selectedTheme.chartContainer.backgroundColor}
               y={-LINE_HEIGHT / 2}
               x={-PADDING_SIZE}
             />
-            <text
-              aria-hidden={ariaHidden}
-              width={width + PADDING_SIZE * 4}
-              height={LINE_HEIGHT}
-              fill={selectedTheme.yAxis.labelColor}
-              fontSize={FONT_SIZE}
+            <SingleTextLine
+              x={0}
+              y={0}
+              ariaHidden={ariaHidden}
+              color={selectedTheme.yAxis.labelColor}
+              targetWidth={clampedWidth}
+              text={formattedValue}
+              textAnchor="left"
               dominantBaseline="middle"
-              style={{
-                fontFeatureSettings: 'tnum',
-              }}
-            >
-              {formattedValue}
-            </text>
+            />
           </g>
         );
       })}

--- a/packages/polaris-viz/src/utilities/getAxisOptions.ts
+++ b/packages/polaris-viz/src/utilities/getAxisOptions.ts
@@ -9,6 +9,7 @@ export function getYAxisOptionsWithDefaults(
   return {
     labelFormatter: (value: number) => `${value}`,
     integersOnly: false,
+    fixedWidth: false,
     ...yAxisOptionsFiltered,
   };
 }


### PR DESCRIPTION
Allow consumers to set a fixed width for the yAxis labels

https://6062ad4a2d14cd0021539c1b-zersnikccu.chromatic.com/?path=/story/polaris-viz-charts-linechart--fixed-y-scale-width