### PR TITLE
Render all zero charts to left of container

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- `<SimpleBarChart />` with all zero values will now render to the left of the chart instead of the middle.
 
 ## [9.14.0] - 2023-10-02
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/chromatic/AllZeroValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/chromatic/AllZeroValues.chromatic.stories.tsx
@@ -1,0 +1,59 @@
+import type {Story} from '@storybook/react';
+
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/SimpleBarChart/AllZeroValues',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+import type {SimpleBarChartProps} from '../../../../components';
+
+import {Template} from '../data';
+
+export const AllZeroValues: Story<SimpleBarChartProps> = Template.bind({});
+
+AllZeroValues.args = {
+  data: [
+    {
+      name: 'BCFM 2019',
+      data: [
+        {
+          key: 'Womens Leggings',
+          value: 0,
+        },
+        {
+          key: 'Mens Bottoms',
+          value: 0,
+        },
+        {
+          key: 'Mens Shorts',
+          value: 0,
+        },
+        {
+          key: 'Socks',
+          value: 0,
+        },
+        {
+          key: 'Hats',
+          value: 0,
+        },
+        {
+          key: 'Ties',
+          value: 0,
+        },
+      ],
+      metadata: {
+        trends: {
+          '0': {
+            value: '10%',
+          },
+        },
+      },
+    },
+  ],
+};

--- a/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
@@ -156,29 +156,57 @@ describe('useDataForHorizontalChart()', () => {
     expect(data.allNumbers).toStrictEqual([0, 0, 0]);
   });
 
-  it('areAllNegative returns true when all numbers are 0', () => {
-    function TestComponent() {
-      const data = useDataForHorizontalChart({
-        ...MOCK_PROPS,
-        data: [
-          {
-            name: 'Group 1',
-            data: [
-              {value: 0, key: 'Label 01'},
-              {value: 0, key: 'Label 02'},
-              {value: 0, key: 'Label 03'},
-            ],
-          },
-        ],
-      });
+  describe('areAllNegative', () => {
+    it('returns false when all numbers are 0', () => {
+      function TestComponent() {
+        const data = useDataForHorizontalChart({
+          ...MOCK_PROPS,
+          data: [
+            {
+              name: 'Group 1',
+              data: [
+                {value: 0, key: 'Label 01'},
+                {value: 0, key: 'Label 02'},
+                {value: 0, key: 'Label 03'},
+              ],
+            },
+          ],
+        });
 
-      return <span data-data={`${JSON.stringify(data)}`} />;
-    }
+        return <span data-data={`${JSON.stringify(data)}`} />;
+      }
 
-    const result = mount(<TestComponent />);
+      const result = mount(<TestComponent />);
 
-    const data = JSON.parse(result.domNode?.dataset.data ?? '');
+      const data = JSON.parse(result.domNode?.dataset.data ?? '');
 
-    expect(data.areAllNegative).toStrictEqual(true);
+      expect(data.areAllNegative).toStrictEqual(false);
+    });
+
+    it('areAllNegative returns true when all numbers are negative and not all 0', () => {
+      function TestComponent() {
+        const data = useDataForHorizontalChart({
+          ...MOCK_PROPS,
+          data: [
+            {
+              name: 'Group 1',
+              data: [
+                {value: 0, key: 'Label 01'},
+                {value: -1, key: 'Label 02'},
+                {value: 0, key: 'Label 03'},
+              ],
+            },
+          ],
+        });
+
+        return <span data-data={`${JSON.stringify(data)}`} />;
+      }
+
+      const result = mount(<TestComponent />);
+
+      const data = JSON.parse(result.domNode?.dataset.data ?? '');
+
+      expect(data.areAllNegative).toStrictEqual(true);
+    });
   });
 });

--- a/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
+++ b/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
@@ -71,9 +71,17 @@ export function useDataForHorizontalChart({
     characterWidths,
   ]);
 
-  const areAllNegative = useMemo(() => {
-    return !allNumbers.some((num) => num !== null && num > 0);
+  const areAllZero = useMemo(() => {
+    return !allNumbers.some((num) => num !== null && num !== 0);
   }, [allNumbers]);
+
+  const areAllNegative = useMemo(() => {
+    if (areAllZero) {
+      return false;
+    }
+
+    return !allNumbers.some((num) => num !== null && num > 0);
+  }, [areAllZero, allNumbers]);
 
   return {
     allNumbers,

--- a/packages/polaris-viz/src/hooks/useHorizontalTicksAndScale.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalTicksAndScale.ts
@@ -21,9 +21,17 @@ export function useHorizontalTicksAndScale({
   stackedMax,
 }: Props) {
   const xScale = useMemo(() => {
+    const areAllZero = !allNumbers.some((num) => num != null && num !== 0);
+
+    const domainValues = [0, ...allNumbers];
+
+    if (areAllZero) {
+      domainValues.push(1);
+    }
+
     return scaleLinear()
       .range([0, maxWidth])
-      .domain(extent([0, ...allNumbers], (num) => num) as [number, number])
+      .domain(extent(domainValues, (num) => num) as [number, number])
       .nice();
   }, [maxWidth, allNumbers]);
 


### PR DESCRIPTION
## What does this implement/fix?

We want to render charts with all zero values at the left side of the container instead of the center

Resolves https://github.com/Shopify/core-issues/issues/61609

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/Shopify/polaris-viz/assets/149873/c950d96e-14b7-40d6-88e2-13433617287c)|![image](https://github.com/Shopify/polaris-viz/assets/149873/2929cea3-fbe0-4a41-90c4-eb7d3e3537b6)|

 
## Storybook link

https://6062ad4a2d14cd0021539c1b-peipdnhbao.chromatic.com/?path=/story/polaris-viz-chromatic-charts-simplebarchart-allzerovalues--all-zero-values

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
