### PR TITLE
Add enableHideLegendOverflow and renderHiddenLegendLabel props

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Hide overflowing LegendItems in LineChart, VerticalBarChart, and StackedAreaChart legends.
 - Update useColorVisionEvents to accept a root prop
+- Add enableHideLegendOverflow props to LineChart, BarChart, and StackedAreaChart
+
+
+### Fixed
+
+- Pass down renderHiddenLegendLabel to child components in BarChart and StachkedAreaChart
 
 ## [10.3.2] - 2024-01-22
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -45,6 +45,8 @@ export type BarChartProps = {
   type?: ChartType;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
+  enableHideLegendOverflow?: boolean;
+  renderHiddenLegendLabel?: (count: number) => string;
 } & ChartProps;
 
 export function BarChart(props: BarChartProps) {
@@ -67,6 +69,8 @@ export function BarChart(props: BarChartProps) {
     xAxisOptions,
     yAxisOptions,
     onError,
+    enableHideLegendOverflow,
+    renderHiddenLegendLabel,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -102,6 +106,8 @@ export function BarChart(props: BarChartProps) {
         type={type}
         xAxisOptions={xAxisOptionsWithDefaults}
         yAxisOptions={yAxisOptionsWithDefaults}
+        enableHideLegendOverflow={enableHideLegendOverflow}
+        renderHiddenLegendLabel={renderHiddenLegendLabel}
       />
     ) : (
       <HorizontalBarChart

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -82,6 +82,7 @@ export interface ChartProps {
     chart?: (props: LineChartSlotProps) => JSX.Element;
   };
   theme?: string;
+  enableHideLegendOverflow?: boolean;
 }
 
 export function Chart({
@@ -97,6 +98,7 @@ export function Chart({
   theme = DEFAULT_THEME_NAME,
   xAxisOptions,
   yAxisOptions,
+  enableHideLegendOverflow = false,
 }: ChartProps) {
   useColorVisionEvents({
     enabled: data.length > 1,
@@ -433,7 +435,7 @@ export function Chart({
           renderHiddenLegendLabel={renderHiddenLegendLabel}
           width={width}
           dimensions={dimensions}
-          enableHideOverflow
+          enableHideOverflow={enableHideLegendOverflow}
         />
       )}
     </Fragment>

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -47,6 +47,7 @@ export type LineChartProps = {
   slots?: {
     chart?: (props: LineChartSlotProps) => JSX.Element;
   };
+  enableHideLegendOverflow?: boolean;
 } & ChartProps;
 
 export function LineChart(props: LineChartProps) {
@@ -69,6 +70,7 @@ export function LineChart(props: LineChartProps) {
     tooltipOptions,
     xAxisOptions,
     yAxisOptions,
+    enableHideLegendOverflow = false,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -119,6 +121,7 @@ export function LineChart(props: LineChartProps) {
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
             slots={props.slots}
+            enableHideLegendOverflow={enableHideLegendOverflow}
           />
         )}
       </ChartContainer>

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -80,6 +80,8 @@ export interface Props {
   yAxisOptions: Required<YAxisOptions>;
   dimensions?: Dimensions;
   renderLegendContent?: RenderLegendContent;
+  enableHideLegendOverflow?: boolean;
+  renderHiddenLegendLabel?: (count: number) => string;
 }
 
 export function Chart({
@@ -92,6 +94,8 @@ export function Chart({
   showLegend,
   theme,
   yAxisOptions,
+  enableHideLegendOverflow = false,
+  renderHiddenLegendLabel,
 }: Props) {
   useColorVisionEvents({enabled: data.length > 1});
 
@@ -398,8 +402,9 @@ export function Chart({
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
           width={width}
-          enableHideOverflow
+          enableHideOverflow={enableHideLegendOverflow}
           dimensions={chartBounds}
+          renderHiddenLegendLabel={renderHiddenLegendLabel}
         />
       )}
     </ChartElements.Div>

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -40,6 +40,8 @@ export type StackedAreaChartProps = {
   theme?: string;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
+  enableHideLegendOverflow?: boolean;
+  renderHiddenLegendLabel?: (count: number) => string;
 } & ChartProps;
 
 export function StackedAreaChart(props: StackedAreaChartProps) {
@@ -59,6 +61,8 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     showLegend = true,
     skipLinkText,
     theme = defaultTheme,
+    enableHideLegendOverflow = false,
+    renderHiddenLegendLabel,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -101,6 +105,8 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
+            enableHideLegendOverflow={enableHideLegendOverflow}
+            renderHiddenLegendLabel={renderHiddenLegendLabel}
           />
         )}
       </ChartContainer>

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -68,6 +68,8 @@ export interface Props {
   dimensions?: BoundingRect;
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
+  enableHideLegendOverflow?: boolean;
+  renderHiddenLegendLabel?: (count: number) => string;
 }
 
 export function Chart({
@@ -81,6 +83,8 @@ export function Chart({
   type,
   xAxisOptions,
   yAxisOptions,
+  enableHideLegendOverflow = false,
+  renderHiddenLegendLabel,
 }: Props) {
   useColorVisionEvents({enabled: data.length > 1, dimensions});
 
@@ -330,8 +334,9 @@ export function Chart({
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
           width={width}
-          enableHideOverflow
+          enableHideOverflow={enableHideLegendOverflow}
           dimensions={dimensions}
+          renderHiddenLegendLabel={renderHiddenLegendLabel}
         />
       )}
     </ChartElements.Div>

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -28,6 +28,8 @@ export interface VerticalBarChartProps {
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
   type?: ChartType;
+  enableHideLegendOverflow?: boolean;
+  renderHiddenLegendLabel?: (count: number) => string;
 }
 
 export function VerticalBarChart({
@@ -41,6 +43,8 @@ export function VerticalBarChart({
   type = 'default',
   xAxisOptions,
   yAxisOptions,
+  enableHideLegendOverflow = false,
+  renderHiddenLegendLabel,
 }: VerticalBarChartProps) {
   const selectedTheme = useTheme();
   const seriesColors = useThemeSeriesColors(data, selectedTheme);
@@ -62,6 +66,8 @@ export function VerticalBarChart({
       type={type}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
+      enableHideLegendOverflow={enableHideLegendOverflow}
+      renderHiddenLegendLabel={renderHiddenLegendLabel}
     />
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

Add enableHideLegendOverflow and renderHiddenLegendLabel props  to Line, VerticalBar, and StackedArea charts. This way we can just turn this feature on for MetricCard vizes. 

I also forgot to pass down the `renderHiddenLegendLabel` prop for the bar and stacked area chart in my previous PR 🙈 

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

https://6062ad4a2d14cd0021539c1b-udkikcqgza.chromatic.com/

Toggle the `enableHideLegendOverflow` prop for the Line, VerticalBar, and StackedArea charts. 




### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
