### PR TITLE
Pass theme down to ChartContainer

### DIFF
--- a/packages/polaris-viz-native/CHANGELOG.md
+++ b/packages/polaris-viz-native/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Pass `theme` prop down to `<ChartContainer />` so `<SparkLineChart />` uses the correct Theme.
 
 ## [9.10.0] - 2023-08-03
 

--- a/packages/polaris-viz-native/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz-native/src/components/SparkLineChart/SparkLineChart.tsx
@@ -37,7 +37,12 @@ export function SparkLineChart(props: SparkLineChartProps) {
   };
 
   return (
-    <ChartContainer data={data} sparkChart isAnimated={isAnimated}>
+    <ChartContainer
+      data={data}
+      sparkChart
+      isAnimated={isAnimated}
+      theme={theme}
+    >
       <Chart
         data={data}
         accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
## What does this implement/fix?

Fixes an issue where the `theme` prop wasn't being applied to native `<SparkLineChart />`.

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="221" alt="image" src="https://github.com/Shopify/polaris-viz/assets/149873/f8b0d0f2-801a-4df9-8afa-eae9184dc9b2">|<img width="222" alt="image" src="https://github.com/Shopify/polaris-viz/assets/149873/4e7cf412-5a92-48ec-b2c1-229f835607b3">|

## Storybook link

https://6062ad4a2d14cd0021539c1b-gwqiiglpim.chromatic.com/?path=/story/polaris-viz-native-charts-sparklinechart--default&args=theme:Light

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
