### PR TITLE
Funnel tooltip - explicitly set line height

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Explicitly set `line-height` for `<FunnelChartNext />` tooltips
 
 ## [16.10.1] - 2025-03-05
 

--- a/packages/polaris-viz/src/components/FunnelChartNext/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/Chart.tsx
@@ -39,6 +39,7 @@ import {
   TOOLTIP_HEIGHT,
   TOOLTIP_WIDTH,
   TOOLTIP_RIGHT_POSITION_THRESHOLD,
+  TOOLTIP_BOTTOM_OFFSET,
 } from './constants';
 import {useBuildFunnelTrends} from './utilities/useBuildFunnelTrends';
 
@@ -286,7 +287,7 @@ export function Chart({
       return yPosition;
     }
 
-    return yPosition - TOOLTIP_HEIGHT;
+    return yPosition - TOOLTIP_HEIGHT - TOOLTIP_BOTTOM_OFFSET;
   }
 
   function getBarHeightPercentage(value: number) {

--- a/packages/polaris-viz/src/components/FunnelChartNext/components/Tooltip/Tooltip.scss
+++ b/packages/polaris-viz/src/components/FunnelChartNext/components/Tooltip/Tooltip.scss
@@ -20,6 +20,7 @@
   grid-template-columns: 8px auto;
   column-gap: 4px;
   align-items: center;
+  line-height: 16px;
 }
 
 .Keys {

--- a/packages/polaris-viz/src/components/FunnelChartNext/constants.ts
+++ b/packages/polaris-viz/src/components/FunnelChartNext/constants.ts
@@ -5,6 +5,7 @@ export const TOOLTIP_HORIZONTAL_OFFSET = 10;
 export const LINE_OFFSET = 3;
 export const LINE_WIDTH = 1;
 export const TOOLTIP_HEIGHT = 130;
+export const TOOLTIP_BOTTOM_OFFSET = 5;
 export const TOOLTIP_RIGHT_POSITION_THRESHOLD = 65;
 export const SHORT_TOOLTIP_HEIGHT = 65;
 export const GAP = 1;


### PR DESCRIPTION
## What does this implement/fix?

We found a small discrepancy in https://github.com/Shopify/analytics-ui-components/pull/471 when viewing the funnel tooltips in web. Because we were not setting an explicit `line-height` in the Funnel tooltips, they were being inherited from web which was causing them to appear larger than desired. This PR just explicitly sets the `line-height` in the tooltip

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->


## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

<!--
🖼 Include screenshots of before and after, if relevant

| Before  | After  |
|---|---|
|   |   |

 -->

 
## Storybook link
https://6062ad4a2d14cd0021539c1b-xtlgbpdvug.chromatic.com/?path=/story/polaris-viz-charts-funnelchartnext--with-trend-indicators
<!-- 🎩 Include links to help tophatting -->


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
