### PR TITLE
Update StackedAreaChart to use tooltip portal

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Changed `<StackedAreaChart />` to use a react portal to allow tooltips to render outside the bounds of the chart.
 
 ## [13.2.0] - 2024-05-27
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedData.ts
@@ -30,5 +30,20 @@ export function useStackedData({data, xAxisOptions}: Props) {
     return Math.max(...stackedValues.map((stack) => stack.length)) - 1;
   }, [stackedValues]);
 
-  return {labels: formattedLabels, longestSeriesLength, stackedValues};
+  const longestSeriesIndex = useMemo(
+    () =>
+      data.reduce((maxIndex, currentSeries, currentIndex) => {
+        return data[maxIndex].data.length < currentSeries.data.length
+          ? currentIndex
+          : maxIndex;
+      }, 0),
+    [data],
+  );
+
+  return {
+    labels: formattedLabels,
+    longestSeriesIndex,
+    longestSeriesLength,
+    stackedValues,
+  };
 }

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/ExternalTooltipPortal.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/ExternalTooltipPortal.stories.tsx
@@ -1,0 +1,52 @@
+import type {Story} from '@storybook/react';
+
+import type {StackedAreaChartProps} from '../../StackedAreaChart';
+import {StackedAreaChart} from '../../StackedAreaChart';
+import {META} from '../meta';
+import {DEFAULT_DATA, DEFAULT_PROPS} from '../data';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+  decorators: [],
+};
+
+function Card(args: StackedAreaChartProps) {
+  return (
+    <div
+      style={{
+        height: 400,
+        width: 400,
+        background: 'white',
+        borderRadius: '8px',
+        padding: 10,
+      }}
+    >
+      <StackedAreaChart {...args} theme="Uplift" />
+    </div>
+  );
+}
+
+const Template: Story<StackedAreaChartProps> = (
+  args: StackedAreaChartProps,
+) => {
+  return (
+    <div style={{overflow: 'auto'}}>
+      <Card {...args} />
+      <div style={{height: 700, width: 10}} />
+      <div style={{display: 'flex', justifyContent: 'space-between'}}>
+        <Card {...args} />
+        <Card {...args} />
+        <Card {...args} />
+      </div>
+    </div>
+  );
+};
+
+export const ExternalTooltipPortal: Story<StackedAreaChartProps> =
+  Template.bind({});
+
+ExternalTooltipPortal.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -184,7 +184,7 @@ describe('<Chart />', () => {
 
     triggerSVGMouseMove(chart);
 
-    const tooltipWrapper = chart.find(TooltipWrapper)!;
+    const tooltipWrapper = chart.find(TooltipAnimatedContainer)!;
     expect(tooltipWrapper).toContainReactText('Mock Tooltip Content');
   });
 

--- a/packages/polaris-viz/src/components/TooltipWrapper/index.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/index.ts
@@ -6,7 +6,11 @@ export type {
   TooltipPositionOffset,
 } from './types';
 export {TooltipHorizontalOffset, TooltipVerticalOffset} from './types';
-export {getAlteredVerticalBarPosition, TOOLTIP_MARGIN} from './utilities';
+export {
+  getAlteredVerticalBarPosition,
+  getRightPosition,
+  TOOLTIP_MARGIN,
+} from './utilities';
 export type {
   AlteredPositionProps,
   AlteredPositionReturn,


### PR DESCRIPTION
## What does this implement/fix?

This PR updates `<StackedAreaChart />` to use a react portal to allow tooltips to render outside the bounds of the chart. This should fix a [tooltip overflow bug](https://github.com/Shopify/core-issues/issues/71914) seen in our metric cards for `StackedLineCharts` with long series names 



<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?
https://github.com/Shopify/core-issues/issues/71914

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

- The tooltip in `StackedAreaChart` can now render a tooltip outside the chart bounds


<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

- Check out the `Default` and `ExternalTooltipPortal` stories under `StackedAreaChart` to confirm the the tooltips render appropriately 

https://6062ad4a2d14cd0021539c1b-myszlyvxrt.chromatic.com/


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
