### PR TITLE
Fix positioning of zero line when all negative values

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed the positioning of the `<ZeroLine />` for the Stacked Horizontal Chart when all values are negative.
 
 ## [10.5.2] - 2024-02-22
 

--- a/packages/polaris-viz/src/components/BarChart/stories/HorizontalStacked.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/HorizontalStacked.stories.tsx
@@ -1,0 +1,52 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {BarChartProps} from '../../../components';
+
+import {Template} from './data';
+
+export const HorizontalStacked: Story<BarChartProps> = Template.bind({});
+
+HorizontalStacked.args = {
+  data: [
+    {
+      name: 'Breakfast',
+      data: [
+        {key: 'Monday', value: -2},
+        {key: 'Tuesday', value: -10},
+        {key: 'Wednesday', value: -7},
+        {key: 'Thursday', value: -0.12},
+        {key: 'Friday', value: 0},
+        {key: 'Saturday', value: 0},
+        {key: 'Sunday', value: 0},
+      ],
+    },
+    {
+      name: 'Lunch',
+      data: [
+        {key: 'Monday', value: -10},
+        {key: 'Tuesday', value: -7},
+        {key: 'Wednesday', value: -12},
+        {key: 'Thursday', value: -4},
+        {key: 'Friday', value: 0},
+        {key: 'Saturday', value: 0},
+        {key: 'Sunday', value: 0},
+      ],
+    },
+    {
+      name: 'Dinner',
+      data: [
+        {key: 'Monday', value: -1},
+        {key: 'Tuesday', value: -4},
+        {key: 'Wednesday', value: -2},
+        {key: 'Thursday', value: -2},
+        {key: 'Friday', value: 0},
+        {key: 'Saturday', value: 0},
+        {key: 'Sunday', value: 0},
+      ],
+    },
+  ],
+  type: 'stacked',
+  direction: 'horizontal'
+};

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -8,7 +8,10 @@ import {
 
 import {useWatchColorVisionEvents} from '../../../hooks';
 import {getBarId} from '../../../utilities';
-import {HORIZONTAL_GROUP_LABEL_HEIGHT} from '../../../constants';
+import {
+  HORIZONTAL_GROUP_LABEL_HEIGHT,
+  NEGATIVE_ZERO_LINE_OFFSET,
+} from '../../../constants';
 import type {FormattedStackedSeries} from '../../../types';
 import {getGradientDefId} from '..';
 import {ZeroValueLine} from '../ZeroValueLine';
@@ -120,7 +123,11 @@ export function HorizontalStackedBars({
         return (
           <Fragment key={`stackedBar ${barId}`}>
             {areAllValuesZero ? (
-              <ZeroValueLine x={x} y={barHeight / 2} direction="horizontal" />
+              <ZeroValueLine
+                x={x - NEGATIVE_ZERO_LINE_OFFSET}
+                y={barHeight / 2}
+                direction="horizontal"
+              />
             ) : (
               <StackedBar
                 animationDelay={animationDelay}

--- a/packages/polaris-viz/src/constants.ts
+++ b/packages/polaris-viz/src/constants.ts
@@ -54,6 +54,7 @@ export const COLLAPSED_ANNOTATIONS_COUNT = 3;
 export const PREVIEW_ICON_SIZE = 12;
 export const ARC_PAD_ANGLE = 0.02;
 export const ZERO_VALUE_LINE_HEIGHT = 6;
+export const NEGATIVE_ZERO_LINE_OFFSET = 10;
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 export const IS_TEST = process.env.NODE_ENV === 'test';
 export const WARN_FOR_DEVELOPMENT = IS_DEVELOPMENT && !IS_TEST;


### PR DESCRIPTION
## What does this implement/fix?

Fixed the positioning of the `<ZeroLine />` for the Stacked Horizontal Chart when all values are negative.


## Does this close any currently open issues?

N/A


## What do the changes look like?

| Before | After |
|--------|------|
|<img width="1093" alt="Screenshot 2024-02-26 at 8 11 58 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/203960fe-d0e1-4228-95d2-f3910100b883">|<img width="832" alt="Screenshot 2024-02-26 at 8 36 55 AM" src="https://github.com/Shopify/polaris-viz/assets/64446645/26210d6a-f862-43cf-b47d-786263c6cc3e">|
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-yzbjqfmezj.chromatic.com/?path=/story/polaris-viz-charts-barchart--horizontal-stacked


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
