### PR TITLE
Stop double formatting in label calculation

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Double formatting in Donut Chart label calculations
 
 ## [15.6.1] - 2024-12-18
 

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx
@@ -85,7 +85,7 @@ export function LegendValues({
   const longestLegendNameWidth = useMemo(() => {
     return legendData.reduce((previous, current) => {
       const estimatedLegendNameWidth = estimateStringWidth(
-        `${seriesNameFormatter(`${current.name || ''}`)}`,
+        current.name,
         characterWidths,
       );
 
@@ -95,7 +95,7 @@ export function LegendValues({
 
       return previous;
     }, 0);
-  }, [legendData, seriesNameFormatter, characterWidths]);
+  }, [legendData, characterWidths]);
 
   const longestLegendValueWidth = useMemo(() => {
     return legendData.reduce((previous, current) => {

--- a/packages/polaris-viz/src/components/DonutChart/components/LegendValues/tests/LegendValues.test.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/components/LegendValues/tests/LegendValues.test.tsx
@@ -1,0 +1,28 @@
+import {mount} from '@shopify/react-testing';
+
+import {LegendValues} from '../LegendValues';
+
+const mockProps = {
+  data: [
+    {
+      name: 'Shopify Payments',
+      data: [{key: 'april - march', value: 50000}],
+    },
+  ],
+  activeIndex: 1,
+  legendFullWidth: false,
+  labelFormatter: (val) => `${val}!`,
+  getColorVisionStyles: jest.fn(),
+  getColorVisionEventAttrs: jest.fn(),
+  seriesNameFormatter: (val) => `${val}!`,
+  renderHiddenLegendLabel: jest.fn(),
+} as any;
+
+describe('<LegendValues />', () => {
+  it('renders a table with max width', async () => {
+    const legendValues = mount(<LegendValues {...mockProps} />);
+    expect(legendValues).toContainReactComponent('table', {
+      style: {maxWidth: 197.22, width: '100%'},
+    });
+  });
+});


### PR DESCRIPTION
## What does this implement/fix?
Fixes double formatting and inaccurate measuring in the Donut Chart

## Does this close any currently open issues?

Should fix https://github.com/Shopify/web/issues/152100 once updated in web


## What do the changes look like?

You can see below in the console that the string we were measuring double formatted the label. You can see that as a result, the container was larger than it needed to be.

After, the container is the correct size, and you can see in the console that the string being measured is not double formatted.

| Before  | After  |
|---|---|
| <img width="1202" alt="Screenshot 2024-12-20 at 9 25 50 AM" src="https://github.com/user-attachments/assets/705cd84f-364e-4019-ac1c-7e077e570ae2" />|  <img width="1197" alt="Screenshot 2024-12-20 at 9 26 28 AM" src="https://github.com/user-attachments/assets/cf194ea7-4174-4992-b08b-f0f1c984d557" /> |
 
## Storybook link
I haven't added a story for this, but you can try it out on the existing donut chart stories by console.logging the label that is getting measured [here](https://github.com/Shopify/polaris-viz/blob/5a84e48677100d6fd0d7718fce90c05e5e61e59c/packages/polaris-viz/src/components/DonutChart/components/LegendValues/LegendValues.tsx#L85) 

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
