### PR TITLE
Allow gap between bars to be overridden

### DIFF
--- a/packages/polaris-viz-core/src/constants.ts
+++ b/packages/polaris-viz-core/src/constants.ts
@@ -28,6 +28,7 @@ export const BORDER_RADIUS = {
   Left: `${DEFAULT_BORDER_RADIUS} 0 0 ${DEFAULT_BORDER_RADIUS}`,
   All: `${DEFAULT_BORDER_RADIUS}`,
 };
+export const DEFAULT_BAR_GAP = null;
 
 export const HORIZONTAL_BAR_LABEL_HEIGHT = 12;
 export const HORIZONTAL_BAR_LABEL_OFFSET = 10;
@@ -191,6 +192,7 @@ export const DARK_THEME: Theme = {
   bar: {
     zeroValueColor: variables.colorGray80,
     borderRadius: DEFAULT_BORDER_RADIUS,
+    gap: DEFAULT_BAR_GAP,
   },
   grid: {
     showHorizontalLines: DEFAULT_GRID_SHOW_HORIZONTAL_LINES,
@@ -301,6 +303,7 @@ export const LIGHT_THEME: Theme = {
   bar: {
     zeroValueColor: variables.colorGray70,
     borderRadius: DEFAULT_BORDER_RADIUS,
+    gap: DEFAULT_BAR_GAP,
   },
   grid: {
     showHorizontalLines: DEFAULT_GRID_SHOW_HORIZONTAL_LINES,

--- a/packages/polaris-viz-core/src/types.ts
+++ b/packages/polaris-viz-core/src/types.ts
@@ -110,6 +110,7 @@ export interface ArcTheme {
 export interface BarTheme {
   zeroValueColor: string;
   borderRadius: number;
+  gap: number | null;
 }
 
 export interface XAxisTheme {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -14,6 +14,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Allow `yAxisOptions.maxYOverride` to be used when chart has data.
+- Added `bar.gap` value to override the spacing between `VerticalBarChart` bars.
 
 ## [16.13.0] - 2025-04-22
 

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
@@ -1,6 +1,10 @@
 import type {Story} from '@storybook/react';
 
-import {BarChart, BarChartProps} from '../../../../components';
+import {
+  BarChart,
+  BarChartProps,
+  PolarisVizProvider,
+} from '../../../../components';
 import type {Annotation} from '../../../../types';
 import {META} from '../meta';
 import {Template} from '../data';
@@ -236,16 +240,35 @@ WebData.args = {
 };
 
 const SingleValuesTemplate: Story<BarChartProps> = (args: BarChartProps) => {
-  return (
-    <div style={{width: 600, height: 400}}>
-      <BarChart {...args} />
-    </div>
-  );
+  return <BarChart {...args} />;
 };
 
 export const SingleValues = SingleValuesTemplate.bind({});
 
 SingleValues.args = {
+  type: 'stacked',
+  data: DATA,
+};
+
+const BarGapOverrideTemplate: Story<BarChartProps> = (args: BarChartProps) => {
+  return (
+    <PolarisVizProvider
+      themes={{
+        Light: {
+          bar: {
+            gap: 0,
+          },
+        },
+      }}
+    >
+      <BarChart {...args} />
+    </PolarisVizProvider>
+  );
+};
+
+export const BarGapOverride = BarGapOverrideTemplate.bind({});
+
+BarGapOverride.args = {
   type: 'stacked',
   data: DATA,
 };

--- a/packages/polaris-viz/src/components/VerticalBarChart/hooks/tests/useXScale.test.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/hooks/tests/useXScale.test.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
+import type {Root} from '@shopify/react-testing';
 import {mount} from '@shopify/react-testing';
 import {scaleBand} from 'd3-scale';
 
+import type {Props} from '../useXScale';
 import {useXScale} from '../useXScale';
 
 jest.mock('d3-scale', () => ({
@@ -11,7 +13,7 @@ jest.mock('d3-scale', () => ({
   }),
 }));
 
-const mockProps = {
+const MOCK_PROPS: Props = {
   drawableWidth: 200,
   data: [
     [10, 20, 30],
@@ -21,6 +23,11 @@ const mockProps = {
 };
 
 describe('useXScale', () => {
+  function TestComponent(props: Props) {
+    useXScale(props);
+    return null;
+  }
+
   afterEach(() => {
     (scaleBand as jest.Mock).mockReset();
   });
@@ -39,13 +46,7 @@ describe('useXScale', () => {
       return scale;
     });
 
-    function TestComponent() {
-      useXScale(mockProps);
-
-      return null;
-    }
-
-    mount(<TestComponent />);
+    mount(<TestComponent {...MOCK_PROPS} />);
 
     expect(rangeSpy).toHaveBeenCalledWith([0, 200]);
   });
@@ -65,12 +66,7 @@ describe('useXScale', () => {
       return scale;
     });
 
-    function TestComponent() {
-      useXScale(mockProps);
-      return null;
-    }
-
-    mount(<TestComponent />);
+    mount(<TestComponent {...MOCK_PROPS} />);
 
     expect(domainSpy).toHaveBeenCalledWith(['0', '1']);
   });
@@ -89,7 +85,7 @@ describe('useXScale', () => {
     });
 
     function TestComponent() {
-      const {xAxisLabels} = useXScale(mockProps);
+      const {xAxisLabels} = useXScale(MOCK_PROPS);
       return (
         <Fragment>
           {xAxisLabels.map(({value, xOffset}, index) => (
@@ -101,5 +97,85 @@ describe('useXScale', () => {
 
     const testComponent = mount(<TestComponent />);
     expect(testComponent).toContainReactText('label 1-50');
+  });
+
+  describe('gapOverride', () => {
+    it('returns gap based on data size when gapOverride is not provided', () => {
+      let paddingInnerSpy;
+      let paddingOuterSpy;
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.range = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+
+        paddingInnerSpy = jest.fn(() => scale);
+        paddingOuterSpy = jest.fn(() => scale);
+
+        scale.paddingInner = paddingInnerSpy;
+        scale.paddingOuter = paddingOuterSpy;
+        scale.domain = () => scale;
+        scale.step = () => 10;
+        return scale;
+      });
+
+      mount(<TestComponent {...MOCK_PROPS} />);
+
+      expect(paddingInnerSpy).toHaveBeenCalledWith(0.25);
+      expect(paddingOuterSpy).toHaveBeenCalledWith(0.125);
+    });
+
+    it('returns gap based on gapOverride when provided', () => {
+      let paddingInnerSpy;
+      let paddingOuterSpy;
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.range = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+
+        paddingInnerSpy = jest.fn(() => scale);
+        paddingOuterSpy = jest.fn(() => scale);
+
+        scale.paddingInner = paddingInnerSpy;
+        scale.paddingOuter = paddingOuterSpy;
+        scale.domain = () => scale;
+        scale.step = () => 10;
+        return scale;
+      });
+
+      mount(<TestComponent {...MOCK_PROPS} gapOverride={0} />);
+
+      expect(paddingInnerSpy).toHaveBeenCalledWith(0);
+      expect(paddingOuterSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('clamps gapOverride to 0 when a negative value is provided', () => {
+      let paddingInnerSpy;
+      let paddingOuterSpy;
+
+      (scaleBand as jest.Mock).mockImplementation(() => {
+        const scale = (value: any) => value;
+        scale.range = () => scale;
+        scale.range = () => scale;
+        scale.bandwidth = () => 10;
+
+        paddingInnerSpy = jest.fn(() => scale);
+        paddingOuterSpy = jest.fn(() => scale);
+
+        scale.paddingInner = paddingInnerSpy;
+        scale.paddingOuter = paddingOuterSpy;
+        scale.domain = () => scale;
+        scale.step = () => 10;
+        return scale;
+      });
+
+      mount(<TestComponent {...MOCK_PROPS} gapOverride={-10} />);
+
+      expect(paddingInnerSpy).toHaveBeenCalledWith(0);
+      expect(paddingOuterSpy).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/packages/polaris-viz/src/components/VerticalBarChart/hooks/useVerticalBarChart.ts
+++ b/packages/polaris-viz/src/components/VerticalBarChart/hooks/useVerticalBarChart.ts
@@ -1,4 +1,5 @@
 import type {DataSeries} from '@shopify/polaris-viz-core';
+import {useTheme} from '@shopify/polaris-viz-core';
 import {useMemo} from 'react';
 
 import {sortBarChartData} from '../utilities/sortBarChartData';
@@ -13,6 +14,9 @@ interface Props {
 
 export function useVerticalBarChart({data, drawableWidth, labels}: Props) {
   const sortedData = sortBarChartData(data);
+  const {
+    bar: {gap: gapOverride},
+  } = useTheme();
 
   const areAllNegative = useMemo(() => {
     return ![...sortedData]
@@ -26,6 +30,7 @@ export function useVerticalBarChart({data, drawableWidth, labels}: Props) {
     drawableWidth,
     data: sortedData,
     labels,
+    gapOverride,
   });
 
   return {sortedData, areAllNegative, xScale, gapWidth};


### PR DESCRIPTION
## What does this implement/fix?

Allows the spacing to be changed by setting the `bar.gap` theme value.

## Does this close any currently open issues?

Resolves https://github.com/shop/issues-analytics/issues/1353

## What do the changes look like?

![image](https://github.com/user-attachments/assets/129e1e7d-6104-473b-b786-fd2355aa5ff6)
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->


### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
