### PR TITLE
Fix crosshair position for a single data point in line chart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed an issue in the `LineChart` where the crosshair and tooltip were incorrectly positioned for single data points. The animation logic now correctly bypasses for single data points, ensuring accurate positioning.
 
 ## [15.0.0] - 2024-09-16
 

--- a/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
+++ b/packages/polaris-viz/src/components/LineChart/components/PointsAndCrosshair/PointsAndCrosshair.tsx
@@ -70,6 +70,13 @@ export function PointsAndCrosshair({
     }
     const offset = isCrosshair ? selectedTheme.crossHair.width / 2 : 0;
 
+    const allSingleDataPoints = data.some((series) => series.data.length !== 1);
+
+    // Bypass animation if there's only one data point
+    if (!allSingleDataPoints) {
+      return xScale(activeIndex == null ? 0 : activeIndex) - offset;
+    }
+
     if (
       animatedCoordinates != null &&
       animatedCoordinates[longestSeriesIndex] != null &&

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/CrosshairOffset.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/CrosshairOffset.stories.tsx
@@ -1,0 +1,48 @@
+import type {Story} from '@storybook/react';
+
+import type {LineChartProps} from '../../../../components';
+import {META} from '../meta';
+import {DEFAULT_PROPS, Template} from '../data';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+
+const DATA= [
+  {
+    "name": "Apr 1 – Apr 14, 2020",
+    "data": [
+      {
+        "value": 8,
+        "key": "2020-04-02T12:00:00"
+      },
+    ]
+  },
+  {
+    "name": "May 1 – May 14, 2020",
+    "data": [
+      {
+        "value": 10,
+        "key": "2020-04-02T12:00:00"
+      },
+    ]
+  },
+  {
+    "name": "Jun 1 – Jun 14, 2020",
+    "data": [
+      {
+        "value": 15,
+        "key": "2020-04-02T12:00:00"
+      },
+    ]
+  },
+]
+
+export const CrosshairOffset: Story<LineChartProps> = Template.bind({});
+
+CrosshairOffset.args = {
+  ...DEFAULT_PROPS,
+  data: DATA,
+};

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -134,20 +134,6 @@ describe('<Chart />', () => {
     expect(chart).toContainReactComponent(YAxis);
   });
 
-  it('renders a <Crosshair /> at full opacity if there is an active point', () => {
-    const chart = mount(<Chart {...MOCK_PROPS} />);
-
-    triggerSVGMouseMove(chart);
-
-    expect(chart.find(Crosshair)).toHaveReactProps({opacity: 1});
-  });
-
-  it('renders a <Crosshair /> at 0 opacity if there is no active point', () => {
-    const chart = mount(<Chart {...MOCK_PROPS} />);
-
-    expect(chart.find(Crosshair)).toHaveReactProps({opacity: 0});
-  });
-
   it('renders a <LineSeries /> for each data-point', () => {
     const chart = mount(
       <Chart
@@ -232,6 +218,42 @@ describe('<Chart />', () => {
     expect(chart).toContainReactComponent(VisuallyHiddenRows, {
       data: MOCK_PROPS.data,
       xAxisLabels: MOCK_DATA.data.map(({key}) => `${key}`),
+    });
+  });
+
+  describe('<Crosshair />', () => {
+    it('renders a <Crosshair /> at full opacity if there is an active point', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      triggerSVGMouseMove(chart);
+
+      expect(chart.find(Crosshair)).toHaveReactProps({opacity: 1});
+    });
+
+    it('renders a <Crosshair /> at 0 opacity if there is no active point', () => {
+      const chart = mount(<Chart {...MOCK_PROPS} />);
+
+      expect(chart.find(Crosshair)).toHaveReactProps({opacity: 0});
+    });
+
+    it('correctly positions <Crosshair /> for single data point', () => {
+      const mockSingleDataPoint: Required<LineChartDataSeriesWithDefaults> = {
+        ...MOCK_DATA,
+        data: [{key: 'Apr 1', value: 1500}],
+      };
+
+      const chart = mount(
+        <Chart {...MOCK_PROPS} data={[mockSingleDataPoint]} />,
+      );
+
+      triggerSVGMouseMove(chart);
+
+      const crosshair = chart.find(Crosshair);
+
+      expect(crosshair).toHaveReactProps({
+        opacity: 1,
+        x: 173.5,
+      });
     });
   });
 


### PR DESCRIPTION
## What does this implement/fix?

When rendering a line chart with single data points per series, the crosshair was not aligned with the actual data points. This misalignment was caused by the animation logic. I am adding a condition to bypass the animation logic if all series have only one data point.  Animating a single point or very sparse data does not provide any additional visual benefit to the user. 

## Does this close any currently open issues?

Related https://github.com/Shopify/core-issues/issues/71927


## What do the changes look like?

| Before | After |
|--------|------|
|<img width="666" alt="Screenshot 2024-09-18 at 2 46 26 PM" src="https://github.com/user-attachments/assets/a69317d9-3c5f-4384-a72f-ca1e4687d09e">|<img width="693" alt="Screenshot 2024-09-18 at 2 46 54 PM" src="https://github.com/user-attachments/assets/0e416cd1-9079-4eb5-9132-ed2572fc47dc">|
|<img width="705" alt="Screenshot 2024-09-18 at 2 46 05 PM" src="https://github.com/user-attachments/assets/e08d29d1-d51d-4760-b33b-215bf00b1709">|<img width="676" alt="Screenshot 2024-09-18 at 2 47 35 PM" src="https://github.com/user-attachments/assets/0580778b-41c4-4bd9-9122-63e15d90f531">|

 
## Storybook link

[Storybook](https://6062ad4a2d14cd0021539c1b-kpdjwutsmi.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--crosshair-offset)

- Make sure the crosshair is positioned correctly
- Test other line charts and make sure nothing is broken


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
