### PR TITLE
Place tooltip above chart on mobile

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -16,6 +16,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Changed `<LineChart />` tooltip positioning to align with the crosshair when on a touch device.
+- Changed `<BarChart />` tooltip positioning to align with the top of the chart on a touch device.
 
 ## [15.3.5] - 2024-12-05
 

--- a/packages/polaris-viz/src/components/TooltipWrapper/utilities/getAlteredVerticalBarPosition.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/utilities/getAlteredVerticalBarPosition.ts
@@ -30,7 +30,20 @@ export function getAlteredVerticalBarPosition(
   //
   // Y POSITIONING
   //
-  if (!props.isPerformanceImpacted) {
+  if (props.isPerformanceImpacted || props.isTouchDevice) {
+    y = clamp({
+      amount:
+        props.containerBounds.y -
+        props.tooltipDimensions.height -
+        (scrollContainer?.scrollTop ?? 0),
+      min: 0,
+      max:
+        window.scrollY +
+        window.innerHeight -
+        props.tooltipDimensions.height -
+        TOOLTIP_MARGIN,
+    });
+  } else {
     if (newPosition.vertical === TooltipVerticalOffset.Inline) {
       newPosition.horizontal = TooltipHorizontalOffset.Left;
 
@@ -60,19 +73,6 @@ export function getAlteredVerticalBarPosition(
         newPosition.horizontal = TooltipHorizontalOffset.Left;
       }
     }
-  } else {
-    y = clamp({
-      amount:
-        (props.chartBounds.y ?? 0) -
-        props.tooltipDimensions.height -
-        (scrollContainer?.scrollTop ?? 0),
-      min: 0,
-      max:
-        window.scrollY +
-        window.innerHeight -
-        props.tooltipDimensions.height -
-        TOOLTIP_MARGIN,
-    });
   }
 
   //


### PR DESCRIPTION
## What does this implement/fix?

Place the tooltip for vertical `BarChart` above the chart on mobile so that the tooltip isn't displayed under the users thumb/finger.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/core-issues/issues/82177

## What do the changes look like?
 
## Storybook link

https://github.com/user-attachments/assets/c459a3fd-aeab-4df9-b8ae-4b721107b22c

https://6062ad4a2d14cd0021539c1b-crdjmhwkgw.chromatic.com/iframe.html?args=&id=polaris-viz-charts-barchart-playground--external-tooltip&viewMode=story

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.
- [x] Update the Changelog's Unreleased section with your changes.
- [ ] Update relevant documentation, tests, and Storybook.
- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
