### PR TITLE
[Donut Chart] Update legend to include numbers

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added ability to toggle showing legend values in `<DonutChart />` with new prop `ShowLegendValues`.
 
 ## [9.10.4] - 2023-08-09
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -46,6 +46,7 @@ export interface ChartProps {
   labelFormatter: LabelFormatter;
   legendPosition: LegendPosition;
   showLegend: boolean;
+  showLegendValues: boolean;
   state: ChartState;
   theme: string;
   accessibilityLabel?: string;
@@ -63,6 +64,7 @@ export function Chart({
   labelFormatter,
   legendPosition = 'right',
   showLegend,
+  showLegendValues,
   state,
   theme,
   accessibilityLabel = '',
@@ -88,10 +90,11 @@ export function Chart({
       : 'horizontal';
 
   const longestLegendWidth = data.reduce((previous, current) => {
-    const estimatedLegendWidth = estimateLegendItemWidth(
-      current.name ?? '',
-      characterWidths,
-    );
+    const text = showLegendValues
+      ? `${current.name} ${current.data[0]?.value}` ?? ''
+      : current.name ?? '';
+
+    const estimatedLegendWidth = estimateLegendItemWidth(text, characterWidths);
 
     if (estimatedLegendWidth > previous) {
       return estimatedLegendWidth;
@@ -113,6 +116,7 @@ export function Chart({
       data: [{series: data, shape: 'Bar'}],
       dimensions,
       showLegend,
+      showLegendValues,
       direction: legendDirection,
       colors: seriesColor,
       maxWidth: maxLegendWidth,

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -17,6 +17,7 @@ import {Chart} from './Chart';
 export type DonutChartProps = {
   comparisonMetric?: ComparisonMetricProps;
   showLegend?: boolean;
+  showLegendValues?: boolean;
   labelFormatter?: LabelFormatter;
   legendFullWidth?: boolean;
   legendPosition?: LegendPosition;
@@ -32,6 +33,7 @@ export function DonutChart(props: DonutChartProps) {
     theme = defaultTheme,
     comparisonMetric,
     showLegend = true,
+    showLegendValues = false,
     labelFormatter = (value) => `${value}`,
     legendFullWidth,
     legendPosition = 'left',
@@ -61,6 +63,7 @@ export function DonutChart(props: DonutChartProps) {
         labelFormatter={labelFormatter}
         comparisonMetric={comparisonMetric}
         showLegend={showLegend}
+        showLegendValues={showLegendValues}
         legendFullWidth={legendFullWidth}
         legendPosition={legendPosition}
         renderInnerValueContent={renderInnerValueContent}

--- a/packages/polaris-viz/src/components/DonutChart/stories/LegendValues.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/LegendValues.stories.tsx
@@ -1,0 +1,55 @@
+import type {Story, StoryFn} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import {DonutChart} from '..';
+import type {DonutChartProps} from '..';
+
+import {DEFAULT_PROPS} from './data';
+
+const data = [
+  {
+    name: 'Mobile',
+    data: [
+      {
+        key: 'Mobile',
+        value: 477,
+      },
+    ],
+  },
+  {
+    name: 'Desktop',
+    data: [
+      {
+        key: 'Desktop',
+        value: 222,
+      },
+    ],
+  },
+  {
+    name: 'Tablet',
+    data: [
+      {
+        key: 'Tablet',
+        value: 80,
+      },
+    ],
+  },
+];
+
+const Template: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
+  return (
+    <div style={{width: 550, height: 400}}>
+      <DonutChart {...args} />
+    </div>
+  );
+};
+
+export const LegendValues: Story<DonutChartProps> = Template.bind({});
+
+LegendValues.args = {
+  ...DEFAULT_PROPS,
+  data,
+  legendPosition: 'right',
+  showLegendValues: true,
+};

--- a/packages/polaris-viz/src/components/DonutChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/meta.tsx
@@ -7,6 +7,7 @@ import {
   LEGEND_FULL_WIDTH_ARGS,
   LEGEND_POSITION_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
+  SHOW_LEGEND_VALUES_ARGS,
   THEME_CONTROL_ARGS,
 } from '../../../storybook/constants';
 import type {DonutChartProps} from '../DonutChart';
@@ -29,6 +30,7 @@ export const META: Meta<DonutChartProps> = {
     data: DATA_SERIES_ARGS,
     legendFullWidth: LEGEND_FULL_WIDTH_ARGS,
     legendPosition: LEGEND_POSITION_ARGS,
+    showLegendValues: SHOW_LEGEND_VALUES_ARGS,
     renderLegendContent: RENDER_LEGEND_CONTENT_ARGS,
     theme: THEME_CONTROL_ARGS,
     state: CHART_STATE_CONTROL_ARGS,

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -11,13 +11,15 @@
 
 .TextContainer {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
   text-align: left;
   gap: 3px;
   line-height: 16px;
   margin: -2px 0;
   font-size: 12px;
   font-family: $font-stack-base;
+  width: 100%;
 }
 
 .IconContainer {

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
@@ -55,6 +55,7 @@ export function LegendItem({
         paddingLeft: LEGEND_ITEM_LEFT_PADDING,
         paddingRight: LEGEND_ITEM_RIGHT_PADDING,
         gap: LEGEND_ITEM_GAP,
+        width: value ? '100%' : 'auto',
       }}
       className={style.Legend}
     >
@@ -67,7 +68,11 @@ export function LegendItem({
       <span className={style.TextContainer}>
         <span style={{color: selectedTheme.legend.labelColor}}>{name}</span>
         {value == null ? null : (
-          <span style={{color: selectedTheme.legend.valueColor}}>{value}</span>
+          <span
+            style={{color: selectedTheme.legend.valueColor, marginLeft: 'auto'}}
+          >
+            {value}
+          </span>
         )}
       </span>
     </button>

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
@@ -21,6 +21,36 @@ const DATA: DataSeries[] = [
   },
 ];
 
+const MOCK_SERIES_DATA_WITH_VALUES: DataSeries[] = [
+  {
+    name: 'Mobile',
+    data: [
+      {
+        key: 'Mobile',
+        value: 477,
+      },
+    ],
+  },
+  {
+    name: 'Desktop',
+    data: [
+      {
+        key: 'Desktop',
+        value: 222,
+      },
+    ],
+  },
+  {
+    name: 'Tablet',
+    data: [
+      {
+        key: 'Tablet',
+        value: 80,
+      },
+    ],
+  },
+];
+
 const DATAGROUP: DataGroup[] = [
   {
     shape: 'Line',
@@ -113,6 +143,58 @@ describe('useLegend()', () => {
             isLegendMounted: true,
           });
         });
+      });
+    });
+  });
+
+  describe('showLegendValues', () => {
+    it('returns data with values when true', () => {
+      function TestComponent() {
+        const data = useLegend({
+          ...MOCK_PROPS,
+          showLegendValues: true,
+          data: [
+            {
+              shape: 'Donut',
+              series: MOCK_SERIES_DATA_WITH_VALUES,
+            },
+          ],
+        });
+
+        return <span data-data={`${JSON.stringify(data)}`} />;
+      }
+
+      const result = mount(<TestComponent />);
+
+      const data = parseData(result);
+
+      data.legend.forEach((legendItem) => {
+        expect(legendItem.value).toBeDefined();
+      });
+    });
+
+    it('returns data with undefined values when false', () => {
+      function TestComponent() {
+        const data = useLegend({
+          ...MOCK_PROPS,
+          showLegendValues: false,
+          data: [
+            {
+              shape: 'Donut',
+              series: MOCK_SERIES_DATA_WITH_VALUES,
+            },
+          ],
+        });
+
+        return <span data-data={`${JSON.stringify(data)}`} />;
+      }
+
+      const result = mount(<TestComponent />);
+
+      const data = parseData(result);
+
+      data.legend.forEach((legendItem) => {
+        expect(legendItem.value).toBeUndefined();
       });
     });
   });

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
@@ -26,8 +26,9 @@ function getAlteredDimensions(
 }
 
 export interface Props {
-  showLegend: boolean;
   data: DataGroup[];
+  showLegend: boolean;
+  showLegendValues?: boolean;
   colors?: Color[];
   dimensions?: Dimensions;
   direction?: Direction;
@@ -39,6 +40,7 @@ export function useLegend({
   data,
   dimensions = {height: 0, width: 0},
   showLegend,
+  showLegendValues,
   direction = 'horizontal',
   maxWidth = 0,
 }: Props) {
@@ -55,9 +57,10 @@ export function useLegend({
     }
 
     const legends = data.map(({series, shape}) => {
-      return series.map(({name, color, isComparison}) => {
+      return series.map(({name, data, color, isComparison}) => {
         return {
           name: name ?? '',
+          value: showLegendValues ? data[0]?.value?.toString() : undefined,
           color,
           shape,
           isComparison,
@@ -71,7 +74,7 @@ export function useLegend({
         color: color ?? colors[index],
       };
     });
-  }, [colors, data, showLegend]);
+  }, [colors, data, showLegend, showLegendValues]);
 
   const {height, width} = useMemo(() => {
     if (showLegend === false) {

--- a/packages/polaris-viz/src/storybook/constants.ts
+++ b/packages/polaris-viz/src/storybook/constants.ts
@@ -47,6 +47,13 @@ export const RENDER_LEGEND_CONTENT_ARGS = {
     'This accepts a function that is called to render the legend content instead of the given legend. If `showLegend` is false, this prop will have no effect.',
 };
 
+export const SHOW_LEGEND_VALUES_ARGS = {
+  description: 'Allows the legend to show values.',
+  control: {
+    type: 'boolean',
+  },
+};
+
 export const RENDER_TOOLTIP_DESCRIPTION =
   'This accepts a function that is called to render the tooltip content. When necessary it calls `formatXAxisLabel` and/or `formatYAxisLabel` to format the `DataSeries[]` values and passes them to `<TooltipContent />`. [RenderTooltipContentData type definition.](https://polaris-viz.shopify.com/?path=/docs/polaris-viz-subcomponents-tooltipcontent-rendertooltipcontent--page)';
 


### PR DESCRIPTION
## What does this implement/fix?
Updates `Donut Chart` to show numbers in legend with new prop `showLegendValues`


<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->
We want to have the ability to toggle showing numbers in the Donut Chart legend.
<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->
See Designs [here](https://www.figma.com/file/lUnNNBLeNTXo8223HRohg5/Smart-viz-updates?type=design&node-id=283-9838&mode=design&t=b9Uxqetvus5eznfs-0)

## Does this close any currently open issues?
Closes https://github.com/Shopify/core-issues/issues/58496
<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?
<img width="551" alt="Screenshot 2023-08-17 at 3 43 33 PM" src="https://github.com/Shopify/polaris-viz/assets/90475364/7d9078cb-cd67-4651-821c-2888f2657fd5">



<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->
http://localhost:6007/?path=/story/polaris-viz-charts-donutchart--legend-values


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
