### PR TITLE
Remove annotations background blur

### DIFF
--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.scss
@@ -1,6 +1,5 @@
 .Container {
   pointer-events: auto;
-  backdrop-filter: blur(5px);
   padding: 8px 12px;
   border-radius: 5px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.4);

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.scss
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationLabel/AnnotationLabel.scss
@@ -5,7 +5,6 @@
   top: 0;
   width: 100%;
   height: 100%;
-  backdrop-filter: blur(5px);
 }
 
 .Button {

--- a/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.test.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.test.tsx
@@ -67,7 +67,7 @@ describe('<ShowMoreAnnotationsButton />', () => {
         text: 'Expand annotations (1)',
         targetWidth: 190,
         y: 6,
-        x: 55,
+        x: 105,
       });
     });
   });

--- a/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/ShowMoreAnnotationsButton/ShowMoreAnnotationsButton.tsx
@@ -1,10 +1,4 @@
-import {
-  estimateStringWidth,
-  FONT_SIZE,
-  LINE_HEIGHT,
-  useChartContext,
-  useTheme,
-} from '@shopify/polaris-viz-core';
+import {FONT_SIZE, LINE_HEIGHT, useTheme} from '@shopify/polaris-viz-core';
 
 import {PILL_HEIGHT, PILL_PADDING, PILL_X_MIN} from '../../constants';
 import {SingleTextLine} from '../../../Labels';
@@ -33,13 +27,11 @@ export function ShowMoreAnnotationsButton({
   tabIndex,
   width,
 }: Props) {
-  const {characterWidths} = useChartContext();
   const selectedTheme = useTheme();
 
   const label = isShowingAllAnnotations
     ? collapseText
     : `${expandText} (${annotationsCount})`;
-  const textWidth = estimateStringWidth(label, characterWidths);
 
   const radius = PILL_HEIGHT / 2;
   const pillWidth = width + Math.abs(PILL_X_MIN);
@@ -79,17 +71,25 @@ export function ShowMoreAnnotationsButton({
       />
 
       <Icon
-        fill={selectedTheme.annotations.textColor}
+        fill={
+          isShowingAllAnnotations
+            ? selectedTheme.annotations.backgroundColor
+            : selectedTheme.annotations.textColor
+        }
         isShowingAllAnnotations={isShowingAllAnnotations}
       />
 
       <SingleTextLine
-        color={selectedTheme.annotations.textColor}
+        color={
+          isShowingAllAnnotations
+            ? selectedTheme.annotations.backgroundColor
+            : selectedTheme.annotations.textColor
+        }
         fontSize={FONT_SIZE}
         text={label}
         targetWidth={pillWidth - PILL_PADDING * 2}
         y={PILL_HEIGHT - LINE_HEIGHT}
-        x={pillWidth / 2 - textWidth / 2}
+        x={pillWidth / 2}
       />
 
       <foreignObject


### PR DESCRIPTION
## What does this implement/fix?

We are seeing a performance hit in production when using a ton of annotations. It seems related to this background blur so we're going to try removing it.
