### PR TITLE
Disable the touch font size

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -9,7 +9,7 @@ import {InternalChartType, ChartState, Hue} from './types';
 export const LINE_HEIGHT = 14;
 export const SMALL_CHART_HEIGHT = 125;
 export const FONT_SIZE = 11;
-export const TOUCH_FONT_SIZE = 14;
+export const TOUCH_FONT_SIZE = 11;
 
 export const FONT_FAMILY =
   'Inter, -apple-system, "system-ui", "San Francisco", "Segoe UI", Roboto, "Helvetica Neue", sans-serif';

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Removed
+
+- Reverted `TOUCH_FONT_SIZE` constant to 11px.
 
 ## [15.3.1] - 2024-11-18
 


### PR DESCRIPTION
## What does this implement/fix?

Based on feedback from @carysmills on https://github.com/Shopify/web/pull/148498#pullrequestreview-2443648407 - we're going to "disable" the touch font size until we can come up with a solution for `HorizontalBarChart`.
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
