### PR TITLE
Add legendPosition to multiple charts

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added `yAxisOptions.ticksOverride` property to render custom yAxis ticks instead of the yScale generated values.
+- Added `legendPosition` to `<BarChart />`, `<LineChart />`, `<LineChartPredictive />`, `<LineChartRelational />`& `<StackedAreaChart />`.
 
 ### Changed
 

--- a/packages/polaris-viz/src/components/BarChart/BarChart.tsx
+++ b/packages/polaris-viz/src/components/BarChart/BarChart.tsx
@@ -21,6 +21,7 @@ import {getTooltipContentRenderer} from '../../utilities/getTooltipContentRender
 import {ChartContainer} from '../../components/ChartContainer';
 import type {
   Annotation,
+  BottomOnlyLegendPosition,
   RenderAnnotationContentData,
   RenderLegendContent,
   TooltipOptions,
@@ -42,6 +43,7 @@ export type BarChartProps = {
   annotations?: Annotation[];
   direction?: Direction;
   emptyStateText?: string;
+  legendPosition?: BottomOnlyLegendPosition;
   renderLegendContent?: RenderLegendContent;
   seriesNameFormatter?: LabelFormatter;
   showLegend?: boolean;
@@ -70,6 +72,7 @@ export function BarChart(props: BarChartProps) {
     id,
     isAnimated,
     tooltipOptions,
+    legendPosition,
     renderLegendContent,
     showLegend = true,
     maxSeries,
@@ -125,6 +128,7 @@ export function BarChart(props: BarChartProps) {
         annotationsLookupTable={annotationsLookupTable}
         data={data}
         emptyStateText={emptyStateText}
+        legendPosition={legendPosition}
         renderAnnotationContent={renderAnnotationContent}
         renderLegendContent={renderLegendContent}
         renderTooltipContent={renderTooltip}
@@ -139,6 +143,7 @@ export function BarChart(props: BarChartProps) {
       <HorizontalBarChart
         annotationsLookupTable={annotationsLookupTable}
         data={data}
+        legendPosition={legendPosition}
         renderHiddenLegendLabel={renderHiddenLegendLabel}
         renderAnnotationContent={renderAnnotationContent}
         renderLegendContent={renderLegendContent}

--- a/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/BarChart/stories/playground/Playground.stories.tsx
@@ -661,3 +661,10 @@ TicksOverride.args = {
     ticksOverride: [0, 10, 20, 40, 70, 100],
   },
 };
+
+export const LegendPosition = Template.bind({});
+
+LegendPosition.args = {
+  data: DATA,
+  legendPosition: 'right',
+};

--- a/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/DonutChart.tsx
@@ -29,7 +29,6 @@ export type DonutChartProps = {
   legendFullWidth?: boolean;
   legendPosition?: LegendPosition;
   tooltipOptions?: TooltipOptions;
-
   renderInnerValueContent?: RenderInnerValueContent;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: RenderHiddenLegendLabel;

--- a/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/Chart.tsx
@@ -25,6 +25,7 @@ import {checkAvailableAnnotations} from '../../components/Annotations';
 import {useFormattedLabels} from '../../hooks/useFormattedLabels';
 import type {
   AnnotationLookupTable,
+  BottomOnlyLegendPosition,
   RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
@@ -63,6 +64,7 @@ export interface ChartProps {
   type: ChartType;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
+  legendPosition?: BottomOnlyLegendPosition;
   renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderHiddenLegendLabel?: (count: number) => string;
   renderLegendContent?: RenderLegendContent;
@@ -71,6 +73,7 @@ export interface ChartProps {
 export function Chart({
   annotationsLookupTable,
   data,
+  legendPosition,
   renderAnnotationContent,
   renderHiddenLegendLabel,
   renderLegendContent,
@@ -318,6 +321,7 @@ export function Chart({
           data={legend}
           enableHideOverflow
           onDimensionChange={setLegendDimensions}
+          position={legendPosition}
           renderLegendContent={renderLegendContent}
           renderHiddenLegendLabel={renderHiddenLegendLabel}
         />

--- a/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/polaris-viz/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -12,6 +12,7 @@ import type {
   RenderTooltipContentData,
   RenderLegendContent,
   RenderAnnotationContentData,
+  BottomOnlyLegendPosition,
 } from '../../types';
 
 import {Chart} from './Chart';
@@ -25,6 +26,7 @@ export interface HorizontalBarChartProps {
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
+  legendPosition?: BottomOnlyLegendPosition;
   renderHiddenLegendLabel?: (count: number) => string;
   renderLegendContent?: RenderLegendContent;
   type?: ChartType;
@@ -33,6 +35,7 @@ export interface HorizontalBarChartProps {
 export function HorizontalBarChart({
   annotationsLookupTable = {},
   data,
+  legendPosition,
   renderAnnotationContent,
   renderHiddenLegendLabel,
   renderLegendContent,
@@ -51,6 +54,7 @@ export function HorizontalBarChart({
       seriesNameFormatter={seriesNameFormatter}
       showLegend={showLegend}
       type={type}
+      legendPosition={legendPosition}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
       renderAnnotationContent={renderAnnotationContent}

--- a/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
+++ b/packages/polaris-viz/src/components/LegendContainer/LegendContainer.tsx
@@ -69,10 +69,10 @@ export function LegendContainer({
   const legendItemDimensions = useRef([{width: 0, height: 0}]);
   const [activatorWidth, setActivatorWidth] = useState(0);
 
-  const overflowLegendProps =
+  const overflowLegendProps: UseOverflowLegendProps =
     direction === 'horizontal'
       ? {
-          direction: 'horizontal' as const,
+          direction: 'horizontal',
           data: allData,
           enableHideOverflow,
           legendItemDimensions,
@@ -82,7 +82,7 @@ export function LegendContainer({
           horizontalMargin,
         }
       : ({
-          direction: 'vertical' as const,
+          direction: 'vertical',
           data: allData,
           height: containerBounds.height,
           enableHideOverflow,
@@ -99,7 +99,7 @@ export function LegendContainer({
 
   const styleMap: {[key: string]: CSSProperties} = {
     horizontal: {
-      justifyContent: 'flex-end',
+      justifyContent: position === 'right' ? 'flex-end' : 'flex-start',
       margin: isPositionTop
         ? `0 ${horizontalMargin}px ${LEGENDS_BOTTOM_MARGIN}px ${leftMargin}px`
         : `${LEGENDS_TOP_MARGIN}px ${horizontalMargin}px 0 ${leftMargin}px`,
@@ -119,7 +119,7 @@ export function LegendContainer({
   };
 
   const shouldCenterTiles = (pos) => {
-    if (pos === 'top' || pos === 'bottom') {
+    if (pos === 'top' || pos === 'bottom' || pos === 'center') {
       return {justifyContent: 'center'};
     }
   };

--- a/packages/polaris-viz/src/components/LineChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/Chart.tsx
@@ -31,6 +31,7 @@ import {
 } from '../Annotations';
 import type {
   AnnotationLookupTable,
+  BottomOnlyLegendPosition,
   LineChartSlotProps,
   RenderAnnotationContentData,
   RenderHiddenLegendLabel,
@@ -68,6 +69,7 @@ export interface ChartProps {
   data: LineChartDataSeriesWithDefaults[];
   emptyStateText?: string;
   hideLegendOverflow: boolean;
+  legendPosition?: BottomOnlyLegendPosition;
   renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderHiddenLegendLabel?: RenderHiddenLegendLabel;
   renderLegendContent?: RenderLegendContent;
@@ -86,6 +88,7 @@ export function Chart({
   annotationsLookupTable,
   emptyStateText,
   data,
+  legendPosition,
   renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
@@ -441,6 +444,7 @@ export function Chart({
           colorVisionType={COLOR_VISION_SINGLE_ITEM}
           data={legend}
           onDimensionChange={setLegendDimensions}
+          position={legendPosition}
           renderLegendContent={renderLegendContent}
           renderHiddenLegendLabel={renderHiddenLegendLabel}
           enableHideOverflow={hideLegendOverflow}

--- a/packages/polaris-viz/src/components/LineChart/LineChart.tsx
+++ b/packages/polaris-viz/src/components/LineChart/LineChart.tsx
@@ -29,6 +29,7 @@ import {SkipLink} from '../SkipLink';
 import {useTheme} from '../../hooks';
 import type {
   Annotation,
+  BottomOnlyLegendPosition,
   LineChartSlotProps,
   RenderAnnotationContentData,
   RenderLegendContent,
@@ -41,6 +42,7 @@ export type LineChartProps = {
   annotations?: Annotation[];
   errorText?: string;
   emptyStateText?: string;
+  legendPosition?: BottomOnlyLegendPosition;
   renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
@@ -68,6 +70,7 @@ export function LineChart(props: LineChartProps) {
     id,
     isAnimated,
     onError,
+    legendPosition,
     renderAnnotationContent,
     renderLegendContent,
     renderHiddenLegendLabel,
@@ -128,6 +131,7 @@ export function LineChart(props: LineChartProps) {
             annotationsLookupTable={annotationsLookupTable}
             data={dataWithDefaults}
             emptyStateText={emptyStateText}
+            legendPosition={legendPosition}
             renderAnnotationContent={renderAnnotationContent}
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -1099,3 +1099,19 @@ TicksOverride.args = {
     ticksOverride: [0, 10, 20, 40, 70, 100],
   },
 };
+
+export const LegendPosition = Template.bind({});
+
+LegendPosition.args = {
+  data: [
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 33, key: '2020-04-01T12:00:00'},
+        {value: 97, key: '2020-04-02T12:00:00'},
+        {value: 34, key: '2020-04-03T12:00:00'},
+      ],
+    },
+  ],
+  legendPosition: 'right',
+};

--- a/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/LineChartPredictive.tsx
@@ -22,6 +22,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
     emptyStateText,
     id,
     isAnimated,
+    legendPosition,
     seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
     skipLinkText,
@@ -111,6 +112,7 @@ export function LineChartPredictive(props: LineChartPredictiveProps) {
       tooltipOptions={tooltipOptions}
       xAxisOptions={xAxisOptions}
       yAxisOptions={yAxisOptions}
+      legendPosition={legendPosition}
       renderAnnotationContent={renderAnnotationContent}
       renderLegendContent={({
         getColorVisionStyles,

--- a/packages/polaris-viz/src/components/LineChartPredictive/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartPredictive/stories/playground/Playground.stories.tsx
@@ -1,0 +1,21 @@
+import type {Story} from '@storybook/react';
+
+import type {LineChartPredictiveProps} from '../../types';
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from '../data';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+export const LegendPosition: Story<LineChartPredictiveProps> = Template.bind(
+  {},
+);
+
+LegendPosition.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  showLegend: true,
+  legendPosition: 'right',
+};

--- a/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/LineChartRelational.tsx
@@ -25,6 +25,7 @@ export function LineChartRelational(props: LineChartRelationalProps) {
     isAnimated,
     seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
+    legendPosition,
     skipLinkText,
     state,
     theme,
@@ -58,6 +59,7 @@ export function LineChartRelational(props: LineChartRelationalProps) {
       errorText={errorText}
       id={id}
       isAnimated={isAnimated}
+      legendPosition={legendPosition}
       renderAnnotationContent={renderAnnotationContent}
       renderLegendContent={(
         {getColorVisionStyles, getColorVisionEventAttrs},

--- a/packages/polaris-viz/src/components/LineChartRelational/stories/playground/LegendPosition.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartRelational/stories/playground/LegendPosition.stories.tsx
@@ -1,0 +1,21 @@
+import type {Story} from '@storybook/react';
+
+import type {LineChartRelationalProps} from '../../LineChartRelational';
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from '../data';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground/LegendPosition`,
+};
+
+export const LegendPosition: Story<LineChartRelationalProps> = Template.bind(
+  {},
+);
+
+LegendPosition.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+  showLegend: true,
+  legendPosition: 'right',
+};

--- a/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/Chart.tsx
@@ -33,6 +33,7 @@ import type {
   RenderLegendContent,
   RenderTooltipContentData,
   RenderAnnotationContentData,
+  BottomOnlyLegendPosition,
 } from '../../types';
 import {XAxis} from '../XAxis';
 import {LegendContainer, useLegend} from '../LegendContainer';
@@ -65,6 +66,7 @@ export interface Props {
   theme: string;
   xAxisOptions: Required<XAxisOptions>;
   yAxisOptions: Required<YAxisOptions>;
+  legendPosition?: BottomOnlyLegendPosition;
   renderAnnotationContent?: (data: RenderAnnotationContentData) => ReactNode;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
@@ -74,6 +76,7 @@ export function Chart({
   annotationsLookupTable,
   xAxisOptions,
   data,
+  legendPosition,
   renderLegendContent,
   renderTooltipContent,
   showLegend,
@@ -399,6 +402,7 @@ export function Chart({
           colorVisionType={COLOR_VISION_SINGLE_ITEM}
           data={legend}
           onDimensionChange={setLegendDimensions}
+          position={legendPosition}
           renderLegendContent={renderLegendContent}
           enableHideOverflow
           renderHiddenLegendLabel={renderHiddenLegendLabel}

--- a/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/StackedAreaChart.tsx
@@ -25,6 +25,7 @@ import {ChartSkeleton} from '../ChartSkeleton';
 import {SkipLink} from '../SkipLink';
 import type {
   Annotation,
+  BottomOnlyLegendPosition,
   RenderAnnotationContentData,
   RenderLegendContent,
   TooltipOptions,
@@ -37,6 +38,7 @@ export type StackedAreaChartProps = {
   tooltipOptions?: TooltipOptions;
   state?: ChartState;
   errorText?: string;
+  legendPosition?: BottomOnlyLegendPosition;
   renderLegendContent?: RenderLegendContent;
   showLegend?: boolean;
   skipLinkText?: string;
@@ -63,6 +65,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
     tooltipOptions,
     id,
     isAnimated,
+    legendPosition,
     renderLegendContent,
     seriesNameFormatter = (value) => `${value}`,
     showLegend = true,
@@ -113,6 +116,7 @@ export function StackedAreaChart(props: StackedAreaChartProps) {
           <Chart
             annotationsLookupTable={annotationsLookupTable}
             data={data}
+            legendPosition={legendPosition}
             renderLegendContent={renderLegendContent}
             renderTooltipContent={renderTooltip}
             seriesNameFormatter={seriesNameFormatter}

--- a/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/StackedAreaChart/stories/playground/Playground.stories.tsx
@@ -300,3 +300,27 @@ TicksOverride.args = {
     ticksOverride: [0, 10, 20, 40, 70],
   },
 };
+
+export const LegendPosition = Template.bind({});
+
+LegendPosition.args = {
+  data: [
+    {
+      name: 'Impressions',
+      data: [
+        {key: '2022-07-10', value: 20},
+        {key: '2022-07-11', value: 34},
+        {key: '2022-07-12', value: 15},
+      ],
+    },
+    {
+      name: 'Conversions',
+      data: [
+        {key: '2022-07-10', value: 13},
+        {key: '2022-07-11', value: 76},
+        {key: '2022-07-12', value: 20},
+      ],
+    },
+  ],
+  legendPosition: 'left',
+};

--- a/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/Chart.tsx
@@ -32,6 +32,7 @@ import {
 } from '../Annotations';
 import type {
   AnnotationLookupTable,
+  BottomOnlyLegendPosition,
   RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
@@ -66,6 +67,7 @@ export interface Props {
   yAxisOptions: Required<YAxisOptions>;
   annotationsLookupTable?: AnnotationLookupTable;
   emptyStateText?: string;
+  legendPosition?: BottomOnlyLegendPosition;
   renderLegendContent?: RenderLegendContent;
   renderHiddenLegendLabel?: (count: number) => string;
 }
@@ -74,6 +76,7 @@ export function Chart({
   annotationsLookupTable = {},
   data,
   emptyStateText,
+  legendPosition,
   renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
@@ -360,6 +363,7 @@ export function Chart({
         <LegendContainer
           colorVisionType={COLOR_VISION_SINGLE_ITEM}
           data={legend}
+          position={legendPosition}
           onDimensionChange={setLegendDimensions}
           renderLegendContent={renderLegendContent}
           enableHideOverflow

--- a/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/polaris-viz/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -9,6 +9,7 @@ import type {ReactNode} from 'react';
 
 import type {
   AnnotationLookupTable,
+  BottomOnlyLegendPosition,
   RenderAnnotationContentData,
   RenderLegendContent,
   RenderTooltipContentData,
@@ -28,6 +29,7 @@ export interface VerticalBarChartProps {
   annotationsLookupTable?: AnnotationLookupTable;
   barOptions?: {isStacked: boolean};
   emptyStateText?: string;
+  legendPosition?: BottomOnlyLegendPosition;
   renderLegendContent?: RenderLegendContent;
   type?: ChartType;
   renderHiddenLegendLabel?: (count: number) => string;
@@ -37,6 +39,7 @@ export function VerticalBarChart({
   annotationsLookupTable = {},
   data,
   emptyStateText,
+  legendPosition,
   renderAnnotationContent,
   renderLegendContent,
   renderTooltipContent,
@@ -60,6 +63,7 @@ export function VerticalBarChart({
       annotationsLookupTable={annotationsLookupTable}
       data={seriesWithDefaults}
       emptyStateText={emptyStateText}
+      legendPosition={legendPosition}
       renderLegendContent={renderLegendContent}
       renderTooltipContent={renderTooltipContent}
       seriesNameFormatter={seriesNameFormatter}

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -215,7 +215,10 @@ export type LegendPosition =
   | 'top'
   | 'right'
   | 'bottom'
-  | 'left';
+  | 'left'
+  | 'center';
+
+export type BottomOnlyLegendPosition = 'left' | 'right' | 'center';
 
 export type MetaDataTrendIndicator = Omit<TrendIndicatorProps, 'theme'>;
 


### PR DESCRIPTION
## What does this implement/fix?

Added `labelPosition` to `BarChart`, `LineChart`, `LineChartPredictive`, `LineChartRelational` & `StackedAreaChart` to allow the legend to be rendered left, center or right aligned.

## Does this close any currently open issues?

Resolves https://github.com/shop/issues-analytics/issues/1352

## What do the changes look like?

![image](https://github.com/user-attachments/assets/f0a6f26e-998d-4723-98db-4dc5ca4e051b)
 
## Storybook link

- [BarChart](https://6062ad4a2d14cd0021539c1b-biiqylypld.chromatic.com/?path=/story/polaris-viz-charts-barchart-playground--legend-position)
- [LineChartRelational](https://6062ad4a2d14cd0021539c1b-biiqylypld.chromatic.com/?path=/story/polaris-viz-charts-linechartrelational-playground-legendposition--legend-position)
- [LineChartPredictive](https://6062ad4a2d14cd0021539c1b-biiqylypld.chromatic.com/?path=/story/polaris-viz-charts-linechartpredictive-playground--legend-position)
- [LineChart](https://6062ad4a2d14cd0021539c1b-biiqylypld.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--legend-position)
- [StackedAreaChart](https://6062ad4a2d14cd0021539c1b-biiqylypld.chromatic.com/?path=/story/polaris-viz-charts-stackedareachart-playground--legend-position)

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
