### PR TITLE
Render single data point values for comparison line chart

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -137,6 +137,34 @@ export function LineSeries({
 
   const zeroLineY = yScale(0);
 
+  /* Renders visual points for isolated data points in a comparison dataset.
+  The dash stroke is too small to render these points effectively. */
+  const renderIsolatedPoints = (
+    data: LineChartDataSeriesWithDefaults,
+  ): JSX.Element[] => {
+    const points: JSX.Element[] = [];
+    data.data.forEach((point, index) => {
+      const prev = data.data[index - 1];
+      const next = data.data[index + 1];
+      if (
+        point.value !== null &&
+        (!prev || prev.value === null) &&
+        (!next || next.value === null)
+      ) {
+        points.push(
+          <circle
+            cx={xScale(index)}
+            cy={yScale(point.value)}
+            r={1}
+            fill={String(color)}
+            key={index}
+          />,
+        );
+      }
+    });
+    return points;
+  };
+
   return (
     <Fragment>
       <AnimatedGroup
@@ -222,7 +250,7 @@ export function LineSeries({
           mask={`url(#mask-${`${id}`})`}
           style={{pointerEvents: 'none'}}
         />
-
+        {data.isComparison && renderIsolatedPoints(data)}
         <Path
           d={lineShape}
           strokeWidth={PathHoverTargetSize}

--- a/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/tests/LineSeries.test.tsx
@@ -27,6 +27,19 @@ const mockData = {
   ],
 };
 
+const mockDataWithIsolatedPoints = {
+  color: 'red',
+  data: [
+    {key: '2020-01-01', value: null},
+    {key: '2020-01-02', value: 50},
+    {key: '2020-01-03', value: null},
+    {key: '2020-01-04', value: 100},
+    {key: '2020-01-05', value: 200},
+    {key: '2020-01-06', value: null},
+  ],
+  isComparison: true,
+};
+
 const defaultProps: LineSeriesProps = {
   xScale: someScale,
   yScale: someScale,
@@ -45,6 +58,37 @@ describe('<LineSeries />', () => {
     );
 
     expect(lineSeries).toContainReactComponent('svg');
+  });
+
+  it('renders isolated points as circles for comparsion data', () => {
+    const lineSeries = mountWithProvider(
+      <svg>
+        <LineSeries {...defaultProps} data={mockDataWithIsolatedPoints} />
+      </svg>,
+    );
+
+    const circles = lineSeries.findAll('circle');
+
+    expect(circles).toHaveLength(1);
+
+    expect(circles[0]).toHaveReactProps({
+      cx: expect.any(Number),
+      cy: expect.any(Number),
+      fill: 'red',
+    });
+  });
+
+  it('does not render isolated points as circles for non-comparison data', () => {
+    const lineSeries = mountWithProvider(
+      <svg>
+        <LineSeries
+          {...defaultProps}
+          data={{...mockDataWithIsolatedPoints, isComparison: false}}
+        />
+      </svg>,
+    );
+
+    expect(lineSeries).not.toContainReactComponent('circle');
   });
 
   describe('svgDimensions', () => {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Bug in the `LineChart`. Render individual points for comparison data when surrounded by null values.
 
 ## [14.7.0] - 2024-08-30
 

--- a/packages/polaris-viz/src/components/LineChart/stories/WithNullValues.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/WithNullValues.stories.tsx
@@ -1,0 +1,55 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {LineChartProps} from '../../../components';
+
+import {DEFAULT_PROPS, Template} from './data';
+
+export const WithNullValues: Story<LineChartProps> = Template.bind({});
+
+WithNullValues.args = {
+  ...DEFAULT_PROPS,
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: null, key: '2020-04-01T12:00:00'},
+        {value: null, key: '2020-04-02T12:00:00'},
+        {value: 0, key: '2020-04-03T12:00:00'},
+        {value: null, key: '2020-04-04T12:00:00'},
+        {value: 234, key: '2020-04-05T12:00:00'},
+        {value: 159, key: '2020-04-06T12:00:00'},
+        {value: 239, key: '2020-04-07T12:00:00'},
+        {value: 708, key: '2020-04-08T12:00:00'},
+        {value: null, key: '2020-04-09T12:00:00'},
+        {value: 645, key: '2020-04-10T12:00:00'},
+        {value: 543, key: '2020-04-11T12:00:00'},
+        {value: 89, key: '2020-04-12T12:00:00'},
+        {value: 849, key: '2020-04-13T12:00:00'},
+        {value: 129, key: '2020-04-14T12:00:00'},
+      ],
+    },
+    {
+      name: 'Previous month',
+      data: [
+        {value: 709, key: '2020-03-02T12:00:00'},
+        {value: null, key: '2020-03-01T12:00:00'},
+        {value: 190, key: '2020-03-03T12:00:00'},
+        {value: 90, key: '2020-03-04T12:00:00'},
+        {value: 237, key: '2020-03-05T12:00:00'},
+        {value: 580, key: '2020-03-07T12:00:00'},
+        {value: 172, key: '2020-03-06T12:00:00'},
+        {value: 12, key: '2020-03-08T12:00:00'},
+        {value: null, key: '2020-03-09T12:00:00'},
+        {value: 43, key: '2020-03-10T12:00:00'},
+        {value: 710, key: '2020-03-11T12:00:00'},
+        {value: 791, key: '2020-03-12T12:00:00'},
+        {value: null, key: '2020-03-13T12:00:00'},
+        {value: 21, key: '2020-03-14T12:00:00'},
+      ],
+      color: 'red',
+      isComparison: true,
+    },
+  ]
+};


### PR DESCRIPTION
## What does this implement/fix?

We have cases in the comparison data array where one non-null value is followed by a null value; this point is not rendered on the screen because the size of the dash stroke is too small. In order for the comparison line to be visualized on the screen, we need to have at least two consecutive non-null values or set the stroke to "none." My approach to fix it is to render these values as individual standing points instead of as a part of the line.

## Does this close any currently open issues?
 
No

## What do the changes look like?

Before:

https://github.com/user-attachments/assets/0593cad8-5db5-431b-8679-6ab86ace67a3

After:


https://github.com/user-attachments/assets/b83735b4-7887-4505-a67a-4e33d0c7843d





## Storybook link

[Storybook](https://6062ad4a2d14cd0021539c1b-zzykkiadxr.chromatic.com/?path=/story/polaris-viz-charts-linechart--with-null-values)

- Make sure the standalone values in the comparison chart are rendered as the individual points.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
