### PR TITLE
Added seriesNameFormatter to SimpleNormalizedChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `seriesNameFormatter` prop to `<SimpleNormalizedChart />` to allow consumers to format the series name.
 
 ## [12.1.0] - 2024-04-01
 

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/Chart.tsx
@@ -29,8 +29,9 @@ import styles from './SimpleNormalizedChart.scss';
 
 export interface ChartProps {
   data: DataSeries[];
+  labelFormatter: LabelFormatter;
+  seriesNameFormatter: LabelFormatter;
   comparisonMetrics?: Omit<ComparisonMetricProps, 'theme'>[];
-  labelFormatter?: LabelFormatter;
   legendPosition?: LegendPosition;
   direction?: Direction;
   size?: Size;
@@ -41,8 +42,9 @@ export interface ChartProps {
 export function Chart({
   comparisonMetrics = [],
   data,
-  labelFormatter = (value) => `${value}`,
+  labelFormatter,
   legendPosition = 'top-left',
+  seriesNameFormatter,
   direction = 'horizontal',
   size = 'small',
   showLegend = true,
@@ -146,12 +148,16 @@ export function Chart({
           );
 
           const formattedValue = labelFormatter(value);
+          const formattedName = seriesNameFormatter(
+            data[index].name?.toString() ?? '',
+          );
+
           return (
             <BarLabel
               activeIndex={activeIndex}
               index={index}
               key={`${key}-${formattedValue}-${index}`}
-              label={`${data[index].name}`}
+              label={formattedName}
               value={formattedValue}
               color={colors[index]}
               comparisonMetric={comparisonMetric}

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.tsx
@@ -21,6 +21,7 @@ export type SimpleNormalizedChartProps = {
   comparisonMetrics?: ComparisonMetricProps[];
   labelFormatter?: LabelFormatter;
   legendPosition?: LegendPosition;
+  seriesNameFormatter?: LabelFormatter;
   direction?: Direction;
   size?: Size;
   showLegend?: boolean;
@@ -35,6 +36,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
     data,
     labelFormatter = (value) => `${value}`,
     legendPosition = 'top-left',
+    seriesNameFormatter = (value) => `${value}`,
     direction = 'horizontal',
     size = 'small',
     showLegend = true,
@@ -73,6 +75,7 @@ export function SimpleNormalizedChart(props: SimpleNormalizedChartProps) {
           data={data}
           labelFormatter={labelFormatter}
           legendPosition={legendPosition}
+          seriesNameFormatter={seriesNameFormatter}
           showLegend={showLegend}
           direction={direction}
           size={size}

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/FormattedValues.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/FormattedValues.stories.tsx
@@ -1,0 +1,18 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {SimpleNormalizedChartProps} from '../../../components';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const FormattedValues: Story<SimpleNormalizedChartProps> = Template.bind(
+  {},
+);
+
+FormattedValues.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  labelFormatter: (value) => `$${value}`,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+};


### PR DESCRIPTION
## What does this implement/fix?

In order to fix https://github.com/Shopify/core-issues/issues/68614 & https://github.com/Shopify/core-issues/issues/68845 we need to be able to format the name differently than the data we provide to `polaris-viz`.
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-xgegmpkewo.chromatic.com/?path=/story/polaris-viz-charts-simplenormalizedchart--formatted-values

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
