### PR TITLE
Tooltip positioning fixes

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where tooltips did not account for scroll position when rendered below the viewport bounds.
+
+- Fixed issue where tooltips used chart bounds instead of viewport bounds to determine position.
 
 ## [15.0.6] - 2024-10-11
 

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
@@ -50,7 +50,9 @@ const TemplateWithFrame: Story<BarChartProps> = (args: BarChartProps) => {
     <div style={{overflow: 'hidden', position: 'fixed', inset: 0}}>
       <div style={{height: 100, background: 'black', width: '100%'}}></div>
       <div style={{overflow: 'auto', height: '100vh'}} ref={setRef}>
-        <Card {...props} />
+        <div style={{marginLeft: '300px'}}>
+          <Card {...props} />
+        </div>
         <div style={{height: 700, width: 10}} />
         <div style={{display: 'flex', justifyContent: 'space-between'}}>
           <Card {...props} />

--- a/packages/polaris-viz/src/components/TooltipWrapper/tests/utils.test.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/tests/utils.test.ts
@@ -78,8 +78,17 @@ describe('utilities', () => {
 
   describe('getAbovePosition()', () => {
     it('returns altered values', () => {
-      expect(getAbovePosition(0, {...BASE_PROPS, currentY: 0})).toStrictEqual({
-        value: 0,
+      const currentY = 0;
+      const scrollTop = 15;
+
+      expect(
+        getAbovePosition(0, {
+          ...BASE_PROPS,
+          currentY,
+          scrollContainer: {scrollTop} as Element,
+        }),
+      ).toStrictEqual({
+        value: currentY - scrollTop,
         wasOutsideBounds: true,
       });
 
@@ -167,7 +176,7 @@ describe('utilities', () => {
       });
 
       expect(getCenterPosition(690, BASE_PROPS)).toStrictEqual({
-        value: 40,
+        value: 440,
         wasOutsideBounds: true,
       });
     });

--- a/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/utilities.ts
@@ -210,7 +210,7 @@ export function getVerticalCenterPosition(
     if (y <= 0) {
       y = 0;
     } else {
-      y = props.chartBounds.height - props.tooltipDimensions.height;
+      y = window.scrollY + window.innerHeight - props.tooltipDimensions.height;
     }
   }
 
@@ -228,9 +228,8 @@ export function getAbovePosition(
     direction: 'y',
     alteredPosition: props,
   });
-
   if (wasOutsideBounds) {
-    y = props.currentY;
+    y = props.currentY - (props.scrollContainer?.scrollTop ?? 0);
   }
 
   return {value: y, wasOutsideBounds};
@@ -315,10 +314,7 @@ export function getCenterPosition(
   });
 
   if (wasOutsideBounds) {
-    x =
-      props.chartBounds.width -
-      props.tooltipDimensions.width -
-      TOOLTIP_MARGIN * 2;
+    x = window.innerWidth - props.tooltipDimensions.width - TOOLTIP_MARGIN * 2;
   }
 
   return {value: x, wasOutsideBounds};


### PR DESCRIPTION
## What does this implement/fix?

- Fixes an issue in tooltips positioned `"above"`, where tooltips that were originally above the viewport were altered to be below the chart incorrectly. See video in [issue](https://github.com/Shopify/core-issues/issues/77868). 
- Fixes another similar issue where we were using the chart bounds instead of the viewport bounds to alter the position of the tooltip. 

I think it would be worth doing a more thorough audit of what position-altering logic we can get rid of, some of it doesn't seem applicable anymore.

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?


[Before fix 1:](https://6062ad4a2d14cd0021539c1b-zfywbkjnnm.chromatic.com/iframe.html?args=&id=polaris-viz-charts-barchart-playground--external-tooltip-with-frame&viewMode=story)

https://github.com/user-attachments/assets/4730c6c5-a70d-4938-afca-d7dd86288293

[After fix 1](https://6062ad4a2d14cd0021539c1b-bcdorysbsq.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--external-tooltip-with-frame)

https://github.com/user-attachments/assets/8610f68b-6749-4a3c-9f65-d48045e4ed29

Before fix 2:

https://github.com/user-attachments/assets/5ec1ec9a-0ff8-4aa3-85ad-8f5b2983920b

[After fix 2:](https://6062ad4a2d14cd0021539c1b-dpdgxtraae.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--external-tooltip-with-frame)

https://github.com/user-attachments/assets/b40c9401-820c-4635-a478-f1632e63e97f

 
## Storybook link

https://6062ad4a2d14cd0021539c1b-dpdgxtraae.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--external-tooltip-with-frame

- Scroll down so that there is not enough room above the bar for the tooltip to be rendered
- Confirm the tooltip is rendered at the top of the chart within the chart bounds

Test all charts with tooltips that have a `vertical` position of `TooltipVerticalOffset.Above`

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
