### PR TITLE
Show error state when chart contains infinity

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## Unreleased
+
+- Fixed an issue where the bar chart collapsed if a value of Infinity was passed to it.
+
 ## [15.0.4] - 2024-09-26
 
 - No updates. Transitive dependency bump.

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
@@ -554,3 +554,43 @@ export const BadData: Story<BarChartProps> = (args: BarChartProps) => {
 BadData.args = {
   data: [{name: 'Empty', data: []}],
 };
+
+export const InfinityData: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <div style={{width: 500, height: 100}}>
+      <BarChart {...args} />
+    </div>
+  );
+};
+
+InfinityData.args = {
+  data: [
+    {
+      name: 'Oct 7–Oct 13, 2024',
+      data: [
+        {
+          key: '0',
+          value: 0,
+        },
+        {
+          key: '1',
+          value: 0,
+        },
+      ],
+    },
+    {
+      isComparison: true,
+      name: 'Sep 30–Oct 6, 2024',
+      data: [
+        {
+          key: '9',
+          value: Infinity,
+        },
+        {
+          key: '10',
+          value: 0,
+        },
+      ],
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -150,6 +150,10 @@ export function Chart({
     yScaleMax = allValuesAreZero ? 0 : max;
   }
 
+  if (!isFinite(yScaleMax) || !isFinite(min)) {
+    throw new Error('min and max must be finite numbers.');
+  }
+
   const yScaleOptions = {
     formatYAxisLabel: yAxisOptions.labelFormatter,
     integersOnly: yAxisOptions.integersOnly,


### PR DESCRIPTION
## What does this implement/fix?
Fixes this broken chart we saw on Sidekick this morning, which results from us passing the chart a value of Infinity
<img width="822" alt="Screenshot 2024-10-10 at 10 25 46 AM" src="https://github.com/user-attachments/assets/b2c8bdad-4c5a-4065-8d63-99681f9c24ab">

Using the existing error handling in the chart, we can just make the chart show the error state. An error will be thrown, so we should see these errors in bugsnag if the consuming project surfaces them.

Note: I spent a while trying to add a test for this but had issues checking for the error. Please let me know if you have any ideas!

## Does this close any currently open issues?

Resolves https://github.com/Shopify/web/issues/144056

## What do the changes look like?

| Before  | After  |
|---|---|
| <img width="556" alt="Screenshot 2024-10-10 at 2 59 49 PM" src="https://github.com/user-attachments/assets/db769849-e3cb-491a-a7b6-be2f974149f7">  | <img width="547" alt="Screenshot 2024-10-10 at 2 59 36 PM" src="https://github.com/user-attachments/assets/3c1f8e5a-2f7d-4300-b1fd-b33f7f159d11">  |
 
## Storybook link
You can check the storybook I added: http://localhost:6006/?path=/story/polaris-viz-charts-barchart-playground--infinity-data


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
