### PR TITLE
Calculate inner content value font size based on donut diameter

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Dynamically calculate the inner value content font size of the `DonutChart` based on the diameter to improve responsiveness and scaling across different screen sizes.
+
 - Replaced `UpChevron` and `DownChevron` components with `TrendIndicator` in the `ComparisonMetric` component. This change applies to the `DonutChart` and the `SimpleNormalizedChart`, standardizing the display of trend directions across these visualizations.
 
 ## [14.4.0] - 2024-07-25

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -262,6 +262,7 @@ export function Chart({
               comparisonMetric={comparisonMetric}
               labelFormatter={labelFormatter}
               renderInnerValueContent={renderInnerValueContent}
+              diameter={diameter}
             />
           </Fragment>
         ) : (

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.scss
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.scss
@@ -22,14 +22,12 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
-  font-size: 20px;
   pointer-events: none;
   width: 100%;
   height: 100%;
 }
 
 .ContentValue {
-  font-size: 20px;
   line-height: 24px;
   font-weight: 700;
   user-select: text;

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment} from 'react';
 import {useSpring, animated, config} from '@react-spring/web';
 import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {useTheme} from '@shopify/polaris-viz-core';
@@ -33,7 +33,6 @@ export function InnerValue({
   diameter,
 }: InnerValueProps) {
   const selectedTheme = useTheme();
-  const [fontSize, setFontSize] = useState(0);
 
   const {animatedValue} = useSpring({
     animatedValue: totalValue,
@@ -44,9 +43,7 @@ export function InnerValue({
     },
   });
 
-  useEffect(() => {
-    setFontSize(diameter * SCALING_FACTOR);
-  }, [diameter]);
+  const fontSize = diameter * SCALING_FACTOR;
 
   const animatedTotalValue = (
     <animated.span>

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {useSpring, animated, config} from '@react-spring/web';
 import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {useTheme} from '@shopify/polaris-viz-core';
@@ -9,12 +9,15 @@ import type {ComparisonMetricProps} from '../../../ComparisonMetric';
 import {ComparisonMetric} from '../../../ComparisonMetric';
 import styles from '../../DonutChart.scss';
 
+const SCALING_FACTOR = 0.07;
+
 export interface InnerValueProps {
   activeValue: number | null | undefined;
   activeIndex: number;
   labelFormatter: LabelFormatter;
   isAnimated: boolean;
   totalValue: number;
+  diameter: number;
   comparisonMetric?: ComparisonMetricProps;
   renderInnerValueContent?: RenderInnerValueContent;
 }
@@ -27,8 +30,10 @@ export function InnerValue({
   isAnimated,
   renderInnerValueContent,
   totalValue,
+  diameter,
 }: InnerValueProps) {
   const selectedTheme = useTheme();
+  const [fontSize, setFontSize] = useState(0);
 
   const {animatedValue} = useSpring({
     animatedValue: totalValue,
@@ -38,6 +43,10 @@ export function InnerValue({
       immediate: !isAnimated,
     },
   });
+
+  useEffect(() => {
+    setFontSize(diameter * SCALING_FACTOR);
+  }, [diameter]);
 
   const animatedTotalValue = (
     <animated.span>
@@ -63,7 +72,7 @@ export function InnerValue({
     <Fragment>
       <animated.p
         className={classNames(styles.ContentValue)}
-        style={{color: selectedTheme.xAxis.labelColor}}
+        style={{color: selectedTheme.xAxis.labelColor, fontSize}}
       >
         {valueToDisplay}
       </animated.p>

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/tests/InnerValue.test.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/tests/InnerValue.test.tsx
@@ -12,6 +12,7 @@ const mockProps: InnerValueProps = {
   totalValue: 1000,
   labelFormatter: (value) => value,
   isAnimated: true,
+  diameter: 200,
 };
 
 jest.mock('@react-spring/web', () => ({
@@ -49,6 +50,17 @@ describe('<InnerValue />', () => {
     expect(innerValue).toContainReactComponent('span', {
       children: mockProps.totalValue,
     });
+  });
+
+  it('calculates and applies font size based on diameter', () => {
+    const scalingFactor = 0.07;
+    const expectedFontSize = mockProps.diameter * scalingFactor;
+    const innerValue = mount(<InnerValue {...mockProps} />);
+
+    const contentValue = innerValue.find('p');
+    const fontSize = contentValue?.prop('style')?.fontSize;
+
+    expect(fontSize).toBe(expectedFontSize);
   });
 
   describe('<ComparisonMetric />', () => {

--- a/packages/polaris-viz/src/components/DonutChart/stories/TruncatedLegends.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/TruncatedLegends.stories.tsx
@@ -1,12 +1,23 @@
-import type {Story} from '@storybook/react';
+import type {Story, StoryFn} from '@storybook/react';
 
 export {META as default} from './meta';
-
+import {PolarisVizProvider} from '../../PolarisVizProvider';
+import {DonutChart} from '../DonutChart';
 import type {DonutChartProps} from '../../DonutChart';
 
-import {DEFAULT_PROPS, Template} from './data';
+import {DEFAULT_PROPS} from './data';
 
-export const TruncatedLegends: Story<DonutChartProps> = Template.bind({});
+const TruncatedLegendsTemplate: StoryFn<DonutChartProps> = (args: DonutChartProps) => {
+  return (
+    <div style={{width: 550, height: 200}}>
+      <PolarisVizProvider>
+        <DonutChart {...args} />
+      </PolarisVizProvider>
+    </div>
+  );
+};
+
+export const TruncatedLegends: Story<DonutChartProps> = TruncatedLegendsTemplate.bind({});
 
 TruncatedLegends.args = {
   ...DEFAULT_PROPS,


### PR DESCRIPTION
## What does this implement/fix?

The inner value content font size in the donut chart was set to a static value, which led to this value not being scaled with the donut size. Now, we calculate the font size based on the donut diameter.


## Does this close any currently open issues?

Related https://github.com/Shopify/core-issues/issues/74510


## What do the changes look like?

| Before | After |
|--------|------|
|<img width="331" alt="Screenshot 2024-07-31 at 6 58 49 PM" src="https://github.com/user-attachments/assets/f9340deb-65cd-4005-9f6e-497723026026">|<img width="207" alt="Screenshot 2024-07-31 at 6 59 05 PM" src="https://github.com/user-attachments/assets/3d6057ee-0f47-49d8-8430-5d6d167b45a1">|


 
## Storybook link

[🎩  Small donut](https://6062ad4a2d14cd0021539c1b-fiwbylwivc.chromatic.com/?path=/story/polaris-viz-charts-donutchart--truncated-legends)
[🎩  Medium donut](https://6062ad4a2d14cd0021539c1b-fiwbylwivc.chromatic.com/?path=/story/polaris-viz-charts-donutchart--with-legend-values)
[🎩  Large donut](https://6062ad4a2d14cd0021539c1b-fiwbylwivc.chromatic.com/?path=/story/polaris-viz-charts-donutchart--without-rounded-corners)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
