### PR TITLE
Change touch font size to 12px

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -9,7 +9,7 @@ import {InternalChartType, ChartState, Hue} from './types';
 export const LINE_HEIGHT = 14;
 export const SMALL_CHART_HEIGHT = 125;
 export const FONT_SIZE = 11;
-export const TOUCH_FONT_SIZE = 11;
+export const TOUCH_FONT_SIZE = 12;
 
 export const FONT_FAMILY =
   'Inter, -apple-system, "system-ui", "San Francisco", "Segoe UI", Roboto, "Helvetica Neue", sans-serif';

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,9 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Removed
+### Changed
 
-- Reverted `TOUCH_FONT_SIZE` constant to 11px.
+- Changed `TOUCH_FONT_SIZE` constant to `12px`.
 
 ## [15.3.1] - 2024-11-18
 


### PR DESCRIPTION
## What does this implement/fix?

Based on feedback in https://github.com/Shopify/web/pull/148498#pullrequestreview-2443648407 we want to change the touch font size to `12px`.

Before we reverted, it was `14px`. @pabmtl and I decided that `12px` should address the sizing issues.

## What do the changes look like?

https://6062ad4a2d14cd0021539c1b-zxnowkgpzy.chromatic.com/
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
