### PR TITLE
Limit Donut legend to 50% of chart width

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Limit `<DonutChart />` legends from taking up more than 50% of the chart width.
 
 ## [12.2.2] - 2024-04-01
 

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.scss
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.scss
@@ -2,4 +2,5 @@
   width: 100%;
   border-collapse: separate;
   border-spacing: 0 10px;
+  table-layout: fixed;
 }

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
@@ -24,6 +24,7 @@ interface LegendContentProps {
   activeIndex: number;
   dimensions: BoundingRect;
   labelFormatter: LabelFormatter;
+  longestLegendValueWidth: number;
   renderHiddenLegendLabel?: RenderHiddenLegendLabel;
   getColorVisionStyles: ColorVisionInteractionMethods['getColorVisionStyles'];
   getColorVisionEventAttrs: ColorVisionInteractionMethods['getColorVisionEventAttrs'];
@@ -33,6 +34,7 @@ export function LegendValues({
   data: allData,
   activeIndex,
   labelFormatter,
+  longestLegendValueWidth,
   renderHiddenLegendLabel = (count) => `+${count} more`,
   getColorVisionStyles,
   getColorVisionEventAttrs,
@@ -90,6 +92,7 @@ export function LegendValues({
                 value={value}
                 trend={trend}
                 index={index}
+                longestLegendValueWidth={longestLegendValueWidth}
                 maxTrendIndicatorWidth={maxTrendIndicatorWidth}
                 seriesColors={seriesColors}
                 onDimensionChange={(dimensions) => {

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.scss
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.scss
@@ -4,13 +4,10 @@
 
 .Name {
   overflow: hidden;
-  text-wrap: nowrap;
+  white-space: nowrap;
   text-overflow: ellipsis;
   padding-left: 4px;
-}
-
-.TableSpacer {
-  padding-left: 30px;
+  padding-right: 20px;
 }
 
 .alignLeft {

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.tsx
@@ -21,6 +21,7 @@ interface Props {
   value?: string;
   trend?: MetaDataTrendIndicator;
   labelFormatter: LabelFormatter;
+  longestLegendValueWidth: number;
   seriesColors: Color[];
   maxTrendIndicatorWidth: number;
   onDimensionChange: (dimensions: Dimensions) => void;
@@ -33,6 +34,7 @@ export function LegendValueItem({
   value,
   index,
   labelFormatter,
+  longestLegendValueWidth,
   trend,
   seriesColors,
   maxTrendIndicatorWidth,
@@ -73,13 +75,12 @@ export function LegendValueItem({
         style={{
           color: selectedTheme.legend.labelColor,
         }}
+        title={name}
       >
         <span>{name}</span>
       </td>
 
-      <td className={styles.TableSpacer} />
-
-      <td className={styles.alignRight}>
+      <td className={styles.alignRight} width={longestLegendValueWidth}>
         <span
           style={{
             color: selectedTheme.legend.labelColor,
@@ -89,12 +90,17 @@ export function LegendValueItem({
         </span>
       </td>
 
-      <td
-        className={styles.alignLeft}
-        style={{minWidth: maxTrendIndicatorWidth, paddingLeft: '4px'}}
-      >
-        <span>{trend && valueExists && <TrendIndicator {...trend} />}</span>
-      </td>
+      {trend && valueExists && (
+        <td
+          className={styles.alignLeft}
+          width={maxTrendIndicatorWidth}
+          style={{minWidth: maxTrendIndicatorWidth, paddingLeft: '4px'}}
+        >
+          <span>
+            <TrendIndicator {...trend} />
+          </span>
+        </td>
+      )}
     </tr>
   );
 }

--- a/packages/polaris-viz/src/components/DonutChart/stories/DonutChart.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/DonutChart.chromatic.stories.tsx
@@ -1,0 +1,112 @@
+import {storiesOf} from '@storybook/react';
+import type {PropCombinations} from '../../../chromatic/types';
+
+import {
+  addWithPropsCombinations,
+  renderCombinationSections,
+} from '../../../chromatic';
+import {DonutChart} from '../';
+import type {DonutChartProps} from '../DonutChart';
+import {DEFAULT_DATA} from './data';
+
+const stories = storiesOf('Chromatic/Components', module).addParameters({
+  docs: {page: null},
+  chromatic: {disableSnapshot: false},
+});
+
+const DEFAULT_PROPS: PropCombinations<DonutChartProps> = {
+  data: [DEFAULT_DATA],
+  comparisonMetric: [
+    {
+      metric: '6%',
+      trend: 'positive',
+      accessibilityLabel: 'trending up 6%',
+    },
+  ],
+  legendPosition: ['left'],
+  isAnimated: [false],
+};
+
+const CHART_SIZE = {style: {width: 500, height: 300}};
+
+const combinations = renderCombinationSections([
+  [
+    'Data',
+    addWithPropsCombinations<DonutChartProps>(
+      DonutChart,
+      {
+        ...DEFAULT_PROPS,
+      },
+      CHART_SIZE,
+    ),
+  ],
+  [
+    'Legend Position',
+    addWithPropsCombinations(
+      DonutChart,
+      {
+        ...DEFAULT_PROPS,
+        legendPosition: [
+          'top-left',
+          'top-right',
+          'bottom-left',
+          'bottom-right',
+          'top',
+          'right',
+          'bottom',
+          'left',
+        ],
+      },
+      CHART_SIZE,
+    ),
+  ],
+  [
+    'Truncated Legends',
+    addWithPropsCombinations(
+      DonutChart,
+      {
+        ...DEFAULT_PROPS,
+        data: [
+          [
+            {
+              name: 'This is a long name that will get truncated',
+              data: [{key: 'april - march', value: 50000}],
+              metadata: {
+                trend: {
+                  value: '5%',
+                },
+              },
+            },
+            {
+              name: 'This is another long name that will get truncated',
+              data: [{key: 'april - march', value: 250000}],
+              metadata: {
+                trend: {
+                  value: '50%',
+                  direction: 'downward',
+                  trend: 'negative',
+                },
+              },
+            },
+            {
+              name: 'This is the last long name that will get truncated',
+              data: [{key: 'april - march', value: 10000}],
+              metadata: {
+                trend: {
+                  value: '100%',
+                  direction: 'upward',
+                  trend: 'positive',
+                },
+              },
+            },
+          ],
+        ],
+        legendPosition: ['left', 'right'],
+        showLegendValues: [true, false],
+      },
+      CHART_SIZE,
+    ),
+  ],
+]);
+
+stories.add('DonutChart', combinations);

--- a/packages/polaris-viz/src/components/DonutChart/stories/TruncatedLegends.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/TruncatedLegends.stories.tsx
@@ -1,0 +1,51 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {DonutChartProps} from '../../DonutChart';
+
+import {DEFAULT_PROPS, Template} from './data';
+
+export const TruncatedLegends: Story<DonutChartProps> = Template.bind({});
+
+TruncatedLegends.args = {
+  ...DEFAULT_PROPS,
+  showLegendValues: true,
+  legendPosition: 'right',
+  legendFullWidth: false,
+  labelFormatter: (value) => `$${value}`,
+  isAnimated: false,
+  data: [
+    {
+      name: 'This is a long name that will get truncated',
+      data: [{key: 'april - march', value: 50000}],
+      metadata: {
+        trend: {
+          value: '5%',
+        },
+      },
+    },
+    {
+      name: 'This is another long name that will get truncated',
+      data: [{key: 'april - march', value: 250000}],
+      metadata: {
+        trend: {
+          value: '50%',
+          direction: 'downward',
+          trend: 'negative',
+        },
+      },
+    },
+    {
+      name: 'This is the last long name that will get truncated',
+      data: [{key: 'april - march', value: 10000}],
+      metadata: {
+        trend: {
+          value: '100%',
+          direction: 'upward',
+          trend: 'positive',
+        },
+      },
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
@@ -93,12 +93,13 @@ export function LegendItem({
         paddingRight: LEGEND_ITEM_RIGHT_PADDING,
         gap: LEGEND_ITEM_GAP,
         // if there is overflow, add a max width and truncate with ellipsis
-        maxWidth: truncate ? minWidth : undefined,
+        maxWidth: truncate ? minWidth : '100%',
         // if the item width is less than the minWidth, don't set a min width
         minWidth: width < minWidth ? undefined : minWidth,
       }}
       className={style.Legend}
       ref={ref}
+      title={name}
     >
       {renderSeriesIcon == null ? (
         <span


### PR DESCRIPTION
## What does this implement/fix?

Limit the `DonutChart` legends from taking up more than 50% of the chart space.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/68612

## What do the changes look like?

![image](https://github.com/Shopify/polaris-viz/assets/149873/58761ce0-cf36-4f53-a6fa-f298e471c677)

## Storybook link

https://6062ad4a2d14cd0021539c1b-xydvmesepk.chromatic.com/?path=/story/polaris-viz-charts-donutchart--truncated-legends

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
