### PR TITLE
Re-export fillMissingDataPoints

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Re-export `fillMissingDataPoints`.
 
 ## [13.1.1] - 2024-05-03
 

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -87,7 +87,11 @@ export type {
   ChartState,
 } from '@shopify/polaris-viz-core';
 
-export {renderLinearTooltipContent, setSingleSeriesActive} from './utilities';
+export {
+  renderLinearTooltipContent,
+  setSingleSeriesActive,
+  fillMissingDataPoints,
+} from './utilities';
 
 export {getTooltipContentRenderer} from './utilities/getTooltipContentRenderer';
 


### PR DESCRIPTION
## What does this implement/fix?

When I exported  the `fillMissingDataPoint` utility, I forgot to export it in the `packages/polaris-viz/src/index.ts`


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
