### PR TITLE
Fix percentile index for line chart relational

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed issue in `<LineChartRelational />` where the `percentileIndex` was not being set correctly.
+
 ### Added
 
 - Added Tooltips to `<FunnelChartNext />`

--- a/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/RelatedAreas.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/RelatedAreas.tsx
@@ -15,11 +15,9 @@ export interface RelatedAreaProps extends LineChartSlotProps {
 export function RelatedAreas({yScale, xScale, data}: RelatedAreaProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
 
-  const lineSeries = data.filter(
-    (series) => series?.metadata?.relatedIndex == null,
+  const percentileIndex = data.findIndex(
+    (series) => series.metadata?.relatedIndex != null,
   );
-
-  const percentileIndex = lineSeries.length + 1;
 
   const {hiddenIndexes} = useExternalHideEvents();
   const {id} = useChartContext();

--- a/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/tests/RelatedAreas.test.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/components/RelatedAreas/tests/RelatedAreas.test.tsx
@@ -60,4 +60,16 @@ describe('<RelatedAreas />', () => {
 
     expect(chart).toContainReactComponentTimes(Area, 2);
   });
+
+  it('sets the Area index to the index of the first related percentile series', () => {
+    const chart = mount(
+      <svg>
+        <RelatedAreas {...MOCK_PROPS} />
+      </svg>,
+    );
+
+    expect(chart).toContainReactComponent(Area, {
+      index: 1,
+    });
+  });
 });


### PR DESCRIPTION
## What does this implement/fix?

We have two different logics for calculating the `percentileIndex` for `LineChartRelational`. This was causing a mismatch on indexes when trying to highlight a path in the chart from the legend item.

The solution is to unify this with the same logic so that there is always a match.


https://github.com/user-attachments/assets/0a2dbf5e-74c6-4f3a-ab4d-0003b2ec2ae5

