### PR TITLE
Adds an offset to y-axis label in LineChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Added an offset to y-axis labels for `<LineChart />` to accommodate variations in font rendering
 
 ## [9.16.0] - 2023-10-17
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -53,6 +53,7 @@ import {
 import {
   ChartMargin,
   ANNOTATIONS_LABELS_OFFSET,
+  Y_AXIS_LABEL_OFFSET,
   CROSSHAIR_ID,
 } from '../../constants';
 import {VisuallyHiddenRows} from '../VisuallyHiddenRows';
@@ -316,7 +317,7 @@ export function Chart({
 
         <YAxis
           ticks={ticks}
-          width={yAxisLabelWidth}
+          width={yAxisLabelWidth + Y_AXIS_LABEL_OFFSET}
           textAlign="right"
           ariaHidden
           x={yAxisBounds.x}

--- a/packages/polaris-viz/src/constants.ts
+++ b/packages/polaris-viz/src/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULT_LEGEND_HEIGHT = 24;
 export const DEFAULT_LEGEND_WIDTH = 29;
 export const BAR_CONTAINER_TEXT_HEIGHT = 48;
 export const ANNOTATIONS_LABELS_OFFSET = 10;
+export const Y_AXIS_LABEL_OFFSET = 2;
 export const TOOLTIP_BG_OPACITY = 0.8;
 export const COLLAPSED_ANNOTATIONS_COUNT = 3;
 export const PREVIEW_ICON_SIZE = 12;


### PR DESCRIPTION
## What does this implement/fix?

We are currently facing an issue in the Customer Cohort Report where some labels are truncated despite having the same number of characters as other labels. This leads to an inconsistent visual experience. This happens because certain numbers are rendered slightly wider than others due to font rendering variations. I'm adding an offset to y-axis labels to fix this issue.

 
<img width="106" alt="Screenshot 2023-11-07 at 10 52 23 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/7267befb-3483-45a2-866f-fed25d33af71"><img width="140" alt="Screenshot 2023-11-07 at 10 51 35 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/89c91ec4-6740-4952-8fb4-c86a95050ded">


## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/62706


## What do the changes look like?

| Before | After |
|--------|------|
|<img width="177" alt="Screenshot 2023-11-07 at 10 40 05 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/87a9b9e0-8463-4608-828a-9996b954613c">|<img width="130" alt="Screenshot 2023-11-07 at 10 40 32 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/d284314e-2bed-4790-895c-4207ce3904dc">|

 
## Storybook link

[Storybook](http://localhost:6006/?path=/story/polaris-viz-charts-linechart--series-colors-up-to-eight)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
