### PR TITLE
Render TrendIndicator in tooltips

### DIFF
--- a/packages/polaris-viz-core/src/index.ts
+++ b/packages/polaris-viz-core/src/index.ts
@@ -158,4 +158,7 @@ export type {
   TargetLine,
   ErrorBoundaryResponse,
   Position,
+  TrendIndicator,
+  Trend,
+  TrendDirection,
 } from './types';

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -6,6 +6,7 @@ export type LabelFormatter = (value: string | number | null) => string;
 export interface DataPoint {
   key: number | string;
   value: number | null;
+  trend?: TrendIndicator;
 }
 
 export interface DataSeries {
@@ -30,6 +31,16 @@ interface StyleOverride {
   tooltip?: {
     shape?: Shape;
   };
+}
+
+export type Trend = 'positive' | 'negative' | 'neutral';
+export type TrendDirection = 'upward' | 'downward';
+
+export interface TrendIndicator {
+  accessibilityLabel?: string;
+  direction?: TrendDirection;
+  trend?: Trend;
+  value?: string | null;
 }
 
 export interface DataGroup {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `trend` value to `DataPoint` to render `<TrendIndicator />` in tooltips.
 
 ## [16.7.1] - 2025-03-03
 

--- a/packages/polaris-viz/src/components/ComparisonMetric/ComparisonMetric.tsx
+++ b/packages/polaris-viz/src/components/ComparisonMetric/ComparisonMetric.tsx
@@ -1,4 +1,4 @@
-import type {Trend} from 'types';
+import type {Trend} from '@shopify/polaris-viz-core';
 
 import {TrendIndicator} from '../TrendIndicator';
 

--- a/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
+++ b/packages/polaris-viz/src/components/LineChart/hooks/useLineChartTooltipContent.ts
@@ -46,7 +46,7 @@ export function useLineChartTooltipContent({
         if (!seriesData[activeIndex]) {
           return;
         }
-        const {value} = seriesData[activeIndex];
+        const {value, trend} = seriesData[activeIndex];
 
         tooltipData[0].data.push({
           key: `${seriesNameFormatter(name ?? '')}`,
@@ -54,6 +54,7 @@ export function useLineChartTooltipContent({
           color: color!,
           isComparison,
           isHidden: hiddenIndexes.includes(index),
+          trend,
         });
       });
 

--- a/packages/polaris-viz/src/components/LineChart/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/data.tsx
@@ -1,4 +1,5 @@
 import type {Story} from '@storybook/react';
+import type {DataSeries} from '@shopify/polaris-viz-core';
 
 import type {LineChartProps} from '../LineChart';
 import {LineChart} from '../LineChart';
@@ -22,23 +23,35 @@ export const DEFAULT_PROPS: Partial<LineChartProps> = {
   },
 };
 
-export const DEFAULT_DATA = [
+export const DEFAULT_DATA: DataSeries[] = [
   {
     name: 'Apr 1 – Apr 14, 2020',
     data: [
       {value: 333, key: '2020-04-01T12:00:00'},
-      {value: 797, key: '2020-04-02T12:00:00'},
+      {
+        value: 797,
+        key: '2020-04-02T12:00:00',
+        trend: {value: '123', direction: 'upward', trend: 'positive'},
+      },
       {value: 234, key: '2020-04-03T12:00:00'},
       {value: 534, key: '2020-04-04T12:00:00'},
-      {value: 132, key: '2020-04-05T12:00:00'},
+      {value: 132, key: '2020-04-05T12:00:00', trend: {value: null}},
       {value: 159, key: '2020-04-06T12:00:00'},
       {value: 239, key: '2020-04-07T12:00:00'},
       {value: 708, key: '2020-04-08T12:00:00'},
-      {value: 234, key: '2020-04-09T12:00:00'},
+      {
+        value: 234,
+        key: '2020-04-09T12:00:00',
+        trend: {value: '123', direction: 'downward'},
+      },
       {value: 645, key: '2020-04-10T12:00:00'},
       {value: 543, key: '2020-04-11T12:00:00'},
       {value: 89, key: '2020-04-12T12:00:00'},
-      {value: 849, key: '2020-04-13T12:00:00'},
+      {
+        value: 849,
+        key: '2020-04-13T12:00:00',
+        trend: {value: '123', direction: 'upward', trend: 'negative'},
+      },
       {value: 129, key: '2020-04-14T12:00:00'},
     ],
   },
@@ -46,7 +59,7 @@ export const DEFAULT_DATA = [
     name: 'Previous month',
     data: [
       {value: 709, key: '2020-03-02T12:00:00'},
-      {value: 238, key: '2020-03-01T12:00:00'},
+      {value: 238, key: '2020-03-01T12:00:00', trend: {value: null}},
       {value: 190, key: '2020-03-03T12:00:00'},
       {value: 90, key: '2020-03-04T12:00:00'},
       {value: 237, key: '2020-03-05T12:00:00'},

--- a/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/utilities/renderLinearPredictiveTooltipContent.tsx
@@ -60,7 +60,8 @@ export function renderLinearPredictiveTooltipContent(
       if (
         isComparison !== true &&
         activeColorVisionIndex !== -1 &&
-        index !== activeColorVisionIndex
+        index !== activeColorVisionIndex &&
+        !isHidden
       ) {
         return null;
       }
@@ -68,7 +69,6 @@ export function renderLinearPredictiveTooltipContent(
       return (
         <TooltipRow
           color={color}
-          isHidden={isHidden}
           key={`row-${seriesIndex}`}
           label={formatters.keyFormatter(key)}
           renderSeriesIcon={() => renderSeriesIcon(color, isComparison)}

--- a/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/TooltipContent.tsx
@@ -10,9 +10,9 @@ import {
   TooltipContentContainer,
   TooltipRow,
   TooltipSeries,
-  TooltipSeriesName,
   TooltipTitle,
-} from './components/';
+} from './components';
+import {getTooltipContentTemplateColumnCount} from './utilities/get-tooltip-template-content-column-count';
 
 export interface TooltipContentProps {
   data: TooltipData[];
@@ -50,18 +50,27 @@ export function TooltipContent({
         <Fragment>
           {title != null && <TooltipTitle theme={theme}>{title}</TooltipTitle>}
 
-          {data.map(({data: series, name, shape}, dataIndex) => {
+          {data.map((tooltipData, dataIndex) => {
+            const {data: series, name, shape} = tooltipData;
+
             const hasName = name != null;
             const isEmpty = !hasName && series.length === 0;
 
+            if (isEmpty) {
+              return null;
+            }
+
             return (
-              <TooltipSeries isEmpty={isEmpty} key={dataIndex}>
-                {hasName && (
-                  <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
+              <TooltipSeries
+                key={dataIndex}
+                name={name}
+                templateColumnCount={getTooltipContentTemplateColumnCount(
+                  tooltipData,
                 )}
+              >
                 {series.map(
                   (
-                    {key, value, color, isComparison, isHidden},
+                    {key, value, color, isComparison, isHidden, trend},
                     seriesIndex,
                   ) => {
                     // This check is for when we are rendering multiple series lines
@@ -69,6 +78,7 @@ export function TooltipContent({
                     // We only want to render the active series line and it's
                     // matching comparison series line.
                     if (
+                      !isHidden &&
                       // If we more than 2 series lines...
                       isMultiSeries &&
                       // and the series is not a comparison series...
@@ -93,12 +103,12 @@ export function TooltipContent({
 
                     return (
                       <TooltipRow
-                        key={`row-${seriesIndex}`}
                         color={color}
                         isComparison={isComparison}
-                        isHidden={isHidden}
+                        key={`row-${seriesIndex}`}
                         label={key}
                         shape={shape}
+                        trend={trend}
                         value={value}
                       />
                     );

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.scss
@@ -4,16 +4,23 @@
   line-height: 16px;
   font-size: 11px;
   gap: 8px;
-  display: flex;
+  display: grid;
+  grid-template-columns: subgrid;
   align-items: center;
+  grid-column: 1 / -1;
 }
 
 .Value {
   margin-left: auto;
   text-align: right;
   white-space: nowrap;
+  font-feature-settings: 'tnum';
 }
 
 .Truncate {
   @include ellipsis-overflow;
+}
+
+.Trend {
+  margin-top: -2px;
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/TooltipRow.tsx
@@ -1,36 +1,37 @@
 import {useTheme} from '@shopify/polaris-viz-core';
-import type {Shape, Color} from '@shopify/polaris-viz-core';
+import type {
+  Shape,
+  Color,
+  TrendIndicator as TrendIndicatorType,
+} from '@shopify/polaris-viz-core';
 
+import {TrendIndicator} from '../../../TrendIndicator';
 import {PREVIEW_ICON_SIZE} from '../../../../constants';
 import {SeriesIcon} from '../../../shared/SeriesIcon';
 import {TITLE_MARGIN} from '../../constants';
 
 import styles from './TooltipRow.scss';
 
-interface Props {
+export interface Props {
   label: string;
   shape: Shape;
   value: string;
   color?: Color;
   isComparison?: boolean;
-  isHidden?: boolean;
   renderSeriesIcon?: () => React.ReactNode;
+  trend?: TrendIndicatorType;
 }
 
 export function TooltipRow({
   color,
   isComparison = false,
-  isHidden = false,
   label,
   renderSeriesIcon,
   shape,
+  trend,
   value,
 }: Props) {
   const selectedTheme = useTheme();
-
-  if (isHidden) {
-    return null;
-  }
 
   return (
     <div className={styles.Row}>
@@ -62,6 +63,11 @@ export function TooltipRow({
       >
         {value}
       </span>
+      {trend != null && (
+        <div className={styles.Trend}>
+          <TrendIndicator {...trend} />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/test/TooltipRow.test.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipRow/test/TooltipRow.test.tsx
@@ -1,0 +1,128 @@
+import {mount} from '@shopify/react-testing';
+import {LIGHT_THEME} from '@shopify/polaris-viz-core';
+
+import type {Props} from '../TooltipRow';
+import {TooltipRow} from '../TooltipRow';
+import {SeriesIcon} from '../../../../shared/SeriesIcon';
+import {PREVIEW_ICON_SIZE} from '../../../../../constants';
+import {TrendIndicator} from '../../../..';
+
+describe('<TooltipRow />', () => {
+  describe('label', () => {
+    it('renders the label', () => {
+      const component = mount(
+        <TooltipRow {...MOCK_PROPS} label="Text Label" />,
+      );
+
+      expect(component).toContainReactComponent('span', {
+        className: 'Truncate',
+        style: {
+          color: LIGHT_THEME.tooltip.textColor,
+          marginRight: 10,
+        },
+        children: 'Text Label',
+      });
+    });
+  });
+
+  describe('shape', () => {
+    it('renders a <SeriesIcon /> with provided shape', () => {
+      const component = mount(
+        <TooltipRow {...MOCK_PROPS} shape="Bar" color="red" />,
+      );
+
+      expect(component).toContainReactComponent(SeriesIcon, {
+        shape: 'Bar',
+      });
+    });
+  });
+
+  describe('value', () => {
+    it('renders the value', () => {
+      const component = mount(<TooltipRow {...MOCK_PROPS} value="200" />);
+
+      expect(component).toContainReactComponent('span', {
+        className: 'Value',
+        style: {
+          color: LIGHT_THEME.tooltip.textColor,
+        },
+        children: '200',
+      });
+    });
+  });
+
+  describe('color', () => {
+    it('renders a <SeriesIcon /> with provided color', () => {
+      const component = mount(<TooltipRow {...MOCK_PROPS} color="red" />);
+
+      expect(component).toContainReactComponent('div', {
+        style: {
+          width: PREVIEW_ICON_SIZE,
+        },
+      });
+
+      expect(component).toContainReactComponent(SeriesIcon, {
+        color: 'red',
+      });
+    });
+
+    it('does not render a <SeriesIcon /> when color is null', () => {
+      const component = mount(<TooltipRow {...MOCK_PROPS} />);
+
+      expect(component).not.toContainReactComponent(SeriesIcon);
+    });
+  });
+
+  describe('isComparison', () => {
+    it('overrides <SeriesIcon /> values when true', () => {
+      const component = mount(
+        <TooltipRow {...MOCK_PROPS} color="red" isComparison />,
+      );
+
+      expect(component).toContainReactComponent(SeriesIcon, {
+        lineStyle: 'dotted',
+      });
+    });
+  });
+
+  describe('renderSeriesIcon?', () => {
+    it('renders custom content instead of <SeriesIcon /> when provided', () => {
+      const component = mount(
+        <TooltipRow
+          {...MOCK_PROPS}
+          renderSeriesIcon={() => <div>Custom Icon</div>}
+          color="red"
+        />,
+      );
+
+      expect(component).toContainReactComponent('div', {
+        children: 'Custom Icon',
+      });
+      expect(component).not.toContainReactComponent(SeriesIcon);
+    });
+  });
+
+  describe('trend', () => {
+    it('renders a <TrendIndicator /> when provided', () => {
+      const component = mount(
+        <TooltipRow {...MOCK_PROPS} trend={{value: '100'}} />,
+      );
+
+      expect(component).toContainReactComponent(TrendIndicator, {
+        value: '100',
+      });
+    });
+
+    it('does not render a <TrendIndicator /> when null', () => {
+      const component = mount(<TooltipRow {...MOCK_PROPS} />);
+
+      expect(component).not.toContainReactComponent(TrendIndicator);
+    });
+  });
+});
+
+const MOCK_PROPS: Props = {
+  label: 'Label',
+  shape: 'Line',
+  value: '100',
+};

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/TooltipSeries.scss
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/TooltipSeries.scss
@@ -1,5 +1,4 @@
 .Series {
   gap: 4px;
-  display: flex;
-  flex-direction: column;
+  display: grid;
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/TooltipSeries.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/TooltipSeries.tsx
@@ -1,16 +1,35 @@
 import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import {useChartContext} from '@shopify/polaris-viz-core';
+
+import {TooltipSeriesName} from '../TooltipSeriesName';
 
 import styles from './TooltipSeries.scss';
 
-interface Props {
+export interface Props {
   children: ReactNode;
-  isEmpty?: boolean;
+  name?: string;
+  templateColumnCount?: number;
 }
 
-export function TooltipSeries({children, isEmpty = false}: Props) {
-  if (isEmpty) {
-    return null;
-  }
+export function TooltipSeries({
+  children,
+  templateColumnCount = 2,
+  name,
+}: Props) {
+  const {theme} = useChartContext();
 
-  return <div className={styles.Series}>{children}</div>;
+  return (
+    <Fragment>
+      {name != null && (
+        <TooltipSeriesName theme={theme}>{name}</TooltipSeriesName>
+      )}
+      <div
+        className={styles.Series}
+        style={{gridTemplateColumns: `repeat(${templateColumnCount}, auto)`}}
+      >
+        {children}
+      </div>
+    </Fragment>
+  );
 }

--- a/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/test/TooltipSeries.test.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/components/TooltipSeries/test/TooltipSeries.test.tsx
@@ -1,0 +1,63 @@
+import {mount} from '@shopify/react-testing';
+
+import type {Props} from '../TooltipSeries';
+import {TooltipSeries} from '../TooltipSeries';
+import {TooltipSeriesName} from '../../TooltipSeriesName';
+
+describe('<TooltipSeries />', () => {
+  describe('children', () => {
+    it('renders children', () => {
+      const component = mount(
+        <TooltipSeries {...MOCK_PROPS}>
+          <div>Children</div>
+        </TooltipSeries>,
+      );
+
+      expect(component).toContainReactText('Children');
+    });
+  });
+
+  describe('templateColumnCount', () => {
+    it('passes a value of 2 to gridTemplateColumns when null', () => {
+      const component = mount(<TooltipSeries {...MOCK_PROPS} />);
+
+      expect(component).toContainReactComponent('div', {
+        style: {
+          gridTemplateColumns: 'repeat(2, auto)',
+        },
+      });
+    });
+
+    it('passes value to gridTemplateColumns when provided', () => {
+      const component = mount(
+        <TooltipSeries {...MOCK_PROPS} templateColumnCount={3} />,
+      );
+
+      expect(component).toContainReactComponent('div', {
+        style: {
+          gridTemplateColumns: 'repeat(3, auto)',
+        },
+      });
+    });
+  });
+
+  describe('name', () => {
+    it('renders <TooltipSeriesName /> when provided', () => {
+      const component = mount(<TooltipSeries {...MOCK_PROPS} name="Test" />);
+
+      expect(component).toContainReactComponent(TooltipSeriesName, {
+        children: 'Test',
+      });
+    });
+
+    it('does not render <TooltipSeriesName /> when null', () => {
+      const component = mount(<TooltipSeries {...MOCK_PROPS} />);
+
+      expect(component).not.toContainReactComponent(TooltipSeriesName);
+    });
+  });
+});
+
+const MOCK_PROPS: Props = {
+  children: null,
+};

--- a/packages/polaris-viz/src/components/TooltipContent/index.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/index.ts
@@ -7,3 +7,4 @@ export {
   TooltipRow,
   TooltipSeries,
 } from './components';
+export {getTooltipContentTemplateColumnCount} from './utilities/get-tooltip-template-content-column-count';

--- a/packages/polaris-viz/src/components/TooltipContent/stories/WithTrendIndicator.stories.tsx
+++ b/packages/polaris-viz/src/components/TooltipContent/stories/WithTrendIndicator.stories.tsx
@@ -1,0 +1,43 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {TooltipContentProps} from '../../../components';
+
+import {Template} from './data';
+import {LIGHT_THEME} from '../../../constants';
+
+export const WithTrendIndicator: Story<TooltipContentProps> = Template.bind({});
+
+WithTrendIndicator.args = {
+  data: [
+    {
+      name: 'Sessions',
+      shape: 'Line',
+      data: [
+        {
+          key: 'Sessions from Google ads',
+          value: '5250',
+          color: LIGHT_THEME.seriesColors.all[0],
+          trend: {
+            direction: 'upward',
+            trend: 'positive',
+            value: '10%',
+          },
+        },
+        {
+          key: 'Sessions from Facebook ads',
+          value: '650',
+          color: LIGHT_THEME.seriesColors.all[1],
+          isComparison: true,
+          trend: {
+            direction: 'downward',
+            trend: 'negative',
+            value: '20%',
+          },
+        },
+      ],
+    },
+  ],
+  title: 'Tuesday',
+};

--- a/packages/polaris-viz/src/components/TooltipContent/utilities/get-tooltip-template-content-column-count.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/utilities/get-tooltip-template-content-column-count.ts
@@ -1,0 +1,10 @@
+import type {TooltipData} from '../../../types';
+
+const DEFAULT_COLUMN_COUNT = 2;
+
+export function getTooltipContentTemplateColumnCount(data: TooltipData) {
+  const hasTrend = data.data.some(({trend}) => trend != null);
+  const hasColor = data.data.some(({color}) => color != null);
+
+  return DEFAULT_COLUMN_COUNT + (hasColor ? 1 : 0) + (hasTrend ? 1 : 0);
+}

--- a/packages/polaris-viz/src/components/TooltipContent/utilities/tests/get-tooltip-template-content-column-count.test.ts
+++ b/packages/polaris-viz/src/components/TooltipContent/utilities/tests/get-tooltip-template-content-column-count.test.ts
@@ -1,0 +1,50 @@
+import type {TooltipData} from '../../../../types';
+import {getTooltipContentTemplateColumnCount} from '../get-tooltip-template-content-column-count';
+
+describe('getTooltipContentTemplateColumnCount()', () => {
+  it('returns the default column count when data does not have a trend or color', () => {
+    const data: TooltipData = {
+      shape: 'Line',
+      data: [
+        {
+          key: 'Sessions from Google ads',
+          value: '5250',
+        },
+      ],
+    };
+    expect(getTooltipContentTemplateColumnCount(data)).toBe(2);
+  });
+
+  it('adds a column when data has a color', () => {
+    const data: TooltipData = {
+      shape: 'Line',
+      data: [{key: 'Sessions from Google ads', value: '5250', color: 'red'}],
+    };
+    expect(getTooltipContentTemplateColumnCount(data)).toBe(3);
+  });
+
+  it('adds a column when data has a trend', () => {
+    const data: TooltipData = {
+      shape: 'Line',
+      data: [
+        {key: 'Sessions from Google ads', value: '5250', trend: {value: '10%'}},
+      ],
+    };
+    expect(getTooltipContentTemplateColumnCount(data)).toBe(3);
+  });
+
+  it('returns all columns when data has a color and trend', () => {
+    const data: TooltipData = {
+      shape: 'Line',
+      data: [
+        {
+          key: 'Sessions from Google ads with color and trend',
+          value: '5250',
+          color: 'red',
+          trend: {value: '10%'},
+        },
+      ],
+    };
+    expect(getTooltipContentTemplateColumnCount(data)).toBe(4);
+  });
+});

--- a/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
+++ b/packages/polaris-viz/src/components/TrendIndicator/TrendIndicator.tsx
@@ -1,7 +1,7 @@
+import type {TrendIndicator as TrendIndicatorType} from '@shopify/polaris-viz-core';
 import {useTheme, FONT_FAMILY} from '@shopify/polaris-viz-core';
 
 import {getFontSize} from '../../utilities/getFontSize';
-import type {Trend, TrendDirection} from '../../types';
 
 import {ArrowDown, ArrowUp, Svg} from './components/';
 import {estimateTrendIndicatorWidth} from './utilities/estimateTrendIndicatorWidth';
@@ -16,13 +16,9 @@ import {
 
 const TREND_FONT_WEIGHT = 650;
 
-export interface TrendIndicatorProps {
-  accessibilityLabel?: string;
-  direction?: TrendDirection;
+export interface TrendIndicatorProps extends TrendIndicatorType {
   tabIndex?: number;
   theme?: string;
-  trend?: Trend;
-  value?: string;
 }
 
 export function TrendIndicator({

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -40,6 +40,7 @@ export {
   TooltipTitle,
   TooltipRow,
   TooltipSeries,
+  getTooltipContentTemplateColumnCount,
 } from './TooltipContent';
 export type {TooltipContentProps} from './TooltipContent';
 export {ConicGradientWithStops} from './ConicGradientWithStops';

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -54,8 +54,6 @@ export type {
   InnerValueContents,
   RenderInnerValueContent,
   TooltipData,
-  Trend,
-  TrendDirection,
   RenderTooltipContentData,
   RenderLegendContent,
   TooltipOptions,
@@ -91,6 +89,8 @@ export type {
   GradientStop,
   DataPoint,
   ChartState,
+  Trend,
+  TrendDirection,
 } from '@shopify/polaris-viz-core';
 
 export {

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -6,6 +6,7 @@ import type {
   Shape,
   LabelFormatter,
   LineStyle,
+  TrendIndicator,
 } from '@shopify/polaris-viz-core';
 import type {Series, SeriesPoint} from 'd3-shape';
 import type {ScaleLinear} from 'd3-scale';
@@ -75,6 +76,7 @@ export interface RenderTooltipDataPoint {
   key: number | string;
   value: number | string | null;
   isHidden?: boolean;
+  trend?: TrendIndicator;
 }
 
 export interface TooltipFormatters {
@@ -104,6 +106,7 @@ export interface TooltipData {
     color?: Color;
     isComparison?: boolean;
     isHidden?: boolean;
+    trend?: TrendIndicatorProps;
   }[];
   name?: string;
 }
@@ -240,9 +243,6 @@ export interface InnerValueContents {
 }
 
 export type RenderInnerValueContent = (values: InnerValueContents) => ReactNode;
-
-export type Trend = 'positive' | 'negative' | 'neutral';
-export type TrendDirection = 'upward' | 'downward';
 
 export interface ColorVisionEventReturn extends CustomEvent {
   detail: {

--- a/packages/polaris-viz/src/utilities/fillMissingDataPoints.ts
+++ b/packages/polaris-viz/src/utilities/fillMissingDataPoints.ts
@@ -3,7 +3,7 @@ import type {DataSeries} from '@shopify/polaris-viz-core';
 export function fillMissingDataPoints(
   dataSeries: DataSeries[],
   isLinearData: boolean,
-) {
+): DataSeries[] {
   if (isLinearData) {
     const areAnyComparison = dataSeries.some(
       ({isComparison}) => isComparison === true,

--- a/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
+++ b/packages/polaris-viz/src/utilities/renderLinearTooltipContent.tsx
@@ -5,12 +5,16 @@ import {Fragment} from 'react';
 import {
   TooltipSeries,
   TooltipContentContainer,
-  TooltipSeriesName,
   TooltipTitle,
   TooltipRow,
   LinePreview,
+  getTooltipContentTemplateColumnCount,
 } from '../components';
-import type {RenderTooltipContentData, TooltipFormatters} from '../types';
+import type {
+  RenderTooltipContentData,
+  TooltipData,
+  TooltipFormatters,
+} from '../types';
 
 interface Group {
   title: string;
@@ -107,7 +111,8 @@ export function renderLinearTooltipContent(
             if (
               metadata?.relatedIndex !== activeColorVisionIndex &&
               activeColorVisionIndex !== -1 &&
-              groupIndex !== activeColorVisionIndex
+              groupIndex !== activeColorVisionIndex &&
+              !isHidden
             ) {
               return null;
             }
@@ -116,7 +121,6 @@ export function renderLinearTooltipContent(
               <TooltipRow
                 color={color}
                 isComparison={isComparison}
-                isHidden={isHidden}
                 key={`row-${groupIndex}`}
                 label={name}
                 renderSeriesIcon={() => renderSeriesIcon(color, styleOverride)}
@@ -128,15 +132,18 @@ export function renderLinearTooltipContent(
         )
         .filter(Boolean);
 
-      if (content.length === 0) {
+      if (content.length === 0 || !hasTitle) {
         return null;
       }
 
       return (
-        <TooltipSeries isEmpty={!hasTitle} key={seriesName}>
-          {hasTitle && (
-            <TooltipSeriesName theme={theme}>{seriesName}</TooltipSeriesName>
+        <TooltipSeries
+          key={seriesName}
+          name={seriesName.toString()}
+          templateColumnCount={getTooltipContentTemplateColumnCount(
+            tooltipData.data[0] as TooltipData,
           )}
+        >
           {content}
         </TooltipSeries>
       );


### PR DESCRIPTION
## What does this implement/fix?

Adds the ability to render a `TrendIndicator` along side a data point in the tooltips. This should allow us to remove the `AnalyticsTooltip` need in `analytics-ui-components` and we can rely on using only the PV tooltip rendering.

## What do the changes look like?

![image](https://github.com/user-attachments/assets/951ae416-78dc-49f0-943b-ba02b225c3e0)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-iwwvtwfwgf.chromatic.com/?path=/story/polaris-viz-charts-linechart--default

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
