### PR TITLE
fix: Expose Uplift theme

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Added `PolarisUpliftTheme` to better support extending the Uplift theme.
 
 ## [11.0.0] - 2024-03-12
 

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -40,6 +40,7 @@ export {
   DEFAULT_THEME as PolarisVizDefaultTheme,
   LIGHT_THEME as PolarisVizLightTheme,
   PRINT_THEME as PolarisVizPrintTheme,
+  UPLIFT_THEME as PolarisUpliftTheme,
 } from './constants';
 
 export type {


### PR DESCRIPTION
## What does this implement/fix?

We need to be able to have two variations of the Uplift theme: a standard and a "ghost" version.

As such we can't simply overwrite properties of the theme as shown [here](https://polaris-viz.shopify.com/iframe.html?viewMode=docs&id=shared-themes-customizing--page#titleAnchor-81).

Instead we need to define multiple themes as shown [here](https://polaris-viz.shopify.com/iframe.html?viewMode=docs&id=shared-themes-customizing--page#titleAnchor-86).

To do this with Uplift as a base however, the theme needs to be exposed, which it currently isn't.

In theory this can be retrieved via the `@shopify/polaris-viz-core`, but the same is true for the other themes and that would mean that dependency becomes a direct dependency of the project, rather than through `@shopify/polaris-viz`.

Instead, it's proposed here that we just expose the Uplift theme in a manner similar to the others.

## Does this close any currently open issues?

Related:
- https://github.com/Shopify/order-risk/issues/1694

## What do the changes look like?

There are no visual changes, this is a package API change.
 
## Storybook link

There are no visual changes, this is a package API change.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
