### PR TITLE
Make small chart check for a smaller value

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -7,7 +7,7 @@ import type {SvgComponents, Theme} from './types';
 import {InternalChartType, ChartState, Hue} from './types';
 
 export const LINE_HEIGHT = 14;
-export const SMALL_CHART_HEIGHT = 200;
+export const SMALL_CHART_HEIGHT = 125;
 export const FONT_SIZE = 11;
 export const FONT_FAMILY =
   'Inter, -apple-system, "system-ui", "San Francisco", "Segoe UI", Roboto, "Helvetica Neue", sans-serif';

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Reduced small chart check to 125px
 
 ## [15.1.2] - 2024-10-29
 

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -549,7 +549,7 @@ describe('<Chart />', () => {
       expect(svg?.props.height).toStrictEqual(250);
     });
 
-    it('does not render <LegendContainer /> when the chart has a height of less than 200', () => {
+    it('does not render <LegendContainer /> when the chart has a height of less than 125', () => {
       const chart = mount(
         <Chart {...MOCK_PROPS} dimensions={{width: 100, height: 100}} />,
       );

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -370,7 +370,7 @@ describe('<Chart />', () => {
       expect(svg?.props.height).toStrictEqual(250);
     });
 
-    it('does not render <LegendContainer /> when the chart has a height of less than 200', () => {
+    it('does not render <LegendContainer /> when the chart has a height of less than 125', () => {
       const chart = mount(
         <Chart {...MOCK_PROPS} dimensions={{width: 100, height: 100}} />,
       );

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -337,7 +337,7 @@ describe('Chart />', () => {
       expect(svg?.props.height).toStrictEqual(250);
     });
 
-    it('does not render <LegendContainer /> when the chart has a height of less than 200', () => {
+    it('does not render <LegendContainer /> when the chart has a height of less than 125', () => {
       const chart = mount(
         <Chart {...MOCK_PROPS} dimensions={{width: 100, height: 100}} />,
       );


### PR DESCRIPTION
## What does this implement/fix?

I realized we stopped showing labels on the xAxis before we really wanted to. This decreases the threshold from 200px to 125px, so specifically target the charts that were having issues.

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
