### PR TITLE
Allow different series length in StackedAreaChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed an issue in the `LineChart` where the crosshair and tooltip were incorrectly positioned for single data points. The animation logic now correctly bypasses for single data points, ensuring accurate positioning.
+- Fixed an issue where `DataSeries` with different lengths would crash the `StackedAreaChart`.
 
 ## [15.0.0] - 2024-09-16
 

--- a/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/StackedAreaChart/hooks/useStackedChartTooltipContent.ts
@@ -38,6 +38,10 @@ export function useStackedChartTooltipContent({
       ];
 
       data.forEach(({name, data: seriesData, color}, index) => {
+        if (seriesData == null || seriesData[activeIndex] == null) {
+          return;
+        }
+
         const {value} = seriesData[activeIndex];
 
         tooltipData[0].data.push({
@@ -46,6 +50,10 @@ export function useStackedChartTooltipContent({
           color: color ?? seriesColors[index],
         });
       });
+
+      if (data[0] == null || data[0].data[activeIndex] == null) {
+        return null;
+      }
 
       return renderTooltipContent({
         data: tooltipData,

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/LongerComparison.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/LongerComparison.stories.tsx
@@ -1,0 +1,73 @@
+import type {Story} from '@storybook/react';
+
+import {StackedAreaChart, StackedAreaChartProps} from '../../../../components';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+const DATA = [
+  {
+    name: 'Jul 8–Jul 11, 2024',
+    data: [
+      {
+        key: 'Mon Jul 08 2024 00:00:00 GMT-0500 (Central Daylight Time)',
+        value: 309.862,
+      },
+      {
+        key: 'Tue Jul 09 2024 00:00:00 GMT-0500 (Central Daylight Time)',
+        value: 367.701,
+      },
+      {
+        key: 'Wed Jul 10 2024 00:00:00 GMT-0500 (Central Daylight Time)',
+        value: 66.938,
+      },
+      {
+        key: 'Thu Jul 11 2024 00:00:00 GMT-0500 (Central Daylight Time)',
+        value: 344.069,
+      },
+    ],
+  },
+  {
+    isComparison: true,
+    name: 'Jul 7–Jul 13, 2024',
+    data: [
+      {
+        key: 'Jul 07, 2024',
+        value: 156.146,
+      },
+      {
+        key: 'Jul 08, 2024',
+        value: 309.862,
+      },
+      {
+        key: 'Jul 09, 2024',
+        value: 367.701,
+      },
+      {
+        key: 'Jul 10, 2024',
+        value: 66.938,
+      },
+      {
+        key: 'Jul 11, 2024',
+        value: 344.069,
+      },
+      {
+        key: 'Jul 12, 2024',
+        value: 286.229,
+      },
+      {
+        key: 'Jul 13, 2024',
+        value: 66.912,
+      },
+    ],
+  },
+];
+
+const Template: Story<StackedAreaChartProps> = () => {
+  return <StackedAreaChart data={DATA} isAnimated={false} />;
+};
+
+export const LongerComparison = Template.bind({});

--- a/packages/polaris-viz/src/utilities/getStackedValues.ts
+++ b/packages/polaris-viz/src/utilities/getStackedValues.ts
@@ -22,7 +22,7 @@ export function getStackedValues({series, labels, order, offset}: Options) {
     series.reduce((acc, {name, data}, index) => {
       const indexData = data[labelIndex];
       const namedData = {
-        [getKey(index, name)]: indexData.value == null ? 0 : indexData.value,
+        [getKey(index, name)]: indexData?.value == null ? 0 : indexData.value,
       };
 
       return Object.assign(acc, namedData);


### PR DESCRIPTION
## What does this implement/fix?

Fixes and issue where data series with different lengths would cause the `StackedAreaChart` to crash because it was looking for points that didn't exist.

## Storybook link

https://6062ad4a2d14cd0021539c1b-xzoptwehfg.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart-playground--longer-comparison

This story should not crash

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
