### PR TITLE
Fix performant tooltips rendering at the top of the page

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -9,7 +9,11 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
--  Changed `<DonutChart />` to show value of hovered item in the center.
+- Changed `<DonutChart />` to show value of hovered item in the center.
+
+### Fixed
+
+- Fixed issue in `<LineChart />` where tooltip would be rendered in the wrong position when performance was impacted.
 
 ## [9.10.4] - 2023-08-09
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -267,8 +267,8 @@ export function Chart({
   const chartBounds: BoundingRect = {
     width,
     height,
-    x: chartXPosition,
-    y: chartYPosition,
+    x: dimensions?.x ?? chartXPosition,
+    y: dimensions?.y ?? chartYPosition,
   };
 
   const {hasXAxisAnnotations, hasYAxisAnnotations} = checkAvailableAnnotations(

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/ExternalTooltip.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/ExternalTooltip.stories.tsx
@@ -2,6 +2,7 @@ import type {Story} from '@storybook/react';
 
 import {LineChart, LineChartProps} from '../../LineChart';
 import {META} from '../meta';
+import {randomNumber} from '../../../Docs/utilities';
 
 export default {
   ...META,
@@ -25,13 +26,27 @@ function Card(args: LineChartProps) {
   );
 }
 
+const HOURLY_DATA = [
+  {
+    name: 'Hourly Data',
+    data: Array(743)
+      .fill(null)
+      .map((_, index) => {
+        return {
+          key: new Date(2021, 1, 1, index).toISOString(),
+          value: randomNumber(0, 400),
+        };
+      }),
+  },
+];
+
 const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return (
     <div style={{overflow: 'auto'}}>
       <Card {...args} />
       <div style={{height: 700, width: 10}} />
       <div style={{display: 'flex', justifyContent: 'space-between'}}>
-        <Card {...args} />
+        <Card {...args} data={HOURLY_DATA} />
         <Card {...args} />
         <Card {...args} />
       </div>

--- a/packages/polaris-viz/src/components/LineChart/utilities/getAlteredLineChartPosition.ts
+++ b/packages/polaris-viz/src/components/LineChart/utilities/getAlteredLineChartPosition.ts
@@ -31,7 +31,7 @@ export type AlteredPosition = (
 export function getAlteredLineChartPosition(
   props: AlteredPositionProps,
 ): AlteredPositionReturn {
-  const {currentX, currentY} = props;
+  const {currentX, currentY, chartBounds} = props;
 
   let x = currentX;
   let y = currentY;
@@ -41,7 +41,7 @@ export function getAlteredLineChartPosition(
   //
 
   if (props.isPerformanceImpacted) {
-    y = 0;
+    y = chartBounds.y ?? 0;
   }
 
   //

--- a/packages/polaris-viz/src/components/LineChart/utilities/tests/getAlteredLineChartPosition.test.ts
+++ b/packages/polaris-viz/src/components/LineChart/utilities/tests/getAlteredLineChartPosition.test.ts
@@ -9,7 +9,7 @@ const MARGIN = {Top: 0, Left: 0, Right: 0, Bottom: 0};
 
 const BASE_PROPS: AlteredPositionProps = {
   isPerformanceImpacted: false,
-  chartBounds: {height: 100, width: 200, x: 0, y: 0},
+  chartBounds: {height: 100, width: 200, x: 0, y: 100},
   tooltipDimensions: {height: 40, width: 60},
   margin: MARGIN,
   bandwidth: 40,
@@ -67,6 +67,17 @@ describe('getAlteredLineChartPosition', () => {
           currentY: 2000,
         }),
       ).toStrictEqual({x: 60, y: 1340});
+    });
+
+    it('uses chartBounds whe performance is impacted', () => {
+      expect(
+        getAlteredLineChartPosition({
+          ...BASE_PROPS,
+          isPerformanceImpacted: true,
+          currentX: 0,
+          currentY: 2000,
+        }),
+      ).toStrictEqual({x: 60, y: 100});
     });
   });
 


### PR DESCRIPTION
## What does this implement/fix?

Fixed the `y` position of tooltips when performance is impacted.

## Storybook link

https://6062ad4a2d14cd0021539c1b-hfmodciywx.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--external-tooltip

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
