### PR TITLE
Fix bar chart animation when sign changes

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Bar chart animation when value goes from positive to negative or vice versa
+
 ### Added
 
 - Added support for responsive legends in `<LineChartRelational />`

--- a/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/components/VerticalBar/VerticalBar.tsx
@@ -4,6 +4,7 @@ import {
   DataType,
   getRoundedRectPath,
   useTheme,
+  usePrevious,
 } from '@shopify/polaris-viz-core';
 
 import {useBarSpringConfig} from '../../../../hooks/useBarSpringConfig';
@@ -69,15 +70,31 @@ export const VerticalBar = memo(function Bar({
   const springConfig = useBarSpringConfig({animationDelay});
   const rotate = `${treatAsNegative ? 'rotate(180)' : 'rotate(0)'}`;
 
+  const prevValue = usePrevious(rawValue);
+  const signIsChanging =
+    prevValue == null ? false : Math.sign(prevValue) !== Math.sign(rawValue);
+
   const {pathD, transform} = useSpring({
     from: {
       pathD: getPath(1, width),
       transform: `translate(0 ${zeroPosition}) ${rotate}`,
     },
-    to: {
-      pathD: getPath(height, width),
-      transform: `translate(0 ${yPosition}) ${rotate}`,
-    },
+    to: signIsChanging
+      ? [
+          {
+            pathD: getPath(0, width),
+            transform: `translate(0 ${zeroPosition}) ${rotate}`,
+            immediate: true,
+          },
+          {
+            pathD: getPath(height, width),
+            transform: `translate(0 ${yPosition}) ${rotate}`,
+          },
+        ]
+      : {
+          pathD: getPath(height, width),
+          transform: `translate(0 ${yPosition}) ${rotate}`,
+        },
     ...springConfig,
   });
 


### PR DESCRIPTION
## What does this implement/fix?

Improve the bar animation when the value changes from negative to positive for vice versa 


## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/81906


## What do the changes look like?

| Before  | After  |
|---|---|
|<video src="https://github.com/user-attachments/assets/4c221ef6-f180-48ce-828d-e17ee8d20471" />|  <video src="https://github.com/user-attachments/assets/50603191-8989-44e5-8038-3ed045fe0931" />|




 
## Storybook link

https://6062ad4a2d14cd0021539c1b-kipahzvwhw.chromatic.com/?path=/story/polaris-viz-charts-barchart--default

Note: I removed these changes in Storybook so they aren't on the PR

### Before merging

- [X] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [X] Update the Changelog's Unreleased section with your changes.

- [X] Update relevant documentation, tests, and Storybook.

- [X] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
