### PR TITLE
fix validation of dates in BarChart to correctly fill missing data for concatenated string keys

### DIFF
--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -176,5 +176,11 @@ function isValidDate(dateString: string | number | null) {
   }
 
   const parsedDate = Date.parse(dateString.toString());
-  return !isNaN(parsedDate);
+  if (isNaN(parsedDate)) {
+    return dateString
+      .toString()
+      .split(' · ')
+      .some((date) => !isNaN(Date.parse(date)));
+  }
+  return true;
 }

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -175,12 +175,8 @@ function isValidDate(dateString: string | number | null) {
     return false;
   }
 
-  const parsedDate = Date.parse(dateString.toString());
-  if (isNaN(parsedDate)) {
-    return dateString
-      .toString()
-      .split(' · ')
-      .some((date) => !isNaN(Date.parse(date)));
-  }
-  return true;
+  return dateString
+    .toString()
+    .split(' · ')
+    .some((date) => !isNaN(Date.parse(date)));
 }


### PR DESCRIPTION
…them

## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->

Data points with keys like 'Product · January 1' sometimes fail to parse as a Date, meaning that the data is not correctly backfilled and comparison bars are not matched up correctly to primary bars.

Before this fix:
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/a83016f7-6c5f-470b-926f-38e31976ef83" />
After this fix:
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/0482be65-6246-4349-9fe5-0bf9424a997a" />

Notice that bars with concatenated date strings for comparisons are correctly grouped with their corresponding primary bar.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->

part of https://github.com/Shopify/core-issues/issues/84103

## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
