### PR TITLE
Add overflow legend prop and update Donut Chart legend width

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `hideLegendOverflow` prop to `<LineChart />` to all toggling of legend overflow behaviour
+
+### Changed
+
+- Changed `<DonutChart />` table legend width to only take as much space as the content requires.
 
 ## [14.1.2] - 2024-07-11
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -7,7 +7,6 @@ import {
   useUniqueId,
   ChartState,
   useChartContext,
-  estimateStringWidth,
 } from '@shopify/polaris-viz-core';
 import type {
   DataPoint,
@@ -82,7 +81,7 @@ export function Chart({
   seriesNameFormatter,
   total,
 }: ChartProps) {
-  const {shouldAnimate, characterWidths} = useChartContext();
+  const {shouldAnimate} = useChartContext();
   const chartId = useUniqueId('Donut');
   const [activeIndex, setActiveIndex] = useState<number>(-1);
   const selectedTheme = useTheme();
@@ -113,19 +112,6 @@ export function Chart({
       maxWidth: maxLegendWidth,
       seriesNameFormatter,
     });
-
-  const longestLegendValueWidth = legend.reduce((previous, current) => {
-    const estimatedLegendWidth = estimateStringWidth(
-      `${labelFormatter(`${current.value || ''}`)}`,
-      characterWidths,
-    );
-
-    if (estimatedLegendWidth > previous) {
-      return estimatedLegendWidth;
-    }
-
-    return previous;
-  }, 0);
 
   const shouldUseColorVisionEvents = Boolean(
     width && height && isLegendMounted,
@@ -185,11 +171,11 @@ export function Chart({
       <LegendValues
         data={data}
         activeIndex={activeIndex}
+        dimensions={{...dimensions, x: 0, y: 0}}
+        legendFullWidth={legendFullWidth}
         labelFormatter={labelFormatter}
-        longestLegendValueWidth={longestLegendValueWidth}
         getColorVisionStyles={getColorVisionStyles}
         getColorVisionEventAttrs={getColorVisionEventAttrs}
-        dimensions={{...dimensions, x: 0, y: 0}}
         renderHiddenLegendLabel={renderHiddenLegendLabel}
         seriesNameFormatter={seriesNameFormatter}
       />

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -175,7 +175,9 @@ export function LegendContainer({
             colorVisionType={colorVisionType}
             data={hasHiddenData ? displayedData : allData}
             theme={theme}
-            itemDimensions={legendItemDimensions}
+            itemDimensions={
+              enableHideOverflow ? legendItemDimensions : undefined
+            }
             truncate={hasHiddenData}
           />
           {hasHiddenData && (

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -74,6 +74,7 @@ export interface ChartProps {
   data: LineChartDataSeriesWithDefaults[];
   seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
+  hideLegendOverflow: boolean;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
   dimensions?: BoundingRect;
@@ -96,6 +97,7 @@ export function Chart({
   renderHiddenLegendLabel,
   seriesNameFormatter,
   showLegend = true,
+  hideLegendOverflow = true,
   slots,
   theme = DEFAULT_THEME_NAME,
   xAxisOptions,
@@ -442,7 +444,7 @@ export function Chart({
           renderLegendContent={renderLegendContent}
           renderHiddenLegendLabel={renderHiddenLegendLabel}
           dimensions={dimensions}
-          enableHideOverflow
+          enableHideOverflow={hideLegendOverflow}
         />
       )}
     </Fragment>

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -43,6 +43,7 @@ export type LineChartProps = {
   renderHiddenLegendLabel?: (count: number) => string;
   seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
+  hideLegendOverflow?: boolean;
   skipLinkText?: string;
   tooltipOptions?: TooltipOptions;
   xAxisOptions?: Partial<XAxisOptions>;
@@ -67,6 +68,7 @@ export function LineChart(props: LineChartProps) {
     renderHiddenLegendLabel,
     seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
+    hideLegendOverflow = true,
     skipLinkText,
     state,
     theme = defaultTheme,
@@ -124,6 +126,7 @@ export function LineChart(props: LineChartProps) {
             renderHiddenLegendLabel={renderHiddenLegendLabel}
             seriesNameFormatter={seriesNameFormatter}
             showLegend={showLegend}
+            hideLegendOverflow={hideLegendOverflow}
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}


### PR DESCRIPTION
## What does this implement/fix?

Part of: https://github.com/Shopify/core-issues/issues/73397

- Updates Donut Chart table legend width to only take up required space
- This PR also adds a `hideOverflowLegend` prop to the LIne Chart to be able to opt in and out of that behaviour 

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link
https://6062ad4a2d14cd0021539c1b-jnckoierdc.chromatic.com/
<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
