### PR TITLE
Fix stacked area arity bug

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -16,6 +16,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed issue in `<LineChart />` where tooltip would be rendered in the wrong position when performance was impacted.
+- Fixed issue in `<StackedArea />` where changing data to new data with different length would cause the chart to throw
 
 ## [9.10.4] - 2023-08-09
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/AnimatedArea.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/AnimatedArea.tsx
@@ -1,0 +1,115 @@
+import {useRef} from 'react';
+import {animated, useSpring} from '@react-spring/web';
+import type {SpringValue} from '@react-spring/web';
+import type {GradientStop} from '@shopify/polaris-viz-core';
+import {
+  LinearGradientWithStops,
+  getColorVisionEventAttrs,
+  COLOR_VISION_SINGLE_ITEM,
+  getColorVisionStylesForActiveIndex,
+  useChartContext,
+  AREAS_LOAD_ANIMATION_CONFIG,
+  getGradientFromColor,
+  useSpringConfig,
+  AREAS_TRANSITION_CONFIG,
+} from '@shopify/polaris-viz-core';
+
+import type {AreaProps} from './types';
+import styles from './Area.scss';
+
+export function AnimatedArea({
+  activeLineIndex,
+  animationIndex,
+  areaGenerator,
+  colors,
+  data,
+  duration,
+  id,
+  index,
+  lineGenerator,
+  selectedTheme,
+  zeroLineValues,
+}: AreaProps) {
+  const {shouldAnimate} = useChartContext();
+  const delay = animationIndex * (duration / 2);
+
+  const mounted = useRef(false);
+
+  const springConfig = useSpringConfig({
+    shouldAnimate,
+    animationDelay: delay,
+    mountedSpringConfig: AREAS_TRANSITION_CONFIG,
+    unmountedSpringConfig: AREAS_LOAD_ANIMATION_CONFIG,
+  });
+
+  const {
+    animatedAreaShape,
+    animatedLineShape,
+    opacity,
+  }: {
+    animatedAreaShape: SpringValue;
+    animatedLineShape: SpringValue;
+    opacity: SpringValue;
+  } = useSpring({
+    from: {
+      opacity: 0,
+      animatedAreaShape: areaGenerator(mounted.current ? data : zeroLineValues),
+      animatedLineShape: lineGenerator(mounted.current ? data : zeroLineValues),
+    },
+    to: {
+      opacity: 0.25,
+      animatedAreaShape: areaGenerator(data),
+      animatedLineShape: lineGenerator(data),
+    },
+    ...springConfig,
+  });
+
+  if (animatedAreaShape == null || animatedLineShape == null) {
+    return null;
+  }
+
+  const gradient = getGradientFromColor(colors[index]);
+
+  return (
+    <g
+      {...getColorVisionEventAttrs({
+        type: COLOR_VISION_SINGLE_ITEM,
+        index,
+      })}
+      tabIndex={-1}
+    >
+      <defs>
+        <LinearGradientWithStops
+          id={`area-${id}-${index}`}
+          gradient={gradient as GradientStop[]}
+          gradientUnits="userSpaceOnUse"
+          y1="100%"
+          y2="0%"
+        />
+      </defs>
+      <g
+        style={getColorVisionStylesForActiveIndex({
+          activeIndex: activeLineIndex,
+          index,
+        })}
+        aria-hidden="true"
+        tabIndex={-1}
+        className={styles.Group}
+      >
+        <animated.path
+          key={`line-${index}`}
+          d={animatedLineShape}
+          fill="none"
+          stroke={`url(#area-${id}-${index})`}
+          strokeWidth={selectedTheme.line.width}
+        />
+        <animated.path
+          key={index}
+          style={{opacity}}
+          d={animatedAreaShape}
+          fill={`url(#area-${id}-${index})`}
+        />
+      </g>
+    </g>
+  );
+}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/Area.tsx
@@ -1,86 +1,30 @@
-import {useRef} from 'react';
-import {animated, useSpring} from '@react-spring/web';
-import type {SpringValue} from '@react-spring/web';
-import type {Area as D3Area, Line} from 'd3-shape';
 import {
   LinearGradientWithStops,
   getColorVisionEventAttrs,
   COLOR_VISION_SINGLE_ITEM,
   getColorVisionStylesForActiveIndex,
-  useChartContext,
-  AREAS_LOAD_ANIMATION_CONFIG,
   getGradientFromColor,
-  useSpringConfig,
-  AREAS_TRANSITION_CONFIG,
 } from '@shopify/polaris-viz-core';
-import type {Color, Theme, GradientStop} from '@shopify/polaris-viz-core';
-
-import type {StackedSeries} from '../../../../types';
+import type {GradientStop} from '@shopify/polaris-viz-core';
 
 import styles from './Area.scss';
-
-export interface AreaProps {
-  activeLineIndex: number;
-  animationIndex: number;
-  areaGenerator: D3Area<number[]>;
-  colors: Color[];
-  data: StackedSeries;
-  zeroLineValues: StackedSeries;
-  duration: number;
-  id: string;
-  index: number;
-  lineGenerator: Line<number[]>;
-  selectedTheme: Theme;
-}
+import type {AreaProps} from './types';
 
 export function Area({
   activeLineIndex,
-  animationIndex,
   areaGenerator,
   colors,
   data,
-  duration,
   id,
   index,
   lineGenerator,
   selectedTheme,
-  zeroLineValues,
 }: AreaProps) {
-  const {shouldAnimate} = useChartContext();
-  const delay = animationIndex * (duration / 2);
+  const opacity = 0.25;
+  const areaShape = areaGenerator(data);
+  const lineShape = lineGenerator(data);
 
-  const mounted = useRef(false);
-
-  const springConfig = useSpringConfig({
-    shouldAnimate,
-    animationDelay: delay,
-    mountedSpringConfig: AREAS_TRANSITION_CONFIG,
-    unmountedSpringConfig: AREAS_LOAD_ANIMATION_CONFIG,
-  });
-
-  const {
-    animatedAreaShape,
-    animatedLineShape,
-    opacity,
-  }: {
-    animatedAreaShape: SpringValue;
-    animatedLineShape: SpringValue;
-    opacity: SpringValue;
-  } = useSpring({
-    from: {
-      opacity: 0,
-      animatedAreaShape: areaGenerator(mounted.current ? data : zeroLineValues),
-      animatedLineShape: lineGenerator(mounted.current ? data : zeroLineValues),
-    },
-    to: {
-      opacity: 0.25,
-      animatedAreaShape: areaGenerator(data),
-      animatedLineShape: lineGenerator(data),
-    },
-    ...springConfig,
-  });
-
-  if (animatedAreaShape == null || animatedLineShape == null) {
+  if (areaShape == null || lineShape == null) {
     return null;
   }
 
@@ -112,17 +56,17 @@ export function Area({
         tabIndex={-1}
         className={styles.Group}
       >
-        <animated.path
+        <path
           key={`line-${index}`}
-          d={animatedLineShape}
+          d={lineShape}
           fill="none"
           stroke={`url(#area-${id}-${index})`}
           strokeWidth={selectedTheme.line.width}
         />
-        <animated.path
+        <path
           key={index}
           style={{opacity}}
-          d={animatedAreaShape}
+          d={areaShape}
           fill={`url(#area-${id}-${index})`}
         />
       </g>

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/index.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/index.ts
@@ -1,1 +1,2 @@
 export {Area} from './Area';
+export {AnimatedArea} from './AnimatedArea';

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/tests/AnimatedArea.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/tests/AnimatedArea.test.tsx
@@ -1,19 +1,20 @@
 import {mount} from '@shopify/react-testing';
 import {area, line} from 'd3-shape';
 import {scaleLinear} from 'd3-scale';
+import React from 'react';
 
 import {mountWithProvider} from '../../../../../test-utilities';
 import {mockDefaultTheme} from '../../../../../test-utilities/mountWithProvider';
-import type {AreaProps} from '../Area';
-import {Area} from '../Area';
 import {DEFAULT_THEME} from '../../../../../constants';
 import type {StackedSeries, Theme} from '../../../../../types';
+import type {AreaProps} from '../types';
+import {AnimatedArea} from '../AnimatedArea';
 
 jest.mock('d3-scale', () => ({
   scaleLinear: jest.requireActual('d3-scale').scaleLinear,
 }));
 
-describe('<Area />', () => {
+describe('<AnimatedArea />', () => {
   const xScale = scaleLinear();
   const yScale = scaleLinear();
 
@@ -54,7 +55,7 @@ describe('<Area />', () => {
   it('renders a path for each series', () => {
     const stackedArea = mount(
       <svg>
-        <Area {...mockProps} />
+        <AnimatedArea {...mockProps} />
       </svg>,
     );
 
@@ -65,7 +66,7 @@ describe('<Area />', () => {
     const {themes} = mockDefaultTheme({line: {width: 10}});
     const stackedArea = mountWithProvider(
       <svg>
-        <Area {...mockProps} selectedTheme={themes.Default as Theme} />
+        <AnimatedArea {...mockProps} selectedTheme={themes.Default as Theme} />
       </svg>,
     );
 
@@ -79,7 +80,7 @@ describe('<Area />', () => {
   it('renders correctly when line.hasSpline is false', () => {
     const stackedArea = mountWithProvider(
       <svg>
-        <Area {...mockProps} />
+        <AnimatedArea {...mockProps} />
       </svg>,
 
       mockDefaultTheme({line: {hasSpline: false}}),
@@ -98,7 +99,7 @@ describe('<Area />', () => {
 
     const stackedArea = mount(
       <svg>
-        <Area {...mockProps} />
+        <AnimatedArea {...mockProps} />
       </svg>,
     );
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/Area/types.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/Area/types.ts
@@ -1,0 +1,18 @@
+import type {Area as D3Area, Line} from 'd3-shape';
+import type {Color, Theme} from '@shopify/polaris-viz-core';
+
+import type {StackedSeries} from '../../../../types';
+
+export interface AreaProps {
+  activeLineIndex: number;
+  animationIndex: number;
+  areaGenerator: D3Area<number[]>;
+  colors: Color[];
+  data: StackedSeries;
+  zeroLineValues: StackedSeries;
+  duration: number;
+  id: string;
+  index: number;
+  lineGenerator: Line<number[]>;
+  selectedTheme: Theme;
+}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -6,6 +6,7 @@ import {
   curveStepRounded,
   uniqueId,
   COLOR_VISION_SINGLE_ITEM,
+  usePrevious,
 } from '@shopify/polaris-viz-core';
 
 import {
@@ -16,7 +17,7 @@ import {
 } from '../../../../constants';
 import type {StackedSeries} from '../../../../types';
 import {useTheme, useWatchColorVisionEvents} from '../../../../hooks';
-import {Area} from '..';
+import {AnimatedArea, Area} from '../Area';
 
 interface Props {
   colors: Color[];
@@ -36,6 +37,7 @@ export function StackedAreas({
   zeroLineValues,
 }: Props) {
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
+  const previousStackedValues = usePrevious(stackedValues);
 
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
@@ -84,8 +86,14 @@ export function StackedAreas({
   return (
     <Fragment>
       {stackedValues.map((data, index) => {
+        const dataIsValidForAnimation =
+          !previousStackedValues ||
+          data.length === previousStackedValues[index].length;
+
+        const AreaComponent = dataIsValidForAnimation ? AnimatedArea : Area;
+
         return (
-          <Area
+          <AreaComponent
             activeLineIndex={activeLineIndex}
             animationIndex={stackedValues.length - 1 - index}
             areaGenerator={areaGenerator}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -1,8 +1,9 @@
 import {mount} from '@shopify/react-testing';
 import {scaleLinear} from 'd3-scale';
+import React from 'react';
 
 import {StackedAreas} from '../StackedAreas';
-import {Area} from '../../Area';
+import {AnimatedArea, Area} from '../../Area';
 import type {StackedSeries} from '../../../../../types';
 
 jest.mock('d3-scale', () => ({
@@ -29,16 +30,17 @@ describe('<StackedAreas />', () => {
     isAnimated: true,
     stackedValues: mockStackedValues,
     zeroLineValues: mockStackedValues,
+    theme: `Default`,
   };
 
-  it('renders a <Area /> for each stacked series', () => {
+  it('renders a <AnimatedArea /> for each stacked series', () => {
     const stackedArea = mount(
       <svg>
         <StackedAreas {...mockProps} />
       </svg>,
     );
 
-    expect(stackedArea).toContainReactComponentTimes(Area, 2);
+    expect(stackedArea).toContainReactComponentTimes(AnimatedArea, 2);
   });
 
   it('passes index and animationIndex to <Area />', () => {
@@ -48,7 +50,7 @@ describe('<StackedAreas />', () => {
       </svg>,
     );
 
-    const stacks = stackedArea.findAll(Area);
+    const stacks = stackedArea.findAll(AnimatedArea);
 
     expect(stacks[0]).toHaveReactProps({
       animationIndex: 1,
@@ -62,21 +64,21 @@ describe('<StackedAreas />', () => {
   });
 
   describe('stackedValues', () => {
-    it('passes SLOW_DURATION to <Area /> .length is less than 10', () => {
+    it('passes SLOW_DURATION to <AnimatedArea /> .length is less than 10', () => {
       const stackedArea = mount(
         <svg>
           <StackedAreas {...mockProps} />
         </svg>,
       );
 
-      const stacks = stackedArea.findAll(Area);
+      const stacks = stackedArea.findAll(AnimatedArea);
 
       expect(stacks[0]).toHaveReactProps({
         duration: 275,
       });
     });
 
-    it('passes FAST_DURATION to <Area /> .length is greater than 10', () => {
+    it('passes FAST_DURATION to <AnimatedArea /> .length is greater than 10', () => {
       const mockValues = new Array(11).fill([
         [163, 269],
         [0, 0],
@@ -91,7 +93,7 @@ describe('<StackedAreas />', () => {
         </svg>,
       );
 
-      const stacks = stackedArea.findAll(Area);
+      const stacks = stackedArea.findAll(AnimatedArea);
 
       expect(stacks[0]).toHaveReactProps({
         duration: 100,

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/DynamicData.stories.tsx
@@ -8,24 +8,26 @@ export const DynamicData = () => {
   const [data, setData] = useState({
     name: 'Sales',
     data: [
-      {value: 100, key: '2020-04-01T12:00:00'},
-      {value: 99, key: '2020-04-02T12:00:00'},
-      {value: 1000, key: '2020-04-03T12:00:00'},
-      {value: 2, key: '2020-04-04T12:00:00'},
-      {value: 22, key: '2020-04-05T12:00:00'},
-      {value: 6, key: '2020-04-06T12:00:00'},
-      {value: 5, key: '2020-04-07T12:00:00'},
+      {value: 100, key: '0'},
+      {value: 99, key: '1'},
+      {value: 1000, key: '2'},
+      {value: 2, key: '3'},
+      {value: 22, key: '4'},
+      {value: 6, key: '5'},
+      {value: 5, key: '6'},
     ],
   });
 
   const onClick = () => {
-    const newData = data.data.map(({key}) => {
+    const dataLength = Math.floor(Math.random() * 10) + 2;
+    const newData = [...Array(dataLength)].map((_, index) => {
       const newValue = Math.floor(Math.random() * 200);
       return {
-        key,
+        key: String(index),
         value: newValue,
       };
     });
+
     setData({
       name: data.name,
       data: newData,


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->
This PR fixes a bug we are seeing with the stacked area chart throwing when the length of the data changes. After some investigation we found that React spring is unable to animate svgs of different lengths without a custom interpolator but that seemed like overkill for now. Instead I've decided to just not animate when the length of data changes. 

I've updated the Dynamic Data story for the Stacked Area component to change data length as well as value.  


<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?
Part of the work for: https://github.com/Shopify/core-issues/issues/59450


<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

🖼 Include screenshots of before and after, if relevant

Before: 

https://github.com/Shopify/polaris-viz/assets/13425309/342fe148-e3b3-442b-ba89-74c2c6a0d5ad

After:

https://github.com/Shopify/polaris-viz/assets/13425309/e06036cc-3239-4f2a-903b-97649de7d581


## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [x] Update the Changelog's Unreleased section with your changes.
- [x] Update relevant documentation, tests, and Storybook.
- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
