### PR TITLE
Fix story colors and remove unused renderCustomTooltip controls

### DIFF
--- a/packages/polaris-viz/src/components/BarChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/InteractiveCustomLegend.stories.tsx
@@ -10,7 +10,7 @@ import {DEFAULT_DATA, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/BarChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/data.tsx
@@ -1,49 +1,11 @@
 import type {DataSeries} from '@shopify/polaris-viz-core';
 import type {Story} from '@storybook/react';
 
-import {SquareColorPreview} from '../../SquareColorPreview';
-import type {RenderTooltipContentData} from '../../../types';
 import type {BarChartProps} from '../BarChart';
 import {BarChart} from '../BarChart';
 
 export const Template: Story<BarChartProps> = (args: BarChartProps) => {
   return <BarChart {...args} />;
-};
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: (tooltipData: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          padding: '8px',
-          borderRadius: '4px',
-          color: 'white',
-        }}
-      >
-        {tooltipData.title}
-        <div>
-          {tooltipData.data[0].data.map(({key, value, color}) => (
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '12px 1fr 1fr',
-                gridGap: '5px',
-                fontSize: '12px',
-                marginTop: '4px',
-              }}
-              key={key}
-            >
-              <SquareColorPreview color={color!} />
-              <div>{key}</div>
-              <div style={{textAlign: 'right'}}>{value}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  },
 };
 
 export const DEFAULT_DATA: DataSeries[] = [

--- a/packages/polaris-viz/src/components/BarChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/meta.tsx
@@ -1,5 +1,6 @@
 import type {Meta} from '@storybook/react';
 
+import type {BarChartProps} from '../../../components';
 import {BarChart} from '../../../components';
 import {
   ANNOTATIONS_ARGS,
@@ -13,7 +14,6 @@ import {
   MAX_SERIES_ARGS,
   RENDER_BUCKET_LEGEND_LABEL_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
-  RENDER_TOOLTIP_DESCRIPTION,
   SKIP_LINK_ARGS,
   THEME_CONTROL_ARGS,
   TYPE_CONTROL_ARGS,
@@ -22,9 +22,7 @@ import {
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 
-import {TOOLTIP_CONTENT} from './data';
-
-export const META: Meta = {
+export const META: Meta<BarChartProps> = {
   title: 'polaris-viz/Charts/BarChart',
   component: BarChart,
   parameters: {
@@ -48,18 +46,6 @@ export const META: Meta = {
     skipLinkText: SKIP_LINK_ARGS,
     xAxisOptions: X_AXIS_OPTIONS_ARGS,
     yAxisOptions: Y_AXIS_OPTIONS_ARGS,
-    renderTooltipContent: {
-      options: Object.keys(TOOLTIP_CONTENT),
-      mapping: TOOLTIP_CONTENT,
-      control: {
-        type: 'select',
-        labels: {
-          empty: 'Default',
-          Annotation: 'Custom',
-        },
-      },
-      description: RENDER_TOOLTIP_DESCRIPTION,
-    },
     direction: DIRECTION_CONTROL_ARGS,
     theme: THEME_CONTROL_ARGS,
     state: CHART_STATE_CONTROL_ARGS,

--- a/packages/polaris-viz/src/components/ComboChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/stories/InteractiveCustomLegend.stories.tsx
@@ -43,7 +43,7 @@ const LEGEND_ITEMS_DATA = [
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/DonutChart/stories/CustomInnerValueContent.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/CustomInnerValueContent.stories.tsx
@@ -38,6 +38,7 @@ CustomInnerValueContent.args = {
             style={{
               fontSize: 36,
               margin: 0,
+              color: 'black',
               ...numberStyles,
             }}
           >
@@ -50,6 +51,7 @@ CustomInnerValueContent.args = {
             alignItems: 'center',
             gap: 4,
             margin: '8px 0',
+            color: 'black',
           }}
         >
           Total:
@@ -57,6 +59,7 @@ CustomInnerValueContent.args = {
             style={{
               fontSize: 20,
               ...numberStyles,
+              color: 'black',
             }}
           >
             {animatedTotalValue}

--- a/packages/polaris-viz/src/components/DonutChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/InteractiveCustomLegend.stories.tsx
@@ -10,7 +10,7 @@ import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/LineChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/InteractiveCustomLegend.stories.tsx
@@ -10,7 +10,7 @@ import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/LineChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/data.tsx
@@ -1,5 +1,4 @@
 import type {Story} from '@storybook/react';
-import type {RenderTooltipContentData} from 'types';
 
 import type {LineChartProps} from '../LineChart';
 import {LineChart} from '../LineChart';
@@ -7,32 +6,6 @@ import {
   formatLinearXAxisLabel,
   formatLinearYAxisLabel,
 } from '../../../storybook/utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${formatLinearYAxisLabel(
-            Number(value!),
-          )}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
 
 export const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return <LineChart {...args} />;

--- a/packages/polaris-viz/src/components/LineChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/meta.tsx
@@ -9,7 +9,6 @@ import {
   IS_ANIMATED_ARGS,
   LEGEND_CONTROL_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
-  RENDER_TOOLTIP_DESCRIPTION,
   SKIP_LINK_ARGS,
   THEME_CONTROL_ARGS,
   X_AXIS_OPTIONS_ARGS,
@@ -17,8 +16,6 @@ import {
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 import {LineChart} from '../LineChart';
-
-import {TOOLTIP_CONTENT} from './data';
 
 export const META: Meta = {
   title: 'polaris-viz/Charts/LineChart',
@@ -40,11 +37,6 @@ export const META: Meta = {
     emptyStateText: EMPTY_STATE_TEXT_ARGS,
     isAnimated: IS_ANIMATED_ARGS,
     renderLegendContent: RENDER_LEGEND_CONTENT_ARGS,
-    renderTooltipContent: {
-      options: Object.keys(TOOLTIP_CONTENT),
-      mapping: TOOLTIP_CONTENT,
-      description: RENDER_TOOLTIP_DESCRIPTION,
-    },
     skipLinkText: SKIP_LINK_ARGS,
     yAxisOptions: Y_AXIS_OPTIONS_ARGS,
     theme: THEME_CONTROL_ARGS,

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/data.tsx
@@ -1,5 +1,4 @@
 import type {Story} from '@storybook/react';
-import type {RenderTooltipContentData} from 'types';
 import type {DataSeries} from '@shopify/polaris-viz-core';
 import {LIGHT_THEME} from '@shopify/polaris-viz-core';
 import type {LineChartProps} from 'components/LineChart/LineChart';
@@ -10,32 +9,6 @@ import {
   formatLinearYAxisLabel,
 } from '../../../storybook/utilities';
 import {renderLinearTooltipContent} from '../../../utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${formatLinearYAxisLabel(
-            Number(value!),
-          )}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
 
 export const Template: Story<LineChartProps> = (args: LineChartProps) => {
   return <LineChartRelational {...args} />;

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/meta.tsx
@@ -9,7 +9,6 @@ import {
   IS_ANIMATED_ARGS,
   LEGEND_CONTROL_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
-  RENDER_TOOLTIP_DESCRIPTION,
   SKIP_LINK_ARGS,
   THEME_CONTROL_ARGS,
   X_AXIS_OPTIONS_ARGS,
@@ -17,8 +16,6 @@ import {
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 import {LineChartRelational} from '../LineChartRelational';
-
-import {TOOLTIP_CONTENT} from './data';
 
 export const META: Meta = {
   title: 'polaris-viz/Charts/LineChartRelational',
@@ -40,11 +37,6 @@ export const META: Meta = {
     emptyStateText: EMPTY_STATE_TEXT_ARGS,
     isAnimated: IS_ANIMATED_ARGS,
     renderLegendContent: RENDER_LEGEND_CONTENT_ARGS,
-    renderTooltipContent: {
-      options: Object.keys(TOOLTIP_CONTENT),
-      mapping: TOOLTIP_CONTENT,
-      description: RENDER_TOOLTIP_DESCRIPTION,
-    },
     skipLinkText: SKIP_LINK_ARGS,
     yAxisOptions: Y_AXIS_OPTIONS_ARGS,
     theme: THEME_CONTROL_ARGS,

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/InteractiveCustomLegend.stories.tsx
@@ -10,7 +10,7 @@ import {SERIES, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleNormalizedChart/stories/InteractiveCustomLegend.stories.tsx
@@ -12,7 +12,7 @@ const LABELS = ['Apple', 'Facebook', 'Netflix', 'Google'];
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/InteractiveCustomLegend.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/InteractiveCustomLegend.stories.tsx
@@ -10,7 +10,7 @@ import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
 
 const liStyles = {
   alignItems: 'center',
-  color: 'white',
+  color: 'black',
   display: 'flex',
   fontWeight: 'bold',
   gap: 4,

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/data.tsx
@@ -1,34 +1,9 @@
 import type {DataSeries} from '@shopify/polaris-viz-core';
 import type {Story} from '@storybook/react';
 
-import type {RenderTooltipContentData} from '../../../types';
 import type {StackedAreaChartProps} from '../StackedAreaChart';
 import {StackedAreaChart} from '../StackedAreaChart';
 import {formatLinearYAxisLabel} from '../../../storybook/utilities';
-
-export const TOOLTIP_CONTENT = {
-  empty: undefined,
-  Custom: ({data}: RenderTooltipContentData) => {
-    return (
-      <div
-        style={{
-          background: 'black',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          fontSize: 12,
-        }}
-      >
-        {data[0].data.map(({key, value}) => (
-          // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
-          <div key={key}>{`${key}: ${value}`}</div>
-        ))}
-      </div>
-    );
-  },
-};
 
 export const DEFAULT_PROPS = {
   skipLinkText: 'Skip chart content',

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/meta.tsx
@@ -8,7 +8,6 @@ import {
   IS_ANIMATED_ARGS,
   LEGEND_CONTROL_ARGS,
   RENDER_LEGEND_CONTENT_ARGS,
-  RENDER_TOOLTIP_DESCRIPTION,
   SKIP_LINK_ARGS,
   THEME_CONTROL_ARGS,
   X_AXIS_OPTIONS_ARGS,
@@ -16,8 +15,6 @@ import {
 } from '../../../storybook/constants';
 import {PageWithSizingInfo} from '../../Docs/stories';
 import {StackedAreaChart} from '../StackedAreaChart';
-
-import {TOOLTIP_CONTENT} from './data';
 
 export const META: Meta = {
   title: 'polaris-viz/Charts/StackedAreaChart',
@@ -40,11 +37,6 @@ export const META: Meta = {
     isAnimated: IS_ANIMATED_ARGS,
     yAxisOptions: Y_AXIS_OPTIONS_ARGS,
     renderLegendContent: RENDER_LEGEND_CONTENT_ARGS,
-    renderTooltipContent: {
-      options: Object.keys(TOOLTIP_CONTENT),
-      mapping: TOOLTIP_CONTENT,
-      description: RENDER_TOOLTIP_DESCRIPTION,
-    },
     skipLinkText: SKIP_LINK_ARGS,
     theme: THEME_CONTROL_ARGS,
     state: CHART_STATE_CONTROL_ARGS,

--- a/packages/polaris-viz/src/storybook/constants.ts
+++ b/packages/polaris-viz/src/storybook/constants.ts
@@ -76,9 +76,6 @@ export const RENDER_BUCKET_LEGEND_LABEL_ARGS = {
     'This accepts a function that is called to render the bucket legend label shown when series are bucketed. Defaults to "Other".',
 };
 
-export const RENDER_TOOLTIP_DESCRIPTION =
-  'This accepts a function that is called to render the tooltip content. When necessary it calls `formatXAxisLabel` and/or `formatYAxisLabel` to format the `DataSeries[]` values and passes them to `<TooltipContent />`. [RenderTooltipContentData type definition.](https://polaris-viz.shopify.com/?path=/docs/polaris-viz-subcomponents-tooltipcontent-rendertooltipcontent--page)';
-
 export const DATA_ARGS = {
   description:
     'A collection of named data sets to be rendered in the chart. An optional color can be provided for each series, to overwrite the theme `seriesColors` defined in `PolarisVizProvider`',


### PR DESCRIPTION
## What does this implement/fix?

We had a few stories that were still using `white` text from when we defaulted to `dark` theme so it looked like the story was broken.

Also, we had storybook controls for `renderCustomTooltip` that are no longer working since we moved that prop into `tooltipOptions`.

There's no way to render controls for object props [without a plugin](https://www.npmjs.com/package/storybook-addon-deep-controls). It doesn't seem worth it to get the plugin setup, so I'm removing the dead code.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/07931482-27f2-4357-99c6-cb40491b5af6)|![image](https://github.com/user-attachments/assets/07b0286b-86a6-4c7e-bb04-1891441f640d)|

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
