### PR TITLE
Rework LineChartPredictive to use in chart LineSeries

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -42,13 +42,15 @@ export function LineSeries({
   activeLineIndex = -1,
   data,
   hiddenIndexes = [],
-  index = 0,
+  index: lineSeriesIndex = 0,
   svgDimensions,
   theme,
   type = 'default',
   xScale,
   yScale,
 }: LineSeriesProps) {
+  const index = data?.metadata?.relatedIndex ?? lineSeriesIndex;
+
   const {
     // eslint-disable-next-line id-length
     components: {Defs, Mask, G, Rect, Path},

--- a/packages/polaris-viz/src/components/ComboChart/components/ComboLineChart/ComboLineChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/components/ComboLineChart/ComboLineChart.tsx
@@ -39,7 +39,7 @@ export function ComboLineChart({
 
   const dataWithDefaults = getLineChartDataWithDefaults(data.series, colors);
 
-  const {reversedSeries, longestSeriesIndex} = useFormatData(dataWithDefaults);
+  const {longestSeriesIndex} = useFormatData(dataWithDefaults);
 
   return (
     <Fragment>
@@ -60,10 +60,10 @@ export function ComboLineChart({
       })}
       <PointsAndCrosshair
         activeIndex={activeIndex}
+        data={dataWithDefaults}
         drawableHeight={drawableHeight}
         emptyState={false}
         longestSeriesIndex={longestSeriesIndex}
-        reversedSeries={reversedSeries}
         theme={theme}
         tooltipId="none"
         xScale={xScale}

--- a/packages/polaris-viz/src/components/Docs/utilities/index.ts
+++ b/packages/polaris-viz/src/components/Docs/utilities/index.ts
@@ -21,7 +21,7 @@ export function randomNumber(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-function generateDayRange(numDays: number) {
+export function generateDayRange(numDays: number) {
   const currentDate = new Date('April 1, 2020');
   const dayRange: string[] = [];
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -152,8 +152,7 @@ export function Chart({
     verticalOverflow: selectedTheme.grid.verticalOverflow,
   });
 
-  const {reversedSeries, longestSeriesLength, longestSeriesIndex} =
-    useFormatData(data);
+  const {longestSeriesLength, longestSeriesIndex} = useFormatData(data);
 
   const {
     drawableWidth,
@@ -208,11 +207,7 @@ export function Chart({
     if (eventType === 'mouse') {
       const point = eventPointNative(event!);
 
-      if (
-        point == null ||
-        xScale == null ||
-        reversedSeries[longestSeriesIndex] == null
-      ) {
+      if (point == null || xScale == null || data[longestSeriesIndex] == null) {
         return TOOLTIP_POSITION_DEFAULT_RETURN;
       }
 
@@ -223,7 +218,7 @@ export function Chart({
       const activeIndex = clamp({
         amount: closestIndex,
         min: 0,
-        max: reversedSeries[longestSeriesIndex].data.length - 1,
+        max: data[longestSeriesIndex].data.length - 1,
       });
 
       return {
@@ -340,13 +335,13 @@ export function Chart({
             theme,
           })}
 
-          {reversedSeries.map((singleSeries, index) => {
+          {data.map((singleSeries, index) => {
             return (
               <LineSeries
                 activeLineIndex={activeLineIndex}
                 data={singleSeries}
                 hiddenIndexes={hiddenLineIndexes}
-                index={reversedSeries.length - 1 - index}
+                index={index}
                 key={`${name}-${index}`}
                 svgDimensions={{height: drawableHeight, width: drawableWidth}}
                 theme={theme}
@@ -359,11 +354,11 @@ export function Chart({
 
           <PointsAndCrosshair
             activeIndex={activeIndex}
+            data={data}
             drawableHeight={drawableHeight}
             emptyState={emptyState}
             hiddenIndexes={hiddenLineIndexes}
             longestSeriesIndex={longestSeriesIndex}
-            reversedSeries={reversedSeries}
             theme={theme}
             tooltipId={tooltipId.current}
             xScale={xScale}

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -64,10 +64,10 @@ export function Points({
 
   return (
     <Fragment>
-      {data.map((singleSeries, index) => {
-        const unreversedIndex = data.length - 1 - index;
+      {data.map((singleSeries, seriesIndex) => {
+        const index = singleSeries.metadata?.relatedIndex ?? seriesIndex;
 
-        if (hiddenIndexes.includes(unreversedIndex)) {
+        if (hiddenIndexes.includes(index)) {
           return null;
         }
 
@@ -85,10 +85,12 @@ export function Points({
             : singleData[activeIndex ?? -1]?.value != null;
 
         const isLineActive =
-          activeLineIndex !== -1 && activeLineIndex !== unreversedIndex;
+          activeLineIndex !== -1 && activeLineIndex !== index;
 
-        const hidePoint =
+        const isPointVisuallyHidden =
           !hasValidData || animatedCoordinates == null || isLineActive;
+
+        const isPointActive = hasValidData && activeIndex != null;
 
         const pointColor = isGradientType(color)
           ? `url(#${pointGradientId})`
@@ -112,11 +114,11 @@ export function Points({
                 color={pointColor}
                 cx={getXPosition({isCrosshair: false})}
                 cy={animatedYPosition}
-                active={hasValidData && activeIndex != null}
+                active={isPointActive}
                 index={index}
                 tabIndex={-1}
                 isAnimated={shouldAnimate}
-                visuallyHidden={hidePoint}
+                visuallyHidden={isPointVisuallyHidden}
                 ariaHidden
               />
             ) : null}
@@ -131,7 +133,7 @@ export function Points({
                   key={`${name}-${index}-${dataIndex}`}
                   style={getColorVisionStylesForActiveIndex({
                     activeIndex: activeLineIndex,
-                    index: data.length - 1 - index,
+                    index,
                     fadedOpacity: 0,
                   })}
                 >

--- a/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
@@ -19,24 +19,24 @@ import {Points} from '../Points';
 
 interface PointsAndCrosshairProps {
   activeIndex: number | null;
+  data: LineChartDataSeriesWithDefaults[];
   drawableHeight: number;
   emptyState: boolean;
+  hiddenIndexes?: number[];
   longestSeriesIndex: number;
-  reversedSeries: LineChartDataSeriesWithDefaults[];
   theme: string;
   tooltipId: string;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
-  hiddenIndexes?: number[];
 }
 
 export function PointsAndCrosshair({
   activeIndex,
+  data,
   drawableHeight,
   emptyState,
   hiddenIndexes = [],
   longestSeriesIndex,
-  reversedSeries,
   theme,
   tooltipId,
   xScale,
@@ -59,7 +59,7 @@ export function PointsAndCrosshair({
   }, [selectedTheme.line.hasSpline, xScale, yScale]);
 
   const {animatedCoordinates} = useLinearChartAnimations({
-    data: reversedSeries,
+    data,
     lineGenerator,
     activeIndex,
   });
@@ -97,7 +97,7 @@ export function PointsAndCrosshair({
         <Points
           activeIndex={emptyState ? null : activeIndex}
           animatedCoordinates={animatedCoordinates}
-          data={reversedSeries}
+          data={data}
           getXPosition={getXPosition}
           gradientId={gradientId.current}
           hiddenIndexes={hiddenIndexes}

--- a/packages/polaris-viz/src/components/LineChart/hooks/useFormatData.ts
+++ b/packages/polaris-viz/src/components/LineChart/hooks/useFormatData.ts
@@ -2,21 +2,19 @@ import {useMemo} from 'react';
 import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
 
 export function useFormatData(data: LineChartDataSeriesWithDefaults[]) {
-  const reversedSeries = useMemo(() => data.slice().reverse(), [data]);
-
   const longestSeriesIndex = useMemo(
     () =>
-      reversedSeries.reduce((maxIndex, currentSeries, currentIndex) => {
-        return reversedSeries[maxIndex].data.length < currentSeries.data.length
+      data.reduce((maxIndex, currentSeries, currentIndex) => {
+        return data[maxIndex].data.length < currentSeries.data.length
           ? currentIndex
           : maxIndex;
       }, 0),
-    [reversedSeries],
+    [data],
   );
 
-  const longestSeriesLength = reversedSeries[longestSeriesIndex]
-    ? reversedSeries[longestSeriesIndex].data.length - 1
+  const longestSeriesLength = data[longestSeriesIndex]
+    ? data[longestSeriesIndex].data.length - 1
     : 0;
 
-  return {reversedSeries, longestSeriesLength, longestSeriesIndex};
+  return {longestSeriesLength, longestSeriesIndex};
 }

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.scss
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.scss
@@ -4,11 +4,3 @@
   flex-wrap: wrap;
   list-style: none;
 }
-
-.IconContainer {
-  display: flex;
-  align-items: center;
-  justify-items: center;
-  height: 12px;
-  width: 20px;
-}

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.tsx
@@ -1,25 +1,13 @@
-import {
-  LinearGradientWithStops,
-  changeGradientOpacity,
-  isGradientType,
-  uniqueId,
-} from '@shopify/polaris-viz-core';
-import type {Color} from '@shopify/polaris-viz-core';
-import {useMemo} from 'react';
-
 import type {LineChartPredictiveDataSeries} from '../../../../components/LineChartPredictive/types';
 import type {ColorVisionInteractionMethods} from '../../../../types';
-import {getLineChartDataWithDefaults} from '../../../../utilities/getLineChartDataWithDefaults';
 import {LegendItem} from '../../../../components/Legend';
+import {SeriesIcon} from '../SeriesIcon';
 
 import styles from './CustomLegend.scss';
 
 interface Props extends ColorVisionInteractionMethods {
   data: LineChartPredictiveDataSeries[];
   predictiveSeriesNames: string[];
-  getColorVisionEventAttrs: any;
-  getColorVisionStyles: any;
-  seriesColors: Color[];
   theme: string;
 }
 
@@ -28,20 +16,17 @@ export function CustomLegend({
   predictiveSeriesNames,
   getColorVisionEventAttrs,
   getColorVisionStyles,
-  seriesColors,
   theme,
 }: Props) {
-  const id = useMemo(() => uniqueId('CustomLegen'), []);
-
-  const dataWithDefaults = getLineChartDataWithDefaults(data, seriesColors);
-
   return (
     <ul className={styles.Container}>
-      {dataWithDefaults.map(({color, name, isComparison}, index) => {
-        const gradientId = `${id}-${index}`;
+      {data.map(({color, name, isComparison, metadata}, index) => {
+        if (metadata?.isPredictive) {
+          return null;
+        }
 
         function renderSeriesIcon() {
-          return <SeriesIcon color={color} gradientId={gradientId} />;
+          return <SeriesIcon color={color!} />;
         }
 
         return (
@@ -69,37 +54,5 @@ export function CustomLegend({
         );
       })}
     </ul>
-  );
-}
-
-function SeriesIcon({color, gradientId}: {color: Color; gradientId: string}) {
-  return (
-    <div className={styles.IconContainer}>
-      <svg
-        width="19"
-        height="4"
-        viewBox="0 0 19 4"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          d="M8 2C8 0.89543 8.89543 0 10 0C11.1046 0 12 0.89543 12 2C12 3.10457 11.1046 4 10 4C8.89543 4 8 3.10457 8 2ZM7.17071 1C7.06015 1.31278 7 1.64936 7 2C7 2.35064 7.06015 2.68722 7.17071 3H1C0.447715 3 0 2.55228 0 2C0 1.44772 0.447715 1 1 1H7.17071ZM13 2C13 2.55228 13.4477 3 14 3H14.4C14.9523 3 15.4 2.55228 15.4 2C15.4 1.44772 14.9523 1 14.4 1H14C13.4477 1 13 1.44772 13 2ZM17.6 1C17.0477 1 16.6 1.44772 16.6 2C16.6 2.55228 17.0477 3 17.6 3H18C18.5523 3 19 2.55228 19 2C19 1.44772 18.5523 1 18 1H17.6Z"
-          fill={`url(#${gradientId})`}
-        />
-        {isGradientType(color) ? (
-          <defs>
-            <LinearGradientWithStops
-              id={gradientId}
-              gradient={changeGradientOpacity(color)}
-              gradientUnits="userSpaceOnUse"
-              y1="100%"
-              y2="0%"
-            />
-          </defs>
-        ) : null}
-      </svg>
-    </div>
   );
 }

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLinePoints/PredictiveLinePoints.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLinePoints/PredictiveLinePoints.tsx
@@ -1,7 +1,5 @@
-import type {Color} from '@shopify/polaris-viz-core';
 import {
   COLOR_VISION_SINGLE_ITEM,
-  LineSeries,
   LinearGradientWithStops,
   changeColorOpacity,
   changeGradientOpacity,
@@ -11,46 +9,42 @@ import {
 import {Fragment, useMemo, useState} from 'react';
 import type {LineChartSlotProps} from 'types';
 
-import {Point} from '../../../../components/Point';
+import {Point} from '../../../Point';
 import {useWatchColorVisionEvents} from '../../../../hooks';
-import {getLineChartDataWithDefaults} from '../../../../utilities/getLineChartDataWithDefaults';
 import type {LineChartPredictiveProps} from '../../types';
 
-interface PredictiveLinesProps extends LineChartSlotProps {
+interface PredictiveLinePointsProps extends LineChartSlotProps {
   data: LineChartPredictiveProps['data'];
-  seriesColors: Color[];
-  theme: string;
 }
 
-export function PredictiveLineSeries({
+export function PredictiveLinePoints({
   data,
-  drawableHeight,
-  drawableWidth,
-  seriesColors,
-  theme,
   xScale,
   yScale,
-}: PredictiveLinesProps) {
+}: PredictiveLinePointsProps) {
   const [activeLineIndex, setActiveLineIndex] = useState(-1);
-  const id = useMemo(() => uniqueId('PredictiveLines'), []);
+  const id = useMemo(() => uniqueId('PredictiveLinePoints'), []);
 
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
     onIndexChange: ({detail}) => setActiveLineIndex(detail.index),
   });
 
-  const dataWithDefaults = getLineChartDataWithDefaults(data, seriesColors);
-
   return (
     <Fragment>
-      {dataWithDefaults.map((series, index) => {
+      {data.map((series, seriesIndex) => {
+        if (series.metadata?.isPredictive == null) {
+          return false;
+        }
+
+        const index = series.metadata?.relatedIndex ?? seriesIndex;
         const pointGradientId = `${id}-point-${index}`;
 
         const predictiveStartIndex = series.data.findIndex(
           ({key}) => key === series.metadata?.startKey,
         );
 
-        const color = series.color;
+        const color = series.color!;
 
         const pointColor = isGradientType(color)
           ? `url(#${pointGradientId})`
@@ -58,18 +52,6 @@ export function PredictiveLineSeries({
 
         return (
           <Fragment key={`${series.name}-${index}`}>
-            <LineSeries
-              activeLineIndex={activeLineIndex}
-              data={series}
-              index={index}
-              svgDimensions={{
-                height: drawableHeight,
-                width: drawableWidth,
-              }}
-              xScale={xScale}
-              yScale={yScale}
-              theme={theme}
-            />
             {isGradientType(color) ? (
               <defs>
                 <LinearGradientWithStops

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLinePoints/index.ts
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLinePoints/index.ts
@@ -1,0 +1,1 @@
+export {PredictiveLinePoints} from './PredictiveLinePoints';

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLineSeries/index.ts
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/PredictiveLineSeries/index.ts
@@ -1,1 +1,0 @@
-export {PredictiveLineSeries} from './PredictiveLineSeries';

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/SeriesIcon.scss
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/SeriesIcon.scss
@@ -1,0 +1,7 @@
+.IconContainer {
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  height: 12px;
+  width: 20px;
+}

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/SeriesIcon.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/SeriesIcon.tsx
@@ -1,0 +1,44 @@
+import type {Color} from '@shopify/polaris-viz-core';
+import {
+  isGradientType,
+  LinearGradientWithStops,
+  changeGradientOpacity,
+  uniqueId,
+} from '@shopify/polaris-viz-core';
+import {useMemo} from 'react';
+
+import styles from './SeriesIcon.scss';
+
+export function SeriesIcon({color}: {color: Color}) {
+  const id = useMemo(() => uniqueId('SeriesIcon'), []);
+
+  return (
+    <div className={styles.IconContainer}>
+      <svg
+        width="19"
+        height="4"
+        viewBox="0 0 19 4"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8 2C8 0.89543 8.89543 0 10 0C11.1046 0 12 0.89543 12 2C12 3.10457 11.1046 4 10 4C8.89543 4 8 3.10457 8 2ZM7.17071 1C7.06015 1.31278 7 1.64936 7 2C7 2.35064 7.06015 2.68722 7.17071 3H1C0.447715 3 0 2.55228 0 2C0 1.44772 0.447715 1 1 1H7.17071ZM13 2C13 2.55228 13.4477 3 14 3H14.4C14.9523 3 15.4 2.55228 15.4 2C15.4 1.44772 14.9523 1 14.4 1H14C13.4477 1 13 1.44772 13 2ZM17.6 1C17.0477 1 16.6 1.44772 16.6 2C16.6 2.55228 17.0477 3 17.6 3H18C18.5523 3 19 2.55228 19 2C19 1.44772 18.5523 1 18 1H17.6Z"
+          fill={isGradientType(color) ? `url(#${id})` : color}
+        />
+        {isGradientType(color) ? (
+          <defs>
+            <LinearGradientWithStops
+              id={id}
+              gradient={changeGradientOpacity(color)}
+              gradientUnits="userSpaceOnUse"
+              y1="100%"
+              y2="0%"
+            />
+          </defs>
+        ) : null}
+      </svg>
+    </div>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/index.ts
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/SeriesIcon/index.ts
@@ -1,0 +1,1 @@
+export {SeriesIcon} from './SeriesIcon';

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/index.ts
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/index.ts
@@ -1,2 +1,3 @@
-export {PredictiveLineSeries} from './PredictiveLineSeries';
+export {PredictiveLinePoints} from './PredictiveLinePoints';
 export {CustomLegend} from './CustomLegend';
+export {SeriesIcon} from './SeriesIcon';

--- a/packages/polaris-viz/src/components/LineChartPredictive/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/stories/Default.stories.tsx
@@ -3,7 +3,7 @@ import type {Story} from '@storybook/react';
 export {META as default} from './meta';
 
 import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
-import type {LineChartProps} from 'components/LineChart/LineChart';
+import type {LineChartProps} from '../../LineChart/LineChart';
 
 export const Default: Story<LineChartProps> = Template.bind({});
 

--- a/packages/polaris-viz/src/components/LineChartPredictive/stories/playground/SeriesColors.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/stories/playground/SeriesColors.stories.tsx
@@ -1,0 +1,87 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from '../meta';
+
+import {DEFAULT_PROPS, Template} from '../data';
+import type {LineChartProps} from '../../../LineChart/LineChart';
+import {generateDayRange, randomNumber} from '../../../Docs/utilities';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+export const SeriesColors: Story<LineChartProps> = Template.bind({});
+
+const data = generateMultipleSeries(13);
+
+SeriesColors.args = {
+  ...DEFAULT_PROPS,
+  data,
+  isAnimated: false,
+  showLegend: true,
+};
+
+function generateMultipleSeries(quantity: number, dataSetLength = 10) {
+  const dataSeries: DataSeries[] = [];
+
+  for (const [index] of Array(quantity).fill(null).entries()) {
+    const data = generateDataSet(dataSetLength);
+
+    dataSeries.push({
+      name: `Series ${index + 1}`,
+      data: alterData(data, false),
+    });
+
+    dataSeries.push({
+      name: `Predictive ${index + 1}`,
+      data: alterData(data, true),
+      metadata: {
+        isPredictive: true,
+        startKey: data[5].key,
+      },
+      styleOverride: {
+        line: {
+          strokeDasharray: '1 10 1',
+          hasArea: false,
+        },
+      },
+    });
+  }
+
+  for (const [index, series] of dataSeries.entries()) {
+    if (series?.metadata == null) {
+      continue;
+    }
+
+    if (series.metadata.isPredictive) {
+      series.metadata.relatedIndex = index - 1;
+    }
+  }
+
+  return dataSeries;
+}
+
+function alterData(data, isPredictive) {
+  const half = data.length / 2;
+
+  return [...data].map((series, index) => {
+    const isNull =
+      ((isPredictive && index < half) || (!isPredictive && index > half)) ??
+      false;
+
+    return {
+      ...series,
+      value: isNull ? null : series.value,
+    };
+  });
+}
+
+function generateDataSet(dataLength: number) {
+  const dates = generateDayRange(dataLength);
+
+  return Array(dataLength)
+    .fill(null)
+    .map((_, index) => {
+      return {
+        value: randomNumber(20, 50),
+        key: dates[index],
+      };
+    });
+}

--- a/packages/polaris-viz/src/components/LineChartPredictive/utilities/Styles.scss
+++ b/packages/polaris-viz/src/components/LineChartPredictive/utilities/Styles.scss
@@ -1,0 +1,6 @@
+.Icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 4px;
+}

--- a/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
@@ -1,0 +1,90 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+
+import {PREVIEW_ICON_SIZE} from '../../../constants';
+import {
+  TooltipContentContainer,
+  TooltipTitle,
+  TooltipRow,
+  LinePreview,
+} from '../../';
+import type {RenderTooltipContentData} from '../../../types';
+import {SeriesIcon} from '../components';
+
+import styles from './Styles.scss';
+
+export function renderLinearPredictiveTooltipContent(
+  tooltipData: RenderTooltipContentData,
+): ReactNode {
+  const {theme} = tooltipData;
+
+  const formatters = {
+    keyFormatter: (key) => `${key}`,
+    valueFormatter: (value) => `${value}`,
+    titleFormatter: (title) => `${title}`,
+    ...tooltipData.formatters,
+  };
+
+  function renderSeriesIcon(color, isComparison): ReactNode {
+    return (
+      <div
+        className={styles.Icon}
+        style={{height: PREVIEW_ICON_SIZE, width: PREVIEW_ICON_SIZE}}
+      >
+        {isComparison ? (
+          <LinePreview color={color} lineStyle="dotted" />
+        ) : (
+          <SeriesIcon color={color} />
+        )}
+      </div>
+    );
+  }
+
+  function renderContent({
+    activeColorVisionIndex,
+  }: {
+    activeColorVisionIndex: number;
+  }) {
+    const item = tooltipData.data[0];
+
+    return item.data.map(({color, key, value, isComparison}, seriesIndex) => {
+      const metadata = tooltipData.dataSeries[seriesIndex].metadata;
+      const activeKey =
+        tooltipData.dataSeries[seriesIndex].data[tooltipData.activeIndex].key;
+      const index = metadata?.relatedIndex ?? seriesIndex;
+
+      const isNull = value == null;
+      const isPredictiveStartKey = metadata?.startKey === activeKey;
+      const isHidden = isNull || isPredictiveStartKey;
+
+      return (
+        <TooltipRow
+          activeIndex={activeColorVisionIndex}
+          color={color}
+          index={index}
+          isHidden={isHidden}
+          key={`row-${seriesIndex}`}
+          label={formatters.keyFormatter(key)}
+          renderSeriesIcon={() => renderSeriesIcon(color, isComparison)}
+          shape="Line"
+          value={formatters.valueFormatter(value ?? 0)}
+        />
+      );
+    });
+  }
+
+  return (
+    <TooltipContentContainer maxWidth={300} theme={theme}>
+      {({activeColorVisionIndex}) => (
+        <Fragment>
+          {tooltipData.title != null && (
+            <TooltipTitle theme={theme}>
+              {formatters.titleFormatter(tooltipData.title)}
+            </TooltipTitle>
+          )}
+          {renderContent({activeColorVisionIndex})}
+        </Fragment>
+      )}
+    </TooltipContentContainer>
+  );
+}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -95,7 +95,7 @@ export function StackedAreas({
         return (
           <AreaComponent
             activeLineIndex={activeLineIndex}
-            animationIndex={stackedValues.length - 1 - index}
+            animationIndex={index}
             areaGenerator={areaGenerator}
             colors={colors}
             data={data}

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -53,12 +53,12 @@ describe('<StackedAreas />', () => {
     const stacks = stackedArea.findAll(AnimatedArea);
 
     expect(stacks[0]).toHaveReactProps({
-      animationIndex: 1,
+      animationIndex: 0,
       index: 0,
     });
 
     expect(stacks[1]).toHaveReactProps({
-      animationIndex: 0,
+      animationIndex: 1,
       index: 1,
     });
   });

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -48,7 +48,7 @@ export function TooltipRow({
       })}
     >
       {color != null && (
-        <div className={styles.SeriesIcon} style={{width: PREVIEW_ICON_SIZE}}>
+        <div style={{width: PREVIEW_ICON_SIZE}}>
           {renderSeriesIcon?.() ?? (
             <SeriesIcon
               color={color!}


### PR DESCRIPTION
## What does this implement/fix?

Refactor `LineSeriesPredictive` to use real `LineSeries` components so we get all the functionality for each line.