### PR TITLE
Change font size for touch devices

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -9,6 +9,8 @@ import {InternalChartType, ChartState, Hue} from './types';
 export const LINE_HEIGHT = 14;
 export const SMALL_CHART_HEIGHT = 125;
 export const FONT_SIZE = 11;
+export const TOUCH_FONT_SIZE = 14;
+
 export const FONT_FAMILY =
   'Inter, -apple-system, "system-ui", "San Francisco", "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
 

--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -68,6 +68,7 @@ export {
   STROKE_DOT_ARRAY_WIDTH,
   EXTERNAL_EVENTS_SET_HIDDEN_ITEMS,
   FONT_FAMILY,
+  TOUCH_FONT_SIZE,
 } from './constants';
 export {
   clamp,

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Increase font size of labels and legends when viewing charts on a touch device.
 
 ## [15.2.1] - 2024-11-05
 

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.tsx
@@ -1,6 +1,6 @@
 import type {Dispatch, SetStateAction} from 'react';
 import {Fragment} from 'react';
-import {LINE_HEIGHT, useTheme} from '@shopify/polaris-viz-core';
+import {FONT_SIZE, LINE_HEIGHT, useTheme} from '@shopify/polaris-viz-core';
 
 import {useBrowserCheck} from '../../../../hooks/useBrowserCheck';
 import {SingleTextLine} from '../../../Labels';
@@ -65,6 +65,7 @@ export function AnnotationLabel({
       <SingleTextLine
         ariaHidden
         color={selectedTheme.annotations.textColor}
+        fontSize={FONT_SIZE}
         text={label}
         targetWidth={width - PILL_PADDING * 2 + PX_OFFSET}
         y={PILL_HEIGHT - LINE_HEIGHT - PX_OFFSET}

--- a/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.tsx
@@ -1,5 +1,6 @@
 import {
   estimateStringWidth,
+  FONT_SIZE,
   LINE_HEIGHT,
   useChartContext,
   useTheme,
@@ -84,6 +85,7 @@ export function ShowMoreAnnotationsButton({
 
       <SingleTextLine
         color={selectedTheme.annotations.textColor}
+        fontSize={FONT_SIZE}
         text={label}
         targetWidth={pillWidth - PILL_PADDING * 2}
         y={PILL_HEIGHT - LINE_HEIGHT}

--- a/packages/polaris-viz/src/components/ComboChart/components/AxisLabel/AxisLabel.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/components/AxisLabel/AxisLabel.tsx
@@ -1,5 +1,6 @@
 import {LINE_HEIGHT, useTheme} from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../../utilities/getFontSize';
 import {useEstimateStringWidth} from '../../../../hooks/useEstimateStringWidth';
 import {SingleTextLine} from '../../../Labels';
 
@@ -12,7 +13,9 @@ export interface AxisLabelProps {
 }
 
 export function AxisLabel({height, name, axis, x, y}: AxisLabelProps) {
-  const stringWidth = useEstimateStringWidth(name);
+  const fontSize = getFontSize();
+
+  const stringWidth = useEstimateStringWidth(name, fontSize);
   const selectedTheme = useTheme();
 
   const rotate = axis === 'primary' ? -90 : 90;
@@ -36,6 +39,7 @@ export function AxisLabel({height, name, axis, x, y}: AxisLabelProps) {
       />
       <SingleTextLine
         color={selectedTheme.yAxis.labelColor}
+        fontSize={fontSize}
         targetWidth={Math.max(stringWidth, height)}
         text={name}
         x={0}

--- a/packages/polaris-viz/src/components/Labels/SingleTextLine.tsx
+++ b/packages/polaris-viz/src/components/Labels/SingleTextLine.tsx
@@ -5,12 +5,11 @@ import {
   useChartContext,
 } from '@shopify/polaris-viz-core';
 
-import {FONT_SIZE} from '../../constants';
-
 import {endLineTruncate} from './utilities/endLineTruncate';
 
 interface SingleTextLineProps {
   color: string;
+  fontSize: number;
   targetWidth: number;
   text: string;
   x: number;
@@ -24,6 +23,7 @@ export function SingleTextLine({
   ariaHidden = false,
   color,
   dominantBaseline = 'hanging',
+  fontSize,
   targetWidth,
   text,
   textAnchor = 'center',
@@ -48,7 +48,7 @@ export function SingleTextLine({
         height={LINE_HEIGHT}
         width={targetWidth}
         fill={color}
-        fontSize={FONT_SIZE}
+        fontSize={fontSize}
         fontFamily={FONT_FAMILY}
         y={y}
         x={x}

--- a/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
+++ b/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
@@ -1,7 +1,9 @@
 import type {Dispatch, SetStateAction} from 'react';
 import {useEffect, useMemo} from 'react';
-import {estimateStringWidth, useChartContext} from '@shopify/polaris-viz-core';
+import {useChartContext} from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../utilities/getFontSize';
+import {estimateStringWidthWithOffset} from '../../../utilities';
 import {
   LINE_HEIGHT,
   DIAGONAL_LABEL_MIN_WIDTH,
@@ -28,21 +30,24 @@ export function useLabels({
 }: Props) {
   const {characterWidths} = useChartContext();
 
+  const fontSize = getFontSize();
+
   const preparedLabels = useMemo(() => {
     return labels.map((label) => {
       return {
         text: label,
+        fontSize,
         words: [],
         truncatedWords: [],
         truncatedName: '',
         truncatedWidth: 0,
       };
     });
-  }, [labels]);
+  }, [labels, fontSize]);
 
   const longestLabelWidth = useMemo(() => {
     return labels.reduce((prev, string) => {
-      const newWidth = estimateStringWidth(string, characterWidths);
+      const newWidth = estimateStringWidthWithOffset(string, fontSize);
 
       if (newWidth > prev) {
         return newWidth;
@@ -50,7 +55,7 @@ export function useLabels({
 
       return prev;
     }, 0);
-  }, [labels, characterWidths]);
+  }, [labels, fontSize]);
 
   const {lines, containerHeight} = useMemo(() => {
     const shouldDrawHorizontal = checkIfShouldDrawHorizontal({

--- a/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
@@ -48,6 +48,7 @@ export function getDiagonalLabels({
     lines[i].push({
       truncatedText: truncatedLabels[i].truncatedName,
       fullText: truncatedLabels[i].text,
+      fontSize: labels[i].fontSize,
       y: centerPoint,
       x: centerPoint,
       dominantBaseline: 'hanging',

--- a/packages/polaris-viz/src/components/Labels/utilities/getHorizontalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getHorizontalLabels.ts
@@ -75,6 +75,7 @@ export function getHorizontalLabels({
         fullText: truncatedLabels[index].text,
         x: targetWidth / 2,
         y: lineNumber * LINE_HEIGHT,
+        fontSize: label.fontSize,
         width: targetWidth,
         height: LINE_HEIGHT,
         textAnchor: 'middle',

--- a/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
@@ -41,6 +41,7 @@ export function getVerticalLabels({
     lines[i] = [];
     lines[i].push({
       truncatedText: truncatedLabels[i].truncatedName,
+      fontSize: labels[i].fontSize,
       fullText: truncatedLabels[i].text,
       y: LINE_HEIGHT / QUARTER,
       x: 0,

--- a/packages/polaris-viz/src/components/Labels/utilities/truncateLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/truncateLabels.ts
@@ -1,6 +1,6 @@
 import type {CharacterWidths} from '@shopify/polaris-viz-core';
-import {estimateStringWidth} from '@shopify/polaris-viz-core';
 
+import {estimateStringWidthWithOffset} from '../../../utilities';
 import type {PreparedLabels} from '../../../types';
 
 import {endLineTruncate} from './endLineTruncate';
@@ -23,7 +23,7 @@ export function truncateLabels({
 }: Props) {
   const truncatedLabels = [...labels];
 
-  labels.forEach((_, index) => {
+  labels.forEach(({fontSize}, index) => {
     truncatedLabels[index].truncatedWords = [];
     truncatedLabels[index].words = [];
 
@@ -35,7 +35,7 @@ export function truncateLabels({
       truncatedLabels[index].truncatedWords.push(truncatedLabels[index].text);
     } else {
       words.forEach((word) => {
-        const wordWidth = estimateStringWidth(word, characterWidths);
+        const wordWidth = estimateStringWidthWithOffset(word, fontSize);
 
         truncatedLabels[index].words.push({
           word,
@@ -66,9 +66,9 @@ export function truncateLabels({
       characterWidths,
     });
 
-    truncatedLabels[index].truncatedWidth = estimateStringWidth(
+    truncatedLabels[index].truncatedWidth = estimateStringWidthWithOffset(
       truncatedLabels[index].truncatedName,
-      characterWidths,
+      truncatedLabels[index].fontSize,
     );
 
     truncatedLabels[index].truncatedWords =

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -25,7 +25,6 @@
   gap: 3px;
   line-height: 16px;
   margin: -2px 0;
-  font-size: 11px;
   font-family: $font-stack-base;
   white-space: nowrap;
   min-width: 0;

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.tsx
@@ -6,6 +6,7 @@ import {
 import type {ReactNode} from 'react';
 import {useEffect, useRef, useState} from 'react';
 
+import {getFontSize} from '../../../../utilities/getFontSize';
 import {
   LEGEND_ITEM_LEFT_PADDING,
   LEGEND_ITEM_RIGHT_PADDING,
@@ -61,6 +62,8 @@ export function LegendItem({
   const selectedTheme = useTheme(theme);
   const ref = useRef<HTMLButtonElement | null>(null);
   const [width, setWidth] = useState(0);
+
+  const fontSize = getFontSize();
 
   const renderLegendValues = showLegendValues && value != null;
 
@@ -122,7 +125,12 @@ export function LegendItem({
       ) : (
         renderSeriesIcon()
       )}
-      <span className={style.TextContainer}>
+      <span
+        className={style.TextContainer}
+        style={{
+          fontSize: `${fontSize}px`,
+        }}
+      >
         <span
           className={style.Text}
           style={{

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
@@ -15,6 +15,7 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {BoundingRect, LabelFormatter} from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../utilities/getFontSize';
 import type {LegendData} from '../../../types';
 import {TOOLTIP_BG_OPACITY} from '../../../constants';
 import {useBrowserCheck} from '../../../hooks/useBrowserCheck';
@@ -141,6 +142,7 @@ export function HiddenLegendTooltip({
         onBlur={handleMouseLeave}
         style={{
           color: selectedTheme.legend.labelColor,
+          fontSize: getFontSize(),
         }}
       >
         {label}

--- a/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/Chart.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@shopify/polaris-viz-core';
 import {animated} from '@react-spring/web';
 
+import {getFontSize} from '../../utilities/getFontSize';
 import {ChartElements} from '../ChartElements';
 import {LegendContainer, useLegend} from '../../components/LegendContainer';
 import {GradientDefs, HorizontalGroup} from '../shared';
@@ -57,6 +58,7 @@ export function Chart({
 }: ChartProps) {
   useColorVisionEvents({enabled: data.length > 1});
 
+  const fontSize = getFontSize();
   const id = useMemo(() => uniqueId('SimpleBarChart'), []);
 
   const {labelFormatter} = xAxisOptions;
@@ -89,7 +91,7 @@ export function Chart({
     data,
   });
 
-  const longestTrendIndicator = getLongestTrendIndicator(data);
+  const longestTrendIndicator = getLongestTrendIndicator(data, fontSize);
 
   const trendIndicatorOffset =
     longestTrendIndicator.positive + longestTrendIndicator.negative;

--- a/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/tests/utilities.test.ts
@@ -13,9 +13,6 @@ const negativeValues = [
   {value: -3, key: 'Label 03'},
 ];
 
-const highestPositive = 3;
-const lowestNegative = -3;
-
 const trends = {
   '0': {
     value: '77%',
@@ -46,7 +43,7 @@ describe('getLongestTrendIndicator()', () => {
   it('returns a value for positive when positive values have a trend indicator', () => {
     const {positive, negative} = getLongestTrendIndicator([positiveSeries]);
 
-    expect(positive).toStrictEqual(51);
+    expect(positive).toStrictEqual(53);
     expect(negative).toBe(0);
   });
 
@@ -54,7 +51,7 @@ describe('getLongestTrendIndicator()', () => {
     const {positive, negative} = getLongestTrendIndicator([negativeSeries]);
 
     expect(positive).toBe(0);
-    expect(negative).toStrictEqual(51);
+    expect(negative).toStrictEqual(53);
   });
 
   it('returns values for both positive and negative when positive and negative values have trend indicators', () => {
@@ -63,8 +60,8 @@ describe('getLongestTrendIndicator()', () => {
       negativeSeries,
     ]);
 
-    expect(positive).toStrictEqual(51);
-    expect(negative).toStrictEqual(51);
+    expect(positive).toStrictEqual(53);
+    expect(negative).toStrictEqual(53);
   });
 
   it('returns 0 for both values if there are no trend indicators', () => {

--- a/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
+++ b/packages/polaris-viz/src/components/SimpleBarChart/utilities.ts
@@ -1,6 +1,9 @@
 import {HORIZONTAL_BAR_LABEL_OFFSET} from '@shopify/polaris-viz-core';
 
-import {estimateTrendIndicatorWidth} from '../TrendIndicator';
+import {
+  estimateTrendIndicatorWidth,
+  TREND_INDICATOR_FONT_WEIGHT,
+} from '../TrendIndicator';
 
 import type {SimpleBarChartDataSeries} from './types';
 
@@ -8,7 +11,10 @@ import type {SimpleBarChartDataSeries} from './types';
  * Returns the widths of the trend indicators por positive or negative values,
  * or 0 if the value doesn't have a trend indicator.
  */
-export function getLongestTrendIndicator(data: SimpleBarChartDataSeries[]) {
+export function getLongestTrendIndicator(
+  data: SimpleBarChartDataSeries[],
+  fontSize: number,
+) {
   const longestTrendIndicator = data.reduce(
     (longestTrendIndicator, series) => {
       const {data: seriesData, metadata} = series;
@@ -18,12 +24,14 @@ export function getLongestTrendIndicator(data: SimpleBarChartDataSeries[]) {
       for (const [index, trend] of trendEntries) {
         const dataPoint = seriesData[index];
 
-        if (trend == null || dataPoint?.value == null) {
+        if (trend == null || trend.value == null || dataPoint?.value == null) {
           return longestTrendIndicator;
         }
 
         const trendStringWidth = estimateTrendIndicatorWidth(
           trend.value,
+          fontSize,
+          TREND_INDICATOR_FONT_WEIGHT,
         ).totalWidth;
 
         // Positive value

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.scss
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.scss
@@ -3,6 +3,7 @@
   position: relative;
   display: flex;
   align-items: baseline;
+  width: 100%;
 }
 
 .ContainerDefaultLabel {
@@ -52,6 +53,7 @@
   top: 16px;
   margin-top: 4px;
   display: flex;
+  align-items: center;
 }
 
 .Value {

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/components/BarLabel/BarLabel.tsx
@@ -6,6 +6,7 @@ import {
 } from '@shopify/polaris-viz-core';
 import type {Color, Direction} from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../../utilities/getFontSize';
 import {getCSSBackgroundFromColor} from '../../../../utilities/getCSSBackgroundFromColor';
 import {classNames} from '../../../../utilities';
 import type {ComparisonMetricProps} from '../../../ComparisonMetric';
@@ -36,6 +37,8 @@ export function BarLabel({
   legendPosition,
 }: Props) {
   const selectedTheme = useTheme();
+
+  const fontSize = getFontSize();
   const {labelColor, valueColor} = selectedTheme.legend;
 
   const comparisonIndicator = comparisonMetric ? (
@@ -66,7 +69,7 @@ export function BarLabel({
       />
       <div className={styles.Label}>
         <div
-          style={{color: labelColor}}
+          style={{color: labelColor, fontSize: `${fontSize}px`}}
           className={
             direction === 'horizontal'
               ? styles.FormattedHorizontalLabel
@@ -76,7 +79,7 @@ export function BarLabel({
           {label}
         </div>
         <div
-          style={{color: valueColor}}
+          style={{color: valueColor, fontSize: `${fontSize}px`}}
           className={
             direction === 'horizontal'
               ? styles.ValueHorizontalContainer

--- a/packages/polaris-viz/src/components/TextLine/TextLine.tsx
+++ b/packages/polaris-viz/src/components/TextLine/TextLine.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import {FONT_FAMILY} from '@shopify/polaris-viz-core';
 
 import {useTheme} from '../../hooks';
-import {FONT_SIZE} from '../../constants';
 import type {FormattedLine} from '../../types';
 
 interface TextLineProps {
@@ -20,6 +19,7 @@ export function TextLine({index, line}: TextLineProps) {
           {
             dominantBaseline,
             height,
+            fontSize,
             fullText,
             truncatedText,
             textAnchor,
@@ -42,7 +42,7 @@ export function TextLine({index, line}: TextLineProps) {
                 x={x}
                 y={y}
                 fill={selectedTheme.xAxis.labelColor}
-                fontSize={FONT_SIZE}
+                fontSize={fontSize}
                 fontFamily={FONT_FAMILY}
                 transform={transform}
               >

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -1,5 +1,6 @@
 import {useTheme, FONT_FAMILY} from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../utilities/getFontSize';
 import type {Trend, TrendDirection} from '../../types';
 
 import {ArrowDown, ArrowUp, Svg} from './components/';
@@ -9,7 +10,6 @@ import {
   NO_VALUE_ICON_HEIGHT,
   TEXT_ICON_SPACING,
   ICON_SIZE,
-  FONT_SIZE,
   HEIGHT,
   Y_OFFSET,
 } from './constants';
@@ -34,6 +34,7 @@ export function TrendIndicator({
   value,
 }: TrendIndicatorProps) {
   const selectedTheme = useTheme(theme);
+  const fontSize = getFontSize();
 
   const svgProps = {
     accessibilityLabel,
@@ -57,6 +58,7 @@ export function TrendIndicator({
 
   const {textWidth, totalWidth} = estimateTrendIndicatorWidth(
     value,
+    fontSize,
     TREND_FONT_WEIGHT,
   );
 
@@ -70,7 +72,7 @@ export function TrendIndicator({
         <text
           x={ICON_SIZE + TEXT_ICON_SPACING}
           y={(HEIGHT + Y_OFFSET) / 2}
-          fontSize={FONT_SIZE}
+          fontSize={fontSize}
           fill="currentColor"
           fontWeight={TREND_FONT_WEIGHT}
           dominantBaseline="middle"

--- a/packages/polaris-viz/src/components/TrendIndicator/index.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/index.ts
@@ -2,3 +2,4 @@ export {TrendIndicator} from './TrendIndicator';
 export type {TrendIndicatorProps} from './TrendIndicator';
 export {estimateTrendIndicatorWidth} from './utilities/estimateTrendIndicatorWidth';
 export {HEIGHT as TREND_INDICATOR_HEIGHT} from './constants';
+export {FONT_WEIGHT as TREND_INDICATOR_FONT_WEIGHT} from './constants';

--- a/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
+++ b/packages/polaris-viz/src/components/TrendIndicator/utilities/estimateTrendIndicatorWidth.ts
@@ -1,18 +1,13 @@
 import {estimateStringWidthWithOffset} from '../../../utilities';
-import {
-  FONT_SIZE,
-  FONT_WEIGHT,
-  ICON_SIZE,
-  NO_VALUE_WIDTH,
-  TEXT_ICON_SPACING,
-} from '../constants';
+import {ICON_SIZE, NO_VALUE_WIDTH, TEXT_ICON_SPACING} from '../constants';
 
 export function estimateTrendIndicatorWidth(
-  value,
-  fontWeight: number = FONT_WEIGHT,
+  value: string,
+  fontSize: number,
+  fontWeight: number,
 ) {
   const textWidth = value
-    ? estimateStringWidthWithOffset(value, FONT_SIZE, fontWeight)
+    ? estimateStringWidthWithOffset(value, fontSize, fontWeight)
     : NO_VALUE_WIDTH;
   const totalWidth = Math.round(ICON_SIZE + TEXT_ICON_SPACING + textWidth);
 

--- a/packages/polaris-viz/src/components/YAxis/YAxis.tsx
+++ b/packages/polaris-viz/src/components/YAxis/YAxis.tsx
@@ -1,13 +1,11 @@
-import {
-  clamp,
-  estimateStringWidth,
-  useChartContext,
-} from '@shopify/polaris-viz-core';
+import {clamp} from '@shopify/polaris-viz-core';
 
+import {estimateStringWidthWithOffset} from '../../utilities';
 import {SingleTextLine} from '../Labels';
 import {useTheme} from '../../hooks';
 import {LINE_HEIGHT} from '../../constants';
 import type {YAxisTick} from '../../types';
+import {getFontSize} from '../../utilities/getFontSize';
 
 interface Props {
   ticks: YAxisTick[];
@@ -29,14 +27,14 @@ export function YAxis({
   y,
 }: Props) {
   const selectedTheme = useTheme();
-  const {characterWidths} = useChartContext();
+  const fontSize = getFontSize();
 
   return (
     <g transform={`translate(${x},${y})`} aria-hidden="true">
       {ticks.map(({value, formattedValue, yOffset}) => {
-        const stringWidth = estimateStringWidth(
+        const stringWidth = estimateStringWidthWithOffset(
           formattedValue,
-          characterWidths,
+          fontSize,
         );
 
         const clampedWidth = clamp({
@@ -61,6 +59,7 @@ export function YAxis({
               y={0}
               ariaHidden={ariaHidden}
               color={selectedTheme.yAxis.labelColor}
+              fontSize={fontSize}
               targetWidth={clampedWidth}
               text={formattedValue}
               textAnchor="left"

--- a/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
+++ b/packages/polaris-viz/src/components/shared/GroupLabel/GroupLabel.tsx
@@ -1,7 +1,7 @@
-import {estimateStringWidth, useChartContext} from '@shopify/polaris-viz-core';
-
+import {estimateStringWidthWithOffset} from '../../../utilities';
+import {getFontSize} from '../../../utilities/getFontSize';
 import {useTheme} from '../../../hooks';
-import {FONT_SIZE, HORIZONTAL_GROUP_LABEL_HEIGHT} from '../../../constants';
+import {HORIZONTAL_GROUP_LABEL_HEIGHT} from '../../../constants';
 
 import styles from './GroupLabel.scss';
 
@@ -20,12 +20,14 @@ export function GroupLabel({
   label,
   zeroPosition,
 }: GroupLabelProps) {
-  const {characterWidths} = useChartContext();
+  const fontSize = getFontSize();
 
-  const labelWidth = estimateStringWidth(label, characterWidths);
+  const labelWidth = estimateStringWidthWithOffset(label, fontSize);
   const selectedTheme = useTheme();
 
-  const maxWidth = areAllNegative ? labelWidth : containerWidth - zeroPosition;
+  const maxWidth = areAllNegative
+    ? labelWidth + LABEL_RIGHT_PADDING
+    : containerWidth - zeroPosition;
 
   return (
     <foreignObject
@@ -38,7 +40,7 @@ export function GroupLabel({
         className={styles.Label}
         style={{
           background: selectedTheme.chartContainer.backgroundColor,
-          fontSize: `${FONT_SIZE}px`,
+          fontSize: `${fontSize}px`,
           color: selectedTheme.yAxis.labelColor,
           maxWidth,
           height: HORIZONTAL_GROUP_LABEL_HEIGHT,

--- a/packages/polaris-viz/src/components/shared/GroupLabel/tests/GroupLabel.test.tsx
+++ b/packages/polaris-viz/src/components/shared/GroupLabel/tests/GroupLabel.test.tsx
@@ -46,7 +46,7 @@ describe('<GroupLabel />', () => {
 
       const object = label.find('foreignObject');
 
-      expect(object?.props.x).toStrictEqual(-100);
+      expect(object?.props.x).toStrictEqual(-92);
     });
 
     it('positions label at 0 when false', () => {
@@ -70,7 +70,7 @@ describe('<GroupLabel />', () => {
 
       const object = label.find('foreignObject');
 
-      expect(object?.props.x).toStrictEqual(-80);
+      expect(object?.props.x).toStrictEqual(-72);
     });
 
     it('renders max-width when true', () => {
@@ -82,7 +82,7 @@ describe('<GroupLabel />', () => {
 
       const div = label.find('div');
 
-      expect(div?.props?.style?.maxWidth).toStrictEqual(100);
+      expect(div?.props?.style?.maxWidth).toStrictEqual(107);
     });
 
     it('renders max-width when false', () => {

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -3,15 +3,18 @@ import type {ScaleLinear} from 'd3-scale';
 import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
 import {
   getColorVisionEventAttrs,
-  estimateStringWidth,
   COLOR_VISION_SINGLE_ITEM,
   useChartContext,
   clamp,
 } from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../utilities/getFontSize';
 import {getTrendIndicatorData} from '../../../utilities/getTrendIndicatorData';
 import {TREND_INDICATOR_HEIGHT, TrendIndicator} from '../../TrendIndicator';
-import {getHoverZoneOffset} from '../../../utilities';
+import {
+  estimateStringWidthWithOffset,
+  getHoverZoneOffset,
+} from '../../../utilities';
 import {
   HORIZONTAL_BAR_LABEL_OFFSET,
   HORIZONTAL_GROUP_LABEL_HEIGHT,
@@ -59,7 +62,9 @@ export function HorizontalBars({
   areAllNegative,
 }: HorizontalBarsProps) {
   const selectedTheme = useTheme();
-  const {characterWidths, theme} = useChartContext();
+  const {theme} = useChartContext();
+
+  const fontSize = getFontSize();
 
   const [activeBarIndex, setActiveBarIndex] = useState(-1);
 
@@ -102,7 +107,7 @@ export function HorizontalBars({
             data[seriesIndex]?.metadata?.trends[groupIndex],
           );
 
-        const labelWidth = estimateStringWidth(`${label}`, characterWidths);
+        const labelWidth = estimateStringWidthWithOffset(`${label}`, fontSize);
 
         function getBarWidthAndLabelX() {
           const width = Math.abs(xScale(value ?? 0) - xScale(0));
@@ -168,6 +173,7 @@ export function HorizontalBars({
                 <Label
                   barHeight={barHeight}
                   color={selectedTheme.xAxis.labelColor}
+                  fontSize={fontSize}
                   label={label}
                   labelWidth={labelWidth}
                   y={y}

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/tests/HorizontalBars.test.tsx
@@ -200,7 +200,7 @@ describe('<HorizontalBars />', () => {
 
       const labels = chart.findAll(LabelWrapper);
 
-      expect(labels[0].props.x).toStrictEqual(-225);
+      expect(labels[0].props.x).toStrictEqual(-217);
     });
   });
 
@@ -253,7 +253,7 @@ describe('<HorizontalBars />', () => {
       const wrapper = chart.find(LabelWrapper)?.findAll('g');
 
       expect(wrapper && wrapper[1]?.prop('transform')).toStrictEqual(
-        'translate(110, 2)',
+        'translate(102, 2)',
       );
     });
   });

--- a/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalStackedBars/HorizontalStackedBars.tsx
@@ -5,11 +5,11 @@ import {
   COLOR_VISION_SINGLE_ITEM,
   BORDER_RADIUS,
   useChartContext,
-  estimateStringWidth,
 } from '@shopify/polaris-viz-core';
 
+import {getFontSize} from '../../../utilities/getFontSize';
 import {useWatchColorVisionEvents, useTheme} from '../../../hooks';
-import {getBarId} from '../../../utilities';
+import {estimateStringWidthWithOffset, getBarId} from '../../../utilities';
 import {
   HORIZONTAL_GROUP_LABEL_HEIGHT,
   HORIZONTAL_BAR_LABEL_OFFSET,
@@ -76,9 +76,11 @@ export function HorizontalStackedBars({
   labelFormatter,
 }: HorizontalStackedBarsProps) {
   const selectedTheme = useTheme();
-  const {theme, characterWidths} = useChartContext();
+  const {theme} = useChartContext();
   const [activeBarIndex, setActiveBarIndex] = useState(-1);
   const hideGroupLabel = selectedTheme.groupLabel.hide;
+
+  const fontSize = getFontSize();
 
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
@@ -118,7 +120,7 @@ export function HorizontalStackedBars({
   const isNegative = groupSum && groupSum < 0;
   const label = labelFormatter(groupSum);
 
-  const labelWidth = estimateStringWidth(`${label}`, characterWidths);
+  const labelWidth = estimateStringWidthWithOffset(`${label}`, fontSize);
 
   const minGroupStartPoint = stackedValues[groupIndex].reduce((min, item) => {
     const start = item[0];
@@ -191,6 +193,7 @@ export function HorizontalStackedBars({
           <Label
             barHeight={barHeight}
             color={selectedTheme.xAxis.labelColor}
+            fontSize={fontSize}
             label={label}
             labelWidth={labelWidth}
             y={0}

--- a/packages/polaris-viz/src/components/shared/Label/Label.tsx
+++ b/packages/polaris-viz/src/components/shared/Label/Label.tsx
@@ -1,16 +1,24 @@
 import {FONT_FAMILY} from '@shopify/polaris-viz-core';
 
-import {HORIZONTAL_BAR_LABEL_HEIGHT, FONT_SIZE} from '../../../constants';
+import {HORIZONTAL_BAR_LABEL_HEIGHT} from '../../../constants';
 
 export interface LabelProps {
   barHeight: number;
   color: string;
+  fontSize: number;
   label: string;
   labelWidth: number;
   y: number;
 }
 
-export function Label({barHeight, color, label, labelWidth, y}: LabelProps) {
+export function Label({
+  barHeight,
+  color,
+  fontSize,
+  label,
+  labelWidth,
+  y,
+}: LabelProps) {
   const labelYOffset = barHeight / 2;
 
   return (
@@ -19,7 +27,7 @@ export function Label({barHeight, color, label, labelWidth, y}: LabelProps) {
       width={labelWidth}
       aria-hidden="true"
       y={y + labelYOffset}
-      fontSize={`${FONT_SIZE}px`}
+      fontSize={`${fontSize}px`}
       fontFamily={FONT_FAMILY}
       fill={color}
       dominantBaseline="central"

--- a/packages/polaris-viz/src/components/shared/Label/tests/Label.test.tsx
+++ b/packages/polaris-viz/src/components/shared/Label/tests/Label.test.tsx
@@ -11,6 +11,7 @@ jest.mock('@shopify/polaris-viz-core/src/utilities', () => ({
 const MOCK_PROPS: LabelProps = {
   barHeight: 15,
   color: 'red',
+  fontSize: 11,
   label: 'Label Text',
   labelWidth: 100,
   y: 20,

--- a/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
+++ b/packages/polaris-viz/src/hooks/useLinearLabelsAndDimensions.ts
@@ -1,13 +1,10 @@
 import {useMemo} from 'react';
 import type {DataSeries} from '@shopify/polaris-viz-core';
-import {
-  LINEAR_LABELS_INNER_PADDING,
-  estimateStringWidth,
-  clamp,
-  useChartContext,
-} from '@shopify/polaris-viz-core';
+import {LINEAR_LABELS_INNER_PADDING, clamp} from '@shopify/polaris-viz-core';
 
+import {estimateStringWidthWithOffset} from '../utilities';
 import {HORIZONTAL_LABEL_MIN_WIDTH} from '../constants';
+import {getFontSize} from '../utilities/getFontSize';
 
 import {useLinearXScale} from './useLinearXScale';
 import {useReducedLabelIndexes} from './useReducedLabelIndexes';
@@ -29,7 +26,7 @@ export function useLinearLabelsAndDimensions({
   labels,
   longestSeriesLength,
 }: Props) {
-  const {characterWidths} = useChartContext();
+  const fontSize = getFontSize();
 
   const longestSeriesLastIndex = useMemo(
     () =>
@@ -43,7 +40,7 @@ export function useLinearLabelsAndDimensions({
   const longestLabelWidth = useMemo(() => {
     const longestLabelWidth =
       labels.reduce((prev, cur) => {
-        const width = estimateStringWidth(cur, characterWidths);
+        const width = estimateStringWidthWithOffset(cur, fontSize);
 
         if (width > prev) {
           return width;
@@ -57,7 +54,7 @@ export function useLinearLabelsAndDimensions({
       min: 0,
       max: MAX_LINEAR_LABEL_WIDTH,
     });
-  }, [labels, characterWidths]);
+  }, [labels, fontSize]);
 
   const numberOfLabelsThatFit = Math.floor(
     initialDrawableWidth / longestLabelWidth,

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -112,6 +112,7 @@ export interface TooltipOptions extends TooltipFormatters {
 }
 
 export interface PreparedLabels {
+  fontSize: number;
   text: string;
   words: {word: string; wordWidth: number}[];
   truncatedWords: string[];
@@ -122,6 +123,7 @@ export interface PreparedLabels {
 export interface FormattedLine {
   height: number;
   truncatedText: string;
+  fontSize: number;
   fullText: string;
   textAnchor: string;
   width: number;

--- a/packages/polaris-viz/src/utilities/estimateStringWidthWithOffset.ts
+++ b/packages/polaris-viz/src/utilities/estimateStringWidthWithOffset.ts
@@ -6,7 +6,7 @@ import characterWidthOffsets from '../data/character-width-offsets.json';
 export function estimateStringWidthWithOffset(
   string: string,
   fontSize: number,
-  fontWeight: number,
+  fontWeight = 400,
 ) {
   const width = estimateStringWidth(string, characterWidths);
 

--- a/packages/polaris-viz/src/utilities/getFontSize.ts
+++ b/packages/polaris-viz/src/utilities/getFontSize.ts
@@ -1,0 +1,9 @@
+import {FONT_SIZE, TOUCH_FONT_SIZE} from '@shopify/polaris-viz-core';
+
+export function getFontSize() {
+  const isMobile = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+
+  const fontSize = isMobile ? TOUCH_FONT_SIZE : FONT_SIZE;
+
+  return fontSize;
+}

--- a/packages/polaris-viz/src/utilities/getTrendIndicatorData.ts
+++ b/packages/polaris-viz/src/utilities/getTrendIndicatorData.ts
@@ -1,12 +1,19 @@
 import type {MetaDataTrendIndicator} from 'types';
 
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {TREND_INDICATOR_FONT_WEIGHT} from '../components/TrendIndicator';
+import {FONT_SIZE} from '../constants';
 import {estimateTrendIndicatorWidth} from '../components';
 
 export function getTrendIndicatorData(
   trendMetadata: MetaDataTrendIndicator | undefined,
 ) {
   if (trendMetadata != null) {
-    const {totalWidth} = estimateTrendIndicatorWidth(trendMetadata.value ?? '');
+    const {totalWidth} = estimateTrendIndicatorWidth(
+      trendMetadata.value ?? '',
+      FONT_SIZE,
+      TREND_INDICATOR_FONT_WEIGHT,
+    );
 
     return {
       trendIndicatorProps: trendMetadata,

--- a/packages/polaris-viz/src/utilities/tests/getFontSize.test.tsx
+++ b/packages/polaris-viz/src/utilities/tests/getFontSize.test.tsx
@@ -1,0 +1,32 @@
+import {FONT_SIZE, TOUCH_FONT_SIZE} from '@shopify/polaris-viz-core';
+
+import {getFontSize} from '../getFontSize';
+
+const originalWindow = {...window};
+
+describe('getFontSize()', () => {
+  afterEach(() => {
+    // eslint-disable-next-line no-global-assign
+    window = {...originalWindow};
+  });
+
+  it('returns default font size', () => {
+    expect(getFontSize()).toStrictEqual(FONT_SIZE);
+  });
+
+  it('returns mobile font size when ontouchstart is in window', () => {
+    Object.defineProperty(window, 'ontouchstart', {
+      value: () => {},
+    });
+
+    expect(getFontSize()).toStrictEqual(TOUCH_FONT_SIZE);
+  });
+
+  it('returns mobile font size when maxTouchPoints is greater than 0', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: 1,
+    });
+
+    expect(getFontSize()).toStrictEqual(TOUCH_FONT_SIZE);
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?

Resolves https://github.com/Shopify/core-issues/issues/80051

Change all the font-sizes to `14px` when on a mobile/touch device. This applies to legends, labels and values for all charts. 

## What do the changes look like?

**Desktop**

![image](https://github.com/user-attachments/assets/2cc301bb-a5c2-4fcf-b131-a7d3a2ebddc9)

**Mobile/Touch**

![image](https://github.com/user-attachments/assets/4a92b577-4497-4946-b9f0-7e584274aeb7)

## Storybook link

https://6062ad4a2d14cd0021539c1b-xwoqqwlwwf.chromatic.com/

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
