### PR TITLE
Move 0 value labels to left when all value are negative

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed issue in `<SimpleBarChart />` where the trend indicator was not being positioned correctly when the value was `null`.
+- Fixed issue in `<SimpleBarChart />` where labels are not positioned correctly when all values were negative and `0`.
 
 ## [15.8.0] - 2025-01-16
 

--- a/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/AllNegative.stories.tsx
+++ b/packages/polaris-viz/src/components/SimpleBarChart/stories/playground/AllNegative.stories.tsx
@@ -1,0 +1,71 @@
+import type {Story} from '@storybook/react';
+
+import {SimpleBarChart, SimpleBarChartProps} from '../../../../components';
+import {META} from '../meta';
+import type {SimpleBarChartDataSeries} from '../../types';
+import {
+  DEFAULT_THEME_NAME,
+  PolarisVizProvider,
+} from '@shopify/polaris-viz-core';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+const DATA: SimpleBarChartDataSeries[] = [
+  {
+    name: '',
+    data: [
+      {key: 'One', value: 0},
+      {key: 'Two', value: 0},
+      {key: 'Three', value: -22.1},
+      {key: 'Four', value: 0},
+      {key: 'Five', value: -17.5},
+    ],
+    metadata: {
+      trends: {
+        '0': {},
+      },
+    },
+  },
+  {
+    name: '',
+    data: [
+      {key: 'One', value: 0},
+      {key: 'Two', value: 0},
+      {key: 'Three', value: 0},
+      {key: 'Four', value: 0},
+      {key: 'Five', value: 0},
+    ],
+  },
+];
+
+const Template: Story<SimpleBarChartProps> = () => {
+  const svgStyle = `
+    svg {
+      background: rgba(0, 255, 0, 0.1);
+    }
+  `;
+
+  return (
+    <div style={{height: 600, width: 800}}>
+      <style>{svgStyle}</style>
+      <PolarisVizProvider
+        animated={{} as any}
+        themes={{
+          [DEFAULT_THEME_NAME]: {
+            chartContainer: {
+              backgroundColor: 'rgba(255, 0, 0, 0.1)',
+              padding: '20px',
+            },
+          },
+        }}
+      >
+        <SimpleBarChart data={DATA} showLegend={false} />
+      </PolarisVizProvider>
+    </div>
+  );
+};
+
+export const AllNegative = Template.bind({});

--- a/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalBars/HorizontalBars.tsx
@@ -126,7 +126,7 @@ export function HorizontalBars({
             min: 1,
           });
 
-          if (isNegative) {
+          if (areAllNegative || isNegative) {
             return {
               labelX: -(clampedWidth + leftLabelOffset),
               barWidth: clampedWidth,


### PR DESCRIPTION
## What does this implement/fix?

When all values are negative and `0`, the `0` labels would be positioned to the right of the bars, which pushed them outside the bounds.

## Does this close any currently open issues?

https://github.com/Shopify/core-issues/issues/81855

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/89c2f046-c4b5-43f2-b387-b203cce2ea75)|![image](https://github.com/user-attachments/assets/d2fb5463-6875-4c92-bf38-0698de9c6352)|

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
