### PR TITLE
Add React 18 setup to Polaris Viz Native

### DIFF
--- a/packages/polaris-viz-native/CHANGELOG.md
+++ b/packages/polaris-viz-native/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where components wouldn't be correctly rendered in React 18.
+
 ## [9.10.2] - 2023-08-09
 
 - No updates. Transitive dependency bump.

--- a/packages/polaris-viz-native/loom.config.ts
+++ b/packages/polaris-viz-native/loom.config.ts
@@ -6,6 +6,8 @@ import {createPackage, createProjectPlugin} from '@shopify/loom';
 // Needed so TS realises what configuration hooks are provided by Jest (in `jestAdjustments` below)
 import type {} from '@shopify/loom-plugin-jest';
 
+import {setupReact18} from '../../loom.config';
+
 // eslint-disable-next-line import/no-default-export
 export default createPackage((pkg) => {
   pkg.entry({root: './src/index.ts'});
@@ -18,6 +20,7 @@ export default createPackage((pkg) => {
       rootEntrypoints: false,
       jestTestEnvironment: 'jsdom',
     }),
+    setupReact18(),
     jestAdjustments(),
   );
 });


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->

This PR fixes the build step for `@shopify/polaris-viz-native`, where the `@shopify/babel-preset` configuration wasn't being correctly applied, thus leading to a `React is not defined` crash when loading some components in React Native.

Ideally, the changes should be applied at the workspace level (it even looks like [we have it set up](https://github.com/Shopify/polaris-viz/blob/eebef89280b19d911d5d5d1dd2951662f0dd82a8/loom.config.ts#L18)), but all the other packages manually apply the configuration, so I thought the RN counterpart should probably follow suit.

## What do the changes look like?

| **Before** | **After** |
| ----------- | -------- |
| ![snippet (old)](https://github.com/Shopify/polaris-viz/assets/5504958/6043d83a-4135-40b8-b030-21023f6f1d8e) |  ![snippet](https://github.com/Shopify/polaris-viz/assets/5504958/68458244-1947-497f-8550-ddab4eb18711) |

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
