### PR TITLE
Add Support for Dynamic Annotation Popover Rendering

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Add support for custom annotiation content rendering using `renderAnnotationContent`
 
 ## [16.11.0] - 2025-03-10
 

--- a/packages/polaris-viz/src/components/Annotations/Annotations.tsx
+++ b/packages/polaris-viz/src/components/Annotations/Annotations.tsx
@@ -2,7 +2,11 @@ import {Fragment, useMemo, useState} from 'react';
 import type {ScaleBand, ScaleLinear} from 'd3-scale';
 import type {LabelFormatter} from '@shopify/polaris-viz-core';
 
-import type {Annotation, AnnotationLookupTable} from '../../types';
+import type {
+  Annotation,
+  AnnotationLookupTable,
+  RenderAnnotationContentData,
+} from '../../types';
 import {useSVGBlurEvent} from '../../hooks/useSVGBlurEvent';
 import {shouldHideAnnotation} from '../../utilities/shouldHideAnnotation';
 import {isShowMoreAnnotationsButtonVisible} from '../../utilities/isShowMoreAnnotationsButtonVisible';
@@ -25,6 +29,9 @@ export interface AnnotationsProps {
   labelFormatter: LabelFormatter;
   labels: string[];
   onHeightChange: (height: number) => void;
+  renderAnnotationContent?: (
+    data: RenderAnnotationContentData,
+  ) => React.ReactNode;
   xScale: ScaleLinear<number, number> | ScaleBand<string>;
 }
 
@@ -37,6 +44,7 @@ export function Annotations({
   onHeightChange,
   xScale,
   labelFormatter,
+  renderAnnotationContent,
 }: AnnotationsProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
   const [isShowingAllAnnotations, setIsShowingAllAnnotations] = useState(false);
@@ -159,6 +167,7 @@ export function Annotations({
                   onMouseLeave={handleOnMouseLeave}
                   parentRef={ref}
                   position={position}
+                  renderAnnotationContent={renderAnnotationContent}
                   tabIndex={tabIndex}
                   x={line.x}
                   y={y}

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
@@ -13,10 +13,12 @@
   margin: 0 0 4px;
 }
 
-.Content {
+.Content,
+.Content p {
   font-size: 11px;
   line-height: 16px;
   margin: 0;
+  color: inherit;
 }
 
 .Link {

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.test.tsx
@@ -177,6 +177,32 @@ describe('<AnnotationContent />', () => {
     });
   });
 
+  describe('renderAnnotationContent', () => {
+    it('renders custom content', () => {
+      const chart = mount(
+        <AnnotationContent
+          {...MOCK_PROPS}
+          parentRef={svg}
+          renderAnnotationContent={() => (
+            <p>
+              Custom content that is{' '}
+              <span style={{fontWeight: 'bold'}}>bolded</span>
+            </p>
+          )}
+        />,
+      );
+
+      expect(chart).not.toContainReactText(
+        MOCK_PROPS.annotation.content.content,
+      );
+
+      expect(chart).toContainReactComponent('span', {
+        children: 'bolded',
+        style: {fontWeight: 'bold'},
+      });
+    });
+  });
+
   it('renders background with opacity', () => {
     const chart = mount(<AnnotationContent {...MOCK_PROPS} parentRef={svg} />);
 

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
@@ -1,10 +1,10 @@
-import {useEffect, useLayoutEffect, useState} from 'react';
+import {Fragment, useEffect, useLayoutEffect, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {changeColorOpacity, clamp, useTheme} from '@shopify/polaris-viz-core';
 
 import {TOOLTIP_BG_OPACITY} from '../../../../constants';
 import {useBrowserCheck} from '../../../../hooks/useBrowserCheck';
-import type {Annotation} from '../../../../types';
+import type {Annotation, RenderAnnotationContentData} from '../../../../types';
 import type {AnnotationPosition} from '../../types';
 
 import styles from './AnnotationContent.scss';
@@ -18,6 +18,9 @@ export interface AnnotationContentProps {
   onMouseLeave: () => void;
   parentRef: SVGElement | null;
   position: AnnotationPosition;
+  renderAnnotationContent?: (
+    data: RenderAnnotationContentData,
+  ) => React.ReactNode;
   tabIndex: number;
   x: number;
   y: number;
@@ -30,6 +33,7 @@ export function AnnotationContent({
   onMouseLeave,
   parentRef,
   tabIndex,
+  renderAnnotationContent,
   x,
   y,
 }: AnnotationContentProps) {
@@ -93,6 +97,7 @@ export function AnnotationContent({
             selectedTheme.tooltip.backgroundColor,
             isFirefox ? 1 : TOOLTIP_BG_OPACITY,
           ),
+          color: selectedTheme.tooltip.textColor,
         }}
         id={`annotation-content-${index}`}
         role="dialog"
@@ -107,24 +112,30 @@ export function AnnotationContent({
             {title}
           </p>
         )}
-        <p
+        <div
           className={styles.Content}
           style={{color: selectedTheme.tooltip.textColor}}
           data-is-annotation-content
         >
-          {content}
+          {renderAnnotationContent ? (
+            renderAnnotationContent({annotation})
+          ) : (
+            <Fragment>
+              <p style={{color: selectedTheme.tooltip.textColor}}>{content}</p>
 
-          {linkUrl != null && (
-            <a
-              href={linkUrl}
-              className={styles.Link}
-              tabIndex={tabIndex}
-              style={{color: selectedTheme.annotations.linkColor}}
-            >
-              {linkText}
-            </a>
+              {linkUrl != null && (
+                <a
+                  href={linkUrl}
+                  className={styles.Link}
+                  tabIndex={tabIndex}
+                  style={{color: selectedTheme.annotations.linkColor}}
+                >
+                  {linkText}
+                </a>
+              )}
+            </Fragment>
           )}
-        </p>
+        </div>
       </div>
     </Wrapper>,
     parentRef ?? document.body,

--- a/packages/polaris-viz/src/components/Annotations/tests/Annotations.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/tests/Annotations.test.tsx
@@ -83,6 +83,7 @@ const MOCK_PROPS: AnnotationsProps = {
   onHeightChange: jest.fn(),
   xScale: scaleBand(),
   labelFormatter: (value) => `${value}`,
+  renderAnnotationContent: undefined,
 };
 
 describe('<Annotations />', () => {
@@ -214,5 +215,24 @@ describe('<Annotations />', () => {
     );
 
     expect(component).toContainReactComponentTimes(AnnotationLabel, 1);
+  });
+
+  it('renders custom annotation content', () => {
+    const component = mount(
+      <svg>
+        <Annotations
+          {...MOCK_PROPS}
+          renderAnnotationContent={() => <p>Custom content</p>}
+        />
+      </svg>,
+    );
+
+    const labels = component.findAll(AnnotationLabel);
+
+    labels[1].trigger('setActiveIndex', 1);
+
+    expect(component).toContainReactComponent(AnnotationContent, {
+      renderAnnotationContent: expect.any(Function),
+    });
   });
 });

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {Fragment, useRef} from 'react';
 import {
   uniqueId,
@@ -20,6 +21,7 @@ import {getTooltipContentRenderer} from '../../utilities/getTooltipContentRender
 import {ChartContainer} from '../../components/ChartContainer';
 import type {
   Annotation,
+  RenderAnnotationContentData,
   RenderLegendContent,
   TooltipOptions,
 } from '../../types';
@@ -49,6 +51,7 @@ export type BarChartProps = {
   type?: ChartType;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderHiddenLegendLabel?: (count: number) => string;
   renderBucketLegendLabel?: () => string;
   scrollContainer?: Element | null;
@@ -76,6 +79,7 @@ export function BarChart(props: BarChartProps) {
     xAxisOptions,
     yAxisOptions,
     onError,
+    renderAnnotationContent,
     renderHiddenLegendLabel,
     renderBucketLegendLabel,
     seriesNameFormatter = (value) => `${value}`,
@@ -121,6 +125,7 @@ export function BarChart(props: BarChartProps) {
         annotationsLookupTable={annotationsLookupTable}
         data={data}
         emptyStateText={emptyStateText}
+        renderAnnotationContent={renderAnnotationContent}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
         seriesNameFormatter={seriesNameFormatter}
@@ -135,6 +140,7 @@ export function BarChart(props: BarChartProps) {
         annotationsLookupTable={annotationsLookupTable}
         data={data}
         renderHiddenLegendLabel={renderHiddenLegendLabel}
+        renderAnnotationContent={renderAnnotationContent}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
         seriesNameFormatter={seriesNameFormatter}

--- a/packages/polaris-viz/src/components/ComboChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/Chart.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {useState} from 'react';
 import * as React from 'react';
 import {
@@ -26,6 +27,7 @@ import {
 import {TooltipWrapper} from '../TooltipWrapper';
 import type {
   AnnotationLookupTable,
+  RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -49,6 +51,7 @@ import {useComboChartPositions} from './hooks/useComboChartPositions';
 export interface ChartProps {
   annotationsLookupTable: AnnotationLookupTable;
   data: DataGroup[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderTooltipContent(data: RenderTooltipContentData): React.ReactNode;
   seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
@@ -60,6 +63,7 @@ export interface ChartProps {
 export function Chart({
   annotationsLookupTable,
   data,
+  renderAnnotationContent,
   renderTooltipContent,
   showLegend,
   theme,
@@ -268,6 +272,7 @@ export function Chart({
               labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
+              renderAnnotationContent={renderAnnotationContent}
             />
           </g>
         )}

--- a/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
+++ b/packages/polaris-viz/src/components/ComboChart/ComboChart.tsx
@@ -17,6 +17,7 @@ import {getXAxisOptionsWithDefaults, normalizeData} from '../../utilities';
 import {ChartContainer} from '../ChartContainer';
 import type {
   ComboAnnotation,
+  RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -27,6 +28,7 @@ import {formatDataForTooltip} from './utilities/formatDataForTooltip';
 export type ComboChartProps = {
   data: DataGroup[];
   annotations?: ComboAnnotation[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderTooltipContent?(data: RenderTooltipContentData): ReactNode;
   seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
@@ -43,6 +45,7 @@ export function ComboChart(props: ComboChartProps) {
     onError,
     id,
     isAnimated,
+    renderAnnotationContent,
     renderTooltipContent,
     seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
@@ -86,6 +89,7 @@ export function ComboChart(props: ComboChartProps) {
       <Chart
         annotationsLookupTable={annotationsLookupTable}
         data={data}
+        renderAnnotationContent={renderAnnotationContent}
         renderTooltipContent={renderTooltip}
         seriesNameFormatter={seriesNameFormatter}
         showLegend={showLegend}

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -29,6 +29,7 @@ export type DonutChartProps = {
   legendFullWidth?: boolean;
   legendPosition?: LegendPosition;
   tooltipOptions?: TooltipOptions;
+
   renderInnerValueContent?: RenderInnerValueContent;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: RenderHiddenLegendLabel;

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -25,6 +25,7 @@ import {checkAvailableAnnotations} from '../../components/Annotations';
 import {useFormattedLabels} from '../../hooks/useFormattedLabels';
 import type {
   AnnotationLookupTable,
+  RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -62,6 +63,7 @@ export interface ChartProps {
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderHiddenLegendLabel?: (count: number) => string;
   renderLegendContent?: RenderLegendContent;
 }
@@ -69,6 +71,7 @@ export interface ChartProps {
 export function Chart({
   annotationsLookupTable,
   data,
+  renderAnnotationContent,
   renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
@@ -273,6 +276,7 @@ export function Chart({
               drawableHeight={annotationsDrawableHeight}
               drawableWidth={drawableWidth}
               onHeightChange={setAnnotationsHeight}
+              renderAnnotationContent={renderAnnotationContent}
               xScale={xScale}
             />
           </g>
@@ -285,6 +289,7 @@ export function Chart({
               drawableWidth={drawableWidth}
               groupHeight={groupHeight}
               labels={unformattedLabels}
+              renderAnnotationContent={renderAnnotationContent}
               zeroPosition={zeroPosition}
             />
           </g>

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -11,12 +11,14 @@ import type {
   AnnotationLookupTable,
   RenderTooltipContentData,
   RenderLegendContent,
+  RenderAnnotationContentData,
 } from '../../types';
 
 import {Chart} from './Chart';
 
 export interface HorizontalBarChartProps {
   data: DataSeries[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
   seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
@@ -31,6 +33,7 @@ export interface HorizontalBarChartProps {
 export function HorizontalBarChart({
   annotationsLookupTable = {},
   data,
+  renderAnnotationContent,
   renderHiddenLegendLabel,
   renderLegendContent,
   renderTooltipContent,
@@ -50,6 +53,7 @@ export function HorizontalBarChart({
       type={type}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
+      renderAnnotationContent={renderAnnotationContent}
       renderLegendContent={renderLegendContent}
       renderHiddenLegendLabel={renderHiddenLegendLabel}
     />

--- a/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartXAnnotations/HorizontalBarChartXAnnotations.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartXAnnotations/HorizontalBarChartXAnnotations.tsx
@@ -1,8 +1,13 @@
+import type {ReactNode} from 'react';
 import {Fragment, useMemo, useState} from 'react';
 import type {ScaleLinear} from 'd3-scale';
 import {isValueWithinDomain} from '@shopify/polaris-viz-core';
 
-import type {Annotation, AnnotationLookupTable} from '../../../../types';
+import type {
+  Annotation,
+  AnnotationLookupTable,
+  RenderAnnotationContentData,
+} from '../../../../types';
 import {useSVGBlurEvent} from '../../../../hooks/useSVGBlurEvent';
 import {
   AnnotationLabel,
@@ -22,6 +27,7 @@ export interface AnnotationsProps {
   drawableHeight: number;
   drawableWidth: number;
   onHeightChange: (height: number) => void;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   xScale: ScaleLinear<number, number>;
 }
 
@@ -30,6 +36,7 @@ export function HorizontalBarChartXAnnotations({
   drawableHeight,
   drawableWidth,
   onHeightChange,
+  renderAnnotationContent,
   xScale,
 }: AnnotationsProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -146,6 +153,7 @@ export function HorizontalBarChartXAnnotations({
                   onMouseLeave={handleOnMouseLeave}
                   parentRef={ref}
                   position={position}
+                  renderAnnotationContent={renderAnnotationContent}
                   tabIndex={tabIndex}
                   x={line.x}
                   y={y}

--- a/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartYAnnotations/HorizontalBarChartYAnnotations.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/components/HorizontalBarChartYAnnotations/HorizontalBarChartYAnnotations.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {Fragment, useMemo, useState} from 'react';
 
 import {
@@ -5,7 +6,11 @@ import {
   AnnotationLabel,
   AnnotationLine,
 } from '../../../Annotations';
-import type {Annotation, AnnotationLookupTable} from '../../../../types';
+import type {
+  Annotation,
+  AnnotationLookupTable,
+  RenderAnnotationContentData,
+} from '../../../../types';
 import {useSVGBlurEvent} from '../../../../hooks/useSVGBlurEvent';
 
 import {useHorizontalBarChartYAnnotationsPositions} from './hooks/useHorizontalBarChartYAnnotationsPositions';
@@ -15,6 +20,7 @@ export interface YAxisAnnotationsProps {
   drawableWidth: number;
   groupHeight: number;
   labels: string[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   zeroPosition: number;
 }
 
@@ -23,6 +29,7 @@ export function HorizontalBarChartYAnnotations({
   drawableWidth,
   groupHeight,
   labels,
+  renderAnnotationContent,
   zeroPosition,
 }: YAxisAnnotationsProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -115,6 +122,7 @@ export function HorizontalBarChartYAnnotations({
                   onMouseLeave={handleOnMouseLeave}
                   parentRef={ref}
                   position={position}
+                  renderAnnotationContent={renderAnnotationContent}
                   tabIndex={tabIndex}
                   x={drawableWidth - (drawableWidth - x)}
                   y={y}

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -32,6 +32,7 @@ import {
 import type {
   AnnotationLookupTable,
   LineChartSlotProps,
+  RenderAnnotationContentData,
   RenderHiddenLegendLabel,
   RenderLegendContent,
   RenderTooltipContentData,
@@ -63,27 +64,29 @@ import {useFormatData} from './hooks';
 import {yAxisMinMax} from './utilities';
 
 export interface ChartProps {
-  renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
   annotationsLookupTable: AnnotationLookupTable;
   data: LineChartDataSeriesWithDefaults[];
+  emptyStateText?: string;
+  hideLegendOverflow: boolean;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
+  renderHiddenLegendLabel?: RenderHiddenLegendLabel;
+  renderLegendContent?: RenderLegendContent;
+  renderTooltipContent: (data: RenderTooltipContentData) => ReactNode;
   seriesNameFormatter: LabelFormatter;
   showLegend: boolean;
-  hideLegendOverflow: boolean;
-  xAxisOptions: Required<XAxisOptions>;
-  yAxisOptions: Required<YAxisOptions>;
-  emptyStateText?: string;
-  renderLegendContent?: RenderLegendContent;
-  renderHiddenLegendLabel?: RenderHiddenLegendLabel;
   slots?: {
     chart?: (props: LineChartSlotProps) => JSX.Element;
   };
   theme?: string;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
 }
 
 export function Chart({
   annotationsLookupTable,
   emptyStateText,
   data,
+  renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
   renderHiddenLegendLabel,
@@ -387,6 +390,7 @@ export function Chart({
               labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
+              renderAnnotationContent={renderAnnotationContent}
             />
           </g>
         )}

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {Fragment, useRef} from 'react';
 import type {
   XAxisOptions,
@@ -29,6 +30,7 @@ import {useTheme} from '../../hooks';
 import type {
   Annotation,
   LineChartSlotProps,
+  RenderAnnotationContentData,
   RenderLegendContent,
   TooltipOptions,
 } from '../../types';
@@ -39,6 +41,7 @@ export type LineChartProps = {
   annotations?: Annotation[];
   errorText?: string;
   emptyStateText?: string;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
   seriesNameFormatter?: LabelFormatter;
@@ -65,6 +68,7 @@ export function LineChart(props: LineChartProps) {
     id,
     isAnimated,
     onError,
+    renderAnnotationContent,
     renderLegendContent,
     renderHiddenLegendLabel,
     seriesNameFormatter = (value) => `${value}`,
@@ -124,6 +128,7 @@ export function LineChart(props: LineChartProps) {
             annotationsLookupTable={annotationsLookupTable}
             data={dataWithDefaults}
             emptyStateText={emptyStateText}
+            renderAnnotationContent={renderAnnotationContent}
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}
             renderHiddenLegendLabel={renderHiddenLegendLabel}

--- a/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/Annotations.stories.tsx
@@ -40,6 +40,11 @@ Annotations.args = {
       },
     },
   ],
+  renderAnnotationContent: (data) => (
+    <p>
+      Rendering custom content for the label <b>{data.annotation.label}</b>
+    </p>
+  ),
   xAxisOptions: {
     labelFormatter: (value) =>
       new Intl.DateTimeFormat('en-US', {

--- a/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
+++ b/packages/polaris-viz/src/components/LineChart/tests/Chart.test.tsx
@@ -67,6 +67,7 @@ const MOCK_PROPS: ChartProps = {
   annotationsLookupTable: {},
   xAxisOptions,
   yAxisOptions,
+  renderAnnotationContent: jest.fn(() => <p>Mock Annotation</p>),
   renderTooltipContent: jest.fn(() => <p>Mock Tooltip</p>),
   showLegend: false,
   seriesNameFormatter: (value) => `${value}`,

--- a/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
@@ -28,6 +28,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
     state,
     theme,
     tooltipOptions: initialTooltipOptions,
+    renderAnnotationContent,
     xAxisOptions,
     yAxisOptions,
   } = {
@@ -110,6 +111,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
       tooltipOptions={tooltipOptions}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
+      renderAnnotationContent={renderAnnotationContent}
       renderLegendContent={({
         getColorVisionStyles,
         getColorVisionEventAttrs,

--- a/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
@@ -31,6 +31,7 @@ export function LineChartRelational(props: LineChartRelationalProps) {
     tooltipOptions,
     xAxisOptions,
     yAxisOptions,
+    renderAnnotationContent,
     renderHiddenLegendLabel,
   } = {
     ...DEFAULT_CHART_PROPS,
@@ -57,6 +58,7 @@ export function LineChartRelational(props: LineChartRelationalProps) {
       errorText={errorText}
       id={id}
       isAnimated={isAnimated}
+      renderAnnotationContent={renderAnnotationContent}
       renderLegendContent={(
         {getColorVisionStyles, getColorVisionEventAttrs},
         activeIndex,

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -32,6 +32,7 @@ import type {
   GetXPosition,
   RenderLegendContent,
   RenderTooltipContentData,
+  RenderAnnotationContentData,
 } from '../../types';
 import {XAxis} from '../XAxis';
 import {LegendContainer, useLegend} from '../LegendContainer';
@@ -64,6 +65,7 @@ export interface Props {
   theme: string;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
 }
@@ -77,6 +79,7 @@ export function Chart({
   showLegend,
   theme,
   yAxisOptions,
+  renderAnnotationContent,
   renderHiddenLegendLabel,
   seriesNameFormatter,
 }: Props) {
@@ -351,6 +354,7 @@ export function Chart({
               labels={labels}
               labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
+              renderAnnotationContent={renderAnnotationContent}
               xScale={xScale}
             />
           </g>

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {Fragment, useRef} from 'react';
 import {
   uniqueId,
@@ -24,6 +25,7 @@ import {ChartSkeleton} from '../ChartSkeleton';
 import {SkipLink} from '../SkipLink';
 import type {
   Annotation,
+  RenderAnnotationContentData,
   RenderLegendContent,
   TooltipOptions,
 } from '../../types';
@@ -41,6 +43,7 @@ export type StackedAreaChartProps = {
   theme?: string;
   xAxisOptions?: Partial<XAxisOptions>;
   yAxisOptions?: Partial<YAxisOptions>;
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderHiddenLegendLabel?: (count: number) => string;
   seriesNameFormatter?: LabelFormatter;
   scrollContainer?: Element | null;
@@ -65,6 +68,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     showLegend = true,
     skipLinkText,
     theme = defaultTheme,
+    renderAnnotationContent,
     renderHiddenLegendLabel,
     scrollContainer,
   } = {
@@ -116,6 +120,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
             theme={theme}
             xAxisOptions={xAxisOptionsWithDefaults}
             yAxisOptions={yAxisOptionsWithDefaults}
+            renderAnnotationContent={renderAnnotationContent}
             renderHiddenLegendLabel={renderHiddenLegendLabel}
           />
         )}

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -32,6 +32,7 @@ import {
 } from '../Annotations';
 import type {
   AnnotationLookupTable,
+  RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -56,6 +57,7 @@ import {useVerticalBarChart} from './hooks/useVerticalBarChart';
 
 export interface Props {
   data: DataSeries[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderTooltipContent(data: RenderTooltipContentData): ReactNode;
   showLegend: boolean;
   seriesNameFormatter: LabelFormatter;
@@ -72,6 +74,7 @@ export function Chart({
   annotationsLookupTable = {},
   data,
   emptyStateText,
+  renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
   showLegend,
@@ -313,6 +316,7 @@ export function Chart({
               labelFormatter={xAxisOptions.labelFormatter}
               onHeightChange={setAnnotationsHeight}
               xScale={xScale}
+              renderAnnotationContent={renderAnnotationContent}
             />
           </g>
         )}

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -9,6 +9,7 @@ import type {ReactNode} from 'react';
 
 import type {
   AnnotationLookupTable,
+  RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
 } from '../../types';
@@ -18,6 +19,7 @@ import {Chart} from './Chart';
 
 export interface VerticalBarChartProps {
   data: DataSeries[];
+  renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderTooltipContent(data: RenderTooltipContentData): ReactNode;
   showLegend: boolean;
   xAxisOptions: Required<XAxisOptions>;
@@ -35,6 +37,7 @@ export function VerticalBarChart({
   annotationsLookupTable = {},
   data,
   emptyStateText,
+  renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
   showLegend,
@@ -64,6 +67,7 @@ export function VerticalBarChart({
       type={type}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
+      renderAnnotationContent={renderAnnotationContent}
       renderHiddenLegendLabel={renderHiddenLegendLabel}
     />
   );

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -98,6 +98,10 @@ export interface RenderTooltipContentData {
   formatters?: TooltipFormatters;
 }
 
+export interface RenderAnnotationContentData {
+  annotation: Annotation;
+}
+
 export interface TooltipData {
   shape: Shape;
   data: {


### PR DESCRIPTION
## What does this implement/fix?

In order to display custom annotations for an upcoming report, looking to provide support to render more than just a `string` within the annotations popover. Allowing for more dynamism and flexibility in how we represent data and annotations. This was the recommended approach discussing in Slack, and UX was also looking to gain this functionality.

Includes adding a `renderAnnotationContent` prop for all charts that support annotations (some don't seem to). I've split the commits so that the initial commit is adding the code for this, along with one usage for LineChart.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->
Relates to https://github.com/Shopify/temp-project-mover-Archetypically-20250318093910/issues/239

## What do the changes look like?

| Before  | After  |
|---|---|
|<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2165b85c-c401-4e12-a9c3-80e7b9410f5c" />|<img width="1512" alt="image" src="https://github.com/user-attachments/assets/21533cf1-d29a-49b2-ab81-a6b9e10bd874" />|
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->

I've updated the Annotations story for LineChart.

http://localhost:6006/?path=/story/polaris-viz-charts-linechart--annotations

### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
