### PR TITLE
Remove line gradient for line charts with over 3 lines

### DIFF
--- a/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
+++ b/packages/polaris-viz-core/src/components/LineSeries/LineSeries.tsx
@@ -36,6 +36,7 @@ export interface LineSeriesProps {
   hiddenIndexes?: number[];
   theme: string;
   type?: 'default' | 'spark';
+  shouldShowArea?: boolean;
 }
 
 export function LineSeries({
@@ -48,6 +49,7 @@ export function LineSeries({
   type = 'default',
   xScale,
   yScale,
+  shouldShowArea = true,
 }: LineSeriesProps) {
   const index = data?.metadata?.relatedIndex ?? lineSeriesIndex;
 
@@ -133,7 +135,9 @@ export function LineSeries({
   const PathHoverTargetSize = 15;
 
   const showArea =
-    selectedTheme.line.hasArea && data?.styleOverride?.line?.hasArea !== false;
+    selectedTheme.line.hasArea &&
+    data?.styleOverride?.line?.hasArea !== false &&
+    shouldShowArea;
 
   const zeroLineY = yScale(0);
 

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -242,6 +242,8 @@ export function Chart({
 
   const halfXAxisLabelWidth = xAxisDetails.labelWidth / 2;
 
+  const shouldShowArea = data.length <= 3;
+
   return (
     <Fragment>
       <ChartElements.Svg
@@ -321,6 +323,7 @@ export function Chart({
                 xScale={xScale}
                 yScale={yScale}
                 type="default"
+                shouldShowArea={shouldShowArea}
               />
             );
           })}


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->
This removes the area gradients for line charts with over 3 lines.
<img width="294" alt="409775550-8cea2dac-2068-4b8e-a547-f560cc0d8387" src="https://github.com/user-attachments/assets/091cfc7b-4a06-4ae1-b645-7ebab705980c" />

check https://github.com/Shopify/temp-project-mover-Archetypically-20250415162442/issues/229 for issue description


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
