### PR TITLE
passanelli, Fix Grid chart responsiveness issues and hide Labels on small heights

### DIFF
--- a/packages/polaris-viz/src/components/Grid/Grid.scss
+++ b/packages/polaris-viz/src/components/Grid/Grid.scss
@@ -9,6 +9,9 @@
   font-size: 12px;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .FadeIn {

--- a/packages/polaris-viz/src/components/Grid/Grid.tsx
+++ b/packages/polaris-viz/src/components/Grid/Grid.tsx
@@ -24,8 +24,8 @@ import {
   X_AXIS_HEIGHT,
   DEFAULT_GROUP_COLOR,
   DEFAULT_TEXT_COLOR,
-  SVG_OFFSET,
   SMALL_CONTAINER_WIDTH,
+  SMALL_CONTAINER_HEIGHT,
 } from './utilities/constants';
 import type {
   CellGroup,
@@ -234,24 +234,16 @@ export function Grid(props: GridProps) {
   useEffect(() => {
     if (entry?.contentRect) {
       // we want to make sure the container is not too small to allow hover interactions
-      setIsSmallContainer(entry.contentRect.width <= SMALL_CONTAINER_WIDTH);
+      setIsSmallContainer(
+        entry.contentRect.width <= SMALL_CONTAINER_WIDTH ||
+          entry.contentRect.height <= SMALL_CONTAINER_HEIGHT,
+      );
     }
   }, [entry]);
 
-  const containerStyle = useMemo(
-    () => ({
-      height: dimensions.height ? `${dimensions.height}px` : '100%',
-    }),
-    [dimensions.height],
-  );
-
   return (
-    <div ref={setRef} className={styles.Container} style={containerStyle}>
-      <svg
-        width="100%"
-        height="100%"
-        viewBox={`0 0 ${dimensions.width} ${dimensions.height + SVG_OFFSET}`}
-      >
+    <div ref={setRef} className={styles.Container}>
+      <svg width="100%" height="100%">
         <YAxisLabels
           yTicks={yTicks}
           chartPositions={chartPositions}
@@ -279,6 +271,7 @@ export function Grid(props: GridProps) {
               handleGroupHover={handleGroupHover}
               getColors={getColors}
               containerWidth={dimensions.width}
+              containerHeight={dimensions.height}
               isAnimated={isAnimated}
             />
           ))}

--- a/packages/polaris-viz/src/components/Grid/components/GridBackground.tsx
+++ b/packages/polaris-viz/src/components/Grid/components/GridBackground.tsx
@@ -34,7 +34,7 @@ export function GridBackground({
   }
 
   // Horizontal lines
-  for (let i = 1; i <= rows + 1; i++) {
+  for (let i = 1; i <= rows; i++) {
     const y = i * cellHeight;
     lines.push(
       <line

--- a/packages/polaris-viz/src/components/Grid/components/GroupCell.tsx
+++ b/packages/polaris-viz/src/components/Grid/components/GroupCell.tsx
@@ -2,7 +2,10 @@ import React, {useCallback, useEffect, useState} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 
 import type {CellGroup} from '../types';
-import {HIDE_NAME_AND_SECONDARY_VALUE_WIDTH_THRESHOLD} from '../utilities/constants';
+import {
+  HIDE_NAME_AND_SECONDARY_VALUE_HEIGHT_THRESHOLD,
+  HIDE_NAME_AND_SECONDARY_VALUE_WIDTH_THRESHOLD,
+} from '../utilities/constants';
 
 import styles from './GroupCell.scss';
 import {Background} from './Background';
@@ -21,6 +24,7 @@ interface GroupCellProps {
   ) => void;
   getColors: (group: CellGroup) => {bgColor: string; textColor: string};
   containerWidth: number;
+  containerHeight: number;
   isAnimated: boolean;
   index: number;
 }
@@ -35,6 +39,7 @@ export const GroupCell: React.FC<GroupCellProps> = ({
   handleGroupHover,
   getColors,
   containerWidth,
+  containerHeight,
   isAnimated,
   index,
 }) => {
@@ -60,7 +65,8 @@ export const GroupCell: React.FC<GroupCellProps> = ({
 
   const groupNameOffset = 10;
   const showNameAndSecondaryValue =
-    containerWidth > HIDE_NAME_AND_SECONDARY_VALUE_WIDTH_THRESHOLD;
+    containerWidth > HIDE_NAME_AND_SECONDARY_VALUE_WIDTH_THRESHOLD &&
+    containerHeight > HIDE_NAME_AND_SECONDARY_VALUE_HEIGHT_THRESHOLD;
   const mainFontSize = showNameAndSecondaryValue
     ? 20
     : Math.min(groupWidth, cellHeight) / 4;

--- a/packages/polaris-viz/src/components/Grid/stories/ResizeableChart.stories.tsx
+++ b/packages/polaris-viz/src/components/Grid/stories/ResizeableChart.stories.tsx
@@ -1,0 +1,32 @@
+export {META as default} from './meta';
+
+import {Grid, GridProps} from '../Grid';
+import type {Story} from '@storybook/react';
+import {CELL_GROUPS, Template} from './data';
+
+export const ResizeableChart: Story<GridProps> = (args: GridProps) => {
+  return (
+    <div
+      style={{
+        resize: 'both',
+        overflow: 'hidden',
+        maxHeight: '100%',
+        maxWidth: '100%',
+        height: '450px',
+      }}
+    >
+      <Grid {...args} />
+    </div>
+  );
+};
+
+ResizeableChart.args = {
+  ...Template.args,
+  cellGroups: CELL_GROUPS,
+  xAxisOptions: {
+    label: 'Recency score',
+  },
+  yAxisOptions: {
+    label: 'Frequency + Monetary score',
+  },
+};

--- a/packages/polaris-viz/src/components/Grid/tests/GroupCell.test.tsx
+++ b/packages/polaris-viz/src/components/Grid/tests/GroupCell.test.tsx
@@ -80,6 +80,7 @@ const MOCK_PROPS = {
   handleGroupHover: () => {},
   getColors: jest.fn(() => ({bgColor: 'red', textColor: 'white'})),
   containerWidth: 600,
+  containerHeight: 600,
   isAnimated: true,
   description: '',
   goal: '',

--- a/packages/polaris-viz/src/components/Grid/utilities/constants.ts
+++ b/packages/polaris-viz/src/components/Grid/utilities/constants.ts
@@ -14,7 +14,7 @@ export const DEFAULT_TEXT_COLOR = '#FFFFFF';
 
 export const SVG_OFFSET = 10;
 export const SMALL_CONTAINER_WIDTH = 400;
-
+export const SMALL_CONTAINER_HEIGHT = 350;
 export const ARROW_X_POSITION_OFFSET = 18;
 export const ARROW_LENGTH = 35;
 export const ARROW_HEAD_SIZE_RATIO = 17;
@@ -22,5 +22,5 @@ export const ARROW_START_OFFSET = 4;
 
 export const BACKGROUND_GAP = 9;
 export const HIDE_NAME_AND_SECONDARY_VALUE_WIDTH_THRESHOLD = 500;
-
-export const X_AXIS_LABEL_BOTTOM_OFFSET = 10;
+export const HIDE_NAME_AND_SECONDARY_VALUE_HEIGHT_THRESHOLD = 350;
+export const X_AXIS_LABEL_BOTTOM_OFFSET = 20;


### PR DESCRIPTION
## What does this implement?

This PR fix the responsiveness of the chart `Grid`. This visualization is going to be used in `RFM analysis`.

Designs: [Link](https://www.figma.com/design/ADgpIRzImXVud8ngDgonDk/RFM-analysis?node-id=2964-88879&node-type=section&m=dev) 

<img width="1050" alt="Screenshot 2024-09-25 at 4 30 34 PM" src="https://github.com/user-attachments/assets/949e0aad-896e-48df-9db8-0b083ad24868">

 
## Storybook link

[Link](https://g6lzjwjtzcjc5evv.tunnel.shopifycloud.tech/?path=/docs/polaris-viz-charts-grid--default)


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
