### PR TITLE
Use a portal for horizontal tooltips

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Changed `<HorizontalBarChart />` to use a react portal to allow tooltips to render outside the bounds of the chart.
 
 ## [15.8.1] - 2025-01-21
 

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/ExternalTooltip.stories.tsx
@@ -77,6 +77,7 @@ export const ExternalTooltipWithFrame: Story<BarChartProps> =
   TemplateWithFrame.bind({});
 
 ExternalTooltip.args = {
+  direction: 'horizontal',
   data: [
     {
       name: 'Apr 1 – Apr 14, 2020',

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -148,15 +148,14 @@ export function Chart({
       longestLabel,
     });
 
-  const {barHeight, chartHeight, groupBarsAreaHeight, groupHeight} =
-    useHorizontalBarSizes({
-      chartDimensions: {width: drawableWidth, height: drawableHeight},
-      isSimple: xAxisOptions.hide,
-      isStacked,
-      seriesLength: longestSeriesCount,
-      singleBarCount: data.length,
-      xAxisHeight,
-    });
+  const {barHeight, chartHeight, groupHeight} = useHorizontalBarSizes({
+    chartDimensions: {width: drawableWidth, height: drawableHeight},
+    isSimple: xAxisOptions.hide,
+    isStacked,
+    seriesLength: longestSeriesCount,
+    singleBarCount: data.length,
+    xAxisHeight,
+  });
 
   const annotationsDrawableHeight =
     chartYPosition + chartHeight + ANNOTATIONS_LABELS_OFFSET;
@@ -293,17 +292,19 @@ export function Chart({
 
       {highestValueForSeries.length !== 0 && (
         <TooltipWrapper
-          bandwidth={groupBarsAreaHeight}
+          bandwidth={groupHeight}
           chartBounds={chartBounds}
           chartType={InternalChartType.HorizontalBar}
           data={data}
           focusElementDataType={DataType.BarGroup}
           getMarkup={getTooltipMarkup}
-          margin={ChartMargin}
+          margin={{...ChartMargin, Top: chartYPosition}}
           parentElement={svgRef}
           longestSeriesIndex={longestSeriesIndex}
+          highestValueForSeries={highestValueForSeries}
           xScale={xScale}
           type={type}
+          usePortal
         />
       )}
 

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -37,6 +37,7 @@ interface BaseProps {
   xScale: ScaleLinear<number, number> | ScaleBand<string>;
   bandwidth?: number;
   onIndexChange?: (index: number | null) => void;
+  highestValueForSeries?: number[];
   id?: string;
   type?: ChartType;
   yScale?: ScaleLinear<number, number>;
@@ -56,6 +57,7 @@ function TooltipWrapperRaw(props: BaseProps) {
     type,
     xScale,
     yScale,
+    highestValueForSeries,
   } = props;
   const {scrollContainer, isTouchDevice, containerBounds} = useChartContext();
   const [position, setPosition] = useState<TooltipPosition>({
@@ -111,6 +113,7 @@ function TooltipWrapperRaw(props: BaseProps) {
         case InternalChartType.HorizontalBar:
           return getHorizontalBarChartTooltipPosition({
             chartBounds,
+            containerBounds,
             data,
             event,
             eventType,
@@ -118,6 +121,11 @@ function TooltipWrapperRaw(props: BaseProps) {
             longestSeriesIndex,
             type,
             xScale: xScale as ScaleLinear<number, number>,
+            highestValueForSeries: highestValueForSeries ?? [],
+            bandwidth,
+            scrollY: scrollContainer
+              ? scrollContainer.scrollTop
+              : window.scrollY,
           });
         case InternalChartType.Bar:
         default:
@@ -136,6 +144,8 @@ function TooltipWrapperRaw(props: BaseProps) {
       }
     },
     [
+      highestValueForSeries,
+      bandwidth,
       chartBounds,
       containerBounds,
       chartType,

--- a/packages/polaris-viz/src/components/TooltipWrapper/utilities/getAlteredHorizontalBarPosition.ts
+++ b/packages/polaris-viz/src/components/TooltipWrapper/utilities/getAlteredHorizontalBarPosition.ts
@@ -1,7 +1,7 @@
-import type {BoundingRect, Dimensions} from '@shopify/polaris-viz-core';
-import {HORIZONTAL_GROUP_LABEL_HEIGHT} from '@shopify/polaris-viz-core';
+import type {Dimensions} from '@shopify/polaris-viz-core';
+import {clamp, HORIZONTAL_GROUP_LABEL_HEIGHT} from '@shopify/polaris-viz-core';
 
-import {TOOLTIP_MARGIN} from '../constants';
+import {SCROLLBAR_WIDTH, TOOLTIP_MARGIN} from '../constants';
 import type {AlteredPositionProps, AlteredPositionReturn} from '../types';
 
 export function getAlteredHorizontalBarPosition(
@@ -20,100 +20,59 @@ function getNegativeOffset(props: AlteredPositionProps): AlteredPositionReturn {
   const yOffset = (bandwidth - tooltipDimensions.height) / 2;
 
   const y = currentY - tooltipDimensions.height;
+
   if (flippedX - tooltipDimensions.width < 0) {
-    return {x: flippedX, y: y < 0 ? 0 : y};
+    return clampPosition({
+      x: flippedX,
+      y: y < 0 ? 0 : y,
+      tooltipDimensions,
+    });
   }
 
-  return {
+  return clampPosition({
     x: flippedX - tooltipDimensions.width - TOOLTIP_MARGIN,
     y: currentY + HORIZONTAL_GROUP_LABEL_HEIGHT + yOffset,
-  };
+    tooltipDimensions,
+  });
 }
 
 function getPositiveOffset(props: AlteredPositionProps): AlteredPositionReturn {
-  const {bandwidth, currentX, currentY, tooltipDimensions, chartBounds} = props;
+  const {currentX, currentY} = props;
 
-  const isOutside = isOutsideBounds({
+  return clampPosition({
     x: currentX,
     y: currentY,
-    tooltipDimensions,
-    chartBounds,
+    tooltipDimensions: props.tooltipDimensions,
   });
-
-  if (isOutside.top && isOutside.right) {
-    return {
-      x: chartBounds.width - tooltipDimensions.width,
-      y: 0,
-    };
-  }
-
-  if (isOutside.top && !isOutside.right) {
-    return {
-      x: currentX + TOOLTIP_MARGIN,
-      y: 0,
-    };
-  }
-
-  if (!isOutside.right && !isOutside.bottom) {
-    const yOffset = (bandwidth - tooltipDimensions.height) / 2;
-    return {
-      x: currentX + TOOLTIP_MARGIN,
-      y: currentY + HORIZONTAL_GROUP_LABEL_HEIGHT + yOffset,
-    };
-  }
-
-  if (isOutside.right) {
-    const x = currentX - tooltipDimensions.width;
-    const y =
-      currentY -
-      tooltipDimensions.height +
-      HORIZONTAL_GROUP_LABEL_HEIGHT -
-      TOOLTIP_MARGIN;
-
-    if (y < 0) {
-      return {
-        x,
-        y: bandwidth + HORIZONTAL_GROUP_LABEL_HEIGHT + TOOLTIP_MARGIN,
-      };
-    }
-
-    return {
-      x,
-      y,
-    };
-  }
-
-  if (isOutside.bottom) {
-    return {
-      x: currentX + TOOLTIP_MARGIN,
-      y:
-        chartBounds.height -
-        tooltipDimensions.height -
-        HORIZONTAL_GROUP_LABEL_HEIGHT,
-    };
-  }
-
-  return {x: currentX, y: currentY};
 }
 
-function isOutsideBounds({
+function clampPosition({
   x,
   y,
   tooltipDimensions,
-  chartBounds,
 }: {
   x: number;
   y: number;
   tooltipDimensions: Dimensions;
-  chartBounds: BoundingRect;
 }) {
-  const right = x + TOOLTIP_MARGIN + tooltipDimensions.width;
-  const bottom = y + tooltipDimensions.height;
-
   return {
-    left: x <= 0,
-    right: right > chartBounds.width,
-    bottom: bottom > chartBounds.height,
-    top: y <= 0,
+    x: clamp({
+      amount: x,
+      min: TOOLTIP_MARGIN,
+      max:
+        window.innerWidth -
+        tooltipDimensions.width -
+        TOOLTIP_MARGIN -
+        SCROLLBAR_WIDTH,
+    }),
+    y: clamp({
+      amount: y,
+      min: window.scrollY + TOOLTIP_MARGIN,
+      max:
+        window.scrollY +
+        window.innerHeight -
+        tooltipDimensions.height -
+        TOOLTIP_MARGIN,
+    }),
   };
 }

--- a/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
+++ b/packages/polaris-viz/src/components/shared/HorizontalGroup/HorizontalGroup.tsx
@@ -106,7 +106,7 @@ export function HorizontalGroup({
       className={style.Group}
     >
       <rect
-        fill="transparent"
+        fill="green"
         height={groupHeight}
         width={containerWidth}
         y={-(groupHeight - rowHeight) / 2}

--- a/packages/polaris-viz/src/hooks/tests/useHorizontalBarSizes.test.tsx
+++ b/packages/polaris-viz/src/hooks/tests/useHorizontalBarSizes.test.tsx
@@ -32,7 +32,7 @@ describe('useHorizontalBarSizes()', () => {
     expect(data).toStrictEqual({
       barHeight: 44.333333333333336,
       chartHeight: 380,
-      groupBarsAreaHeight: 88.66666666666667,
+
       groupHeight: 126.66666666666667,
     });
   });
@@ -51,7 +51,6 @@ describe('useHorizontalBarSizes()', () => {
     expect(data).toStrictEqual({
       barHeight: 28.88888888888889,
       chartHeight: 380,
-      groupBarsAreaHeight: 86.66666666666667,
       groupHeight: 126.66666666666667,
     });
   });
@@ -69,7 +68,6 @@ describe('useHorizontalBarSizes()', () => {
       const data = parseData(result);
 
       expect(data.chartHeight).toStrictEqual(416);
-      expect(data.groupBarsAreaHeight).toStrictEqual(100.66666666666666);
       expect(data.groupHeight).toStrictEqual(138.66666666666666);
     });
   });

--- a/packages/polaris-viz/src/hooks/useHorizontalBarSizes.ts
+++ b/packages/polaris-viz/src/hooks/useHorizontalBarSizes.ts
@@ -65,7 +65,6 @@ export function useHorizontalBarSizes({
     return {
       barHeight,
       chartHeight,
-      groupBarsAreaHeight,
       groupHeight,
     };
   }, [


### PR DESCRIPTION
## What does this implement/fix?

As part of the UX tooltip audit, we want to enable tooltips on every chart. In order to add tooltips to the `SimpleBarChart` we needed the `HorizontalBarChart` to render it's tooltip in a portal.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
