### PR TITLE
Adds `maxYOverride` prop to `yAxisOptions`

### DIFF
--- a/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
+++ b/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
@@ -379,4 +379,36 @@ describe('useYScale()', () => {
       },
     );
   });
+
+  describe('maxYOverride', () => {
+    it('creates a y scale with the domain maximum set to maxYOverride when both min and max are zero', () => {
+      let domainSpy = jest.fn();
+      const maxYOverride = 1;
+      (scaleLinear as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.ticks = (numTicks: number) => Array.from(Array(numTicks));
+        scale.range = (range: any) => (range ? scale : range);
+        domainSpy = jest.fn((domain: any) => (domain ? scale : domain));
+        scale.domain = domainSpy;
+        scale.nice = () => scale;
+        scale.copy = () => scale;
+        return scale;
+      });
+
+      function TestComponent() {
+        useYScale({
+          ...MOCK_PROPS,
+          min: 0,
+          max: 0,
+          maxYOverride,
+        });
+
+        return null;
+      }
+
+      mount(<TestComponent />);
+
+      expect(domainSpy).toHaveBeenCalledWith([0, maxYOverride]);
+    });
+  });
 });

--- a/packages/polaris-viz-core/src/hooks/useYScale.ts
+++ b/packages/polaris-viz-core/src/hooks/useYScale.ts
@@ -19,6 +19,7 @@ export interface Props {
   shouldRoundUp?: boolean;
   verticalOverflow?: boolean;
   fixedWidth?: number | false;
+  maxYOverride?: number | null;
 }
 
 export function useYScale({
@@ -30,19 +31,30 @@ export function useYScale({
   shouldRoundUp = true,
   verticalOverflow = true,
   fixedWidth,
+  maxYOverride,
 }: Props) {
   const {characterWidths} = useChartContext();
 
+  if (maxYOverride != null && maxYOverride < 0) {
+    throw new Error('maxYOverride must be a non-negative number.');
+  }
+
   const [minY, maxY] = useMemo(() => {
+    const isDataEmpty = min === 0 && max === 0;
     const minY = min;
-    const maxY = max === 0 && min === 0 ? DEFAULT_MAX_Y : max;
+
+    let maxY = isDataEmpty ? DEFAULT_MAX_Y : max;
+
+    if (maxYOverride != null && isDataEmpty) {
+      maxY = maxYOverride;
+    }
 
     if (integersOnly) {
       return [Math.floor(minY), Math.ceil(maxY)];
     }
 
     return [minY, maxY];
-  }, [min, max, integersOnly]);
+  }, [min, max, integersOnly, maxYOverride]);
 
   const {yScale, ticks, yAxisLabelWidth} = useMemo(() => {
     const maxTicks = Math.max(

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -77,6 +77,7 @@ export interface YAxisOptions {
   labelFormatter?: LabelFormatter;
   integersOnly?: boolean;
   fixedWidth?: number | false;
+  maxYOverride?: number | null;
 }
 
 // === Theme types === //

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- `maxYOverride` prop to `yAxisOptions` for `<LineChart />`, `<BarChart />`, and `<StackedAreaChart />`
 
 ## [14.0.0] - 2024-07-03
 

--- a/packages/polaris-viz/src/components/BarChart/stories/YAxisPercentages.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/YAxisPercentages.stories.tsx
@@ -1,0 +1,28 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {BarChartProps} from '../../../components';
+import {formatPercentageYAxisLabel} from '../../../storybook/utilities';
+
+import {Template} from './data';
+
+export const YAxisPercentages: Story<BarChartProps> = Template.bind({});
+
+YAxisPercentages.args = {
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 0, key: '2020-04-01T12:00:00'},
+        {value: 0, key: '2020-04-02T12:00:00'},
+        {value: 0, key: '2020-04-03T12:00:00'},
+        {value: 0, key: '2020-04-04T12:00:00'},
+        {value: 0, key: '2020-04-05T12:00:00'},
+        {value: 0, key: '2020-04-06T12:00:00'},
+        {value: 0, key: '2020-04-07T12:00:00'},
+      ],
+    },
+  ],
+  yAxisOptions: {labelFormatter: formatPercentageYAxisLabel, maxYOverride: 1},
+};

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -152,6 +152,7 @@ export function Chart({
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
     fixedWidth: yAxisOptions.fixedWidth,
+    maxYOverride: yAxisOptions.maxYOverride,
     max: maxY,
     min: minY,
   };

--- a/packages/polaris-viz/src/components/LineChart/stories/YAxisPercentages.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/YAxisPercentages.stories.tsx
@@ -1,0 +1,30 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {LineChartProps} from '../..';
+import {formatPercentageYAxisLabel} from '../../../storybook/utilities';
+
+import {DEFAULT_PROPS, Template} from './data';
+
+export const YAxisPercentages: Story<LineChartProps> = Template.bind({});
+
+YAxisPercentages.args = {
+  ...DEFAULT_PROPS,
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 0, key: '2020-04-01T12:00:00'},
+        {value: 0, key: '2020-04-02T12:00:00'},
+        {value: 0, key: '2020-04-03T12:00:00'},
+        {value: 0, key: '2020-04-04T12:00:00'},
+        {value: 0, key: '2020-04-05T12:00:00'},
+        {value: 0, key: '2020-04-06T12:00:00'},
+        {value: 0, key: '2020-04-07T12:00:00'},
+        {value: 0, key: '2020-04-08T12:00:00'},
+      ],
+    },
+  ],
+  yAxisOptions: {labelFormatter: formatPercentageYAxisLabel, maxYOverride: 1},
+};

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -53,6 +53,7 @@ const yAxisOptions: Required<YAxisOptions> = {
   fixedWidth: false,
   labelFormatter: jest.fn(),
   integersOnly: false,
+  maxYOverride: 1,
 };
 
 const MOCK_PROPS: ChartProps = {
@@ -198,6 +199,17 @@ describe('<Chart />', () => {
       index: 0,
       tabIndex: 0,
     });
+  });
+
+  it('passes maxYOverride as a prop', () => {
+    const chart = mount(
+      <Chart
+        {...MOCK_PROPS}
+        yAxisOptions={{...MOCK_PROPS.yAxisOptions, maxYOverride: 10}}
+      />,
+    );
+
+    expect(chart.prop('yAxisOptions').maxYOverride).toStrictEqual(10);
   });
 
   it('renders tooltip content inside a <TooltipContainer /> if there is an active point', () => {

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -150,6 +150,7 @@ export function Chart({
   const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
+    maxYOverride: yAxisOptions.maxYOverride,
     max: maxY,
     min: minY,
   };

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/YAxisPercentages.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/YAxisPercentages.stories.tsx
@@ -1,0 +1,36 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {StackedAreaChartProps} from '../../../components';
+import {formatPercentageYAxisLabel} from '../../../storybook/utilities';
+
+import {DEFAULT_PROPS, Template} from './data';
+
+export const YAxisPercentages: Story<StackedAreaChartProps> = Template.bind({});
+
+YAxisPercentages.args = {
+  ...DEFAULT_PROPS,
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 0, key: '2020-04-01T12:00:00'},
+        {value: 0, key: '2020-04-02T12:00:00'},
+        {value: 0, key: '2020-04-03T12:00:00'},
+        {value: 0, key: '2020-04-04T12:00:00'},
+        {value: 0, key: '2020-04-05T12:00:00'},
+        {value: 0, key: '2020-04-06T12:00:00'},
+        {value: 0, key: '2020-04-07T12:00:00'},
+        {value: 0, key: '2020-04-08T12:00:00'},
+        {value: 0, key: '2020-04-09T12:00:00'},
+        {value: 0, key: '2020-04-10T12:00:00'},
+        {value: 0, key: '2020-04-11T12:00:00'},
+        {value: 0, key: '2020-04-12T12:00:00'},
+        {value: 0, key: '2020-04-13T12:00:00'},
+        {value: 0, key: '2020-04-14T12:00:00'},
+      ],
+    },
+  ],
+  yAxisOptions: {labelFormatter: formatPercentageYAxisLabel, maxYOverride: 1},
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -75,6 +75,7 @@ const MOCK_PROPS: Props = {
     fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
+    maxYOverride: 10,
   },
   dimensions: {width: 500, height: 250},
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip Content</p>),
@@ -114,6 +115,17 @@ describe('<Chart />', () => {
       colors: ['purple', 'teal'],
       stackedValues: expect.any(Object),
     });
+  });
+
+  it('passes maxYOverride as a prop', () => {
+    const chart = mount(
+      <Chart
+        {...MOCK_PROPS}
+        yAxisOptions={{...MOCK_PROPS.yAxisOptions, maxYOverride: 1}}
+      />,
+    );
+
+    expect(chart.prop('yAxisOptions').maxYOverride).toStrictEqual(1);
   });
 
   it('passes calculated values to StackedAreas', () => {

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -138,10 +138,23 @@ export function Chart({
     integersOnly: yAxisOptions.integersOnly,
   });
 
+  let yScaleMax;
+
+  if (yAxisOptions.maxYOverride === null) {
+    yScaleMax = max;
+  } else {
+    const allValuesAreZero = data.every((series) =>
+      series.data.every((point) => point.value === 0),
+    );
+
+    yScaleMax = allValuesAreZero ? 0 : max;
+  }
+
   const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,
-    max,
+    maxYOverride: yAxisOptions.maxYOverride,
+    max: yScaleMax,
     min,
   };
 

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -65,6 +65,7 @@ const MOCK_PROPS: Props = {
     fixedWidth: false,
     labelFormatter: (value) => `${value}`,
     integersOnly: false,
+    maxYOverride: 1,
   },
   type: 'default',
   showLegend: false,
@@ -85,6 +86,17 @@ describe('Chart />', () => {
     const multiSeriesBarChart = mount(<Chart {...MOCK_PROPS} />);
 
     expect(multiSeriesBarChart).toContainReactComponent('svg');
+  });
+
+  it('passes maxYOverride as a prop', () => {
+    const chart = mount(
+      <Chart
+        {...MOCK_PROPS}
+        yAxisOptions={{...MOCK_PROPS.yAxisOptions, maxYOverride: 1}}
+      />,
+    );
+
+    expect(chart.prop('yAxisOptions').maxYOverride).toStrictEqual(1);
   });
 
   describe('XAxis', () => {

--- a/packages/polaris-viz/src/storybook/utilities.ts
+++ b/packages/polaris-viz/src/storybook/utilities.ts
@@ -25,3 +25,10 @@ export function formatLinearYAxisLabel(value: number) {
     currencyDisplay: 'symbol',
   }).format(value);
 }
+
+export function formatPercentageYAxisLabel(value: number) {
+  return new Intl.NumberFormat('en', {
+    style: 'percent',
+    maximumFractionDigits: 2,
+  }).format(value);
+}

--- a/packages/polaris-viz/src/utilities/getAxisOptions.ts
+++ b/packages/polaris-viz/src/utilities/getAxisOptions.ts
@@ -10,6 +10,7 @@ export function getYAxisOptionsWithDefaults(
     labelFormatter: (value: number) => `${value}`,
     integersOnly: false,
     fixedWidth: false,
+    maxYOverride: null,
     ...yAxisOptionsFiltered,
   };
 }

--- a/packages/polaris-viz/src/utilities/tests/getAxisOptions.test.ts
+++ b/packages/polaris-viz/src/utilities/tests/getAxisOptions.test.ts
@@ -35,6 +35,21 @@ describe('get-axis-options', () => {
       expect(yAxisOptions.integersOnly).toStrictEqual(true);
       expect(yAxisOptions.labelFormatter('foo')).toBe('foo bar');
     });
+
+    it('sets default maxYOverride when not provided', () => {
+      const yAxisOptions = getYAxisOptionsWithDefaults();
+
+      expect(yAxisOptions.maxYOverride).toBeNull();
+    });
+
+    it('overrides maxYOverride when provided', () => {
+      const maxYOverridden = 1;
+      const yAxisOptions = getYAxisOptionsWithDefaults({
+        maxYOverride: maxYOverridden,
+      });
+
+      expect(yAxisOptions.maxYOverride).toBe(maxYOverridden);
+    });
   });
 
   describe('getXAxisOptionsWithDefaults()', () => {


### PR DESCRIPTION
## What does this implement/fix?

This PR addresses a bug in the y-axis scale calculation where charts that use percentage values, with all data points set to zero, displayed incorrect y-axis labels (0.0%, 500.0%, 1000.0%). This is an old standing bug which has been reported [here](https://github.com/Shopify/core-issues/issues/45800#issuecomment-1281284707) and [here](https://github.com/Shopify/discovery-app/issues/1929).

The issue stemmed from the scale calculation not properly handling cases where both the max and min values are zero. We were creating a y-axis scale with the max set to 10.

In order to resolve this issue, I am adding a new prop `maxYOverride` to `yAxisOptions`. This way, we can have control over how the scale is calculated.


## Does this close any currently open issues?

Related https://github.com/Shopify/core-issues/issues/73089

 
## Storybook link

[Line Chart](https://6062ad4a2d14cd0021539c1b-urmbbyyvpj.chromatic.com/?path=/story/polaris-viz-charts-linechart--y-axis-percentages)
[Stacked Are Chart](https://6062ad4a2d14cd0021539c1b-urmbbyyvpj.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart--y-axis-percentages)
[Bar Chart](https://6062ad4a2d14cd0021539c1b-urmbbyyvpj.chromatic.com/?path=/story/polaris-viz-charts-barchart--y-axis-percentages)

- Make sure that when all data is zero, the y-axis labels are set from 0% to 100%. If you change some of the values, the labels should update accordingly.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
