### PR TITLE
Remove delay when isAnimated: false. Fix Tooltip z-index

### DIFF
--- a/packages/polaris-viz-core/src/hooks/useSpringConfig.ts
+++ b/packages/polaris-viz-core/src/hooks/useSpringConfig.ts
@@ -16,10 +16,12 @@ export function useSpringConfig({
 }: Props) {
   const isMounted = useRef(false);
 
+  const delay = shouldAnimate ? animationDelay : 0;
+
   return {
     config: isMounted.current ? mountedSpringConfig : unmountedSpringConfig,
     default: {immediate: !shouldAnimate},
-    delay: isMounted.current ? 0 : animationDelay,
+    delay: isMounted.current ? 0 : delay,
     onRest: () => (isMounted.current = true),
   };
 }

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where `<BarChart />` would still have a staggered delay when rendering bars/groups if `isAnimated: false`.
 
 ## [9.18.0] - 2023-11-07
 

--- a/packages/polaris-viz/src/components/BarChart/stories/DynamicData.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/DynamicData.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import {useState} from 'react';
 
 import {BarChart} from '../BarChart';
 

--- a/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.scss
+++ b/packages/polaris-viz/src/components/TooltipWrapper/components/TooltipAnimatedContainer.scss
@@ -1,5 +1,8 @@
 .Container {
   position: absolute;
   pointer-events: none;
+  // Matches --p-z-index-12
+  // https://polaris.shopify.com/tokens/z-index
+  z-index: 520;
   max-width: 70%;
 }

--- a/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
+++ b/packages/polaris-viz/src/hooks/useBarSpringConfig.ts
@@ -13,7 +13,7 @@ export function useBarSpringConfig({animationDelay = 0}: Props) {
   const {shouldAnimate} = useChartContext();
 
   return useSpringConfig({
-    animationDelay,
+    animationDelay: shouldAnimate ? animationDelay : 0,
     shouldAnimate,
     unmountedSpringConfig: BARS_LOAD_ANIMATION_CONFIG,
     mountedSpringConfig: BARS_TRANSITION_CONFIG,


### PR DESCRIPTION
## What does this implement/fix?

BarChart would still have a staggered in animation even when `isAnimated` was `false` because we weren't setting the delay to `0`.

Also fixes the tooltip z-index to match the polaris tooltip.

Resolves https://github.com/Shopify/core-issues/issues/63108

## What do the changes look like?

**Before**

https://github.com/Shopify/polaris-viz/assets/149873/f8fb7bd9-aa73-4d5c-bcbc-31f49c45a172

**After**

https://github.com/Shopify/polaris-viz/assets/149873/6f90817f-b879-4fb4-adc6-20ef2e9ccc6d
 
## Storybook link

> [!NOTE]  
> There's an issue where we can't alter the controls in Storybook for some reason that I haven't dug into yet.

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
