### PR TITLE
Added seriesNameFormatter

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `seriesNameFormatter` prop to `<BarChart />`, `<ComboChart />`, `<LineChart />`, `<LineChartPredictive />`, `<LineChartRelational />`, `<SimpleBarChart />` & `<StackedAreaChart />`.
 
 ## [12.4.2] - 2024-04-04
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -12,6 +12,7 @@ import type {
   YAxisOptions,
   ChartType,
   ChartProps,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 
 import {getTooltipContentRenderer} from '../../utilities/getTooltipContentRenderer';
@@ -39,6 +40,7 @@ export type BarChartProps = {
   direction?: Direction;
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
+  seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
   skipLinkText?: string;
   theme?: string;
@@ -70,6 +72,7 @@ export function BarChart(props: BarChartProps) {
     yAxisOptions,
     onError,
     renderHiddenLegendLabel,
+    seriesNameFormatter = (value) => `${value}`,
   } = {
     ...DEFAULT_CHART_PROPS,
     ...props,
@@ -105,6 +108,7 @@ export function BarChart(props: BarChartProps) {
         emptyStateText={emptyStateText}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
+        seriesNameFormatter={seriesNameFormatter}
         showLegend={showLegend}
         type={type}
         xAxisOptions={xAxisOptionsWithDefaults}
@@ -118,6 +122,7 @@ export function BarChart(props: BarChartProps) {
         renderHiddenLegendLabel={renderHiddenLegendLabel}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
+        seriesNameFormatter={seriesNameFormatter}
         showLegend={showLegend}
         type={type}
         xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/BarChart/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,51 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {BarChartProps} from '../../../components';
+
+import {DEFAULT_DATA, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/BarChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<BarChartProps> = Template.bind({});
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};
+
+export const FormattedValuesHorizontal: Story<BarChartProps> = Template.bind(
+  {},
+);
+
+FormattedValuesHorizontal.args = {
+  data: DEFAULT_DATA,
+  direction: 'horizontal',
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -13,6 +13,7 @@ import type {
   DataGroup,
   BoundingRect,
   XAxisOptions,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 
 import {ChartElements} from '../ChartElements';
@@ -56,6 +57,7 @@ export interface ChartProps {
   annotationsLookupTable: AnnotationLookupTable;
   data: DataGroup[];
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   theme: string;
   xAxisOptions: Required<XAxisOptions>;
@@ -72,6 +74,7 @@ export function Chart({
   theme,
   xAxisOptions,
   renderLegendContent,
+  seriesNameFormatter,
 }: ChartProps) {
   const selectedTheme = useTheme(theme);
 
@@ -89,6 +92,7 @@ export function Chart({
     data,
     dimensions,
     showLegend,
+    seriesNameFormatter,
   });
 
   const {drawableHeight, chartYPosition, xAxisBounds, yAxisBounds} =
@@ -173,6 +177,7 @@ export function Chart({
     renderTooltipContent,
     data,
     seriesColors: colors,
+    seriesNameFormatter,
   });
 
   const {hasXAxisAnnotations, hasYAxisAnnotations} = checkAvailableAnnotations(

--- a/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
@@ -7,6 +7,7 @@ import type {
   DataGroup,
   ChartProps,
   XAxisOptions,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import type {ReactNode} from 'react';
 
@@ -27,6 +28,7 @@ export type ComboChartProps = {
   data: DataGroup[];
   annotations?: ComboAnnotation[];
   renderTooltipContent?(data: RenderTooltipContentData): ReactNode;
+  seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
   xAxisOptions?: Partial<XAxisOptions>;
   renderLegendContent?: RenderLegendContent;
@@ -42,6 +44,7 @@ export function ComboChart(props: ComboChartProps) {
     id,
     isAnimated,
     renderTooltipContent,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     theme = defaultTheme,
     xAxisOptions,
@@ -84,6 +87,7 @@ export function ComboChart(props: ComboChartProps) {
         annotationsLookupTable={annotationsLookupTable}
         data={data}
         renderTooltipContent={renderTooltip}
+        seriesNameFormatter={seriesNameFormatter}
         showLegend={showLegend}
         theme={theme}
         xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/ComboChart/hooks/tests/useComboChartTooltipContent.test.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/hooks/tests/useComboChartTooltipContent.test.tsx
@@ -1,0 +1,56 @@
+import type {Root} from '@shopify/react-testing';
+import {mount} from '@shopify/react-testing';
+
+import type {Props} from '../useComboChartTooltipContent';
+import {useComboChartTooltipContent} from '../useComboChartTooltipContent';
+
+describe('useComboChartTooltipContent()', () => {
+  it('returns formatted series name', () => {
+    const renderTooltipContentSpy = jest.fn();
+
+    mount(
+      <TestComponent
+        {...MOCK_PROPS}
+        renderTooltipContent={renderTooltipContentSpy}
+        seriesNameFormatter={(value) => `Name: ${value}`}
+      />,
+    );
+
+    expect(renderTooltipContentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({key: 'Name: Bar Name'}),
+            ]),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  function TestComponent(props: Props) {
+    const result = useComboChartTooltipContent(props);
+
+    result(0);
+
+    return null;
+  }
+});
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      shape: 'Bar',
+      series: [
+        {
+          name: 'Bar Name',
+          data: [{value: 100, key: 'key1'}],
+        },
+      ],
+    },
+  ],
+  seriesColors: ['red', 'red', 'red'],
+  renderTooltipContent: jest.fn(),
+  seriesNameFormatter: (value) => `${value}`,
+};

--- a/packages/polaris-viz/src/components/ComboChart/hooks/useComboChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/ComboChart/hooks/useComboChartTooltipContent.ts
@@ -1,6 +1,11 @@
 import type {ReactNode} from 'react';
 import {useCallback} from 'react';
-import type {Color, DataGroup, Shape} from '@shopify/polaris-viz-core';
+import type {
+  Color,
+  DataGroup,
+  LabelFormatter,
+  Shape,
+} from '@shopify/polaris-viz-core';
 import {useChartContext} from '@shopify/polaris-viz-core';
 
 import {flattenDataGroupToDataSeries} from '../../../utilities/flattenDataGroupToDataSeries';
@@ -14,12 +19,14 @@ export interface Props {
   data: DataGroup[];
   seriesColors: Color[];
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
 }
 
 export function useComboChartTooltipContent({
   data,
   renderTooltipContent,
   seriesColors,
+  seriesNameFormatter,
 }: Props) {
   const {theme} = useChartContext();
 
@@ -51,7 +58,7 @@ export function useComboChartTooltipContent({
           const {value} = seriesData[activeIndex];
 
           data.data.push({
-            key: `${name}`,
+            key: `${seriesNameFormatter(name ?? '')}`,
             value: yAxisOptionsWithDefaults.labelFormatter(value),
             color: color ?? seriesColors[index],
             isComparison,
@@ -71,6 +78,6 @@ export function useComboChartTooltipContent({
         theme,
       });
     },
-    [data, seriesColors, renderTooltipContent, theme],
+    [data, seriesColors, renderTooltipContent, theme, seriesNameFormatter],
   );
 }

--- a/packages/polaris-viz/src/components/ComboChart/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,29 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {ComboChartProps} from '../../../components';
+
+import {DEFAULT_DATA, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/ComboChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<ComboChartProps> = Template.bind({});
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/ComboChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/tests/Chart.test.tsx
@@ -72,6 +72,7 @@ const PROPS: ChartProps = {
   showLegend: false,
   theme: 'Default',
   xAxisOptions: getXAxisOptionsWithDefaults(),
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 describe('<Chart />', () => {

--- a/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
+++ b/packages/polaris-viz/src/components/Docs/stories/components/SampleComponents.tsx
@@ -244,6 +244,7 @@ export const SampleLegendContainer = ({theme} = {theme: 'Default'}) => {
     showLegend: true,
     dimensions: {height: 0, width: 0},
     colors,
+    seriesNameFormatter: (value) => `${value}`,
   });
 
   return (

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
@@ -60,6 +60,7 @@ export function LegendValues({
     data: [{series: allData, shape: 'Bar'}],
     colors: seriesColors,
     dimensions,
+    seriesNameFormatter,
   });
 
   const {displayedData, hiddenData} = useOverflowLegend({

--- a/packages/polaris-viz/src/components/DonutChart/tests/DonutChart.test.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/tests/DonutChart.test.tsx
@@ -1,4 +1,5 @@
 import {mount} from '@shopify/react-testing';
+import {ChartState} from '@shopify/polaris-viz-core';
 
 import {Chart as DonutChart} from '../Chart';
 import type {ChartProps} from '../Chart';
@@ -19,7 +20,6 @@ jest.mock('@shopify/polaris-viz-core/src/utilities', () => ({
 describe('<DonutChart />', () => {
   describe('<Chart/>', () => {
     const mockProps: ChartProps = {
-      isAnimated: false,
       showLegend: true,
       theme: `Default`,
       labelFormatter: (value) => `${value}`,
@@ -47,6 +47,10 @@ describe('<DonutChart />', () => {
         trend: 'negative',
         accessibilityLabel: 'trending down 10%',
       },
+      seriesNameFormatter: (value) => `${value}`,
+      legendPosition: 'left',
+      showLegendValues: true,
+      state: ChartState.Success,
     };
 
     // the sum of the values in the data array

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -14,6 +14,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import {animated} from '@react-spring/web';
 
@@ -59,6 +60,7 @@ export interface ChartProps {
   annotationsLookupTable: AnnotationLookupTable;
   data: DataSeries[];
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
@@ -75,6 +77,7 @@ export function Chart({
   renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
+  seriesNameFormatter,
   showLegend,
   type,
   xAxisOptions,
@@ -103,6 +106,7 @@ export function Chart({
     dimensions,
     showLegend,
     colors: seriesColors,
+    seriesNameFormatter,
   });
 
   const {allNumbers, longestLabel, areAllNegative} = useDataForHorizontalChart({
@@ -164,6 +168,7 @@ export function Chart({
     data,
     seriesColors,
     renderTooltipContent,
+    seriesNameFormatter,
   });
 
   const {transitions} = useHorizontalTransitions({

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -5,6 +5,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 
 import type {
@@ -18,6 +19,7 @@ import {Chart} from './Chart';
 export interface HorizontalBarChartProps {
   data: DataSeries[];
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
@@ -35,6 +37,7 @@ export function HorizontalBarChart({
   renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
+  seriesNameFormatter,
   showLegend,
   type = 'default',
   xAxisOptions,
@@ -46,6 +49,7 @@ export function HorizontalBarChart({
       annotationsLookupTable={annotationsLookupTable}
       data={data}
       renderTooltipContent={renderTooltipContent}
+      seriesNameFormatter={seriesNameFormatter}
       showLegend={showLegend}
       type={type}
       xAxisOptions={xAxisOptions}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/tests/Chart.test.tsx
@@ -57,21 +57,24 @@ const MOCK_PROPS: ChartProps = {
   dimensions: {
     height: 300,
     width: 600,
+    x: 0,
+    y: 0,
   },
-  isAnimated: false,
   renderTooltipContent: (value) => `${value}`,
   data: DATA,
   xAxisOptions: {
+    allowLineWrap: false,
     labelFormatter: (value) => `${value}`,
     hide: false,
   },
   yAxisOptions: {
+    fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
   },
   showLegend: false,
   type: 'default',
-  theme: 'Default',
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 describe('<Chart />', () => {

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/tests/useLegend.test.tsx
@@ -36,6 +36,7 @@ const MOCK_PROPS: Props = {
   dimensions: {height: 100, width: 100},
   showLegend: true,
   data: DATAGROUP,
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 function parseData(result: Root<any>) {
@@ -218,6 +219,25 @@ describe('useLegend()', () => {
       const data = parseData(result);
 
       expect(data.isLegendMounted).toStrictEqual(true);
+    });
+  });
+
+  describe('seriesNameFormatter', () => {
+    it('returns true when showLegend=false', () => {
+      function TestComponent() {
+        const data = useLegend({
+          ...MOCK_PROPS,
+          seriesNameFormatter: (value) => `Name: ${value}`,
+        });
+
+        return <span data-data={`${JSON.stringify(data)}`} />;
+      }
+
+      const result = mount(<TestComponent />);
+
+      const data = parseData(result);
+
+      expect(data.legend[0].name).toStrictEqual('Name: Breakfast');
     });
   });
 });

--- a/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
+++ b/packages/polaris-viz/src/components/LegendContainer/hooks/useLegend.ts
@@ -29,11 +29,11 @@ function getAlteredDimensions(
 export interface Props {
   showLegend: boolean;
   data: DataGroup[];
+  seriesNameFormatter: LabelFormatter;
   colors?: Color[];
   dimensions?: Dimensions;
   direction?: Direction;
   maxWidth?: number;
-  seriesNameFormatter?: LabelFormatter;
 }
 
 export function useLegend({
@@ -43,7 +43,7 @@ export function useLegend({
   showLegend,
   direction = 'horizontal',
   maxWidth = 0,
-  seriesNameFormatter = (value) => `${value}`,
+  seriesNameFormatter,
 }: Props) {
   const defaultHeight = showLegend ? DEFAULT_LEGEND_HEIGHT : 0;
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -17,6 +17,7 @@ import type {
   YAxisOptions,
   LineChartDataSeriesWithDefaults,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 
 import {useExternalHideEvents} from '../../hooks/ExternalEvents';
@@ -71,6 +72,7 @@ export interface ChartProps {
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
   annotationsLookupTable: AnnotationLookupTable;
   data: LineChartDataSeriesWithDefaults[];
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
@@ -92,6 +94,7 @@ export function Chart({
   renderLegendContent,
   renderTooltipContent,
   renderHiddenLegendLabel,
+  seriesNameFormatter,
   showLegend = true,
   slots,
   theme = DEFAULT_THEME_NAME,
@@ -120,6 +123,7 @@ export function Chart({
     ],
     dimensions,
     showLegend,
+    seriesNameFormatter,
   });
 
   useWatchColorVisionEvents({
@@ -199,6 +203,7 @@ export function Chart({
     renderTooltipContent,
     indexForLabels,
     hiddenIndexes: hiddenLineIndexes,
+    seriesNameFormatter,
   });
 
   if (xScale == null || drawableWidth == null || yAxisLabelWidth == null) {

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -3,6 +3,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   ChartProps,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import {
   InternalChartType,
@@ -40,6 +41,7 @@ export type LineChartProps = {
   emptyStateText?: string;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
+  seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
   skipLinkText?: string;
   tooltipOptions?: TooltipOptions;
@@ -63,6 +65,7 @@ export function LineChart(props: LineChartProps) {
     onError,
     renderLegendContent,
     renderHiddenLegendLabel,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     skipLinkText,
     state,
@@ -119,6 +122,7 @@ export function LineChart(props: LineChartProps) {
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}
             renderHiddenLegendLabel={renderHiddenLegendLabel}
+            seriesNameFormatter={seriesNameFormatter}
             showLegend={showLegend}
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/LineChart/hooks/tests/useLineChartTooltipContent.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/hooks/tests/useLineChartTooltipContent.test.tsx
@@ -1,0 +1,52 @@
+import type {Root} from '@shopify/react-testing';
+import {mount} from '@shopify/react-testing';
+
+import type {Props} from '../useLineChartTooltipContent';
+import {useLineChartTooltipContent} from '../useLineChartTooltipContent';
+
+describe('useLineChartTooltipContent()', () => {
+  it('returns formatted series name', () => {
+    const renderTooltipContentSpy = jest.fn();
+
+    mount(
+      <TestComponent
+        {...MOCK_PROPS}
+        renderTooltipContent={renderTooltipContentSpy}
+        seriesNameFormatter={(value) => `Name: ${value}`}
+      />,
+    );
+
+    expect(renderTooltipContentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({key: 'Name: Series One'}),
+            ]),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  function TestComponent(props: Props) {
+    const result = useLineChartTooltipContent(props);
+
+    result(0);
+
+    return null;
+  }
+});
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      name: 'Series One',
+      data: [{key: 'One', value: 1}],
+      color: 'red',
+    },
+  ],
+  indexForLabels: 0,
+  renderTooltipContent: jest.fn(),
+  seriesNameFormatter: (value) => `${value}`,
+};

--- a/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
@@ -1,14 +1,18 @@
-import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
+import type {
+  LabelFormatter,
+  LineChartDataSeriesWithDefaults,
+} from '@shopify/polaris-viz-core';
 import {useChartContext} from '@shopify/polaris-viz-core';
 import type {ReactNode} from 'react';
 import {useCallback} from 'react';
 
 import type {RenderTooltipContentData} from '../../../types';
 
-interface Props {
+export interface Props {
   data: LineChartDataSeriesWithDefaults[];
   indexForLabels: number;
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
   hiddenIndexes?: number[];
 }
 
@@ -17,6 +21,7 @@ export function useLineChartTooltipContent({
   hiddenIndexes = [],
   indexForLabels,
   renderTooltipContent,
+  seriesNameFormatter,
 }: Props) {
   const {theme} = useChartContext();
 
@@ -44,7 +49,7 @@ export function useLineChartTooltipContent({
         const {value} = seriesData[activeIndex];
 
         tooltipData[0].data.push({
-          key: `${name}`,
+          key: `${seriesNameFormatter(name ?? '')}`,
           value,
           color: color!,
           isComparison,
@@ -60,6 +65,13 @@ export function useLineChartTooltipContent({
         theme,
       });
     },
-    [data, renderTooltipContent, theme, hiddenIndexes, indexForLabels],
+    [
+      data,
+      renderTooltipContent,
+      theme,
+      hiddenIndexes,
+      indexForLabels,
+      seriesNameFormatter,
+    ],
   );
 }

--- a/packages/polaris-viz/src/components/LineChart/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,32 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {LineChartProps} from '../../../components';
+
+import {DEFAULT_DATA, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/LineChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<LineChartProps> = Template.bind({});
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -50,6 +50,7 @@ const xAxisOptions: Required<XAxisOptions> = {
 };
 
 const yAxisOptions: Required<YAxisOptions> = {
+  fixedWidth: false,
   labelFormatter: jest.fn(),
   integersOnly: false,
 };
@@ -57,11 +58,12 @@ const yAxisOptions: Required<YAxisOptions> = {
 const MOCK_PROPS: ChartProps = {
   data: [MOCK_DATA],
   annotationsLookupTable: {},
-  dimensions: {width: 500, height: 250},
+  dimensions: {width: 500, height: 250, x: 0, y: 0},
   xAxisOptions,
   yAxisOptions,
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
   showLegend: false,
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 jest.mock('@shopify/polaris-viz-core/src/utilities/estimateStringWidth', () => {

--- a/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
@@ -22,6 +22,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
     emptyStateText,
     id,
     isAnimated,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     skipLinkText,
     state,
@@ -87,6 +88,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
       errorText={errorText}
       id={id}
       isAnimated={isAnimated}
+      seriesNameFormatter={seriesNameFormatter}
       showLegend={showLegend}
       skipLinkText={skipLinkText}
       slots={{
@@ -119,6 +121,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
             predictiveSeriesNames={predictiveSeriesNames}
             data={dataWithColors}
             theme={theme ?? DEFAULT_THEME_NAME}
+            seriesNameFormatter={seriesNameFormatter}
           />
         );
       }}

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/CustomLegend.tsx
@@ -1,3 +1,5 @@
+import type {LabelFormatter} from '@shopify/polaris-viz-core';
+
 import type {LineChartPredictiveDataSeries} from '../../../../components/LineChartPredictive/types';
 import type {ColorVisionInteractionMethods} from '../../../../types';
 import {LegendItem} from '../../../../components/Legend';
@@ -5,9 +7,10 @@ import {SeriesIcon} from '../SeriesIcon';
 
 import styles from './CustomLegend.scss';
 
-interface Props extends ColorVisionInteractionMethods {
+export interface Props extends ColorVisionInteractionMethods {
   data: LineChartPredictiveDataSeries[];
   predictiveSeriesNames: string[];
+  seriesNameFormatter: LabelFormatter;
   theme: string;
 }
 
@@ -16,6 +19,7 @@ export function CustomLegend({
   predictiveSeriesNames,
   getColorVisionEventAttrs,
   getColorVisionStyles,
+  seriesNameFormatter,
   theme,
 }: Props) {
   return (
@@ -46,7 +50,7 @@ export function CustomLegend({
                   : undefined
               }
               isComparison={isComparison}
-              name={name!}
+              name={seriesNameFormatter(name ?? '')}
               shape="Line"
               theme={theme}
             />

--- a/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/tests/CustomLegend.test.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/components/CustomLegend/tests/CustomLegend.test.tsx
@@ -1,0 +1,34 @@
+import {mount} from '@shopify/react-testing';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import type {Props} from '../CustomLegend';
+import {CustomLegend} from '../CustomLegend';
+
+describe('<CustomLegend />', () => {
+  describe('seriesNameFormatter', () => {
+    it('renders formatted series name', () => {
+      const component = mount(
+        <CustomLegend
+          {...MOCK_PROPS}
+          seriesNameFormatter={(value) => `Name: ${value}`}
+        />,
+      );
+
+      expect(component).toContainReactText('Name: Series one');
+    });
+  });
+});
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      name: 'Series one',
+      data: [{value: 88, key: '2020-03-01T12:00:00'}],
+    },
+  ],
+  predictiveSeriesNames: [],
+  seriesNameFormatter: (value) => `${value}`,
+  theme: 'Default',
+  getColorVisionEventAttrs: jest.fn(),
+  getColorVisionStyles: jest.fn(),
+};

--- a/packages/polaris-viz/src/components/LineChartPredictive/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,33 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import {DEFAULT_DATA, Template} from './data';
+import type {LineChartPredictiveProps} from '../types';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/LineChartPredictive',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<LineChartPredictiveProps> = Template.bind(
+  {},
+);
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
@@ -9,9 +9,12 @@ import {LineChart} from '../LineChart';
 
 import {RelatedAreas, MissingDataArea, CustomLegend} from './components';
 
-export function LineChartRelational(
-  props: Omit<LineChartProps, 'renderLegendContent'>,
-) {
+export type LineChartRelationalProps = Omit<
+  LineChartProps,
+  'renderLegendContent'
+>;
+
+export function LineChartRelational(props: LineChartRelationalProps) {
   const {
     annotations = [],
     data,
@@ -19,6 +22,7 @@ export function LineChartRelational(
     emptyStateText,
     id,
     isAnimated,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     skipLinkText,
     state,
@@ -59,9 +63,11 @@ export function LineChartRelational(
             getColorVisionEventAttrs={getColorVisionEventAttrs}
             data={data}
             theme={theme ?? DEFAULT_THEME_NAME}
+            seriesNameFormatter={seriesNameFormatter}
           />
         );
       }}
+      seriesNameFormatter={seriesNameFormatter}
       showLegend={showLegend}
       skipLinkText={skipLinkText}
       slots={{

--- a/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/CustomLegend.tsx
@@ -1,12 +1,13 @@
-import type {DataSeries} from '@shopify/polaris-viz-core';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 
 import type {ColorVisionInteractionMethods} from '../../../../types';
 import {LegendItem} from '../../../../components/Legend';
 
 import styles from './CustomLegend.scss';
 
-interface Props extends ColorVisionInteractionMethods {
+export interface Props extends ColorVisionInteractionMethods {
   data: DataSeries[];
+  seriesNameFormatter: LabelFormatter;
   theme: string;
 }
 
@@ -14,6 +15,7 @@ export function CustomLegend({
   data,
   getColorVisionEventAttrs,
   getColorVisionStyles,
+  seriesNameFormatter,
   theme,
 }: Props) {
   const lineSeries = data.filter(
@@ -47,7 +49,7 @@ export function CustomLegend({
               color={color!}
               index={index}
               isComparison={isComparison}
-              name={name!}
+              name={seriesNameFormatter(name ?? '')}
               shape="Line"
               theme={theme}
             />
@@ -66,7 +68,7 @@ export function CustomLegend({
             percentileItems[0].color ?? percentileItems[0]?.metadata?.areaColor
           }
           index={percentileIndex}
-          name={percentileItems[0]?.metadata?.legendLabel}
+          name={seriesNameFormatter(percentileItems[0]?.metadata?.legendLabel)}
           shape="Bar"
           theme={theme}
         />

--- a/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/tests/CustomLegend.test.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/CustomLegend/tests/CustomLegend.test.tsx
@@ -1,0 +1,54 @@
+import {mount} from '@shopify/react-testing';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import type {Props} from '../CustomLegend';
+import {CustomLegend} from '../CustomLegend';
+
+describe('<CustomLegend />', () => {
+  describe('seriesNameFormatter', () => {
+    it('renders formatted series name', () => {
+      const component = mount(
+        <CustomLegend
+          {...MOCK_PROPS}
+          seriesNameFormatter={(value) => `Name: ${value}`}
+        />,
+      );
+
+      expect(component).toContainReactText('Name: Average');
+      expect(component).toContainReactText('Name: 75th - 25th percentile');
+    });
+  });
+});
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      name: 'Average',
+      data: [{value: 333, key: '2020-03-01T12:00:00'}],
+    },
+    {
+      name: '75th Percentile',
+      data: [{value: 388, key: '2020-03-01T12:00:00'}],
+      metadata: {
+        relatedIndex: 2,
+        legendLabel: '75th - 25th percentile',
+      },
+    },
+    {
+      name: 'Median',
+      data: [{value: 238, key: '2020-03-01T12:00:00'}],
+    },
+    {
+      name: '25th percentile',
+      data: [{value: 88, key: '2020-03-01T12:00:00'}],
+      metadata: {
+        relatedIndex: 2,
+        legendLabel: '75th - 25th percentile',
+      },
+    },
+  ],
+  seriesNameFormatter: (value) => `${value}`,
+  theme: 'Default',
+  getColorVisionEventAttrs: jest.fn(),
+  getColorVisionStyles: jest.fn(),
+};

--- a/packages/polaris-viz/src/components/LineChartRelational/index.ts
+++ b/packages/polaris-viz/src/components/LineChartRelational/index.ts
@@ -1,2 +1,3 @@
 export {LineChartRelational} from './LineChartRelational';
 export {MissingDataArea} from './components/MissingDataArea';
+export type {LineChartRelationalProps} from './LineChartRelational';

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/Default.stories.tsx
@@ -3,9 +3,9 @@ import type {Story} from '@storybook/react';
 export {META as default} from './meta';
 
 import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
-import type {LineChartProps} from 'components/LineChart/LineChart';
+import type {LineChartRelationalProps} from '../LineChartRelational';
 
-export const Default: Story<LineChartProps> = Template.bind({});
+export const Default: Story<LineChartRelationalProps> = Template.bind({});
 
 Default.args = {
   ...DEFAULT_PROPS,

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,34 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {LineChartRelationalProps} from '../../LineChartRelational';
+
+import {DEFAULT_DATA, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/LineChartRelational',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<LineChartRelationalProps> = Template.bind(
+  {},
+);
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -7,6 +7,7 @@ import {
 import type {
   ChartType,
   Dimensions,
+  LabelFormatter,
   XAxisOptions,
   YAxisOptions,
 } from '@shopify/polaris-viz-core';
@@ -33,6 +34,7 @@ import {getLongestTrendIndicator} from './utilities';
 
 export interface ChartProps {
   data: SimpleBarChartDataSeries[];
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
@@ -47,6 +49,7 @@ export function Chart({
   dimensions,
   renderLegendContent,
   legendPosition = 'bottom-right',
+  seriesNameFormatter,
   showLegend,
   type,
   xAxisOptions,
@@ -71,6 +74,7 @@ export function Chart({
     dimensions,
     colors: seriesColors,
     showLegend,
+    seriesNameFormatter,
   });
 
   const {

--- a/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/SimpleBarChart.tsx
@@ -3,6 +3,7 @@ import type {
   XAxisOptions,
   ChartProps,
   YAxisOptions,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import {
   DEFAULT_CHART_PROPS,
@@ -25,6 +26,7 @@ export type SimpleBarChartProps = {
   data: SimpleBarChartDataSeries[];
   renderLegendContent?: RenderLegendContent;
   legendPosition?: LegendPosition;
+  seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
   type?: ChartType;
   xAxisOptions?: XAxisOptions;
@@ -41,6 +43,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
     renderLegendContent,
     legendPosition = 'bottom-right',
     onError,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     theme = defaultTheme,
     type = 'default',
@@ -74,6 +77,7 @@ export function SimpleBarChart(props: SimpleBarChartProps) {
         <Chart
           data={data}
           renderLegendContent={renderLegendContent}
+          seriesNameFormatter={seriesNameFormatter}
           legendPosition={legendPosition}
           showLegend={showLegend}
           type={type}

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,32 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {SimpleBarChartProps} from '../../../components';
+
+import {SINGLE_SERIES, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/SimpleBarChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<SimpleBarChartProps> = Template.bind({});
+
+FormattedValues.args = {
+  data: SINGLE_SERIES,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/SimpleBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/tests/Chart.test.tsx
@@ -43,7 +43,6 @@ const MOCK_PROPS: ChartProps = {
     height: 300,
     width: 600,
   },
-  isAnimated: false,
   data: SERIES,
   xAxisOptions: {
     labelFormatter: (value) => `${value}`,
@@ -51,11 +50,13 @@ const MOCK_PROPS: ChartProps = {
     allowLineWrap: true,
   },
   yAxisOptions: {
+    fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
   },
   type: 'default',
   showLegend: true,
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 describe('<Chart />', () => {

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -8,6 +8,7 @@ import type {
   YAxisOptions,
   Dimensions,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import {
   useUniqueId,
@@ -74,6 +75,7 @@ export interface Props {
   annotationsLookupTable: AnnotationLookupTable;
   data: DataSeries[];
   renderTooltipContent(data: RenderTooltipContentData): ReactNode;
+  seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
   theme: string;
   xAxisOptions: Required<XAxisOptions>;
@@ -94,6 +96,7 @@ export function Chart({
   theme,
   yAxisOptions,
   renderHiddenLegendLabel,
+  seriesNameFormatter,
 }: Props) {
   useColorVisionEvents({enabled: data.length > 1});
 
@@ -115,6 +118,7 @@ export function Chart({
     ],
     dimensions,
     showLegend,
+    seriesNameFormatter,
   });
 
   const tooltipId = useUniqueId('stackedAreaChart');
@@ -191,6 +195,7 @@ export function Chart({
     data,
     renderTooltipContent,
     seriesColors,
+    seriesNameFormatter,
   });
 
   const lineGenerator = useMemo(() => {

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -9,6 +9,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   ChartProps,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 
 import {getTooltipContentRenderer} from '../../utilities/getTooltipContentRenderer';
@@ -41,6 +42,7 @@ export type StackedAreaChartProps = {
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
   renderHiddenLegendLabel?: (count: number) => string;
+  seriesNameFormatter?: LabelFormatter;
 } & ChartProps;
 
 export function StackedAreaChart(props: StackedAreaChartProps) {
@@ -58,6 +60,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     id,
     isAnimated,
     renderLegendContent,
+    seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     skipLinkText,
     theme = defaultTheme,
@@ -105,6 +108,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
             data={data}
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}
+            seriesNameFormatter={seriesNameFormatter}
             showLegend={showLegend}
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/tests/useStackedChartTooltipContent.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/tests/useStackedChartTooltipContent.test.tsx
@@ -1,0 +1,52 @@
+import type {Root} from '@shopify/react-testing';
+import {mount} from '@shopify/react-testing';
+
+import type {Props} from '../useStackedChartTooltipContent';
+import {useStackedChartTooltipContent} from '../useStackedChartTooltipContent';
+
+describe('useStackedChartTooltipContent()', () => {
+  it('returns formatted series name', () => {
+    const renderTooltipContentSpy = jest.fn();
+
+    mount(
+      <TestComponent
+        {...MOCK_PROPS}
+        renderTooltipContent={renderTooltipContentSpy}
+        seriesNameFormatter={(value) => `Name: ${value}`}
+      />,
+    );
+
+    expect(renderTooltipContentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.arrayContaining([
+              expect.objectContaining({key: 'Name: Series One'}),
+            ]),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  function TestComponent(props: Props) {
+    const result = useStackedChartTooltipContent(props);
+
+    result(0);
+
+    return null;
+  }
+});
+
+const MOCK_PROPS: Props = {
+  data: [
+    {
+      name: 'Series One',
+      data: [{key: 'One', value: 1}],
+      color: 'red',
+    },
+  ],
+  indexForLabels: 0,
+  renderTooltipContent: jest.fn(),
+  seriesNameFormatter: (value) => `${value}`,
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedChartTooltipContent.ts
@@ -1,20 +1,26 @@
 import type {ReactNode} from 'react';
 import {useCallback} from 'react';
-import type {Color, DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  Color,
+  DataSeries,
+  LabelFormatter,
+} from '@shopify/polaris-viz-core';
 import {useChartContext} from '@shopify/polaris-viz-core';
 
 import type {RenderTooltipContentData} from '../../../types';
 
-interface Props {
+export interface Props {
   data: DataSeries[];
   seriesColors: Color[];
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
 }
 
 export function useStackedChartTooltipContent({
   data,
   renderTooltipContent,
   seriesColors,
+  seriesNameFormatter,
 }: Props) {
   const {theme} = useChartContext();
 
@@ -35,7 +41,7 @@ export function useStackedChartTooltipContent({
         const {value} = seriesData[activeIndex];
 
         tooltipData[0].data.push({
-          key: `${name}`,
+          key: `${seriesNameFormatter(name ?? '')}`,
           value,
           color: color ?? seriesColors[index],
         });
@@ -49,6 +55,6 @@ export function useStackedChartTooltipContent({
         theme,
       });
     },
-    [data, seriesColors, renderTooltipContent, theme],
+    [data, seriesColors, renderTooltipContent, theme, seriesNameFormatter],
   );
 }

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/FormattedValues.chromatic.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/FormattedValues.chromatic.stories.tsx
@@ -1,0 +1,32 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {StackedAreaChartProps} from '../../../components';
+
+import {DEFAULT_DATA, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/StackedAreaChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const FormattedValues: Story<StackedAreaChartProps> = Template.bind({});
+
+FormattedValues.args = {
+  data: DEFAULT_DATA,
+  seriesNameFormatter: (value) => `Name: ${value}`,
+  xAxisOptions: {
+    labelFormatter: (value) => `xAxis: ${value}`,
+  },
+  yAxisOptions: {
+    labelFormatter: (value) => `yAxis: ${value}`,
+  },
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -71,6 +71,7 @@ const MOCK_PROPS: Props = {
     labelFormatter: (value) => `Day ${value}`,
   },
   yAxisOptions: {
+    fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
   },
@@ -78,6 +79,7 @@ const MOCK_PROPS: Props = {
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
   showLegend: false,
   theme: 'Default',
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 describe('<Chart />', () => {

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -16,6 +16,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import {stackOffsetDiverging, stackOrderNone} from 'd3-shape';
 
@@ -61,6 +62,7 @@ export interface Props {
   data: DataSeries[];
   renderTooltipContent(data: RenderTooltipContentData): ReactNode;
   showLegend: boolean;
+  seriesNameFormatter: LabelFormatter;
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
@@ -83,6 +85,7 @@ export function Chart({
   xAxisOptions,
   yAxisOptions,
   renderHiddenLegendLabel,
+  seriesNameFormatter,
 }: Props) {
   useColorVisionEvents({enabled: data.length > 1, dimensions});
 
@@ -103,6 +106,7 @@ export function Chart({
     ],
     dimensions,
     showLegend,
+    seriesNameFormatter,
   });
 
   const emptyState = data.length === 0;
@@ -202,6 +206,7 @@ export function Chart({
     renderTooltipContent,
     data,
     seriesColors: barColors,
+    seriesNameFormatter,
   });
 
   const {hasXAxisAnnotations, hasYAxisAnnotations} = checkAvailableAnnotations(

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -4,6 +4,7 @@ import type {
   XAxisOptions,
   YAxisOptions,
   BoundingRect,
+  LabelFormatter,
 } from '@shopify/polaris-viz-core';
 import type {ReactNode} from 'react';
 
@@ -22,6 +23,7 @@ export interface VerticalBarChartProps {
   showLegend: boolean;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
+  seriesNameFormatter: LabelFormatter;
   annotationsLookupTable?: AnnotationLookupTable;
   barOptions?: {isStacked: boolean};
   dimensions?: BoundingRect;
@@ -43,6 +45,7 @@ export function VerticalBarChart({
   xAxisOptions,
   yAxisOptions,
   renderHiddenLegendLabel,
+  seriesNameFormatter,
 }: VerticalBarChartProps) {
   const selectedTheme = useTheme();
   const seriesColors = useThemeSeriesColors(data, selectedTheme);
@@ -60,6 +63,7 @@ export function VerticalBarChart({
       emptyStateText={emptyStateText}
       renderLegendContent={renderLegendContent}
       renderTooltipContent={renderTooltipContent}
+      seriesNameFormatter={seriesNameFormatter}
       showLegend={showLegend}
       type={type}
       xAxisOptions={xAxisOptions}

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -54,19 +54,21 @@ const MOCK_PROPS: Props = {
       name: 'LABEL2',
     },
   ],
-  dimensions: {width: 500, height: 250},
+  dimensions: {width: 500, height: 250, x: 0, y: 0},
   renderTooltipContent,
   xAxisOptions: {
+    allowLineWrap: false,
     labelFormatter: jest.fn((value) => `${value}`),
     hide: false,
   },
   yAxisOptions: {
+    fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
   },
   type: 'default',
   showLegend: false,
-  theme: 'Default',
+  seriesNameFormatter: (value) => `${value}`,
 };
 
 describe('Chart />', () => {

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -51,6 +51,7 @@ export {XAxis} from './XAxis';
 export {TrendIndicator, estimateTrendIndicatorWidth} from './TrendIndicator';
 export type {TrendIndicatorProps} from './TrendIndicator';
 export {LineChartRelational, MissingDataArea} from './LineChartRelational';
+export type {LineChartRelationalProps} from './LineChartRelational';
 export {LineChartPredictive} from './LineChartPredictive';
 export type {LineChartPredictiveProps} from './LineChartPredictive';
 export type {ComparisonMetricProps} from './ComparisonMetric';

--- a/packages/polaris-viz/src/hooks/tests/useBarChartTooltipContent.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useBarChartTooltipContent.test.tsx
@@ -43,6 +43,7 @@ describe('useBarChartTooltipContent()', () => {
         data: DATA,
         renderTooltipContent: (value) => value,
         seriesColors: ['red', 'green', 'blue'],
+        seriesNameFormatter: (value) => `Name: ${value}`,
       };
 
       const data = useBarChartTooltipContent(props);
@@ -59,17 +60,17 @@ describe('useBarChartTooltipContent()', () => {
         data: [
           {
             color: 'red',
-            key: 'Breakfast',
+            key: 'Name: Breakfast',
             value: 3,
           },
           {
             color: 'green',
-            key: 'Lunch',
+            key: 'Name: Lunch',
             value: 4,
           },
           {
             color: 'blue',
-            key: 'Dinner',
+            key: 'Name: Dinner',
             value: 7,
           },
         ],

--- a/packages/polaris-viz/src/hooks/useBarChartTooltipContent.ts
+++ b/packages/polaris-viz/src/hooks/useBarChartTooltipContent.ts
@@ -1,6 +1,10 @@
 import type {ReactNode} from 'react';
 import {useCallback} from 'react';
-import type {Color, DataSeries} from '@shopify/polaris-viz-core';
+import type {
+  Color,
+  DataSeries,
+  LabelFormatter,
+} from '@shopify/polaris-viz-core';
 import {useChartContext} from '@shopify/polaris-viz-core';
 
 import type {RenderTooltipContentData} from '../types';
@@ -9,12 +13,14 @@ export interface Props {
   data: DataSeries[];
   seriesColors: Color[];
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
+  seriesNameFormatter: LabelFormatter;
 }
 
 export function useBarChartTooltipContent({
   data,
   renderTooltipContent,
   seriesColors,
+  seriesNameFormatter,
 }: Props) {
   const {theme} = useChartContext();
 
@@ -35,7 +41,7 @@ export function useBarChartTooltipContent({
         const {value} = seriesData[activeIndex];
 
         tooltipData[0].data.push({
-          key: `${name}`,
+          key: `${seriesNameFormatter(name ?? '')}`,
           value,
           color: color ?? seriesColors[index],
         });
@@ -49,6 +55,6 @@ export function useBarChartTooltipContent({
         theme,
       });
     },
-    [data, seriesColors, theme, renderTooltipContent],
+    [data, seriesColors, theme, renderTooltipContent, seriesNameFormatter],
   );
 }

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -34,6 +34,7 @@ export type {
   TrendIndicatorProps,
   DonutChartProps,
   ComparisonMetricProps,
+  LineChartRelationalProps,
 } from './components';
 
 export {


### PR DESCRIPTION
## What does this implement/fix?

We have a few (https://github.com/Shopify/core-issues/issues/68882 & https://github.com/Shopify/core-issues/issues/68931) issues in web where we're not showing the correctly formatted data in `Tooltips` and `Legends`.

This is because until recently we were formatting before the data got to `polaris-viz`. Now that we're sending raw data to `polaris-viz`, we need a way to format the series names for `Tooltips` and `Legends`.

Its looks big, but 90% of the changes are tests.

## What do the changes look like?

![image](https://github.com/Shopify/polaris-viz/assets/149873/47886784-c03b-4e4e-a2b0-dc6d111d1b3f)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-jjbevydntl.chromatic.com/?path=/story/polaris-viz-chromatic-charts-barchart--formatted-values

You can check all the `Formatted Values` stories under `Chromatic/Charts/*`.

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
