### PR TITLE
Check chart bounds when mouse enters chart

### DIFF
--- a/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
@@ -43,14 +43,22 @@ const Template: Story<BarChartProps> = (args: BarChartProps) => {
 
 const TemplateWithFrame: Story<BarChartProps> = (args: BarChartProps) => {
   const [ref, setRef] = useState<HTMLDivElement | null>(null);
+  const [height, setHeight] = useState(0);
+  const [marginLeft, setMarginLeft] = useState(0);
 
   const props = {...args, scrollContainer: ref};
 
   return (
     <div style={{overflow: 'hidden', position: 'fixed', inset: 0}}>
-      <div style={{height: 100, background: 'black', width: '100%'}}></div>
+      <div style={{height, background: 'black', width: '100%'}}></div>
       <div style={{overflow: 'auto', height: '100vh'}} ref={setRef}>
-        <div style={{marginLeft: '300px'}}>
+        <button onClick={() => setHeight(height === 0 ? 300 : 0)}>
+          Toggle bar height
+        </button>
+        <button onClick={() => setMarginLeft(marginLeft === 0 ? 300 : 0)}>
+          Toggle left margin
+        </button>
+        <div style={{marginLeft}}>
           <Card {...props} />
         </div>
         <div style={{height: 700, width: 10}} />

--- a/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/ChartContainer.tsx
@@ -93,6 +93,7 @@ export const ChartContainer = (props: Props) => {
           onIsPrintingChange={setIsPrinting}
           skeletonType={props.skeletonType}
           sparkChart={props.sparkChart}
+          scrollContainer={props.scrollContainer}
         >
           {props.children}
         </ChartDimensions>

--- a/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
+++ b/packages/polaris-viz/src/components/ChartContainer/components/ChartDimensions/ChartDimensions.tsx
@@ -112,6 +112,30 @@ export function ChartDimensions({
     chartContainer.sparkChartMinHeight,
   ]);
 
+  const onMouseEnter = useCallback(() => {
+    if (ref == null) {
+      return;
+    }
+
+    const scrollY =
+      scrollContainer == null ? window.scrollY : scrollContainer.scrollTop;
+
+    const bounds = ref.getBoundingClientRect();
+
+    setChartDimensions((prev) => {
+      if (bounds.y === prev?.y && bounds.x === prev?.x) {
+        return prev;
+      }
+
+      return {
+        width: bounds.width,
+        height: bounds.height,
+        x: bounds.x,
+        y: bounds.y + scrollY,
+      };
+    });
+  }, [ref, scrollContainer]);
+
   return (
     <div
       className={styles.ChartDimensions}
@@ -121,6 +145,8 @@ export function ChartDimensions({
           ? chartContainer.sparkChartMinHeight
           : chartContainer.minHeight,
       }}
+      onMouseEnter={onMouseEnter}
+      onFocus={onMouseEnter}
     >
       {!hasValidDimensions(chartDimensions) ? null : (
         <ChartErrorBoundary


### PR DESCRIPTION
## What does this implement/fix?

We were only updating the dimensions on `resize`, so `dimensions.x` and `dimensions.y` were outdated when we were trying to calculate the tooltip position [here](https://github.com/Shopify/polaris-viz/blob/main/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx#L391-L392).

In this PR, we added a `onMouseEnter` and `onFocusIn`  handler to also update the dimensions when you interact with the chart.  

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

Fix https://github.com/Shopify/core-issues/issues/78973


## What do the changes look like?

Before:
https://github.com/user-attachments/assets/7f881726-54ef-45c1-aa6d-3a8634ced5d0

After:
https://github.com/user-attachments/assets/232f1c24-0355-4d1d-bfd0-8c30a6c47516

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

Toggle the top/left margins and make sure the tooltips are in the correct position.
Test with scrolling as well. 

https://6062ad4a2d14cd0021539c1b-whnpeerjyh.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--external-tooltip-with-frame


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [ ] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
