### PR TITLE
Bump TrendIndicator font weight to 650

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Bump `<TrendIndicator />` font weight to 650;
 
 ## [13.4.0] - 2024-06-19
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
@@ -23,11 +23,11 @@ export function getLongestTrendIndicator(
 
         if (dataPoint?.value === highestPositive) {
           longestTrendIndicator.positive = estimateTrendIndicatorWidth(
-            trend.value,
+            trend.value ?? '',
           ).totalWidth;
         } else if (dataPoint?.value === lowestNegative) {
           longestTrendIndicator.negative = estimateTrendIndicatorWidth(
-            trend.value,
+            trend.value ?? '',
           ).totalWidth;
         }
       }

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -12,8 +12,9 @@ import {
   FONT_SIZE,
   HEIGHT,
   Y_OFFSET,
-  FONT_WEIGHT,
 } from './constants';
+
+const TREND_FONT_WEIGHT = 650;
 
 export interface TrendIndicatorProps {
   accessibilityLabel?: string;
@@ -54,7 +55,10 @@ export function TrendIndicator({
     );
   }
 
-  const {textWidth, totalWidth} = estimateTrendIndicatorWidth(value);
+  const {textWidth, totalWidth} = estimateTrendIndicatorWidth(
+    value,
+    TREND_FONT_WEIGHT,
+  );
 
   return (
     <Svg {...svgProps} width={totalWidth}>
@@ -68,7 +72,7 @@ export function TrendIndicator({
           y={(HEIGHT + Y_OFFSET) / 2}
           fontSize={FONT_SIZE}
           fill="currentColor"
-          fontWeight={FONT_WEIGHT}
+          fontWeight={TREND_FONT_WEIGHT}
           dominantBaseline="middle"
           fontFamily={FONT_FAMILY}
           textRendering="geometricPrecision"

--- a/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
@@ -7,9 +7,12 @@ import {
   TEXT_ICON_SPACING,
 } from '../constants';
 
-export function estimateTrendIndicatorWidth(value?: string) {
+export function estimateTrendIndicatorWidth(
+  value,
+  fontWeight: number = FONT_WEIGHT,
+) {
   const textWidth = value
-    ? estimateStringWidthWithOffset(value, FONT_SIZE, FONT_WEIGHT)
+    ? estimateStringWidthWithOffset(value, FONT_SIZE, fontWeight)
     : NO_VALUE_WIDTH;
   const totalWidth = Math.round(ICON_SIZE + TEXT_ICON_SPACING + textWidth);
 

--- a/packages/polaris-viz/src/utilities/getTrendIndicatorData.ts
+++ b/packages/polaris-viz/src/utilities/getTrendIndicatorData.ts
@@ -6,9 +6,7 @@ export function getTrendIndicatorData(
   trendMetadata: MetaDataTrendIndicator | undefined,
 ) {
   if (trendMetadata != null) {
-    const {totalWidth} = estimateTrendIndicatorWidth(
-      `${trendMetadata.value || ''}`,
-    );
+    const {totalWidth} = estimateTrendIndicatorWidth(trendMetadata.value ?? '');
 
     return {
       trendIndicatorProps: trendMetadata,


### PR DESCRIPTION
## What does this implement/fix?

Resolves https://github.com/Shopify/core-issues/issues/72470
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-kviftasjjp.chromatic.com/?path=/story/polaris-viz-subcomponents-trendindicator--default

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
