### PR TITLE
[Bug Fix]: Adjust tooltip position on StackedAreaChart when page is scrolled

### DIFF
--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -62,6 +62,7 @@ import {useStackedData} from './hooks';
 import {StackedAreas, Points} from './components';
 import {useStackedChartTooltipContent} from './hooks/useStackedChartTooltipContent';
 import {yAxisMinMax} from './utilities/yAxisMinMax';
+import {getAlteredStackedAreaChartPosition} from './utilities/getAlteredStackedAreaChartPosition';
 import styles from './Chart.scss';
 
 const TOOLTIP_POSITION: TooltipPositionOffset = {
@@ -382,6 +383,7 @@ export function Chart({
           focusElementDataType={DataType.Point}
           getMarkup={getTooltipMarkup}
           getPosition={getTooltipPosition}
+          getAlteredPosition={getAlteredStackedAreaChartPosition}
           id={tooltipId}
           margin={ChartMargin}
           onIndexChange={(index) => setActivePointIndex(index)}

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/ExternalTooltip.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/ExternalTooltip.stories.tsx
@@ -1,0 +1,40 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import {StackedAreaChart, type StackedAreaChartProps} from '../../../components';
+
+import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
+
+function Card(args: StackedAreaChartProps) {
+  return (
+    <div
+      style={{
+        height: 500,
+        background: 'white',
+        borderRadius: '8px',
+        padding: 10,
+      }}
+    >
+      <StackedAreaChart {...args} theme="Uplift" />
+    </div>
+  );
+}
+
+const Template: Story<StackedAreaChartProps> = (args: StackedAreaChartProps) => {
+  return (
+    <div style={{overflowY: 'scroll', height:500}}>
+      <Card {...args} />
+      <div style={{height: 1500, width: 10}} />
+    </div>
+  );
+}
+
+
+
+export const ExternalTooltip: Story<StackedAreaChartProps> = Template.bind({});
+
+ExternalTooltip.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/utilities/getAlteredStackedAreaChartPosition.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/utilities/getAlteredStackedAreaChartPosition.ts
@@ -1,0 +1,54 @@
+import type {Dimensions} from '@shopify/polaris-viz-core';
+
+import type {TooltipPositionOffset} from '../../TooltipWrapper';
+import type {Margin} from '../../../types';
+
+// The space between the cursor and the tooltip
+const TOOLTIP_MARGIN = 20;
+
+export interface AlteredPositionProps {
+  bandwidth: number;
+  chartBounds: {x: number; y: number; width: number; height: number};
+  currentX: number;
+  currentY: number;
+  isPerformanceImpacted: boolean;
+  margin: Margin;
+  position: TooltipPositionOffset;
+  tooltipDimensions: Dimensions;
+}
+
+export interface AlteredPositionReturn {
+  x: number;
+  y: number;
+}
+
+export type AlteredPosition = (
+  props: AlteredPositionProps,
+) => AlteredPositionReturn;
+
+export function getAlteredStackedAreaChartPosition({
+  currentX,
+  currentY,
+  chartBounds,
+  margin,
+  tooltipDimensions,
+}: AlteredPositionProps): AlteredPositionReturn {
+  const x = Math.min(
+    Math.max(currentX, TOOLTIP_MARGIN),
+    chartBounds.width - tooltipDimensions.width - TOOLTIP_MARGIN,
+  );
+
+  // Y POSITIONING
+  // If y is below the chart, adjust the tooltip position to the bottom of the chart
+  //
+
+  const y =
+    currentY >= chartBounds.y + chartBounds.height
+      ? chartBounds.height -
+        tooltipDimensions.height -
+        TOOLTIP_MARGIN -
+        margin.Bottom
+      : currentY;
+
+  return {x, y};
+}

--- a/packages/polaris-viz/src/components/StackedAreaChart/utilities/tests/getAlteredStackedAreaChartPosition.test.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/utilities/tests/getAlteredStackedAreaChartPosition.test.ts
@@ -1,0 +1,80 @@
+import type {AlteredPositionProps} from '../../../TooltipWrapper';
+import {
+  TooltipVerticalOffset,
+  TooltipHorizontalOffset,
+} from '../../../TooltipWrapper';
+import {getAlteredStackedAreaChartPosition} from '../getAlteredStackedAreaChartPosition';
+
+const MARGIN = {Top: 0, Left: 0, Right: 0, Bottom: 0};
+const TOOLTIP_MARGIN = 20;
+
+const BASE_PROPS: AlteredPositionProps = {
+  isPerformanceImpacted: false,
+  chartBounds: {height: 100, width: 200, x: 0, y: 100},
+  tooltipDimensions: {height: 40, width: 60},
+  margin: MARGIN,
+  bandwidth: 40,
+  currentX: 20,
+  currentY: 0,
+  position: {
+    horizontal: TooltipHorizontalOffset.Left,
+    vertical: TooltipVerticalOffset.Center,
+  },
+};
+
+describe('getAlteredStackedAreaChartPosition', () => {
+  it('returns the original position of y when currentY is within the chart bounds', () => {
+    const props = {
+      ...BASE_PROPS,
+      currentX: 50,
+      currentY: 50,
+    };
+
+    const result = getAlteredStackedAreaChartPosition(props);
+
+    expect(result.x).toBe(50);
+    expect(result.y).toBe(50);
+  });
+
+  it('returns the adjusted position when currentY is greater than chartBounds.y + chartBounds.height', () => {
+    const props = {
+      ...BASE_PROPS,
+      currentY: 300,
+    };
+
+    const chartBounds = props.chartBounds;
+    const tooltipDimensions = props.tooltipDimensions;
+    const margin = props.margin;
+    const result = getAlteredStackedAreaChartPosition(props);
+
+    expect(result.x).toBe(20);
+
+    expect(result.y).toBe(
+      chartBounds.height -
+        tooltipDimensions.height -
+        TOOLTIP_MARGIN -
+        margin.Bottom,
+    );
+  });
+
+  it('returns the adjusted position when currentY is equal to chartBounds.y + chartBounds.height', () => {
+    const props = {
+      ...BASE_PROPS,
+      currentY: 200,
+    };
+
+    const chartBounds = props.chartBounds;
+    const tooltipDimensions = props.tooltipDimensions;
+    const margin = props.margin;
+    const result = getAlteredStackedAreaChartPosition(props);
+
+    expect(result.x).toBe(20);
+
+    expect(result.y).toBe(
+      chartBounds.height -
+        tooltipDimensions.height -
+        TOOLTIP_MARGIN -
+        margin.Bottom,
+    );
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

Fixes: https://github.com/Shopify/core-issues/issues/60331

**Issue**
Received a possible bug that the `ReturningCustomerRate` card was not rendering a tooltip.

- Investigated and found that the tooltip _was_ being rendered, but that when the window was scrolled, the tooltip was rendering outside of the bounds of the chart and was no longer visible. It was also being partially cut off when the scroll value was lower.

https://github.com/Shopify/polaris-viz/assets/33559193/40426d92-6773-4952-b1ad-8458794af3df

- To replicate the issue, staff in to any store and navigate to the Dashboard. Ensure the `ReturningCustomerRate` card is displayed (currently the only StackedArea chart available). 
- If you move this card to a place on the dashboard and have to scroll to access it, hover over and you'll notice the tooltip does not appear in the expected position.
- Move the card to the top of the dashboard and hover over it. Without scroll, the tooltip will appear as expected.
- You can experiment with different scroll amounts to see the full behaviour.

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->
Fixes https://github.com/Shopify/core-issues/issues/60331


## What do the changes look like?
Note: Tested in Storybook - need to confirm this fix works once updated and available in web.

https://github.com/Shopify/polaris-viz/assets/33559193/545208ca-22eb-4ba8-b462-9b4315b0fce7

## Extra Thoughts 
There are a few similar functions across the charts now to adjust the position of the tooltip in various scenarios. I was thinking it might be worth combining these into one function to adjust the positioning that (ideally) works for all of the charts. 

Happy to look into this further if there's consensus this needs to happen.



<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
