### PR TITLE
Format annotation keys

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- **Breaking change** The keys used to display `<Annotiatons />` are now formatted with the `xAxisOptions.labelFormatter` method.
 
 ## [14.9.1] - 2024-09-13
 

--- a/packages/polaris-viz/src/components/Annotations/hooks/tests/useAnnotationPositions.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/hooks/tests/useAnnotationPositions.test.tsx
@@ -32,6 +32,7 @@ const MOCK_PROPS: Props = {
   isShowingAllAnnotations: false,
   onHeightChange: jest.fn(),
   xScale: scaleBand(),
+  labelFormatter: (value) => `${value}`,
 };
 
 describe('useAnnotationPositions', () => {

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
@@ -1,4 +1,5 @@
 import {useEffect, useMemo} from 'react';
+import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {
   clamp,
   estimateStringWidth,
@@ -26,6 +27,7 @@ export interface Props {
   dataIndexes: {[key: string]: string};
   drawableWidth: number;
   isShowingAllAnnotations: boolean;
+  labelFormatter: LabelFormatter;
   onHeightChange: (height: number) => void;
   xScale: ScaleLinear<number, number> | ScaleBand<string>;
 }
@@ -38,6 +40,7 @@ export function useAnnotationPositions({
   isShowingAllAnnotations,
   onHeightChange,
   xScale,
+  labelFormatter,
 }: Props): {
   hiddenAnnotationsCount: number;
   positions: AnnotationPosition[];
@@ -54,7 +57,7 @@ export function useAnnotationPositions({
   const {positions, hiddenAnnotationsCount} = useMemo(() => {
     let positions = annotations.map((annotation, dataIndex) => {
       const xPosition = getValueFromXScale(
-        dataIndexes[annotation.startKey],
+        dataIndexes[labelFormatter(annotation.startKey)],
         xScale,
       );
 
@@ -118,6 +121,7 @@ export function useAnnotationPositions({
     axisLabelWidth,
     xScale,
     drawableWidth,
+    labelFormatter,
   ]);
 
   const {totalRowHeight, rowCount} = useShowMoreAnnotationsButton({

--- a/packages/polaris-viz/src/components/Annotations/tests/Annotations.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/tests/Annotations.test.tsx
@@ -82,6 +82,7 @@ const MOCK_PROPS: AnnotationsProps = {
   ],
   onHeightChange: jest.fn(),
   xScale: scaleBand(),
+  labelFormatter: (value) => `${value}`,
 };
 
 describe('<Annotations />', () => {

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -269,6 +269,7 @@ export function Chart({
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={labels}
+              labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
             />

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -392,6 +392,7 @@ export function Chart({
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={unformattedLabels}
+              labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
             />

--- a/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
@@ -40,4 +40,12 @@ Annotations.args = {
       },
     },
   ],
+  xAxisOptions: {
+    labelFormatter: (value) =>
+      new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(new Date(value as string)),
+  },
 };

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -363,6 +363,7 @@ export function Chart({
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={labels}
+              labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
             />

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -307,6 +307,7 @@ export function Chart({
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={unformattedLabels}
+              labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
             />


### PR DESCRIPTION
Format `<Annotation />` keys with the xAxis formatter so that the keys provided and keys displayed are the same and don't rely on the raw data.