### PR TITLE
Change logic around trend indicator width offset

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Changed logic around how we determine the longest trend width. We now measure the longest trend width for each positive and negative side without associating with the longest date series value.
+
 
 ## [15.0.2] - 2024-09-24
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -77,13 +77,7 @@ export function Chart({
     seriesNameFormatter,
   });
 
-  const {
-    allNumbers,
-    longestLabel,
-    highestPositive,
-    lowestNegative,
-    areAllNegative,
-  } = useDataForHorizontalChart({
+  const {allNumbers, longestLabel, areAllNegative} = useDataForHorizontalChart({
     data,
     isSimple: true,
     isStacked,
@@ -95,11 +89,7 @@ export function Chart({
     data,
   });
 
-  const longestTrendIndicator = getLongestTrendIndicator(
-    data,
-    highestPositive,
-    lowestNegative,
-  );
+  const longestTrendIndicator = getLongestTrendIndicator(data);
 
   const trendIndicatorOffset =
     longestTrendIndicator.positive + longestTrendIndicator.negative;

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/SkinnyTrend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/SkinnyTrend.stories.tsx
@@ -1,3 +1,4 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
 import {SimpleBarChart} from '../../SimpleBarChart';
 import {META} from '../meta';
 
@@ -6,60 +7,89 @@ export default {
   title: `${META.title}/Playground`,
 };
 
+const DATA: DataSeries[] = [
+  {
+    data: [
+      {
+        key: 'search · google',
+        value: 30309.103,
+      },
+      {
+        key: 'None · bullandcleaver',
+        value: 7699.192,
+      },
+      {
+        key: 'search · duckduckgo',
+        value: 3485.793,
+      },
+    ],
+    name: 'Sep 26, 2023–Sep 24, 2024',
+    metadata: {
+      trends: {
+        '0': {
+          trend: 'negative',
+          direction: 'downward',
+          accessibilityLabel: 'Decrease of 20%',
+          value: '20%',
+        },
+        '1': {
+          trend: 'negative',
+          direction: 'downward',
+          accessibilityLabel: 'Decrease of 52%',
+          value: '52%',
+        },
+        '2': {
+          trend: 'positive',
+          direction: 'upward',
+          accessibilityLabel: 'Increase of 81%',
+          value: '81%',
+        },
+        '3': {
+          trend: 'positive',
+          direction: 'upward',
+          accessibilityLabel: 'Increase of 16%',
+          value: '16%',
+        },
+        '4': {
+          trend: 'negative',
+          direction: 'downward',
+          accessibilityLabel: 'Decrease of 8%',
+          value: '8%',
+        },
+      },
+    },
+  },
+  {
+    isComparison: true,
+    data: [
+      {
+        key: 'search · google',
+        value: 37674.902,
+      },
+      {
+        key: 'None · bullandcleaver',
+        value: 16129.352,
+      },
+      {
+        key: 'search · duckduckgo',
+        value: 1925.345,
+      },
+    ],
+    name: 'Sep 26, 2022–Sep 24, 2023',
+  },
+];
+
 export const SkinnyTrend = () => {
   return (
     <div
       style={{
         height: 250,
-        width: 250,
-        background: 'rgba(255,255,255,0.5)',
+        width: 192,
+        background: 'rgba(0,0,0,0.20)',
         padding: 10,
       }}
     >
-      <SimpleBarChart
-        showLegend={false}
-        data={[
-          {
-            data: [
-              {
-                key: 'Unknown',
-                value: 248.14,
-              },
-              {
-                key: 'Social',
-                value: -256.45,
-              },
-              {
-                key: 'Direct',
-                value: -1863.96,
-              },
-              {
-                key: '',
-                value: null,
-              },
-              {
-                key: '',
-                value: null,
-              },
-            ],
-            name: 'Sales by traffic source',
-            metadata: {
-              trends: {
-                '0': {
-                  value: '77%',
-                  trend: 'positive',
-                  direction: 'upward',
-                },
-                '2': {
-                  value: '907%',
-                  trend: 'negative',
-                  direction: 'downward',
-                },
-              },
-            },
-          },
-        ]}
-      />
+      <SimpleBarChart showLegend={false} data={DATA} />
     </div>
   );
 };
@@ -69,8 +99,8 @@ export const PositiveTrendOverflow = () => {
     <div
       style={{
         height: 250,
-        width: 250,
-        background: 'rgba(255,255,255,0.5)',
+        width: 192,
+        background: 'rgba(0,0,0,0.20)',
         padding: 10,
       }}
     >

--- a/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
@@ -43,106 +43,49 @@ const negativeSeries = {
 };
 
 describe('getLongestTrendIndicator()', () => {
-  it('returns a value for positive when the highest positive value has a trend indicator', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [positiveSeries],
-      highestPositive,
-      0,
-    );
+  it('returns a value for positive when positive values have a trend indicator', () => {
+    const {positive, negative} = getLongestTrendIndicator([positiveSeries]);
 
-    expect(positive).toBeGreaterThan(0);
+    expect(positive).toStrictEqual(51);
     expect(negative).toBe(0);
   });
 
-  it('returns a value for negative when the lowest negative value has a trend indicator', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [negativeSeries],
-      0,
-      lowestNegative,
-    );
+  it('returns a value for negative when negative values have a trend indicator', () => {
+    const {positive, negative} = getLongestTrendIndicator([negativeSeries]);
 
     expect(positive).toBe(0);
-    expect(negative).toBeGreaterThan(0);
+    expect(negative).toStrictEqual(51);
   });
 
-  it('returns values for both positive and negative when both the highest positive and lowest negative values have trend indicators', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [positiveSeries, negativeSeries],
-      highestPositive,
-      lowestNegative,
-    );
+  it('returns values for both positive and negative when positive and negative values have trend indicators', () => {
+    const {positive, negative} = getLongestTrendIndicator([
+      positiveSeries,
+      negativeSeries,
+    ]);
 
-    expect(positive).toBeGreaterThan(0);
-    expect(negative).toBeGreaterThan(0);
-  });
-
-  it('returns 0 for positive when a lower value has a trend indicator but the highest positive value does not', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [
-        {
-          ...positiveSeries,
-          metadata: {
-            trends: {
-              '0': trends['0'],
-            },
-          },
-        } as SimpleBarChartDataSeries,
-      ],
-      highestPositive,
-      0,
-    );
-
-    expect(positive).toBe(0);
-    expect(negative).toBe(0);
-  });
-
-  it('returns 0 for negative when a higher value has a trend indicator but the lowest negative value does not', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [
-        {
-          ...negativeSeries,
-          metadata: {
-            trends: {
-              '0': trends['0'],
-            },
-          },
-        } as SimpleBarChartDataSeries,
-      ],
-      0,
-      lowestNegative,
-    );
-
-    expect(positive).toBe(0);
-    expect(negative).toBe(0);
+    expect(positive).toStrictEqual(51);
+    expect(negative).toStrictEqual(51);
   });
 
   it('returns 0 for both values if there are no trend indicators', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [
-        {
-          ...positiveSeries,
-          metadata: {},
-        },
-      ],
-      highestPositive,
-      0,
-    );
+    const {positive, negative} = getLongestTrendIndicator([
+      {
+        ...positiveSeries,
+        metadata: {},
+      },
+    ]);
 
     expect(positive).toBe(0);
     expect(negative).toBe(0);
   });
 
   it('returns 0 for both values if metadata property is not present', () => {
-    const {positive, negative} = getLongestTrendIndicator(
-      [
-        {
-          ...positiveSeries,
-          metadata: undefined,
-        },
-      ],
-      highestPositive,
-      0,
-    );
+    const {positive, negative} = getLongestTrendIndicator([
+      {
+        ...positiveSeries,
+        metadata: undefined,
+      },
+    ]);
 
     expect(positive).toBe(0);
     expect(negative).toBe(0);

--- a/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
@@ -5,13 +5,10 @@ import {estimateTrendIndicatorWidth} from '../TrendIndicator';
 import type {SimpleBarChartDataSeries} from './types';
 
 /**
- * Returns the widths of the trend indicators associated with the highest positive value and the lowest negative value in the dataset, or 0 if the value doesn't have a trend indicator.
+ * Returns the widths of the trend indicators por positive or negative values,
+ * or 0 if the value doesn't have a trend indicator.
  */
-export function getLongestTrendIndicator(
-  data: SimpleBarChartDataSeries[],
-  highestPositive: number,
-  lowestNegative: number,
-) {
+export function getLongestTrendIndicator(data: SimpleBarChartDataSeries[]) {
   const longestTrendIndicator = data.reduce(
     (longestTrendIndicator, series) => {
       const {data: seriesData, metadata} = series;
@@ -21,14 +18,24 @@ export function getLongestTrendIndicator(
       for (const [index, trend] of trendEntries) {
         const dataPoint = seriesData[index];
 
-        if (dataPoint?.value === highestPositive) {
-          longestTrendIndicator.positive = estimateTrendIndicatorWidth(
-            trend.value ?? '',
-          ).totalWidth;
-        } else if (dataPoint?.value === lowestNegative) {
-          longestTrendIndicator.negative = estimateTrendIndicatorWidth(
-            trend.value ?? '',
-          ).totalWidth;
+        if (trend == null || dataPoint?.value == null) {
+          return longestTrendIndicator;
+        }
+
+        const trendStringWidth = estimateTrendIndicatorWidth(
+          trend.value,
+        ).totalWidth;
+
+        // Positive value
+        if (dataPoint.value > 0) {
+          if (trendStringWidth > longestTrendIndicator.positive) {
+            longestTrendIndicator.positive = trendStringWidth;
+          }
+        } else if (dataPoint.value < 0) {
+          // Negative value
+          if (trendStringWidth > longestTrendIndicator.negative) {
+            longestTrendIndicator.negative = trendStringWidth;
+          }
         }
       }
 

--- a/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useDataForHorizontalChart.test.tsx
@@ -1,6 +1,7 @@
 import {mount} from '@shopify/react-testing';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 
+import type {Props} from '../useDataForHorizontalChart';
 import {useDataForHorizontalChart} from '../useDataForHorizontalChart';
 
 jest.mock('@shopify/polaris-viz-core/src/utilities', () => {
@@ -29,11 +30,11 @@ const DATA: DataSeries[] = [
   },
 ];
 
-const MOCK_PROPS = {
+const MOCK_PROPS: Props = {
   data: DATA,
   isSimple: false,
   isStacked: false,
-  labelFormatter: (value: string | number) => `${value}`,
+  labelFormatter: (value) => `${value}`,
 };
 
 describe('useDataForHorizontalChart()', () => {
@@ -51,9 +52,7 @@ describe('useDataForHorizontalChart()', () => {
     expect(data).toStrictEqual({
       allNumbers: [5, -10, 12, 1, -2, 3],
       areAllNegative: false,
-      highestPositive: 12,
       longestLabel: {negative: 0, positive: 0},
-      lowestNegative: -10,
     });
   });
 
@@ -91,9 +90,7 @@ describe('useDataForHorizontalChart()', () => {
     expect(data).toStrictEqual({
       allNumbers: [-5, -10, -12, -1, -2, -3],
       areAllNegative: true,
-      highestPositive: 0,
       longestLabel: {negative: 0, positive: 0},
-      lowestNegative: -12,
     });
   });
 

--- a/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
+++ b/packages/polaris-viz/src/hooks/useDataForHorizontalChart.ts
@@ -4,7 +4,7 @@ import {useChartContext, estimateStringWidth} from '@shopify/polaris-viz-core';
 
 import {HORIZONTAL_BAR_LABEL_OFFSET} from '../constants';
 
-interface Props {
+export interface Props {
   data: DataSeries[];
   isSimple: boolean;
   isStacked: boolean;
@@ -86,8 +86,6 @@ export function useDataForHorizontalChart({
   return {
     allNumbers,
     areAllNegative,
-    highestPositive,
     longestLabel,
-    lowestNegative,
   };
 }


### PR DESCRIPTION
## What does this implement/fix?

When building the width offset values for trends, we were originally trying to associate a trend with the longest value in each series.

This broke down when a series contained a value that was longer than the series that contained the trend.

Now we're going to find the longest trend for each positive and negative side of the chart and use those values.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/77311

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/a0d7f2e5-e0f4-4be0-8821-10d2bad51996)|![image](https://github.com/user-attachments/assets/3e5b3dc5-6c4c-4d8b-b931-579cbed05801)|

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
