### PR TITLE
Switch HorizontalBars label from foreignObject to SVG text element

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Use text element instead of foreignObject for HorizontalBars labels
 
 ## [10.4.1] - 2024-02-01
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/tests/Chart.test.tsx
@@ -144,9 +144,15 @@ describe('<Chart />', () => {
           />,
         );
 
-        const labels = chart.findAll(Label);
+        const expectedValues = SERIES.flatMap((group) =>
+          group.data.map((item) => item.value),
+        );
 
-        expect(labels[0]).toContainReactText('5 pickles');
+        expectedValues.forEach((expectedValue) => {
+          expect(chart).toContainReactComponent(Label, {
+            label: `${expectedValue} pickles`,
+          });
+        });
       });
     });
   });

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/Label.tsx
@@ -9,25 +9,19 @@ export interface LabelProps {
 }
 
 export function Label({barHeight, color, label, labelWidth, y}: LabelProps) {
-  const labelYOffset = (barHeight - HORIZONTAL_BAR_LABEL_HEIGHT) / 2;
+  const labelYOffset = barHeight / 2;
 
   return (
-    <foreignObject
-      height={FONT_SIZE}
+    <text
+      height={HORIZONTAL_BAR_LABEL_HEIGHT}
       width={labelWidth}
       aria-hidden="true"
       y={y + labelYOffset}
+      fontSize={`${FONT_SIZE}px`}
+      fill={color}
+      dominantBaseline="central"
     >
-      <div
-        style={{
-          fontSize: `${FONT_SIZE}px`,
-          color,
-          lineHeight: `${HORIZONTAL_BAR_LABEL_HEIGHT}px`,
-          height: HORIZONTAL_BAR_LABEL_HEIGHT,
-        }}
-      >
-        {label}
-      </div>
-    </foreignObject>
+      {label}
+    </text>
   );
 }

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/components/Label/tests/Label.test.tsx
@@ -2,6 +2,7 @@ import {mount} from '@shopify/react-testing';
 
 import {Label} from '../Label';
 import type {LabelProps} from '../Label';
+import {HORIZONTAL_BAR_LABEL_HEIGHT} from '../../../../../../constants';
 
 jest.mock('@shopify/polaris-viz-core/src/utilities', () => ({
   estimateStringWidth: jest.fn(() => 100),
@@ -16,22 +17,15 @@ const MOCK_PROPS: LabelProps = {
 };
 
 describe('<Label />', () => {
-  it('renders <foreignObject />', () => {
+  it('renders <text> element with label', () => {
     const label = mount(
       <svg>
         <Label {...MOCK_PROPS} />
       </svg>,
     );
-    expect(label).toContainReactComponent('foreignObject');
-  });
-
-  it('renders a text string', () => {
-    const label = mount(
-      <svg>
-        <Label {...MOCK_PROPS} />
-      </svg>,
-    );
-    expect(label).toContainReactText('Label Text');
+    expect(label).toContainReactComponent('text', {
+      children: 'Label Text',
+    });
   });
 
   it('is positioned', () => {
@@ -41,8 +35,16 @@ describe('<Label />', () => {
       </svg>,
     );
 
-    const object = label.find('foreignObject');
+    const object = label.find('text');
 
-    expect(object?.props.y).toStrictEqual(21.5);
+    expect(object?.props).toStrictEqual(
+      expect.objectContaining({
+        y: MOCK_PROPS.y + MOCK_PROPS.barHeight / 2,
+        width: MOCK_PROPS.labelWidth,
+        height: HORIZONTAL_BAR_LABEL_HEIGHT,
+        fontSize: '12px',
+        dominantBaseline: 'central',
+      }),
+    );
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

The `<Label>` component for HorizontalBars currently uses a `<foreignObject>` to render its text. In some rare situations, the browser "disagrees" with what we've computed as the explicit width and height of the element and causes text to wrap to a second line that's outside the bounds of the `<foreignObject>` and therefore invisible. 

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<details><summary>Example:</summary>

https://github.com/Shopify/polaris-viz/assets/4888172/dead1393-f074-42ee-a90b-6cf4d8832e80

</details>

Letters that descend below the line of text, such as "g" or "j," were also clipped if their edges extend past the bounds of the `<foreignObject>`:

<img width="578" alt="Screenshot 2024-02-09 at 16 58 10" src="https://github.com/Shopify/polaris-viz/assets/4888172/9fabb088-ad69-420c-aeb8-ce319eae2e3d">

<img width="1000" alt="Screenshot 2024-02-09 at 16 58 15" src="https://github.com/Shopify/polaris-viz/assets/4888172/74350fce-399b-43ba-b783-105422716914">

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


<!-- ## Does this close any currently open issues? -->

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

This PR replaces the `<foreignObject>` + `<div>` combo with a plain SVG `<text>` element to eliminate the chance of wrapping. Horizontal bar chart bar labels should have the same position and size as they did before this change, but their descenders will no longer be clipped.

<img width="391" alt="Screenshot 2024-02-09 at 17 00 56" src="https://github.com/Shopify/polaris-viz/assets/4888172/ab43dc01-5f68-45c6-ad92-922d65b35cc9">

 
<img width="1000" alt="Screenshot 2024-02-09 at 17 01 19" src="https://github.com/Shopify/polaris-viz/assets/4888172/4f794ace-4e05-4ab7-96ca-f472ec17ddb0">

## Storybook link

<!-- 🎩 Include links to help tophatting -->

Test the simple bar chart variations to confirm that the labels display correctly:

https://6062ad4a2d14cd0021539c1b-eyrgvesvzn.chromatic.com/?path=/docs/polaris-viz-charts-simplebarchart--default

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
