### PR TITLE
Pass id down to all charts

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Pass missing `id` down to `<ChartContainer />` in all charts.
 
 ## [10.4.3] - 2024-02-16
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -58,6 +58,7 @@ export function BarChart(props: BarChartProps) {
     errorText,
     direction = 'vertical',
     emptyStateText,
+    id,
     isAnimated,
     tooltipOptions,
     renderLegendContent,
@@ -124,6 +125,7 @@ export function BarChart(props: BarChartProps) {
         <SkipLink anchorId={skipLinkAnchorId.current}>{skipLinkText}</SkipLink>
       )}
       <ChartContainer
+        id={id}
         isAnimated={isAnimated}
         data={data}
         onError={onError}

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -24,9 +24,9 @@ import {ChartDimensions} from './components/';
 interface Props {
   children: ReactElement;
   data: DataSeries[] | DataGroup[];
+  id: string | undefined;
   isAnimated: boolean;
   theme: string;
-  id?: string;
   onError?: ErrorBoundaryResponse;
   sparkChart?: boolean;
   skeletonType?: SkeletonType;

--- a/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
@@ -39,6 +39,7 @@ export function ComboChart(props: ComboChartProps) {
     data,
     annotations = [],
     onError,
+    id,
     isAnimated,
     renderTooltipContent,
     showLegend = true,
@@ -74,6 +75,7 @@ export function ComboChart(props: ComboChartProps) {
     <ChartContainer
       data={data}
       onError={onError}
+      id={id}
       isAnimated={isAnimated}
       theme={theme}
       type={InternalChartType.Combo}

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -42,6 +42,7 @@ export function DonutChart(props: DonutChartProps) {
     legendFullWidth,
     legendPosition = 'left',
     onError,
+    id,
     isAnimated,
     state,
     errorText,
@@ -60,6 +61,7 @@ export function DonutChart(props: DonutChartProps) {
       onError={onError}
       theme={theme}
       isAnimated={isAnimated}
+      id={id}
     >
       <Chart
         errorText={errorText}

--- a/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChart/FunnelChart.tsx
@@ -40,6 +40,7 @@ export function FunnelChart(props: FunnelChartProps) {
     theme = defaultTheme,
     xAxisOptions,
     yAxisOptions,
+    id,
     isAnimated,
     state,
     errorText,
@@ -66,6 +67,7 @@ export function FunnelChart(props: FunnelChartProps) {
   return (
     <ChartContainer
       data={data}
+      id={id}
       isAnimated={isAnimated}
       onError={onError}
       theme={theme}

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -35,6 +35,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
   const {defaultTheme} = usePolarisVizContext();
 
   const {
+    id,
     isAnimated,
     data,
     renderLegendContent,
@@ -58,6 +59,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
     <ChartContainer
       data={data}
       theme={theme}
+      id={id}
       isAnimated={isAnimated}
       onError={onError}
     >

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -39,6 +39,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
     size = 'small',
     showLegend = true,
     theme = defaultTheme,
+    id,
     isAnimated,
     state,
     errorText,
@@ -53,6 +54,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
     <ChartContainer
       data={data}
       theme={theme}
+      id={id}
       isAnimated={isAnimated}
       onError={onError}
     >

--- a/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
+++ b/packages/polaris-viz/src/components/SparkBarChart/SparkBarChart.tsx
@@ -26,6 +26,7 @@ export function SparkBarChart(props: SparkBarChartProps) {
   const {
     data,
     accessibilityLabel,
+    id,
     isAnimated,
     onError,
     targetLine,
@@ -41,6 +42,7 @@ export function SparkBarChart(props: SparkBarChartProps) {
       data={data}
       theme={theme}
       sparkChart
+      id={id}
       isAnimated={isAnimated}
       onError={onError}
     >

--- a/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/SparkLineChart.tsx
@@ -22,6 +22,7 @@ export function SparkLineChart(props: SparkLineChartProps) {
   const {
     data,
     accessibilityLabel,
+    id,
     isAnimated,
     offsetLeft = 0,
     offsetRight = 0,
@@ -36,6 +37,7 @@ export function SparkLineChart(props: SparkLineChartProps) {
 
   return (
     <ChartContainer
+      id={id}
       isAnimated={isAnimated}
       data={data}
       theme={theme}

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -55,6 +55,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     errorText,
     onError,
     tooltipOptions,
+    id,
     isAnimated,
     renderLegendContent,
     showLegend = true,
@@ -88,6 +89,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
       <ChartContainer
         data={data}
         theme={theme}
+        id={id}
         isAnimated={isAnimated}
         onError={onError}
       >

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/stories/Playground.tsx
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/stories/Playground.tsx
@@ -25,7 +25,7 @@ export function Playground() {
   // Without the id, useColorVisionEvents() won't
   // find any elements to attach the mouse events to.
   return (
-    <ChartContainer theme="Default" data={[]} isAnimated>
+    <ChartContainer id="playground_chart" theme="Default" data={[]} isAnimated>
       <Chart />
     </ChartContainer>
   );


### PR DESCRIPTION
## What does this implement/fix?

While working on https://github.com/Shopify/core-issues/issues/67182 I noticed that we weren't passing the `id` down to all the charts correctly.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
