### PR TITLE
Fix tooltip overflow when displaying long title without space

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Double formatting in Donut Chart label calculations
+- Changed `<TooltipTitle />` to avoid overflow when displaying long titles without spaces.
 
 ## [15.6.1] - 2024-12-18
 

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipTitle/TooltipTitle.scss
@@ -3,4 +3,5 @@
   font-weight: 500;
   line-height: 20px;
   margin: 0;
+  overflow-wrap: break-word;
 }

--- a/packages/polaris-viz/src/components/TooltipContent/stories/LongTitleWithoutSpace.stories.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/stories/LongTitleWithoutSpace.stories.tsx
@@ -1,0 +1,33 @@
+import {DARK_THEME} from '@shopify/polaris-viz-core';
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {TooltipContentProps} from '../../../components';
+
+import {Template} from './data';
+
+export const LongTitleWithoutSpace: Story<TooltipContentProps> = Template.bind(
+  {},
+);
+
+LongTitleWithoutSpace.args = {
+  data: [
+    {
+      shape: 'Line',
+      data: [
+        {
+          key: 'Google ads',
+          value: '5250',
+          color: DARK_THEME.seriesColors.limited[0],
+        },
+        {
+          key: 'Facebook ads',
+          value: '650',
+          color: DARK_THEME.seriesColors.limited[1],
+        },
+      ],
+    },
+  ],
+  title: 'thisisaverylongstringwithoutspace',
+};


### PR DESCRIPTION
## What does this implement/fix?

When displaying long tooltip title without space, the text is overflow. More details and the bug reproduction are mentioned here: https://github.com/Shopify/polaris-viz/issues/1787.

PR aims to fix the issue by adding **overflow-wrap: break-word** to the `<TooltipTitle />` component.

## Does this close any currently open issues?

Issue link: https://github.com/Shopify/polaris-viz/issues/1787.


## What do the changes look like?

Before 

<img width="1466" alt="Screenshot 2025-01-08 at 13 04 00" src="https://github.com/user-attachments/assets/8e60391c-eecc-46c5-9479-7aa09fffb59b" />

After

<img width="1463" alt="Screenshot 2025-01-08 at 13 03 33" src="https://github.com/user-attachments/assets/58389d39-ee4c-4035-8e8c-624ac341082e" />

## Storybook link

<!-- 🎩 Include links to help tophatting -->

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
