### PR TITLE
[Donut chart] Show empty state when all values are zero

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Updated `<DonutChart />` to show empty state when all values are zero
+- Changed `RenderInnerValueContent` type to include dimensions
 
 ## [14.6.0] - 2024-08-21
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -152,8 +152,8 @@ export function Chart({
     .value(({value}) => value!)
     .sort(null);
   const pieChartData = createPie(points);
-
-  const emptyState = pieChartData.length === 0;
+  const isEveryValueZero = points.every(({value}) => value === 0);
+  const emptyState = pieChartData.length === 0 || isEveryValueZero;
 
   const totalValue =
     total || points.reduce((acc, {value}) => (value ?? 0) + acc, 0);
@@ -273,6 +273,7 @@ export function Chart({
               labelFormatter={labelFormatter}
               renderInnerValueContent={renderInnerValueContent}
               diameter={diameter}
+              dimensions={dimensions}
             />
           </Fragment>
         ) : (

--- a/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/InnerValue/InnerValue.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 import {useSpring, animated, config} from '@react-spring/web';
-import type {LabelFormatter} from '@shopify/polaris-viz-core';
+import type {LabelFormatter, Dimensions} from '@shopify/polaris-viz-core';
 import {useTheme} from '@shopify/polaris-viz-core';
 
 import type {RenderInnerValueContent} from '../../../../types';
@@ -14,11 +14,12 @@ const SCALING_FACTOR = 0.07;
 export interface InnerValueProps {
   activeValue: number | null | undefined;
   activeIndex: number;
-  labelFormatter: LabelFormatter;
   isAnimated: boolean;
   totalValue: number;
-  diameter: number;
   comparisonMetric?: ComparisonMetricProps;
+  diameter: number;
+  dimensions: Dimensions;
+  labelFormatter: LabelFormatter;
   renderInnerValueContent?: RenderInnerValueContent;
 }
 
@@ -31,6 +32,7 @@ export function InnerValue({
   renderInnerValueContent,
   totalValue,
   diameter,
+  dimensions,
 }: InnerValueProps) {
   const selectedTheme = useTheme();
 
@@ -65,6 +67,7 @@ export function InnerValue({
     activeIndex,
     animatedTotalValue,
     totalValue,
+    dimensions,
   }) ?? (
     <Fragment>
       <animated.p

--- a/packages/polaris-viz/src/components/DonutChart/stories/EmptyState.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/EmptyState.stories.tsx
@@ -1,0 +1,18 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {DonutChartProps} from '../DonutChart';
+
+import {DEFAULT_PROPS, DEFAULT_DATA, Template} from './data';
+
+export const EmptyState: Story<DonutChartProps> = Template.bind({});
+
+EmptyState.args = {
+  ...DEFAULT_PROPS,
+  comparisonMetric: undefined,
+  data: DEFAULT_DATA.map(({name, data}) => ({
+    name,
+    data: data.map(({key}) => ({key, value: 0})),
+  })),
+};

--- a/packages/polaris-viz/src/components/DonutChart/tests/DonutChart.test.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/tests/DonutChart.test.tsx
@@ -157,6 +157,30 @@ describe('<DonutChart />', () => {
         });
       });
 
+      it('renders the empty state if all data values are 0', () => {
+        const chart = mount(
+          <DonutChart
+            {...mockProps}
+            data={[
+              {
+                name: 'Shopify Payments',
+                data: [{key: 'april - march', value: 0}],
+              },
+              {
+                name: 'Other',
+                data: [{key: 'april - march', value: 0}],
+              },
+            ]}
+          />,
+        );
+
+        chart.act(() => {
+          requestAnimationFrame(() => {
+            expect(chart).toContainReactComponentTimes(Arc, 1);
+          });
+        });
+      });
+
       it('renders multiple <Arc /> when false', () => {
         const chart = mount(<DonutChart {...mockProps} />);
         chart.act(() => {

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -218,6 +218,10 @@ export interface InnerValueContents {
   activeIndex: number;
   animatedTotalValue: ReactNode;
   totalValue: number;
+  dimensions: {
+    width: number;
+    height: number;
+  };
 }
 
 export type RenderInnerValueContent = (values: InnerValueContents) => ReactNode;


### PR DESCRIPTION
## What does this implement/fix?

- Updates empty state to show when all values are zero
- This PR also extends the `RenderInnerValueContent` type to include `dimensions`, this will be useful for the consumer to dynamically changing the size of the inner value based on the size of the chart container

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<img width="637" alt="Screenshot 2024-08-30 at 10 12 57 AM" src="https://github.com/user-attachments/assets/59969dde-ca4c-4d04-8b76-6da8a975dfe3">


<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link
https://6062ad4a2d14cd0021539c1b-rkoidmddvx.chromatic.com/
<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
