### PR TITLE
Fix issue where legends would get formatted twice

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where `<DonutChart />` would run the `seriesNameFormatter` for multiple times on a `<Legend />`.
 
 ## [15.3.3] - 2024-12-02
 

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
@@ -142,7 +142,6 @@ export function LegendValues({
                 longestLegendValueWidth={longestLegendValueWidth}
                 maxTrendIndicatorWidth={maxTrendIndicatorWidth}
                 seriesColors={seriesColors}
-                seriesNameFormatter={seriesNameFormatter}
                 onDimensionChange={(dimensions) => {
                   if (legendItemDimensions.current) {
                     legendItemDimensions.current[index] = dimensions;
@@ -166,7 +165,6 @@ export function LegendValues({
           label={renderHiddenLegendLabel(allData.length - displayedData.length)}
           lastVisibleIndex={allData.length - hiddenData.length}
           setActivatorWidth={() => null}
-          seriesNameFormatter={seriesNameFormatter}
         />
       )}
     </React.Fragment>

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/components/LegendValueItem/LegendValueItem.tsx
@@ -23,7 +23,6 @@ interface Props {
   labelFormatter: LabelFormatter;
   longestLegendValueWidth: number;
   seriesColors: Color[];
-  seriesNameFormatter: LabelFormatter;
   maxTrendIndicatorWidth: number;
   onDimensionChange: (dimensions: Dimensions) => void;
   getColorVisionStyles: ColorVisionInteractionMethods['getColorVisionStyles'];
@@ -38,7 +37,6 @@ export function LegendValueItem({
   longestLegendValueWidth,
   trend,
   seriesColors,
-  seriesNameFormatter,
   maxTrendIndicatorWidth,
   onDimensionChange,
   getColorVisionStyles,
@@ -79,7 +77,7 @@ export function LegendValueItem({
         }}
         title={name}
       >
-        <span>{seriesNameFormatter(name)}</span>
+        <span>{name}</span>
       </td>
 
       <td className={styles.alignRight} width={longestLegendValueWidth}>

--- a/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/components/HiddenLegendTooltip.tsx
@@ -13,7 +13,6 @@ import {
   useChartContext,
   useTheme,
 } from '@shopify/polaris-viz-core';
-import type {LabelFormatter} from '@shopify/polaris-viz-core';
 
 import {getFontSize} from '../../../utilities/getFontSize';
 import type {LegendData} from '../../../types';
@@ -34,7 +33,6 @@ interface Props {
   setActivatorWidth: (width: number) => void;
   theme?: string;
   lastVisibleIndex?: number;
-  seriesNameFormatter?: LabelFormatter;
 }
 
 export const LEGEND_TOOLTIP_ID = 'legend-toolip';
@@ -48,7 +46,6 @@ export function HiddenLegendTooltip({
   label,
   lastVisibleIndex = 0,
   setActivatorWidth,
-  seriesNameFormatter,
 }: Props) {
   const selectedTheme = useTheme();
   const {isFirefox} = useBrowserCheck();
@@ -173,7 +170,6 @@ export function HiddenLegendTooltip({
             theme={theme}
             indexOffset={lastVisibleIndex}
             backgroundColor="transparent"
-            seriesNameFormatter={seriesNameFormatter}
           />
         </div>,
         container,

--- a/packages/polaris-viz/src/components/LegendContainer/tests/LegendsContainer.test.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/tests/LegendsContainer.test.tsx
@@ -3,10 +3,10 @@ import {useChartContext} from '@shopify/polaris-viz-core';
 
 import type {LegendContainerProps} from '../LegendContainer';
 import {LegendContainer} from '../LegendContainer';
-import {Legend, LegendItem} from '../../Legend';
+import {Legend} from '../../Legend';
 import {HiddenLegendTooltip} from '../components/HiddenLegendTooltip';
 
-const WIDTH_WITH_OVERFLOW = 0;
+const WIDTH_WITH_OVERFLOW = 10;
 const WIDTH_WITHOUT_OVERFLOW = 100;
 
 const mockProps: LegendContainerProps = {
@@ -29,12 +29,6 @@ jest.mock('../../../hooks/useResizeObserver', () => {
     },
   };
 });
-
-jest.mock('@shopify/polaris-viz-core/src/hooks/useChartContext', () => ({
-  useChartContext: jest.fn(() => ({
-    containerBounds: {height: 300, width: 100},
-  })),
-}));
 
 const mockUseChartContext = useChartContext as jest.Mock;
 
@@ -166,6 +160,7 @@ describe('<LegendContainer />', () => {
 
     it('renders a custom label if provided', () => {
       mockUseChartContext.mockReturnValue({
+        ...mockUseChartContext(),
         containerBounds: {height: 300, width: WIDTH_WITH_OVERFLOW},
       });
 

--- a/packages/polaris-viz/src/components/SparkLineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/SparkLineChart/tests/Chart.test.tsx
@@ -26,7 +26,7 @@ describe('<Chart />', () => {
     const offsetLeft = 100;
     const offsetRight = 50;
     const margin = 2;
-    const mockWidth = 0;
+    const mockWidth = 600;
 
     mount(
       <Chart

--- a/packages/polaris-viz/src/components/TooltipContent/hooks/tests/useGetLongestLabelFromData.test.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/hooks/tests/useGetLongestLabelFromData.test.tsx
@@ -4,22 +4,6 @@ import {mount} from '@shopify/react-testing';
 import {useGetLongestLabelFromData} from '../useGetLongestLabelFromData';
 import type {TooltipData} from '../../../../types';
 
-jest.mock('react', () => {
-  return {
-    ...jest.requireActual('react'),
-    useContext: () => ({
-      characterWidths: {
-        // eslint-disable-next-line id-length
-        a: 1,
-        // eslint-disable-next-line id-length
-        b: 1,
-        1: 1,
-        0: 1,
-      },
-    }),
-  };
-});
-
 function parseData(result: Root<any>) {
   return JSON.parse(result.domNode?.dataset.data ?? '');
 }
@@ -54,7 +38,7 @@ describe('useGetLongestLabelFromData()', () => {
 
     const data = parseData(result);
 
-    expect(data).toStrictEqual({keyWidth: 1, valueWidth: 4});
+    expect(data).toStrictEqual({keyWidth: 6.63, valueWidth: 22.32});
   });
 
   it('does not throw error when data is missing', () => {

--- a/packages/polaris-viz/src/hooks/ColorVisionA11y/tests/useWatchColorVisionEvents.test.tsx
+++ b/packages/polaris-viz/src/hooks/ColorVisionA11y/tests/useWatchColorVisionEvents.test.tsx
@@ -1,5 +1,9 @@
+import {mount} from '@shopify/react-testing';
+import {useChartContext} from '@shopify/polaris-viz-core';
+
 import {useWatchColorVisionEvents} from '../useWatchColorVisionEvents';
-import {mountWithChartContext} from '../../../test-utilities/mountWithChartContext';
+
+const mockUseChartContext = useChartContext as jest.Mock;
 
 describe('useWatchColorVisionEvents', () => {
   let events: {[key: string]: any} = {};
@@ -35,12 +39,17 @@ describe('useWatchColorVisionEvents', () => {
       return null;
     }
 
-    mountWithChartContext(<TestComponent />, {id: null});
+    mount(<TestComponent />);
 
     expect(Object.keys(events)).toHaveLength(0);
   });
 
   it('attaches events to the window', () => {
+    mockUseChartContext.mockReturnValue({
+      ...mockUseChartContext(),
+      id: '123',
+    });
+
     function TestComponent() {
       useWatchColorVisionEvents({
         type: 'someType',
@@ -50,9 +59,7 @@ describe('useWatchColorVisionEvents', () => {
       return null;
     }
 
-    mountWithChartContext(<TestComponent />, {
-      id: '123',
-    });
+    mount(<TestComponent />);
 
     expect(Object.keys(events)).toHaveLength(1);
     expect(Object.keys(events)[0]).toStrictEqual(
@@ -61,6 +68,11 @@ describe('useWatchColorVisionEvents', () => {
   });
 
   it('responds to event', () => {
+    mockUseChartContext.mockReturnValue({
+      ...mockUseChartContext(),
+      id: '123',
+    });
+
     const spy = jest.fn();
 
     function TestComponent() {
@@ -72,9 +84,7 @@ describe('useWatchColorVisionEvents', () => {
       return null;
     }
 
-    mountWithChartContext(<TestComponent />, {
-      id: '123',
-    });
+    mount(<TestComponent />);
 
     events['123:color-vision-event:someType']();
 

--- a/packages/polaris-viz/src/hooks/tests/useLinearChartAnimations.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useLinearChartAnimations.test.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable react/jsx-no-constructed-context-values */
 import {mount} from '@shopify/react-testing';
 import {line} from 'd3-shape';
 import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
-import {ChartContext} from '@shopify/polaris-viz-core';
+import {useChartContext} from '@shopify/polaris-viz-core';
 
+import type {Props} from '../useLinearChartAnimations';
 import {useLinearChartAnimations} from '../useLinearChartAnimations';
-import characterWidths from '../../data/character-widths.json';
-import characterWidthOffsets from '../../data/character-width-offsets.json';
 
 jest.mock('../../utilities/getPathLength', () => {
   return {
@@ -26,6 +24,8 @@ const lineGeneratorMock = jest.fn(
     .y(({value}) => value),
 ) as any;
 
+const mockUseChartContext = useChartContext as jest.Mock;
+
 const data: LineChartDataSeriesWithDefaults[] = [
   {
     name: 'Primary',
@@ -43,14 +43,20 @@ const data: LineChartDataSeriesWithDefaults[] = [
   },
 ];
 
-const mockProps = {
+const mockProps: Props = {
   activeIndex: 0,
   lineGenerator: lineGeneratorMock,
   data,
-  isAnimated: true,
 };
 
 describe('useLinearChartAnimations', () => {
+  beforeEach(() => {
+    mockUseChartContext.mockReturnValue({
+      ...mockUseChartContext(),
+      shouldAnimate: true,
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -111,17 +117,12 @@ describe('useLinearChartAnimations', () => {
       return null;
     }
 
-    mount(
-      <ChartContext.Provider
-        value={{
-          characterWidths,
-          characterWidthOffsets,
-          shouldAnimate: false,
-        }}
-      >
-        <TestComponent />
-      </ChartContext.Provider>,
-    );
+    mockUseChartContext.mockReturnValue({
+      ...mockUseChartContext(),
+      shouldAnimate: false,
+    });
+
+    mount(<TestComponent />);
 
     expect(lineGeneratorMock).not.toHaveBeenCalled();
   });

--- a/packages/polaris-viz/src/hooks/useLinearChartAnimations.tsx
+++ b/packages/polaris-viz/src/hooks/useLinearChartAnimations.tsx
@@ -13,15 +13,17 @@ export const SPRING_CONFIG = {
   tension: 190,
 };
 
+export interface Props {
+  activeIndex: number | null;
+  lineGenerator: Line<DataPoint>;
+  data: DataSeries[];
+}
+
 export function useLinearChartAnimations({
   activeIndex,
   lineGenerator,
   data,
-}: {
-  activeIndex: number | null;
-  lineGenerator: Line<DataPoint>;
-  data: DataSeries[];
-}) {
+}: Props) {
   const {shouldAnimate} = useChartContext();
 
   const currentIndex = activeIndex == null ? 0 : activeIndex;

--- a/tests/setup/tests.ts
+++ b/tests/setup/tests.ts
@@ -19,6 +19,29 @@ jest.mock('../../packages/polaris-viz/src/components/ChartContainer', () => {
   };
 });
 
+jest.mock('../../packages/polaris-viz-core/src/hooks/useChartContext', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const characterWidths = require('../../packages/polaris-viz/src/data/character-widths.json');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const characterWidthOffsets = require('../../packages/polaris-viz/src/data/character-width-offsets.json');
+
+  return {
+    useChartContext: jest.fn().mockReturnValue({
+      shouldAnimate: false,
+      id: null,
+      characterWidths,
+      characterWidthOffsets,
+      theme: 'Light',
+      isTouchDevice: false,
+      isPerformanceImpacted: false,
+      containerBounds: {
+        width: 600,
+        height: 400,
+      },
+    }),
+  };
+});
+
 jest.mock(
   '../../packages/polaris-viz-core/src/styles/shared/_variables.scss',
   () => {


### PR DESCRIPTION
## What does this implement/fix?

We were running `seriesNameFormatter` multiple times on a `<Legend />` in the `<DonutChart />` component.

This is causing issues in web because the `i18n.translate` function is running the second time on a formatted value, which throws a bugsnag error.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/44e7eb46-d4c2-40c0-af5a-1ec0975635cc)|![image](https://github.com/user-attachments/assets/d8dc033a-36b8-4900-bc64-56b9920c6e2f)|

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
