### PR TITLE
Legend styling changes

### DIFF
--- a/packages/polaris-viz-core/CHANGELOG.md
+++ b/packages/polaris-viz-core/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Update FONT_SIZE to 11px
 
 ## [14.3.0] - 2024-07-19
 

--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -7,7 +7,7 @@ import type {SvgComponents, Theme} from './types';
 import {InternalChartType, ChartState, Hue} from './types';
 
 export const LINE_HEIGHT = 14;
-export const FONT_SIZE = 12;
+export const FONT_SIZE = 11;
 export const FONT_FAMILY =
   'Inter, -apple-system, "system-ui", "San Francisco", "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
 

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated default font-size to 11px
+- Removed focus state on click for LegendItem
 
 ## [14.3.0] - 2024-07-19
 

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
@@ -9,12 +9,12 @@
 .Title {
   font-weight: 500;
   line-height: 20px;
-  font-size: 13px;
+  font-size: 12px;
   margin: 0 0 4px;
 }
 
 .Content {
-  font-size: 12px;
+  font-size: 11px;
   line-height: 16px;
   margin: 0;
 }

--- a/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.scss
+++ b/packages/polaris-viz/src/components/ChartSkeleton/components/DonutSkeleton/DonutSkeleton.scss
@@ -33,7 +33,7 @@
     max-width: 50%;
     text-align: center;
     color: white;
-    font-size: 12px;
+    font-size: 11px;
   }
 }
 

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -7,6 +7,15 @@
   border-radius: 2px;
   display: flex;
   @include focus-outline;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-blue-70;
+    outline-offset: 2px;
+  }
 }
 
 .TextContainer {
@@ -16,7 +25,7 @@
   gap: 3px;
   line-height: 16px;
   margin: -2px 0;
-  font-size: 12px;
+  font-size: 11px;
   font-family: $font-stack-base;
   white-space: nowrap;
   min-width: 0;

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.scss
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.scss
@@ -5,6 +5,7 @@
   background: none;
   border: none;
   border-radius: 2px;
+  font-size: 11px;
 }
 
 .Tooltip {

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.scss
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/SimpleNormalizedChart.scss
@@ -2,7 +2,7 @@
 
 .Container {
   font-family: $font-stack-base;
-  font-size: 14px;
+  font-size: 11px;
   display: flex;
   box-sizing: border-box;
   @include print-color;

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
@@ -1,8 +1,8 @@
 @import '../../../../styles/common';
 
 .Row {
-  line-height: 20px;
-  font-size: 14px;
+  line-height: 16px;
+  font-size: 11px;
   gap: 8px;
   display: flex;
   align-items: center;

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
@@ -1,5 +1,5 @@
 .Title {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 20px;
   margin: 0;

--- a/packages/polaris-viz/src/components/shared/Label/tests/Label.test.tsx
+++ b/packages/polaris-viz/src/components/shared/Label/tests/Label.test.tsx
@@ -42,7 +42,7 @@ describe('<Label />', () => {
         y: MOCK_PROPS.y + MOCK_PROPS.barHeight / 2,
         width: MOCK_PROPS.labelWidth,
         height: HORIZONTAL_BAR_LABEL_HEIGHT,
-        fontSize: '12px',
+        fontSize: '11px',
         dominantBaseline: 'central',
       }),
     );


### PR DESCRIPTION
## What does this implement/fix?

Follow up of https://github.com/Shopify/polaris-viz

- Change font size for legends, labels, and tooltips to 11px
- Remove focus state onClick in `LegendItem` (should still be visible for keyboard interaction)

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?


| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/45eef2b6-5494-4a00-b587-b4cba03deba2)  | ![image](https://github.com/user-attachments/assets/25448ef5-ad24-4ed7-8622-f421ee37a117) |


 
## Storybook link

https://6062ad4a2d14cd0021539c1b-yrsertjuva.chromatic.com/?path=/story/intro--page

* Confirm the body text in legends, tooltips, annotations, axis labels, etc are 11px
* Confirm you do not see the blue outline focus state when clicking on a legend item, but you can see it when focusing on it via keyboard

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
