### PR TITLE
Implement design changes to LineChartRelational

### DIFF
--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -27,6 +27,9 @@ interface StyleOverride {
     width?: number;
     strokeDasharray?: string;
   };
+  tooltip?: {
+    shape?: Shape;
+  };
 }
 
 export interface DataGroup {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `tooltip.shape` override value to `DataSeries.styleOverride`.
+- **Breaking change** Added custom legend to `<LineChartRelational />`.
+
+
+### Changed
+
+- **Breaking change** `<LineChartRelational />` no longer renders all lines in the `DataSeries[]`. Any `DataSeries` with `metadata.relatedIndex` will only render the area in the chart.
+- **Breaking change** `metadata.relatedIndex` should now refer to the single "median" index and not the next index to draw the area to.
 
 ## [11.1.0] - 2024-03-19
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -342,6 +342,10 @@ export function Chart({
           })}
 
           {data.map((singleSeries, index) => {
+            if (singleSeries.metadata?.isVisuallyHidden === true) {
+              return null;
+            }
+
             return (
               <LineSeries
                 activeLineIndex={activeLineIndex}

--- a/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/Points/Points.tsx
@@ -65,6 +65,10 @@ export function Points({
   return (
     <Fragment>
       {data.map((singleSeries, seriesIndex) => {
+        if (singleSeries?.metadata?.isVisuallyHidden === true) {
+          return null;
+        }
+
         const index = singleSeries.metadata?.relatedIndex ?? seriesIndex;
 
         if (hiddenIndexes.includes(index)) {

--- a/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
@@ -1,12 +1,17 @@
-import {DEFAULT_CHART_PROPS} from '@shopify/polaris-viz-core';
+import {
+  DEFAULT_CHART_PROPS,
+  DEFAULT_THEME_NAME,
+} from '@shopify/polaris-viz-core';
 import {Fragment} from 'react';
 
 import type {LineChartProps} from '../LineChart';
 import {LineChart} from '../LineChart';
 
-import {RelatedAreas, MissingDataArea} from './components';
+import {RelatedAreas, MissingDataArea, CustomLegend} from './components';
 
-export function LineChartRelational(props: LineChartProps) {
+export function LineChartRelational(
+  props: Omit<LineChartProps, 'renderLegendContent'>,
+) {
   const {
     annotations = [],
     data,
@@ -14,7 +19,6 @@ export function LineChartRelational(props: LineChartProps) {
     emptyStateText,
     id,
     isAnimated,
-    renderLegendContent,
     showLegend = true,
     skipLinkText,
     state,
@@ -27,15 +31,37 @@ export function LineChartRelational(props: LineChartProps) {
     ...props,
   };
 
+  const dataWithHiddenRelational = data.map((series) => {
+    return {
+      ...series,
+      metadata: {
+        ...series.metadata,
+        isVisuallyHidden: series.metadata?.relatedIndex != null,
+      },
+    };
+  });
+
   return (
     <LineChart
       annotations={annotations}
-      data={data}
+      data={dataWithHiddenRelational}
       emptyStateText={emptyStateText}
       errorText={errorText}
       id={id}
       isAnimated={isAnimated}
-      renderLegendContent={renderLegendContent}
+      renderLegendContent={({
+        getColorVisionStyles,
+        getColorVisionEventAttrs,
+      }) => {
+        return (
+          <CustomLegend
+            getColorVisionStyles={getColorVisionStyles}
+            getColorVisionEventAttrs={getColorVisionEventAttrs}
+            data={data}
+            theme={theme ?? DEFAULT_THEME_NAME}
+          />
+        );
+      }}
       showLegend={showLegend}
       skipLinkText={skipLinkText}
       slots={{

--- a/packages/polaris-viz/src/components/LineChartRelational/components/Area/Area.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/Area/Area.tsx
@@ -57,7 +57,7 @@ export function Area({
       style={{
         ...getColorVisionStylesForActiveIndex({
           activeIndex,
-          index: -1,
+          index,
           fadedOpacity: 0.2,
         }),
       }}

--- a/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.scss
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.scss
@@ -1,0 +1,6 @@
+.Container {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  list-style: none;
+}

--- a/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.tsx
@@ -1,0 +1,76 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import type {ColorVisionInteractionMethods} from '../../../../types';
+import {LegendItem} from '../../../../components/Legend';
+
+import styles from './CustomLegend.scss';
+
+interface Props extends ColorVisionInteractionMethods {
+  data: DataSeries[];
+  theme: string;
+}
+
+export function CustomLegend({
+  data,
+  getColorVisionEventAttrs,
+  getColorVisionStyles,
+  theme,
+}: Props) {
+  const lineSeries = data.filter(
+    (series) => series?.metadata?.relatedIndex == null,
+  );
+
+  const percentileItems = data.filter(
+    (series) => series?.metadata?.relatedIndex != null,
+  );
+
+  const percentileIndex = lineSeries.length + 1;
+
+  return (
+    <ul className={styles.Container}>
+      {lineSeries.map(({color, name, isComparison, metadata}) => {
+        if (metadata?.isPredictive) {
+          return null;
+        }
+
+        const index = data.findIndex((series) => series.name === name);
+
+        return (
+          <li
+            key={index}
+            style={{
+              ...getColorVisionStyles(index),
+            }}
+            {...getColorVisionEventAttrs(index)}
+          >
+            <LegendItem
+              color={color!}
+              index={index}
+              isComparison={isComparison}
+              name={name!}
+              shape="Line"
+              theme={theme}
+            />
+          </li>
+        );
+      })}
+      <li
+        key={percentileIndex}
+        style={{
+          ...getColorVisionStyles(percentileIndex),
+        }}
+        {...getColorVisionEventAttrs(percentileIndex)}
+      >
+        <LegendItem
+          color={
+            percentileItems[0].color ?? percentileItems[0]?.metadata?.areaColor
+          }
+          index={percentileIndex}
+          name={percentileItems[0]?.metadata?.legendLabel}
+          shape="Bar"
+          theme={theme}
+        />
+      </li>
+    </ul>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/index.ts
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/index.ts
@@ -1,0 +1,1 @@
+export {CustomLegend} from './CustomLegend';

--- a/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/RelatedAreas.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/RelatedAreas.tsx
@@ -21,6 +21,12 @@ export interface RelatedAreaProps extends LineChartSlotProps {
 export function RelatedAreas({yScale, xScale, data}: RelatedAreaProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
 
+  const lineSeries = data.filter(
+    (series) => series?.metadata?.relatedIndex == null,
+  );
+
+  const percentileIndex = lineSeries.length + 1;
+
   const {hiddenIndexes} = useExternalHideEvents();
   const {shouldAnimate, id} = useChartContext();
 
@@ -84,7 +90,7 @@ export function RelatedAreas({yScale, xScale, data}: RelatedAreaProps) {
             fill={series.metadata?.areaColor}
             getAreaGenerator={getAreaGenerator}
             hiddenIndexes={hiddenIndexes}
-            index={index}
+            index={percentileIndex}
             key={index}
             series={series}
             shouldAnimate={shouldAnimate}

--- a/packages/polaris-viz/src/components/LineChartRelational/components/index.ts
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/index.ts
@@ -1,3 +1,4 @@
 export {Area} from './Area';
 export {MissingDataArea} from './MissingDataArea';
 export {RelatedAreas} from './RelatedAreas';
+export {CustomLegend} from './CustomLegend';

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/Default.stories.tsx
@@ -11,4 +11,6 @@ Default.args = {
   ...DEFAULT_PROPS,
   data: DEFAULT_DATA,
   isAnimated: false,
+  showLegend: true,
+  theme: 'Uplift',
 };

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-end-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-end-data.js
@@ -40,15 +40,9 @@ export const MISSING_END_DATA = [
       {value: null, key: '2020-03-13T12:00:00'},
       {value: null, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
       areaColor: 'rgba(103, 197, 228, 0.1)',
-    },
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
     },
   },
   {
@@ -70,10 +64,6 @@ export const MISSING_END_DATA = [
       {value: null, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(40, 106, 123, 1)',
-    metadata: {
-      relatedIndex: 3,
-      areaColor: 'rgba(47, 175, 218, 0.2)',
-    },
     styleOverride: {
       line: {
         hasArea: false,
@@ -99,11 +89,9 @@ export const MISSING_END_DATA = [
       {value: null, key: '2020-03-13T12:00:00'},
       {value: null, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
+    metadata: {
+      relatedIndex: 2,
+      areaColor: 'rgba(103, 197, 228, 0.1)',
     },
   },
 ];

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-middle-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-middle-data.js
@@ -40,15 +40,9 @@ export const MISSING_MIDDLE_DATA = [
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
       areaColor: 'rgba(103, 197, 228, 0.1)',
-    },
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
     },
   },
   {
@@ -70,10 +64,6 @@ export const MISSING_MIDDLE_DATA = [
       {value: 21, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(40, 106, 123, 1)',
-    metadata: {
-      relatedIndex: 3,
-      areaColor: 'rgba(47, 175, 218, 0.2)',
-    },
     styleOverride: {
       line: {
         hasArea: false,
@@ -99,11 +89,9 @@ export const MISSING_MIDDLE_DATA = [
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
+    metadata: {
+      relatedIndex: 2,
+      areaColor: 'rgba(103, 197, 228, 0.1)',
     },
   },
 ];

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-random-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-random-data.js
@@ -40,15 +40,9 @@ export const MISSING_RANDOM_DATA = [
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
       areaColor: 'rgba(103, 197, 228, 0.1)',
-    },
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
     },
   },
   {
@@ -70,10 +64,6 @@ export const MISSING_RANDOM_DATA = [
       {value: 21, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(40, 106, 123, 1)',
-    metadata: {
-      relatedIndex: 3,
-      areaColor: 'rgba(47, 175, 218, 0.2)',
-    },
     styleOverride: {
       line: {
         hasArea: false,
@@ -99,11 +89,9 @@ export const MISSING_RANDOM_DATA = [
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
+    metadata: {
+      relatedIndex: 2,
+      areaColor: 'rgba(103, 197, 228, 0.1)',
     },
   },
 ];

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-start-data.js
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/chromatic/data/missing-start-data.js
@@ -40,15 +40,9 @@ export const MISSING_START_DATA = [
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
     metadata: {
       relatedIndex: 2,
       areaColor: 'rgba(103, 197, 228, 0.1)',
-    },
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
     },
   },
   {
@@ -70,10 +64,6 @@ export const MISSING_START_DATA = [
       {value: 21, key: '2020-03-14T12:00:00'},
     ],
     color: 'rgba(40, 106, 123, 1)',
-    metadata: {
-      relatedIndex: 3,
-      areaColor: 'rgba(47, 175, 218, 0.2)',
-    },
     styleOverride: {
       line: {
         hasArea: false,
@@ -99,11 +89,9 @@ export const MISSING_START_DATA = [
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
-    styleOverride: {
-      line: {
-        hasArea: false,
-      },
+    metadata: {
+      relatedIndex: 2,
+      areaColor: 'rgba(103, 197, 228, 0.1)',
     },
   },
 ];

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
@@ -1,6 +1,7 @@
 import type {Story} from '@storybook/react';
 import type {RenderTooltipContentData} from 'types';
 import type {DataSeries} from '@shopify/polaris-viz-core';
+import {UPLIFT_THEME} from '@shopify/polaris-viz-core';
 import type {LineChartProps} from 'components/LineChart/LineChart';
 
 import {LineChartRelational} from '../LineChartRelational';
@@ -80,10 +81,7 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 849, key: '2020-03-13T12:00:00'},
       {value: 129, key: '2020-03-14T12:00:00'},
     ],
-    color: [
-      {offset: 0, color: 'rgba(149, 101, 255, 1)'},
-      {offset: 100, color: 'rgba(75, 146, 229, 1)'},
-    ],
+    color: UPLIFT_THEME.seriesColors.upToEight[0],
   },
   {
     name: '75th Percentile',
@@ -103,14 +101,15 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 773, key: '2020-03-13T12:00:00'},
       {value: 171, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
+    color: 'rgba(218, 182, 242, 1)',
     metadata: {
       relatedIndex: 2,
-      areaColor: 'rgba(103, 197, 228, 0.1)',
+      areaColor: 'rgba(218, 182, 242, 0.2)',
+      legendLabel: '75th - 25th percentile',
     },
     styleOverride: {
-      line: {
-        hasArea: false,
+      tooltip: {
+        shape: 'Bar',
       },
     },
   },
@@ -132,11 +131,7 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 623, key: '2020-03-13T12:00:00'},
       {value: 21, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(40, 106, 123, 1)',
-    metadata: {
-      relatedIndex: 3,
-      areaColor: 'rgba(47, 175, 218, 0.2)',
-    },
+    color: UPLIFT_THEME.seriesColors.upToEight[5],
     styleOverride: {
       line: {
         hasArea: false,
@@ -162,10 +157,15 @@ export const DEFAULT_DATA: DataSeries[] = [
       {value: 473, key: '2020-03-13T12:00:00'},
       {value: 0, key: '2020-03-14T12:00:00'},
     ],
-    color: 'rgba(103, 197, 228, 1)',
+    color: 'rgba(218, 182, 242, 1)',
+    metadata: {
+      relatedIndex: 2,
+      areaColor: 'rgba(218, 182, 242, 0.2)',
+      legendLabel: '75th - 25th percentile',
+    },
     styleOverride: {
-      line: {
-        hasArea: false,
+      tooltip: {
+        shape: 'Bar',
       },
     },
   },

--- a/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
@@ -51,7 +51,7 @@ export function renderLinearTooltipContent(
   };
 
   function renderSeriesIcon(color, styleOverride): ReactNode {
-    if (styleOverride == null) {
+    if (styleOverride?.line == null) {
       return null;
     }
 
@@ -110,7 +110,7 @@ export function renderLinearTooltipContent(
                   renderSeriesIcon={() =>
                     renderSeriesIcon(color, styleOverride)
                   }
-                  shape="Line"
+                  shape={styleOverride?.tooltip?.shape ?? 'Line'}
                   value={formatters.valueFormatter(item.value ?? 0)}
                 />
               );


### PR DESCRIPTION
## What does this implement/fix?

Implementing design changes to `LineChartRelational`.

- Remove percentile lines from the chart.
- Group percentile area in `<Legend />` to render a single item.
- Added `styleOverride.tooltip` property to render different shapes in `renderLinearTooltipContent()`.

Resolves https://github.com/Shopify/core-issues/issues/68245, https://github.com/Shopify/core-issues/issues/68244 & https://github.com/Shopify/core-issues/issues/68246

> [!NOTE]  
> We are not implementing the centered `<Legend />` changes in this PR.

## What do the changes look like?

![image](https://github.com/Shopify/polaris-viz/assets/149873/99e29504-2a2e-4357-b29c-b20733e7decc)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-zeeikswiqb.chromatic.com/?path=/story/polaris-viz-charts-linechartrelational--default

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
