### PR TITLE
Change default series icon shape to circle

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 -  Added tooltip support for `<DonutChart />`
 
+### Changed
+
+- Changed default series icon indicator for non-line charts to a circle from a square.
+
 ## [15.8.1] - 2025-01-21
 
 ### Fixed

--- a/packages/polaris-viz/src/components/DefaultPreview/DefaultPreview.scss
+++ b/packages/polaris-viz/src/components/DefaultPreview/DefaultPreview.scss
@@ -1,0 +1,9 @@
+@import '../../styles/common';
+
+.ColorPreview {
+  border-radius: 100%;
+  display: block;
+  flex: none;
+  @include print-color;
+  overflow: hidden;
+}

--- a/packages/polaris-viz/src/components/DefaultPreview/DefaultPreview.tsx
+++ b/packages/polaris-viz/src/components/DefaultPreview/DefaultPreview.tsx
@@ -1,0 +1,24 @@
+import type {Color} from '@shopify/polaris-viz-core';
+
+import {getCSSBackgroundFromColor} from '../../utilities/getCSSBackgroundFromColor';
+
+import styles from './DefaultPreview.scss';
+
+const ANGLE = 305;
+
+export interface DefaultPreviewProps {
+  color: Color;
+}
+
+const ICON_SIZE = 8;
+
+export function DefaultPreview({color}: DefaultPreviewProps) {
+  const background = getCSSBackgroundFromColor(color, ANGLE);
+
+  return (
+    <span
+      className={styles.ColorPreview}
+      style={{background, height: ICON_SIZE, width: ICON_SIZE}}
+    />
+  );
+}

--- a/packages/polaris-viz/src/components/DefaultPreview/index.ts
+++ b/packages/polaris-viz/src/components/DefaultPreview/index.ts
@@ -1,0 +1,2 @@
+export {DefaultPreview} from './DefaultPreview';
+export type {DefaultPreviewProps} from './DefaultPreview';

--- a/packages/polaris-viz/src/components/DefaultPreview/stories/DefaultPreview.stories.tsx
+++ b/packages/polaris-viz/src/components/DefaultPreview/stories/DefaultPreview.stories.tsx
@@ -1,0 +1,33 @@
+import type {Story} from '@storybook/react';
+import {COLOR_VARIABLES} from '@shopify/polaris-viz-core';
+
+export {META as default} from './meta';
+
+import type {DefaultPreviewProps} from '../..';
+
+import {Template} from './data';
+
+export const Solid: Story<DefaultPreviewProps> = Template.bind({});
+
+Solid.args = {
+  color: COLOR_VARIABLES.colorTeal80,
+};
+
+export const Gradient: Story<DefaultPreviewProps> = Template.bind({});
+
+Gradient.args = {
+  color: [
+    {
+      color: '#39337f',
+      offset: 0,
+    },
+    {
+      color: '#5052b3',
+      offset: 50,
+    },
+    {
+      color: '#1bbe9e',
+      offset: 100,
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/DefaultPreview/stories/data.tsx
+++ b/packages/polaris-viz/src/components/DefaultPreview/stories/data.tsx
@@ -1,0 +1,10 @@
+import type {Story} from '@storybook/react';
+
+import type {DefaultPreviewProps} from '../DefaultPreview';
+import {DefaultPreview} from '../DefaultPreview';
+
+export const Template: Story<DefaultPreviewProps> = (
+  args: DefaultPreviewProps,
+) => {
+  return <DefaultPreview {...args} />;
+};

--- a/packages/polaris-viz/src/components/DefaultPreview/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/DefaultPreview/stories/meta.tsx
@@ -1,0 +1,24 @@
+import type {Meta} from '@storybook/react';
+
+import {CONTROLS_ARGS} from '../../../storybook/constants';
+import {DefaultPreview} from '../DefaultPreview';
+
+export const META: Meta = {
+  title: 'Shared/Subcomponents/DefaultPreview',
+  component: DefaultPreview,
+  argTypes: {
+    color: {
+      description:
+        'The CSS color or gradient array color to be displayed in the square.',
+    },
+  },
+  parameters: {
+    controls: CONTROLS_ARGS,
+    docs: {
+      description: {
+        component:
+          'Used to connect chart colors and gradients to information in tooltips and legends.',
+      },
+    },
+  },
+};

--- a/packages/polaris-viz/src/components/DefaultPreview/tests/DefaultPreview.test.tsx
+++ b/packages/polaris-viz/src/components/DefaultPreview/tests/DefaultPreview.test.tsx
@@ -1,0 +1,17 @@
+import {mount} from '@shopify/react-testing';
+
+import {DefaultPreview} from '../DefaultPreview';
+
+describe('<DefaultPreview/>', () => {
+  it('renders a div with a background color', () => {
+    const actual = mount(<DefaultPreview color="rgb(222, 54, 24)" />);
+
+    expect(actual).toContainReactComponent('span', {
+      style: {
+        background: 'rgb(222, 54, 24)',
+        height: 8,
+        width: 8,
+      },
+    });
+  });
+});

--- a/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
+++ b/packages/polaris-viz/src/components/Legend/components/LegendItem/LegendItem.scss
@@ -38,5 +38,5 @@
 .IconContainer {
   display: flex;
   align-items: center;
-  justify-items: center;
+  justify-content: center;
 }

--- a/packages/polaris-viz/src/components/Legend/constants.ts
+++ b/packages/polaris-viz/src/components/Legend/constants.ts
@@ -1,3 +1,3 @@
 export const LEGEND_ITEM_LEFT_PADDING = 8;
 export const LEGEND_ITEM_RIGHT_PADDING = 16;
-export const LEGEND_ITEM_GAP = 8;
+export const LEGEND_ITEM_GAP = 6;

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -12,6 +12,8 @@ export type {SimpleNormalizedChartProps} from './SimpleNormalizedChart';
 export {YAxis} from './YAxis';
 export {SquareColorPreview} from './SquareColorPreview';
 export type {SquareColorPreviewProps} from './SquareColorPreview';
+export {DefaultPreview} from './DefaultPreview';
+export type {DefaultPreviewProps} from './DefaultPreview';
 export {StackedAreaChart} from './StackedAreaChart';
 export type {StackedAreaChartProps} from './StackedAreaChart';
 export {BarChart} from './BarChart';

--- a/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.test.tsx
+++ b/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.test.tsx
@@ -1,14 +1,14 @@
 import {mount} from '@shopify/react-testing';
 
 import {SeriesIcon} from '../SeriesIcon';
-import {SquareColorPreview} from '../../SquareColorPreview';
+import {DefaultPreview} from '../../DefaultPreview';
 import {LinePreview} from '../../LinePreview';
 
 describe('<SeriesIcon />', () => {
-  it('renders a <SquareColorPreview />', () => {
+  it('renders a <DefaultPreview />', () => {
     const component = mount(<SeriesIcon color="red" />);
 
-    expect(component).toContainReactComponent(SquareColorPreview, {
+    expect(component).toContainReactComponent(DefaultPreview, {
       color: 'red',
     });
   });
@@ -23,10 +23,10 @@ describe('<SeriesIcon />', () => {
 });
 
 describe('color', () => {
-  it('passes color as color prop to <SquareColorPreview />', () => {
+  it('passes color as color prop to <DefaultPreview />', () => {
     const component = mount(<SeriesIcon color="red" />);
 
-    expect(component.find(SquareColorPreview)).toHaveReactProps({color: 'red'});
+    expect(component.find(DefaultPreview)).toHaveReactProps({color: 'red'});
   });
 
   it('passes color as color prop to <LinePreview />', () => {

--- a/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.tsx
+++ b/packages/polaris-viz/src/components/shared/SeriesIcon/SeriesIcon.tsx
@@ -1,7 +1,7 @@
 import type {Shape, Color, LineStyle} from '@shopify/polaris-viz-core';
 
 import {LinePreview} from '../../LinePreview';
-import {SquareColorPreview} from '../../SquareColorPreview';
+import {DefaultPreview} from '../../DefaultPreview';
 
 interface Props {
   color: Color;
@@ -16,8 +16,7 @@ export function SeriesIcon({color, lineStyle, shape = 'Bar'}: Props) {
 
       return <LinePreview color={color} lineStyle={style} />;
     }
-    case 'Bar':
     default:
-      return <SquareColorPreview color={color} />;
+      return <DefaultPreview color={color} />;
   }
 }


### PR DESCRIPTION
## What does this implement/fix?

As part of https://github.com/Shopify/analytics-ui-components/pull/322 we want to change the default series icon to a circle instead of a rounded square.

[Figma](https://www.figma.com/design/UZQSiau68Wh6TbsEowanTH/Visualizations-%2B-Tooltips?node-id=1167-3610&p=f&t=oBAJZkIwWJ71fGv3-0)

## What do the changes look like?

![image](https://github.com/user-attachments/assets/a06e66eb-ffe2-4204-a4b3-5647741e15c3)
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
