### PR TITLE
Bar chart labels to partially display like Linear charts

### DIFF
--- a/packages/polaris-viz/src/components/BarChart/stories/MonthlyReport.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/MonthlyReport.stories.tsx
@@ -1,0 +1,18 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {BarChartProps} from '../../../components';
+
+import {MONTHLY_REPORT_DATA, Template} from './data';
+
+export const MonthlyReport: Story<BarChartProps> = Template.bind({});
+
+console.log(MONTHLY_REPORT_DATA);
+
+MonthlyReport.args = {
+  data: MONTHLY_REPORT_DATA,
+  onError: (a, b) => {
+    console.log({a, b});
+  },
+};

--- a/packages/polaris-viz/src/components/BarChart/stories/MonthlyReport.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/MonthlyReport.stories.tsx
@@ -8,8 +8,6 @@ import {MONTHLY_REPORT_DATA, Template} from './data';
 
 export const MonthlyReport: Story<BarChartProps> = Template.bind({});
 
-console.log(MONTHLY_REPORT_DATA);
-
 MonthlyReport.args = {
   data: MONTHLY_REPORT_DATA,
   onError: (a, b) => {

--- a/packages/polaris-viz/src/components/BarChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/data.tsx
@@ -8,6 +8,29 @@ export const Template: Story<BarChartProps> = (args: BarChartProps) => {
   return <BarChart {...args} />;
 };
 
+const generateDataSeries = (length = 30) =>
+  Array(length)
+    .fill(0)
+    .map((value: number, index) => {
+      const date = new Date();
+      date.setDate(date.getDate() + value + index);
+
+      return {
+        key: date.toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+        }),
+        value: Math.floor(Math.random() * 1000),
+      };
+    });
+
+export const MONTHLY_REPORT_DATA: DataSeries[] = [
+  {
+    name: 'Current month',
+    data: generateDataSeries(),
+  },
+];
+
 export const DEFAULT_DATA: DataSeries[] = [
   {
     name: 'Breakfast',

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -235,7 +235,7 @@ export function Chart({
     annotationsLookupTable,
   );
 
-  const xAxisLabelHalf = xScale.bandwidth() / 2;
+  const xAxisLabelHalf = labelWidth / 2;
 
   return (
     <ChartElements.Div height={height} width={width}>
@@ -312,7 +312,7 @@ export function Chart({
           >
             <Annotations
               annotationsLookupTable={annotationsLookupTable}
-              axisLabelWidth={xScale.bandwidth()}
+              axisLabelWidth={labelWidth}
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               labels={unformattedLabels}

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -48,7 +48,7 @@ import {
   useBarChartTooltipContent,
   useColorVisionEvents,
   useTheme,
-  useReducedLabelIndexes,
+  useLinearLabelsAndDimensions,
 } from '../../hooks';
 
 import {VerticalBarGroup} from './components';
@@ -129,10 +129,6 @@ export function Chart({
       })
     : null;
 
-  const reducedLabelIndexes = useReducedLabelIndexes({
-    dataLength: data[0] ? data[0].data.length : 0,
-  });
-
   const {min, max} = getStackedMinMax({
     stackedValues,
     data,
@@ -210,6 +206,16 @@ export function Chart({
     labels: formattedLabels,
   });
 
+  const {
+    xAxisDetails: {reducedLabelIndexes, labelWidth},
+  } = useLinearLabelsAndDimensions({
+    data,
+    hideXAxis,
+    drawableWidth,
+    labels: formattedLabels,
+    longestSeriesLength: yAxisLabelWidth,
+  });
+
   const {ticks, yScale} = useYScale({
     ...yScaleOptions,
     drawableHeight,
@@ -244,7 +250,7 @@ export function Chart({
           <XAxis
             allowLineWrap={xAxisOptions.allowLineWrap}
             labels={formattedLabels}
-            labelWidth={xScale.bandwidth()}
+            labelWidth={labelWidth}
             onHeightChange={setXAxisHeight}
             reducedLabelIndexes={reducedLabelIndexes}
             x={xAxisBounds.x}


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

With Linear charts, the X-Axis displays labels nicely even if the width does not fit them all. It smartly displays less and less labels as it can, until it can no more show any of them.

However for Bar charts, it behaves differently. If all the labels can't fit within the width, it simply displays none of them. With this PR, it changes this behaviour to be similar to the Linear charts.

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

I have created a new story for Bar Charts, `Monthly Reports`, to show an example with a typical use case, showing a 30-days monthly report.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

No

## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant
 -->

| Before  | After  |
|---|---|
|   <img width="1004" alt="before" src="https://github.com/user-attachments/assets/4b416485-e673-42b0-92fb-80061506d2a0"> | <img width="1005" alt="after" src="https://github.com/user-attachments/assets/86310218-b6a8-4eef-8ecc-f4da3de77105">  |

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
