### PR TITLE
[Donut Chart] Update center to include value of hovered item

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+-  Changed `<DonutChart />` to show value of hovered item in the center.
 
 ## [9.10.4] - 2023-08-09
 

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
@@ -47,6 +47,8 @@ export function InnerValue({
     </animated.span>
   );
 
+  const valueToDisplay = activeValue || animatedTotalValue;
+
   const innerContent = renderInnerValueContent?.({
     activeValue,
     animatedTotalValue,
@@ -57,9 +59,9 @@ export function InnerValue({
         className={classNames(styles.ContentValue)}
         style={{color: selectedTheme.xAxis.labelColor}}
       >
-        {animatedTotalValue}
+        {valueToDisplay}
       </animated.p>
-      {comparisonMetric != null && (
+      {comparisonMetric != null && !activeValue && (
         <div className={styles.ComparisonMetric}>
           <ComparisonMetric
             metric={comparisonMetric.metric}

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/tests/InnerValue.test.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/tests/InnerValue.test.tsx
@@ -1,0 +1,81 @@
+import {mount} from '@shopify/react-testing';
+import {animated, config} from '@react-spring/web';
+import {min} from 'd3-array';
+
+import {InnerValue} from '../InnerValue';
+import {ComparisonMetric} from '../../../../ComparisonMetric';
+
+const mockProps = {
+  activeValue: 100,
+  totalValue: 1000,
+  labelFormatter: jest.fn(),
+  isAnimated: true,
+};
+
+jest.mock('@react-spring/web', () => ({
+  ...jest.requireActual('@react-spring/web'),
+  useSpring: jest.fn(() => ({
+    animatedValue: {to: jest.fn(() => mockProps.totalValue)},
+  })),
+}));
+
+describe('<InnerValue />', () => {
+  it('renders the active value if it exists', async () => {
+    const innerValue = mount(<InnerValue {...mockProps} />);
+
+    expect(innerValue).toContainReactComponent('p', {
+      children: mockProps.activeValue,
+    });
+  });
+
+  it('renders the animated total value if the active value does not exist', async () => {
+    const innerValue = mount(<InnerValue {...mockProps} activeValue={null} />);
+
+    expect(innerValue).toContainReactComponent(animated.span, {
+      children: mockProps.totalValue,
+    });
+  });
+
+  it('renders a custom inner value if prop `renderInnerValueContent` exists', async () => {
+    const innerValue = mount(
+      <InnerValue
+        {...mockProps}
+        renderInnerValueContent={({totalValue}) => <span>{totalValue}</span>}
+      />,
+    );
+
+    expect(innerValue).toContainReactComponent('span', {
+      children: mockProps.totalValue,
+    });
+  });
+
+  describe('<ComparisonMetric />', () => {
+    it('renders a <ComparisonMetric /> if a `comparisonMetric` exists', async () => {
+      const innerValue = mount(
+        <InnerValue
+          {...mockProps}
+          activeValue={null}
+          comparisonMetric={{
+            metric: '6%',
+            trend: 'positive',
+            accessibilityLabel: 'trending up 6%',
+          }}
+        />,
+      );
+
+      expect(innerValue).toContainReactComponent(ComparisonMetric);
+    });
+
+    it('does not render a <ComparisonMetric /> if a `comparisonMetric` does not exist', async () => {
+      const innerValue = mount(
+        <InnerValue
+          {...mockProps}
+          activeValue={null}
+          comparisonMetric={null}
+        />,
+      );
+
+      expect(innerValue).not.toContainReactComponent(ComparisonMetric);
+    });
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

Updates `Donut Chart` to show value of hovered item in the center. 

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->
We want the active value to display as the inner value of the Donut Chart.
<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->
See Designs [here](https://www.figma.com/file/lUnNNBLeNTXo8223HRohg5/Smart-viz-updates?type=design&node-id=283-9838&mode=design&t=9wzCshoEsfPOA0qv-0)


## Does this close any currently open issues?
https://github.com/Shopify/core-issues/issues/58495
<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

![inner-value](https://github.com/Shopify/polaris-viz/assets/90475364/be4826dd-03f5-4897-9c2c-792049fde703)


<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link
http://localhost:6006/?path=/story/polaris-viz-charts-donutchart--default

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
