### PR TITLE
Change legend tooltip z index

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Change z-index of HiddenLegendTooltip
 
 ## [10.4.0] - 2024-01-31
 

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
@@ -37,6 +37,7 @@ interface Props {
 }
 
 export const LEGEND_TOOLTIP_ID = 'legend-toolip';
+export const LEGEND_TOOLIP_Z_INDEX = 520;
 
 export function HiddenLegendTooltip({
   activeIndex,
@@ -152,7 +153,7 @@ export function HiddenLegendTooltip({
           id={tooltipId}
           style={{
             visibility: active ? 'visible' : 'hidden',
-            zIndex: active ? 1 : -100000,
+            zIndex: active ? LEGEND_TOOLIP_Z_INDEX : -100000,
             background: changeColorOpacity(
               selectedTheme.tooltip.backgroundColor,
               isFirefox ? 1 : TOOLTIP_BG_OPACITY,

--- a/packages/polaris-viz/src/components/LegendContainer/components/tests/HiddenLegendTooltip.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/tests/HiddenLegendTooltip.test.tsx
@@ -1,6 +1,9 @@
 import {mount} from '@shopify/react-testing';
 
-import {HiddenLegendTooltip} from '../HiddenLegendTooltip';
+import {
+  HiddenLegendTooltip,
+  LEGEND_TOOLIP_Z_INDEX,
+} from '../HiddenLegendTooltip';
 import {Legend} from '../../../Legend';
 
 const mockProps = {
@@ -51,7 +54,7 @@ describe('<HiddenLegendTooltip />', () => {
     expect(component.find('div')).toHaveReactProps({
       style: expect.objectContaining({
         visibility: 'visible',
-        zIndex: 1,
+        zIndex: LEGEND_TOOLIP_Z_INDEX,
       }),
     });
   });
@@ -64,7 +67,7 @@ describe('<HiddenLegendTooltip />', () => {
     expect(component.find('div')).toHaveReactProps({
       style: expect.objectContaining({
         visibility: 'visible',
-        zIndex: 1,
+        zIndex: LEGEND_TOOLIP_Z_INDEX,
       }),
     });
 


### PR DESCRIPTION
## What does this implement/fix?

I was testing the new legend behavior in web and realized the sticky table header has a higher z-index than the toolip 😭 


<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

| Before  | After  |
|---|---|
| <img width="819" alt="image" src="https://github.com/Shopify/polaris-viz/assets/30587540/bad4c6e1-5c58-4777-aebf-6db0f4a760b6">  | <img width="743" alt="image" src="https://github.com/Shopify/polaris-viz/assets/30587540/b170f817-9a5c-4002-8394-be2a00046bbb"> |



 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

[Spin link with beta version](https://admin.web.merchant-analytics-api-jhcu.susie-kim.us.spin.dev/store/shop1/analytics/reports/1?period=2023-12-01--2024-01-01)




### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
