### PR TITLE
Enable enableHideOverflow in HorizontalBarChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Set `enableHideOverflow` on `<LegendContainer />` in `<HorizontalBarChart />` to render `+ X more` when legends flow outside the chart bounds.
 
 ## [12.0.0] - 2024-03-25
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -115,6 +115,7 @@ export function BarChart(props: BarChartProps) {
       <HorizontalBarChart
         annotationsLookupTable={annotationsLookupTable}
         data={data}
+        renderHiddenLegendLabel={renderHiddenLegendLabel}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
         showLegend={showLegend}

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/StackedHorizontalLotsOfLegends.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/StackedHorizontalLotsOfLegends.stories.tsx
@@ -1,0 +1,45 @@
+import type {Story} from '@storybook/react';
+
+import {META} from '../meta';
+
+import type {BarChartProps} from '../../../../components';
+
+import {Template} from '../data';
+import {PolarisVizProvider} from '../../../PolarisVizProvider';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+export const StackedHorizontalLotsOfLegends: Story<BarChartProps> = (
+  args: BarChartProps,
+) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Default: {
+          groupLabel: {
+            hide: true,
+          },
+        },
+      }}
+    >
+      <Template {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+StackedHorizontalLotsOfLegends.args = {
+  data: [...Array(20).keys()].map((index) => {
+    return {
+      name: `Legend ${index}`,
+      data: [
+        {key: 'Monday', value: -2},
+        {key: 'Tuesday', value: -10},
+      ],
+    };
+  }),
+  type: 'stacked',
+  direction: 'horizontal',
+};

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -11,7 +11,6 @@ import {
 import type {
   DataSeries,
   ChartType,
-  Dimensions,
   XAxisOptions,
   YAxisOptions,
   BoundingRect,
@@ -64,7 +63,8 @@ export interface ChartProps {
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
-  dimensions?: Dimensions;
+  dimensions?: BoundingRect;
+  renderHiddenLegendLabel?: (count: number) => string;
   renderLegendContent?: RenderLegendContent;
 }
 
@@ -72,6 +72,7 @@ export function Chart({
   annotationsLookupTable,
   data,
   dimensions,
+  renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
   showLegend,
@@ -305,8 +306,11 @@ export function Chart({
         <LegendContainer
           colorVisionType={COLOR_VISION_SINGLE_ITEM}
           data={legend}
+          dimensions={dimensions}
+          enableHideOverflow
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
+          renderHiddenLegendLabel={renderHiddenLegendLabel}
         />
       )}
     </ChartElements.Div>

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -4,7 +4,7 @@ import type {
   ChartType,
   XAxisOptions,
   YAxisOptions,
-  Dimensions,
+  BoundingRect,
 } from '@shopify/polaris-viz-core';
 
 import type {
@@ -22,7 +22,8 @@ export interface HorizontalBarChartProps {
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
-  dimensions?: Dimensions;
+  dimensions?: BoundingRect;
+  renderHiddenLegendLabel?: (count: number) => string;
   renderLegendContent?: RenderLegendContent;
   type?: ChartType;
 }
@@ -31,6 +32,7 @@ export function HorizontalBarChart({
   annotationsLookupTable = {},
   data,
   dimensions,
+  renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
   showLegend,
@@ -49,6 +51,7 @@ export function HorizontalBarChart({
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
       renderLegendContent={renderLegendContent}
+      renderHiddenLegendLabel={renderHiddenLegendLabel}
     />
   );
 }


### PR DESCRIPTION
## What does this implement/fix?

Adding `enableHideOverflow` to `<HorizontalBarChart />` so legends will stay on one line.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/68833

## What do the changes look like?

![image](https://github.com/Shopify/polaris-viz/assets/149873/082473eb-f582-4967-bcaf-930228a329b5)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-scefpxtkuj.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--stacked-horizontal-lots-of-legends

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
