### PR TITLE
Add startAxisLabel value to Annotations for formatted key matching

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- **Breaking change** Added `startAxisLabel` value to `Annotation` that uses the `DataPoint.key` value passed through `xAxisOptions.labelFormatter`.
+
+### Changed
+
+- **Breaking change** Reverted changed added in `15.0.0` that would run `startKey` through `xAxisOptions.labelFormatter`. We now use the unformatted value from `startKey` when matching an annotation with a `DataPoint.key`.
+
+If you need to target the formatted axis value, please use `Annotation.startAxisLabel`.
+
 
 ## [15.0.3] - 2024-09-25
 

--- a/packages/polaris-viz/src/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.tsx
@@ -52,26 +52,46 @@ export function Annotations({
 
     const annotations = Object.keys(annotationsLookupTable)
       .map((key) => {
-        const annotation = annotationsLookupTable[key];
+        const annotation: Annotation | null = annotationsLookupTable[key];
 
         if (annotation == null || annotation.axis === 'y') {
           return null;
         }
 
-        const formattedKey = labelFormatter(key);
-
-        if (!formattedLabels.includes(formattedKey)) {
+        if (annotation.startAxisLabel == null && annotation.startKey == null) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'Annotation provided with no startAxisLabel or startKey property',
+            {annotation},
+          );
           return null;
         }
 
-        dataIndexes[formattedKey] = formattedLabels.indexOf(formattedKey);
+        const keyIndex = labels.indexOf(key);
+
+        if (keyIndex !== -1) {
+          dataIndexes[key] = keyIndex;
+        }
+
+        const axisLabelIndex =
+          annotation.startAxisLabel == null
+            ? -1
+            : formattedLabels.indexOf(annotation.startAxisLabel);
+
+        if (annotation.startAxisLabel != null && axisLabelIndex !== -1) {
+          dataIndexes[annotation.startAxisLabel] = axisLabelIndex;
+        }
+
+        if (keyIndex === -1 && axisLabelIndex === -1) {
+          return null;
+        }
 
         return annotation;
       })
       .filter(Boolean) as Annotation[];
 
     return {annotations, dataIndexes};
-  }, [annotationsLookupTable, formattedLabels, labelFormatter]);
+  }, [annotationsLookupTable, formattedLabels, labels]);
 
   const {hiddenAnnotationsCount, positions, rowCount} = useAnnotationPositions({
     annotations,
@@ -81,7 +101,6 @@ export function Annotations({
     isShowingAllAnnotations,
     onHeightChange,
     xScale,
-    labelFormatter,
   });
 
   const handleToggleAllAnnotations = () => {

--- a/packages/polaris-viz/src/components/Annotations/YAxisAnnotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/YAxisAnnotations.tsx
@@ -43,15 +43,16 @@ export function YAxisAnnotations({
         const annotation = annotationsLookupTable[key];
 
         if (
-          !isValueWithinDomain(Number(annotation.startKey), yScale.domain())
+          annotation == null ||
+          annotation.axis == null ||
+          annotation.axis !== axis ||
+          annotation.startKey == null
         ) {
           return null;
         }
 
         if (
-          annotation == null ||
-          annotation.axis == null ||
-          annotation.axis !== axis
+          !isValueWithinDomain(Number(annotation.startKey), yScale.domain())
         ) {
           return null;
         }
@@ -110,7 +111,7 @@ export function YAxisAnnotations({
                 axis={axis}
                 y={line.y}
                 x={axisLabelX}
-                label={annotation.startKey}
+                label={annotation.startKey ?? ''}
               />
             )}
             <AnnotationLine

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.test.tsx
@@ -32,7 +32,6 @@ const ANNOTATION: Annotation = {
   axis: 'x',
   label: '',
   startKey: 0,
-  endKey: 0,
   content: {
     content: 'Some annotation content',
   },

--- a/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
+++ b/packages/polaris-viz/src/components/Annotations/hooks/useAnnotationPositions.ts
@@ -1,5 +1,4 @@
 import {useEffect, useMemo} from 'react';
-import type {LabelFormatter} from '@shopify/polaris-viz-core';
 import {
   clamp,
   estimateStringWidth,
@@ -27,7 +26,6 @@ export interface Props {
   dataIndexes: {[key: string]: string};
   drawableWidth: number;
   isShowingAllAnnotations: boolean;
-  labelFormatter: LabelFormatter;
   onHeightChange: (height: number) => void;
   xScale: ScaleLinear<number, number> | ScaleBand<string>;
 }
@@ -40,7 +38,6 @@ export function useAnnotationPositions({
   isShowingAllAnnotations,
   onHeightChange,
   xScale,
-  labelFormatter,
 }: Props): {
   hiddenAnnotationsCount: number;
   positions: AnnotationPosition[];
@@ -56,10 +53,9 @@ export function useAnnotationPositions({
 
   const {positions, hiddenAnnotationsCount} = useMemo(() => {
     let positions = annotations.map((annotation, dataIndex) => {
-      const xPosition = getValueFromXScale(
-        dataIndexes[labelFormatter(annotation.startKey)],
-        xScale,
-      );
+      const startIndex = annotation.startKey ?? annotation.startAxisLabel ?? 0;
+
+      const xPosition = getValueFromXScale(dataIndexes[startIndex], xScale);
 
       const textWidth = textWidths[dataIndex];
 
@@ -121,7 +117,6 @@ export function useAnnotationPositions({
     axisLabelWidth,
     xScale,
     drawableWidth,
-    labelFormatter,
   ]);
 
   const {totalRowHeight, rowCount} = useShowMoreAnnotationsButton({

--- a/packages/polaris-viz/src/components/BarChart/stories/Annotations/UnformattedAnnotations.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/Annotations/UnformattedAnnotations.stories.tsx
@@ -1,0 +1,52 @@
+import type {Story} from '@storybook/react';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Charts/BarChart/Playground/UnformattedAnnotationKeys',
+};
+
+import type {BarChartProps} from '../../../../components';
+
+import {Template} from '../data';
+import {META} from '../meta';
+
+export const UnformattedAnnotationKeys: Story<BarChartProps> = Template.bind(
+  {},
+);
+
+const MONTHS = 12;
+
+const data = [
+  {
+    name: 'Data Series',
+    data: [...Array(MONTHS).keys()].map((index) => ({
+      key: `${index}`,
+      value: MONTHS - index,
+    })),
+  },
+];
+
+UnformattedAnnotationKeys.args = {
+  data,
+  annotations: [
+    {
+      axis: 'x',
+      label: 'Formatted',
+      startAxisLabel: 'Monday',
+    },
+    {
+      axis: 'x',
+      label: 'Unformatted',
+      startKey: '5',
+    },
+  ],
+  xAxisOptions: {
+    labelFormatter: (value) => {
+      if (value === '3') {
+        return 'Monday';
+      }
+
+      return '';
+    },
+  },
+};

--- a/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartYAnnotations/hooks/useHorizontalBarChartYAnnotationsPositions.ts
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartYAnnotations/hooks/useHorizontalBarChartYAnnotationsPositions.ts
@@ -41,7 +41,9 @@ export function useHorizontalBarChartYAnnotationsPositions({
   const {positions} = useMemo(() => {
     const positions = annotations.map((annotation, dataIndex) => {
       const rawY: number =
-        dataIndexes[annotation.startKey] * groupHeight + Y_OFFSET;
+        annotation.startKey == null
+          ? 0
+          : dataIndexes[annotation.startKey] * groupHeight + Y_OFFSET;
 
       const textWidth = textWidths[dataIndex];
       const labelWidth = estimateStringWidth(

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -143,8 +143,11 @@ export interface LegendData {
 export interface Annotation {
   axis: 'x' | 'y';
   label: string;
-  startKey: string | number;
-  endKey?: string | number;
+  // Matching DataPoint key value as passed in DataSeries
+  startKey?: string | number;
+  // Matching DataPoint key value passed through xAxisOptions.labelFormatter.
+  // This value is the visual formatted text rendered on the axis.
+  startAxisLabel?: string;
   collapseButtonText?: string;
   expandButtonText?: string;
   content?: {


### PR DESCRIPTION
## What does this implement/fix?

To support https://github.com/Shopify/web/pull/140219 we [switched to formatting the `Annotation.startKey`](https://github.com/Shopify/polaris-viz/pull/1723) values so when the `xAxisOptions.labelFormatter` would format the dates different, we could correctly target those labels.

We've had a few instances where consumers were relying on the unformatted values. The screenshot below for example, they were relying on using the index of `8` to render the annotation, while using the `xAxisOptions.labelFormatter` to render blank labels.

![image](https://github.com/user-attachments/assets/da2755f5-d50a-4a20-922c-0c3f3bb37cb9)

In order to allow both use cases, we're adding an `startAxisLabel` that will target the formatted labels and switching back to `startKey` being the unformatted value used in `DataSeries[]`.
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-qltxxnwjyc.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground-unformattedannotationkeys--unformatted-annotation-keys

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
