### PR TITLE
Remove inactive tooltip rows

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Do not render inactive items in the tooltip when a `DataSeries` is hovered/focused.
 
 ## [16.0.0] - 2025-02-13
 

--- a/packages/polaris-viz/src/components/LineChart/stories/SeriesColors.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/SeriesColors.stories.tsx
@@ -10,5 +10,5 @@ import {Template} from './data';
 export const SeriesColorsUpToSixteen: Story<LineChartProps> = Template.bind({});
 
 SeriesColorsUpToSixteen.args = {
-  data: generateMultipleSeries(16, 'dates'),
+  data: generateMultipleSeries(6, 'dates'),
 };

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -116,6 +116,28 @@ jest.mock('@shopify/polaris-viz-core/src/hooks/useChartContext', () => ({
   })),
 }));
 
+jest.mock('../../../hooks/useResizeObserver', () => {
+  return {
+    useResizeObserver: () => {
+      return {
+        setRef: () => {},
+        entry: {
+          contentRect: {
+            width: 100,
+            height: 100,
+          },
+          target: {
+            getBoundingClientRect: () => ({
+              width: 100,
+              height: 100,
+            }),
+          },
+        },
+      };
+    },
+  };
+});
+
 const useChartContextMock = useChartContext as jest.Mock;
 
 describe('<Chart />', () => {

--- a/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
@@ -57,11 +57,17 @@ export function renderLinearPredictiveTooltipContent(
       const isPredictiveStartKey = metadata?.startKey === activeKey;
       const isHidden = isNull || isPredictiveStartKey;
 
+      if (
+        isComparison !== true &&
+        activeColorVisionIndex !== -1 &&
+        index !== activeColorVisionIndex
+      ) {
+        return null;
+      }
+
       return (
         <TooltipRow
-          activeIndex={activeColorVisionIndex}
           color={color}
-          index={index}
           isHidden={isHidden}
           key={`row-${seriesIndex}`}
           label={formatters.keyFormatter(key)}

--- a/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/tests/Chart.test.tsx
@@ -55,6 +55,28 @@ jest.mock('@shopify/polaris-viz-core/src/hooks/useChartContext', () => ({
   })),
 }));
 
+jest.mock('../../../hooks/useResizeObserver', () => {
+  return {
+    useResizeObserver: () => {
+      return {
+        setRef: () => {},
+        entry: {
+          contentRect: {
+            width: 100,
+            height: 100,
+          },
+          target: {
+            getBoundingClientRect: () => ({
+              width: 100,
+              height: 100,
+            }),
+          },
+        },
+      };
+    },
+  };
+});
+
 const MOCK_PROPS: Props = {
   annotationsLookupTable: {},
   data: [

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -60,16 +60,18 @@ export function TooltipContent({
                     {key, value, color, isComparison, isHidden},
                     seriesIndex,
                   ) => {
-                    const indexOffset = data[dataIndex - 1]
-                      ? data[dataIndex - 1].data.length
-                      : 0;
+                    if (
+                      data[0].data.length > 2 &&
+                      activeColorVisionIndex !== -1 &&
+                      seriesIndex !== activeColorVisionIndex
+                    ) {
+                      return null;
+                    }
 
                     return (
                       <TooltipRow
                         key={`row-${seriesIndex}`}
-                        activeIndex={activeColorVisionIndex}
                         color={color}
-                        index={seriesIndex + indexOffset}
                         isComparison={isComparison}
                         isHidden={isHidden}
                         label={key}

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipContentContainer/TooltipContentContainer.tsx
@@ -5,7 +5,7 @@ import {
   useTheme,
 } from '@shopify/polaris-viz-core';
 import type {ReactNode} from 'react';
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 
 import {useWatchColorVisionEvents} from '../../../../hooks';
 import {TOOLTIP_BG_OPACITY} from '../../../../constants';
@@ -38,9 +38,21 @@ export function TooltipContentContainer({
 
   const [activeColorVisionIndex, setActiveIndex] = useState(-1);
 
+  const resetTimer = useRef<number>(0);
+
   useWatchColorVisionEvents({
     type: COLOR_VISION_SINGLE_ITEM,
-    onIndexChange: ({detail}) => setActiveIndex(detail.index),
+    onIndexChange: ({detail}) => {
+      window.clearTimeout(resetTimer.current);
+
+      if (detail.index === -1) {
+        resetTimer.current = window.setTimeout(() => {
+          setActiveIndex(-1);
+        }, 100);
+      } else {
+        setActiveIndex(detail.index);
+      }
+    },
     enabled: !ignoreColorVisionEvents,
   });
 

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -1,7 +1,4 @@
-import {
-  useTheme,
-  getColorVisionStylesForActiveIndex,
-} from '@shopify/polaris-viz-core';
+import {useTheme} from '@shopify/polaris-viz-core';
 import type {Shape, Color} from '@shopify/polaris-viz-core';
 
 import {PREVIEW_ICON_SIZE} from '../../../../constants';
@@ -11,8 +8,6 @@ import {TITLE_MARGIN} from '../../constants';
 import styles from './TooltipRow.scss';
 
 interface Props {
-  activeIndex: number;
-  index: number;
   label: string;
   shape: Shape;
   value: string;
@@ -23,9 +18,7 @@ interface Props {
 }
 
 export function TooltipRow({
-  activeIndex,
   color,
-  index,
   isComparison = false,
   isHidden = false,
   label,
@@ -40,13 +33,7 @@ export function TooltipRow({
   }
 
   return (
-    <div
-      className={styles.Row}
-      style={getColorVisionStylesForActiveIndex({
-        activeIndex,
-        index,
-      })}
-    >
+    <div className={styles.Row}>
       {color != null && (
         <div style={{width: PREVIEW_ICON_SIZE}}>
           {renderSeriesIcon?.() ?? (

--- a/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/packages/polaris-viz/src/components/TooltipWrapper/TooltipWrapper.tsx
@@ -324,7 +324,6 @@ function TooltipWrapperRaw(props: BaseProps) {
 
   return (
     <TooltipAnimatedContainer
-      activePointIndex={position.activeIndex}
       bandwidth={bandwidth}
       chartBounds={chartBounds}
       chartType={chartType}

--- a/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/tests/Chart.test.tsx
@@ -39,6 +39,28 @@ jest.mock('@shopify/polaris-viz-core/src/hooks/useChartContext', () => ({
   })),
 }));
 
+jest.mock('../../../hooks/useResizeObserver', () => {
+  return {
+    useResizeObserver: () => {
+      return {
+        setRef: () => {},
+        entry: {
+          contentRect: {
+            width: 100,
+            height: 100,
+          },
+          target: {
+            getBoundingClientRect: () => ({
+              width: 100,
+              height: 100,
+            }),
+          },
+        },
+      };
+    },
+  };
+});
+
 const renderTooltipContent = () => <p>Mock Tooltip</p>;
 
 const MOCK_PROPS: Props = {

--- a/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
@@ -90,32 +90,54 @@ export function renderLinearTooltipContent(
 
       const hasTitle = dataSeries.some(({isHidden}) => isHidden !== true);
 
+      const content = dataSeries
+        .map(
+          ({
+            name,
+            data,
+            color,
+            isComparison,
+            groupIndex,
+            styleOverride,
+            isHidden,
+            metadata,
+          }) => {
+            const item = data[tooltipData.activeIndex];
+
+            if (
+              metadata?.relatedIndex !== activeColorVisionIndex &&
+              activeColorVisionIndex !== -1 &&
+              groupIndex !== activeColorVisionIndex
+            ) {
+              return null;
+            }
+
+            return (
+              <TooltipRow
+                color={color}
+                isComparison={isComparison}
+                isHidden={isHidden}
+                key={`row-${groupIndex}`}
+                label={name}
+                renderSeriesIcon={() => renderSeriesIcon(color, styleOverride)}
+                shape={styleOverride?.tooltip?.shape ?? 'Line'}
+                value={formatters.valueFormatter(item.value ?? 0)}
+              />
+            );
+          },
+        )
+        .filter(Boolean);
+
+      if (content.length === 0) {
+        return null;
+      }
+
       return (
         <TooltipSeries isEmpty={!hasTitle} key={seriesName}>
           {hasTitle && (
             <TooltipSeriesName theme={theme}>{seriesName}</TooltipSeriesName>
           )}
-          {dataSeries.map(
-            ({name, data, color, groupIndex, styleOverride, isHidden}) => {
-              const item = data[tooltipData.activeIndex];
-
-              return (
-                <TooltipRow
-                  activeIndex={activeColorVisionIndex}
-                  color={color}
-                  index={groupIndex}
-                  isHidden={isHidden}
-                  key={`row-${groupIndex}`}
-                  label={name}
-                  renderSeriesIcon={() =>
-                    renderSeriesIcon(color, styleOverride)
-                  }
-                  shape={styleOverride?.tooltip?.shape ?? 'Line'}
-                  value={formatters.valueFormatter(item.value ?? 0)}
-                />
-              );
-            },
-          )}
+          {content}
         </TooltipSeries>
       );
     });


### PR DESCRIPTION
## What does this implement/fix?

To clean up the visual noise of the tooltips, we're removing inactive items from rendering in the tooltip when other series have focus.

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/f456d553-a5f6-4e88-8fa3-6b9dcb57df1e)|![image](https://github.com/user-attachments/assets/86a81133-7261-4a22-a0ff-86b97ed7bd48)|

 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
