### PR TITLE
Add overflow legend styles to LineChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Hide overflowing LegendItems in LineChart, VerticalBarChart, and StackedAreaChart legends.
+- Update useColorVisionEvents to accept a root prop
 
 ## [10.3.2] - 2024-01-22
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -132,7 +132,7 @@ export function Chart({
     width && height && isLegendMounted,
   );
 
-  useColorVisionEvents(shouldUseColorVisionEvents);
+  useColorVisionEvents({enabled: shouldUseColorVisionEvents});
 
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -79,7 +79,7 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
 }: ChartProps) {
-  useColorVisionEvents(data.length > 1);
+  useColorVisionEvents({enabled: data.length > 1});
 
   const selectedTheme = useTheme();
   const id = useMemo(() => uniqueId('HorizontalBarChart'), []);

--- a/packages/polaris-viz/src/components/Legend/Legend.tsx
+++ b/packages/polaris-viz/src/components/Legend/Legend.tsx
@@ -1,16 +1,22 @@
 import {Fragment} from 'react';
+import type {RefObject} from 'react';
 import {DEFAULT_THEME_NAME} from '@shopify/polaris-viz-core';
 
 import {useExternalHideEvents} from '../../hooks';
 import type {LegendData} from '../../types';
 
-import {LegendItem} from './components/';
+import {LegendItem} from './components';
+import type {LegendItemDimension} from './components';
 
 export interface LegendProps {
   data: LegendData[];
   activeIndex?: number;
   colorVisionType?: string;
   theme?: string;
+  itemDimensions?: RefObject<LegendItemDimension[]>;
+  backgroundColor?: string;
+  indexOffset?: number;
+  truncate?: boolean;
 }
 
 export function Legend({
@@ -18,6 +24,10 @@ export function Legend({
   colorVisionType,
   data,
   theme = DEFAULT_THEME_NAME,
+  itemDimensions,
+  indexOffset = 0,
+  backgroundColor,
+  truncate = false,
 }: LegendProps) {
   const {hiddenIndexes} = useExternalHideEvents();
 
@@ -32,8 +42,15 @@ export function Legend({
         {...legend}
         activeIndex={activeIndex}
         colorVisionType={colorVisionType}
-        index={index}
+        index={index + indexOffset}
         theme={theme}
+        backgroundColor={backgroundColor}
+        onDimensionChange={(dimensions) => {
+          if (itemDimensions?.current) {
+            itemDimensions.current[index + indexOffset] = dimensions;
+          }
+        }}
+        truncate={truncate}
       />
     );
   });

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -18,6 +18,13 @@
   margin: -2px 0;
   font-size: 12px;
   font-family: $font-stack-base;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.Text {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .IconContainer {

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/index.ts
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/index.ts
@@ -1,1 +1,2 @@
 export {LegendItem} from './LegendItem';
+export type {LegendItemDimension} from './LegendItem';

--- a/packages/polaris-viz/src/components/Legend/components/index.ts
+++ b/packages/polaris-viz/src/components/Legend/components/index.ts
@@ -1,1 +1,2 @@
 export {LegendItem} from './LegendItem';
+export type {LegendItemDimension} from './LegendItem';

--- a/packages/polaris-viz/src/components/Legend/index.ts
+++ b/packages/polaris-viz/src/components/Legend/index.ts
@@ -2,3 +2,4 @@ export {Legend} from './Legend';
 export {LegendItem} from './components';
 export type {LegendProps} from './Legend';
 export {estimateLegendItemWidth} from './utilities/estimateLegendItemWidth';
+export type {LegendItemDimension} from './components';

--- a/packages/polaris-viz/src/components/Legend/tests/Legend.test.tsx
+++ b/packages/polaris-viz/src/components/Legend/tests/Legend.test.tsx
@@ -1,8 +1,10 @@
+import {createRef} from 'react';
 import {mount} from '@shopify/react-testing';
 
 import type {LegendProps} from '../Legend';
 import {Legend} from '../Legend';
 import {LegendItem} from '../../Legend/components';
+import type {LegendItemDimension} from '../../Legend/components';
 
 const mockProps: LegendProps = {
   data: [
@@ -16,5 +18,27 @@ describe('<Legend />', () => {
     const component = mount(<Legend {...mockProps} />);
 
     expect(component).toContainReactComponentTimes(LegendItem, 2);
+  });
+
+  it('adds the indexOffset to the index if provided', () => {
+    const component = mount(<Legend {...mockProps} indexOffset={3} />);
+    const legendItems = component.findAll(LegendItem);
+    expect(legendItems[0]).toHaveReactProps({
+      index: 3,
+    });
+    expect(legendItems[1]).toHaveReactProps({
+      index: 4,
+    });
+  });
+
+  it('updates the item dimensions', () => {
+    const ref = createRef<LegendItemDimension[]>();
+    ref.current = [];
+
+    const component = mount(<Legend {...mockProps} itemDimensions={ref} />);
+    const newDimensions = {width: 50, height: 50};
+
+    component.find(LegendItem)?.trigger('onDimensionChange', newDimensions);
+    expect(ref.current[0]).toStrictEqual(newDimensions);
   });
 });

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.scss
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.scss
@@ -1,5 +1,4 @@
 .Container {
   display: flex;
   gap: 10px;
-  flex-wrap: wrap;
 }

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -1,5 +1,5 @@
 import type {CSSProperties, Dispatch, SetStateAction} from 'react';
-import {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import isEqual from 'fast-deep-equal';
 import {
   getColorVisionEventAttrs,
@@ -9,7 +9,11 @@ import {
   useChartContext,
   useTheme,
 } from '@shopify/polaris-viz-core';
-import type {Direction, Dimensions} from '@shopify/polaris-viz-core';
+import type {
+  Direction,
+  Dimensions,
+  BoundingRect,
+} from '@shopify/polaris-viz-core';
 
 import {DEFAULT_LEGEND_HEIGHT, DEFAULT_LEGEND_WIDTH} from '../../constants';
 import {useResizeObserver, useWatchColorVisionEvents} from '../../hooks';
@@ -17,11 +21,15 @@ import {Legend} from '../Legend';
 import type {
   LegendData,
   LegendPosition,
+  RenderHiddenLegendLabel,
   RenderLegendContent,
 } from '../../types';
 import {classNames} from '../../utilities';
 
 import style from './LegendContainer.scss';
+import {HiddenLegendTooltip} from './components/HiddenLegendTooltip';
+
+const LEGEND_GAP = 10;
 
 export interface LegendContainerProps {
   colorVisionType: string;
@@ -32,17 +40,27 @@ export interface LegendContainerProps {
   position?: LegendPosition;
   maxWidth?: number;
   renderLegendContent?: RenderLegendContent;
+  /* If enabled, hides overflowing legend items with "+ n more" */
+  enableHideOverflow?: boolean;
+  /* Width is required if enableHideOverflow is true */
+  width?: number;
+  renderHiddenLegendLabel?: RenderHiddenLegendLabel;
+  dimensions?: BoundingRect;
 }
 
 export function LegendContainer({
   colorVisionType,
-  data,
+  data: allData,
   onDimensionChange,
   direction = 'horizontal',
   fullWidth = false,
   position = 'bottom-right',
   maxWidth,
   renderLegendContent,
+  width = 0,
+  enableHideOverflow = false,
+  renderHiddenLegendLabel = (count) => `+${count} more`,
+  dimensions,
 }: LegendContainerProps) {
   const selectedTheme = useTheme();
   const {setRef, entry} = useResizeObserver();
@@ -57,6 +75,43 @@ export function LegendContainer({
   const {horizontalMargin} = selectedTheme.grid;
   const leftMargin = isPositionLeft ? 0 : horizontalMargin;
 
+  const legendItemDimensions = useRef([{width: 0, height: 0}]);
+  const [activatorWidth, setActivatorWidth] = useState(0);
+
+  const {displayedData, hiddenData} = useMemo(() => {
+    if (!enableHideOverflow || direction === 'vertical') {
+      return {displayedData: allData, hiddenData: []};
+    }
+
+    let lastVisibleIndex = allData.length;
+    const containerWidth =
+      width - leftMargin - horizontalMargin - activatorWidth;
+
+    legendItemDimensions.current.reduce((totalWidth, card, index) => {
+      if (totalWidth + card.width + index * LEGEND_GAP > containerWidth) {
+        lastVisibleIndex = index;
+      } else {
+        return totalWidth + card.width;
+      }
+    }, lastVisibleIndex);
+
+    return {
+      displayedData: allData.slice(0, lastVisibleIndex || 1),
+      hiddenData: allData.slice(lastVisibleIndex || 1, allData.length),
+    };
+  }, [
+    allData,
+    width,
+    leftMargin,
+    horizontalMargin,
+    activatorWidth,
+    enableHideOverflow,
+    direction,
+  ]);
+
+  const hasHiddenData =
+    enableHideOverflow && displayedData.length < allData.length;
+
   const styleMap: {[key: string]: CSSProperties} = {
     horizontal: {
       justifyContent: 'flex-end',
@@ -64,6 +119,7 @@ export function LegendContainer({
         ? `0 ${horizontalMargin}px ${LEGENDS_BOTTOM_MARGIN}px ${leftMargin}px`
         : `${LEGENDS_TOP_MARGIN}px ${horizontalMargin}px 0 ${leftMargin}px`,
       flexDirection: 'row',
+      flexWrap: enableHideOverflow ? 'nowrap' : 'wrap',
     },
     vertical: {
       alignItems: 'flex-start',
@@ -125,12 +181,30 @@ export function LegendContainer({
       style={{...styleMap[direction], ...shouldCenterTiles(position)}}
     >
       {renderLegendContent?.(colorVisionInteractionMethods) ?? (
-        <Legend
-          activeIndex={activeIndex}
-          colorVisionType={colorVisionType}
-          data={data}
-          theme={theme}
-        />
+        <Fragment>
+          <Legend
+            activeIndex={activeIndex}
+            colorVisionType={colorVisionType}
+            data={hasHiddenData ? displayedData : allData}
+            theme={theme}
+            itemDimensions={legendItemDimensions}
+            truncate={hasHiddenData}
+          />
+          {hasHiddenData && (
+            <HiddenLegendTooltip
+              activeIndex={activeIndex}
+              colorVisionType={colorVisionType}
+              data={hiddenData}
+              theme={theme}
+              label={renderHiddenLegendLabel(
+                allData.length - displayedData.length,
+              )}
+              lastVisibleIndex={allData.length - hiddenData.length}
+              setActivatorWidth={setActivatorWidth}
+              dimensions={dimensions}
+            />
+          )}
+        </Fragment>
       )}
     </div>
   );

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.scss
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.scss
@@ -1,0 +1,18 @@
+.MoreText {
+  display: flex;
+  white-space: nowrap;
+  align-items: center;
+  background: none;
+  border: none;
+  border-radius: 2px;
+}
+
+.Tooltip {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  backdrop-filter: blur(5px);
+  border-radius: 5px;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.2), 0 2px 10px rgba(0, 0, 0, 0.1);
+}

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
@@ -1,0 +1,176 @@
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type {ReactNode} from 'react';
+import {createPortal} from 'react-dom';
+import {
+  changeColorOpacity,
+  useChartContext,
+  useTheme,
+} from '@shopify/polaris-viz-core';
+import type {BoundingRect} from '@shopify/polaris-viz-core';
+
+import type {LegendData} from '../../../types';
+import {TOOLTIP_BG_OPACITY} from '../../../constants';
+import {useBrowserCheck} from '../../../hooks/useBrowserCheck';
+import {useRootContainer} from '../../../hooks/useRootContainer';
+import {useColorVisionEvents} from '../../../hooks/ColorVisionA11y';
+import {TOOLTIP_MARGIN} from '../../TooltipWrapper';
+import {Legend} from '../../Legend';
+
+import style from './HiddenLegendTooltip.scss';
+
+interface Props {
+  activeIndex: number;
+  colorVisionType: string;
+  data: LegendData[];
+  label: ReactNode;
+  setActivatorWidth: (width: number) => void;
+  theme?: string;
+  lastVisibleIndex?: number;
+  dimensions?: BoundingRect;
+}
+
+export const LEGEND_TOOLTIP_ID = 'legend-toolip';
+
+export function HiddenLegendTooltip({
+  activeIndex,
+  colorVisionType,
+  data,
+  theme,
+  label,
+  lastVisibleIndex = 0,
+  setActivatorWidth,
+  dimensions,
+}: Props) {
+  const selectedTheme = useTheme();
+  const {isFirefox} = useBrowserCheck();
+  const {id} = useChartContext();
+  const tooltipId = `${LEGEND_TOOLTIP_ID}_${id}`;
+  const container = useRootContainer(tooltipId);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const activatorRef = useRef<HTMLButtonElement>(null);
+  useColorVisionEvents({enabled: true, root: LEGEND_TOOLTIP_ID, dimensions});
+
+  const defaultPosition = useMemo(
+    () => ({
+      top: 0,
+      left: 0,
+    }),
+    [],
+  );
+
+  const [position, setPosition] =
+    useState<{top: number; left: number}>(defaultPosition);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (activatorRef.current == null) {
+      return;
+    }
+    const activator = activatorRef.current.getBoundingClientRect();
+    setActivatorWidth(activator.width);
+  }, [setActivatorWidth]);
+
+  const getTooltipPosition = useCallback(() => {
+    if (tooltipRef.current == null || activatorRef.current == null) {
+      return;
+    }
+
+    setActive(true);
+
+    const activator = activatorRef.current.getBoundingClientRect();
+    const tooltip = tooltipRef.current.getBoundingClientRect();
+
+    const xPosition = activator.x + window.scrollX;
+    const yPosition = activator.y + window.scrollY + activator.height;
+
+    function getXPosition() {
+      const goesPastRightOfWindow =
+        xPosition + tooltip.width + TOOLTIP_MARGIN > window.innerWidth;
+
+      if (goesPastRightOfWindow) {
+        return xPosition - tooltip.width + activator.width;
+      }
+      return xPosition;
+    }
+
+    function getYPosition() {
+      const goesPastBottomOfWindow =
+        yPosition + tooltip.height + TOOLTIP_MARGIN >=
+        window.innerHeight + window.scrollY;
+      if (goesPastBottomOfWindow) {
+        return yPosition - tooltip.height - activator.height;
+      }
+
+      return yPosition;
+    }
+
+    setPosition({
+      top: getYPosition(),
+      left: getXPosition(),
+    });
+  }, [setPosition]);
+
+  const handleMouseLeave = useCallback(
+    (event) => {
+      if (event?.relatedTarget.id !== tooltipId) {
+        setActive(false);
+        setPosition(defaultPosition);
+      }
+    },
+    [setActive, setPosition, defaultPosition, tooltipId],
+  );
+
+  return (
+    <Fragment>
+      <button
+        className={style.MoreText}
+        ref={activatorRef}
+        onMouseEnter={getTooltipPosition}
+        onMouseLeave={handleMouseLeave}
+        onFocus={getTooltipPosition}
+        onBlur={handleMouseLeave}
+        style={{
+          color: selectedTheme.legend.labelColor,
+        }}
+      >
+        {label}
+      </button>
+
+      {createPortal(
+        <div
+          className={style.Tooltip}
+          ref={tooltipRef}
+          onMouseLeave={handleMouseLeave}
+          onBlur={handleMouseLeave}
+          id={tooltipId}
+          style={{
+            visibility: active ? 'visible' : 'hidden',
+            zIndex: active ? 1 : -100000,
+            background: changeColorOpacity(
+              selectedTheme.tooltip.backgroundColor,
+              isFirefox ? 1 : TOOLTIP_BG_OPACITY,
+            ),
+            ...position,
+          }}
+        >
+          <Legend
+            activeIndex={activeIndex}
+            colorVisionType={colorVisionType}
+            data={data}
+            theme={theme}
+            indexOffset={lastVisibleIndex}
+            backgroundColor="transparent"
+          />
+        </div>,
+        container,
+      )}
+    </Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/LegendContainer/components/tests/HiddenLegendTooltip.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/tests/HiddenLegendTooltip.test.tsx
@@ -1,0 +1,180 @@
+import {mount} from '@shopify/react-testing';
+
+import {HiddenLegendTooltip} from '../HiddenLegendTooltip';
+import {Legend} from '../../../Legend';
+
+const mockProps = {
+  activeIndex: 0,
+  colorVisionType: 'someType',
+  label: '+3 more',
+  data: [
+    {name: 'Legend One', color: 'red'},
+    {name: 'Legend Two', color: 'blue'},
+    {name: 'Legend Three', color: 'yellow'},
+  ],
+  setActivatorWidth: jest.fn(),
+};
+
+describe('<HiddenLegendTooltip />', () => {
+  it('renders a legend with the hidden items', () => {
+    const component = mount(<HiddenLegendTooltip {...mockProps} />);
+
+    expect(component).toContainReactComponent(Legend, {
+      data: mockProps.data,
+    });
+  });
+
+  it('calls setActivatorWidth', () => {
+    const mockSetActivatorWidth = jest.fn();
+    mount(
+      <HiddenLegendTooltip
+        {...mockProps}
+        setActivatorWidth={mockSetActivatorWidth}
+      />,
+    );
+
+    expect(mockSetActivatorWidth).toHaveBeenCalled();
+  });
+
+  it('sets visible styles on mouse enter', () => {
+    const component = mount(<HiddenLegendTooltip {...mockProps} />);
+
+    expect(component.find('div')).toHaveReactProps({
+      style: expect.objectContaining({
+        visibility: 'hidden',
+        zIndex: -100000,
+      }),
+    });
+
+    component.find('button')?.trigger('onMouseEnter');
+
+    expect(component.find('div')).toHaveReactProps({
+      style: expect.objectContaining({
+        visibility: 'visible',
+        zIndex: 1,
+      }),
+    });
+  });
+
+  it('sets hidden styles on mouse leave', () => {
+    const component = mount(<HiddenLegendTooltip {...mockProps} />);
+
+    component.find('button')?.trigger('onMouseEnter');
+
+    expect(component.find('div')).toHaveReactProps({
+      style: expect.objectContaining({
+        visibility: 'visible',
+        zIndex: 1,
+      }),
+    });
+
+    component.find('button')?.trigger('onMouseLeave');
+
+    expect(component.find('div')).toHaveReactProps({
+      style: expect.objectContaining({
+        visibility: 'hidden',
+        zIndex: -100000,
+      }),
+    });
+  });
+
+  describe('tooltip position', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(HTMLButtonElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(
+          () =>
+            ({
+              x: buttonX,
+              y: buttonY,
+              width: buttonWidth,
+              height: buttonHeight,
+            } as DOMRect),
+        );
+
+      jest
+        .spyOn(HTMLDivElement.prototype, 'getBoundingClientRect')
+        .mockImplementation(
+          () =>
+            ({
+              width: tooltipWidth,
+              height: tooltipHeight,
+            } as DOMRect),
+        );
+    });
+
+    it('sets the position to top right', () => {
+      window.innerWidth = 1000;
+      window.innerHeight = 100;
+
+      const component = mount(<HiddenLegendTooltip {...mockProps} />);
+      component.find('button')?.trigger('onMouseEnter');
+
+      expect(component.find('div')).toHaveReactProps({
+        style: expect.objectContaining({
+          top: expectedPositions.top,
+          left: expectedPositions.right,
+        }),
+      });
+    });
+
+    it('sets the position to top left', () => {
+      window.innerWidth = 90;
+      window.innerHeight = 100;
+
+      const component = mount(<HiddenLegendTooltip {...mockProps} />);
+      component.find('button')?.trigger('onMouseEnter');
+
+      expect(component.find('div')).toHaveReactProps({
+        style: expect.objectContaining({
+          top: expectedPositions.top,
+          left: expectedPositions.left,
+        }),
+      });
+    });
+
+    it('sets the position to bottom right', () => {
+      window.innerWidth = 1000;
+      window.innerHeight = 1000;
+
+      const component = mount(<HiddenLegendTooltip {...mockProps} />);
+      component.find('button')?.trigger('onMouseEnter');
+
+      expect(component.find('div')).toHaveReactProps({
+        style: expect.objectContaining({
+          top: expectedPositions.bottom,
+          left: expectedPositions.right,
+        }),
+      });
+    });
+
+    it('sets the position to bottom left', () => {
+      window.innerWidth = 90;
+      window.innerHeight = 1000;
+
+      const component = mount(<HiddenLegendTooltip {...mockProps} />);
+      component.find('button')?.trigger('onMouseEnter');
+
+      expect(component.find('div')).toHaveReactProps({
+        style: expect.objectContaining({
+          top: expectedPositions.bottom,
+          left: expectedPositions.left,
+        }),
+      });
+    });
+  });
+});
+
+const tooltipWidth = 75;
+const tooltipHeight = 100;
+const buttonWidth = 50;
+const buttonHeight = 20;
+const buttonX = 0;
+const buttonY = 0;
+
+const expectedPositions = {
+  top: buttonY - tooltipHeight,
+  left: buttonX - tooltipWidth + buttonWidth,
+  bottom: buttonY + buttonHeight,
+  right: buttonX,
+};

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -29,6 +29,7 @@ import {
 import type {
   AnnotationLookupTable,
   LineChartSlotProps,
+  RenderHiddenLegendLabel,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -76,6 +77,7 @@ export interface ChartProps {
   dimensions?: BoundingRect;
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
+  renderHiddenLegendLabel?: RenderHiddenLegendLabel;
   slots?: {
     chart?: (props: LineChartSlotProps) => JSX.Element;
   };
@@ -89,13 +91,17 @@ export function Chart({
   dimensions,
   renderLegendContent,
   renderTooltipContent,
+  renderHiddenLegendLabel,
   showLegend = true,
   slots,
   theme = DEFAULT_THEME_NAME,
   xAxisOptions,
   yAxisOptions,
 }: ChartProps) {
-  useColorVisionEvents(data.length > 1);
+  useColorVisionEvents({
+    enabled: data.length > 1,
+    dimensions,
+  });
 
   const selectedTheme = useTheme(theme);
   const {isPerformanceImpacted} = useChartContext();
@@ -424,6 +430,10 @@ export function Chart({
           data={legend}
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
+          renderHiddenLegendLabel={renderHiddenLegendLabel}
+          width={width}
+          dimensions={dimensions}
+          enableHideOverflow
         />
       )}
     </Fragment>

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -38,6 +38,7 @@ export type LineChartProps = {
   errorText?: string;
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
+  renderHiddenLegendLabel?: (count: number) => string;
   showLegend?: boolean;
   skipLinkText?: string;
   tooltipOptions?: TooltipOptions;
@@ -60,6 +61,7 @@ export function LineChart(props: LineChartProps) {
     isAnimated,
     onError,
     renderLegendContent,
+    renderHiddenLegendLabel,
     showLegend = true,
     skipLinkText,
     state,
@@ -111,6 +113,7 @@ export function LineChart(props: LineChartProps) {
             emptyStateText={emptyStateText}
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}
+            renderHiddenLegendLabel={renderHiddenLegendLabel}
             showLegend={showLegend}
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/LineChart/stories/SeriesColors.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/SeriesColors.stories.tsx
@@ -10,11 +10,11 @@ import {Template} from './data';
 export const SeriesColorsUpToEight: Story<LineChartProps> = Template.bind({});
 
 SeriesColorsUpToEight.args = {
-  data: generateMultipleSeries(4, 'dates'),
+  data: generateMultipleSeries(8, 'dates'),
 };
 
 export const SeriesColorsUpToSixteen: Story<LineChartProps> = Template.bind({});
 
 SeriesColorsUpToSixteen.args = {
-  data: generateMultipleSeries(14, 'dates'),
+  data: generateMultipleSeries(16, 'dates'),
 };

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -1,7 +1,7 @@
 import type {Story} from '@storybook/react';
 
 import {LineChart, LineChartProps} from '../../LineChart';
-import {randomNumber} from '../../../Docs/utilities';
+import {generateDataSet, randomNumber} from '../../../Docs/utilities';
 import {
   formatLinearXAxisLabel,
   formatLinearYAxisLabel,
@@ -1020,6 +1020,50 @@ LinearComparisonTooltip.args = {
           value: 1956721.98,
         },
       ],
+    },
+  ],
+};
+
+export const LongLegend: Story<LineChartProps> = Template.bind({});
+
+LongLegend.args = {
+  data: [
+    {
+      name: 'Garlic & Herb Biltong Slab - Family Size Super Pack',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: 'Chili Biltong Slab 8oz',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: 'Sale',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: '1',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: 'Smokehouse Biltong',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: 'Traditional Biltong Slab 8oz',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: '2',
+      data: generateDataSet(10, 'dates'),
+    },
+    {
+      name: 'A Very Very Very Very Very Long Titled Biltong',
+      data: generateDataSet(10, 'dates'),
+    },
+
+    {
+      name: '3',
+      data: generateDataSet(10, 'dates'),
     },
   ],
 };

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -52,7 +52,7 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
 }: ChartProps) {
-  useColorVisionEvents(data.length > 1);
+  useColorVisionEvents({enabled: data.length > 1});
 
   const id = useMemo(() => uniqueId('SimpleBarChart'), []);
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -93,7 +93,7 @@ export function Chart({
   theme,
   yAxisOptions,
 }: Props) {
-  useColorVisionEvents(data.length > 1);
+  useColorVisionEvents({enabled: data.length > 1});
 
   const selectedTheme = useTheme(theme);
   const seriesColors = useThemeSeriesColors(data, selectedTheme);
@@ -397,6 +397,9 @@ export function Chart({
           data={legend}
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
+          width={width}
+          enableHideOverflow
+          dimensions={chartBounds}
         />
       )}
     </ChartElements.Div>

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -82,7 +82,7 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
 }: Props) {
-  useColorVisionEvents(data.length > 1);
+  useColorVisionEvents({enabled: data.length > 1, dimensions});
 
   const selectedTheme = useTheme();
   const {characterWidths} = useChartContext();
@@ -329,6 +329,9 @@ export function Chart({
           data={legend}
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
+          width={width}
+          enableHideOverflow
+          dimensions={dimensions}
         />
       )}
     </ChartElements.Div>

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/useColorVisionEvents.ts
@@ -1,11 +1,20 @@
 import {useEffect} from 'react';
 import {COLOR_VISION_EVENT, useChartContext} from '@shopify/polaris-viz-core';
+import type {BoundingRect} from '@shopify/polaris-viz-core';
 
 import {useExternalHideEvents} from '../ExternalEvents';
 
 import {getDataSetItem, getEventName} from './utilities';
 
-export function useColorVisionEvents(enabled = true) {
+export interface Props {
+  enabled?: boolean;
+  dimensions?: BoundingRect;
+  root?: string;
+}
+
+export function useColorVisionEvents(props?: Partial<Props>) {
+  const {enabled = true, dimensions, root = 'chart'} = props || {};
+
   const {id} = useChartContext();
   const {hiddenIndexes} = useExternalHideEvents();
 
@@ -15,7 +24,7 @@ export function useColorVisionEvents(enabled = true) {
     }
 
     const items = document.querySelectorAll(
-      `#chart_${id} [${COLOR_VISION_EVENT.dataAttribute}-watch="true"]`,
+      `#${root}_${id} [${COLOR_VISION_EVENT.dataAttribute}-watch="true"]`,
     );
 
     function onMouseEnter(event: MouseEvent) {
@@ -70,5 +79,5 @@ export function useColorVisionEvents(enabled = true) {
         item.removeEventListener('blur', onMouseLeave);
       });
     };
-  }, [id, enabled, hiddenIndexes]);
+  }, [id, enabled, hiddenIndexes, dimensions, root]);
 }

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -208,6 +208,8 @@ export type RenderLegendContent = (
   colorVisionInteractionMethods: ColorVisionInteractionMethods,
 ) => ReactNode;
 
+export type RenderHiddenLegendLabel = (hiddenItemsCount: number) => ReactNode;
+
 export type SortedBarChartData = (number | null)[][];
 
 export interface InnerValueContents {


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

Hide overflowing legend items in a tooltip for horizontal legends. 

**In this PR:**
* Add `enableHideOverflow` prop to `LegendContainer`. Enable by default for `LineChart`, `VerticalBarChart`, and `StackedAreaChart`. 
* Create `HiddenLegendTooltip` component to display hidden legend items. I originally tried to refactor `TooltipWrapper`/`TooltipAnimatedContainer` for this purpose, but creating a separate tooltip seemed to be more appropriate since it's a very different use case. I think there is potential to revisit this in the future. 

**Not in this PR:**
* ~Hover events for legend items in `HiddenLegendTooltip`. This PR was already getting pretty big so before I make any considerable changes to `useColorVisionEvents`, I wanted to merge this first.~ I added this in the second commit.
* Support for vertical legends i.e. in DonutChart. Priority is charts used in MetricReport/MetricCard. 

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

Resolve https://github.com/Shopify/core-issues/issues/64096


## What do the changes look like?

[Figma specs](https://www.figma.com/file/gIwSFwswxls4ZzTM8425I2/%F0%9F%9A%A7-WIP---Shopify-Data-Visualization?type=design&node-id=110839-57381&mode=design&t=HcZ9kfaHliuCqcL7-0)

The overflow rules are:
1. If all legends can be drawn in the provided space, DON’T truncate or overflow
2. If all legends CANNOT be drawn, truncate legend items down to `100px`
3. If there’s still not enough room, begin collapsing legends into hidden overflow

In general, we should try to show as many items as possible.

| Before  | After  |
|---|---|
| ![image](https://github.com/Shopify/polaris-viz/assets/30587540/b0f86c3e-045e-447b-a501-5b13a1dd0218) | ![image](https://github.com/Shopify/polaris-viz/assets/30587540/8c06a05d-ecee-487b-b187-776c06d2f73d) |



 
## Storybook link

[Long Legend story](https://6062ad4a2d14cd0021539c1b-aszbgaclle.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--long-legend)

* Confirm that the overflowing legend items are hidden for Line, VerticalBar, and StackedArea charts
* Confirm there are no regressions in the other charts 
* Confirm the tooltip shows the hidden legend items on hover and focus
* Confirm hovering on a legend items highlights the selected series in the chart and vice versa. 

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
