### PR TITLE
Fix stacked area arity bug regression

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed issue in `<StackedArea />` where changing data series length would cause the chart to throw an error
+
 ### Changed
 
 - Removed main percentage label from `<FunnelChartNext />`

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/StackedAreas.tsx
@@ -86,13 +86,8 @@ export function StackedAreas({
   return (
     <Fragment>
       {stackedValues.map((data, index) => {
-        const isSeriesLengthIncreasing =
-          previousStackedValues &&
-          previousStackedValues.length < stackedValues.length;
-
         const dataIsValidForAnimation =
           !previousStackedValues ||
-          isSeriesLengthIncreasing ||
           data.length === previousStackedValues[index]?.length;
 
         const AreaComponent = dataIsValidForAnimation ? AnimatedArea : Area;

--- a/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/components/StackedAreas/tests/StackedAreas.test.tsx
@@ -100,47 +100,5 @@ describe('<StackedAreas />', () => {
         duration: 100,
       });
     });
-
-    it('renders and animates when series length changes', () => {
-      const singleSeriesValues = [
-        [
-          [163, 269],
-          [0, 0],
-        ],
-      ] as StackedSeries[];
-
-      const stackedArea = mount(
-        <svg>
-          <StackedAreas
-            {...mockProps}
-            stackedValues={singleSeriesValues}
-            zeroLineValues={singleSeriesValues}
-          />
-        </svg>,
-      );
-
-      expect(stackedArea).toContainReactComponentTimes(AnimatedArea, 1);
-
-      // Update with two series
-      stackedArea.setProps({
-        children: (
-          <StackedAreas
-            {...mockProps}
-            stackedValues={mockStackedValues}
-            zeroLineValues={mockStackedValues}
-          />
-        ),
-      });
-
-      const stacks = stackedArea.findAll(AnimatedArea);
-
-      expect(stackedArea).toContainReactComponentTimes(AnimatedArea, 2);
-      expect(stacks[0]).toHaveReactProps({
-        duration: 275,
-      });
-      expect(stacks[1]).toHaveReactProps({
-        duration: 275,
-      });
-    });
   });
 });


### PR DESCRIPTION
## What does this implement/fix?

https://github.com/Shopify/web/issues/152053

The change in https://github.com/Shopify/polaris-viz/pull/1766 fixed a bug with our stacked area charts but introduced a regression to a bug that was previously fixed in https://github.com/Shopify/polaris-viz/pull/1578

The TLDR of the `The arity of each "output" value must be equal` bug was:

>React spring is unable to animate svgs of different lengths without a custom interpolator but that seemed like overkill for now. Instead I've decided to just not animate when the length of data changes

This PR removes the animation when the series length changes. I had previously re-enabled this animation while fixing another issue, not understanding why it was disabled, now I know 😄 

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

Storybook: https://6062ad4a2d14cd0021539c1b-yivymlsivd.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart--default

To tophat, you can visit the storybook link above and try changing the series length in the story to see the chart change, you can paste in the mock data below to make the series change and ensure the chart doesn't break **and** the arity bug is not thrown in console


<details>
  <summary>Larger data</summary>

```
[
  {
    "name": "New",
    "fillValue": 0,
    "data": [
      {
        "key": "Wed Nov 20 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 42.036
      },
      {
        "key": "Tue Nov 26 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 0
      }
    ]
  },
  {
    "name": "Returning",
    "fillValue": 0,
    "data": [
      {
        "key": "Wed Nov 20 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 241.609
      },
      {
        "key": "Tue Nov 26 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 0
      }
    ]
  },
  {
    "name": "NULL",
    "fillValue": 0,
    "data": [
      {
        "key": "Wed Nov 20 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 0
      },
      {
        "key": "Tue Nov 26 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 0
      }
    ]
  }
]
```
</details> 

<details>
  <summary>Small data</summary>

```
[
  {
    "name": "NULL",
    "fillValue": 0,
    "data": [
      {
        "key": "Wed Nov 27 2024 00:00:00 GMT-0500 (Eastern Standard Time)", 
        "value": 100
      },
      {
        "key": "Thu Nov 28 2024 00:00:00 GMT-0500 (Eastern Standard Time)",
        "value": 220
      }
    ]
  }
]
```
</details> 


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
