### PR TITLE
Don't pick largest yAxis value when maxYOverride is set

### DIFF
--- a/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
+++ b/packages/polaris-viz-core/src/hooks/tests/useYScale.test.tsx
@@ -342,7 +342,7 @@ describe('useYScale()', () => {
         <TestComponent
           {...MOCK_PROPS}
           min={0}
-          max={10}
+          max={0}
           maxYOverride={maxYOverride}
         />,
       );

--- a/packages/polaris-viz-core/src/hooks/useYScale.ts
+++ b/packages/polaris-viz-core/src/hooks/useYScale.ts
@@ -50,8 +50,8 @@ export function useYScale({
     const minY = min;
     let maxY = isDataEmpty ? DEFAULT_MAX_Y : max;
 
-    if (maxYOverride != null) {
-      maxY = Math.max(maxY, maxYOverride);
+    if (maxYOverride != null && isDataEmpty) {
+      maxY = maxYOverride;
     }
 
     if (integersOnly) {

--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Fixed issue where a smaller `yAxisOptions.maxYOverride` would always be overtaken by the maxY value.
 
 ## [16.15.0] - 2025-04-29
 

--- a/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChart/stories/playground/Playground.stories.tsx
@@ -1115,3 +1115,70 @@ LegendPosition.args = {
   ],
   legendPosition: 'right',
 };
+
+export const yScale = Template.bind({});
+
+yScale.args = {
+  data: [
+    {
+      name: 'Mar 1, 2024–Mar 25, 2025',
+      data: [
+        {
+          key: '0',
+          value: 0.039603960396039604,
+        },
+        {
+          key: '1',
+          value: 0.07920792079207921,
+        },
+        {
+          key: '2',
+          value: 0.0165016501650165,
+        },
+        {
+          key: '3',
+          value: 0.0462046204620462,
+        },
+        {
+          key: '4',
+          value: 0.026402640264026403,
+        },
+        {
+          key: '5',
+          value: 0.009900990099009901,
+        },
+        {
+          key: '6',
+          value: 0.026402640264026403,
+        },
+        {
+          key: '7',
+          value: 0.009900990099009901,
+        },
+        {
+          key: '8',
+          value: 0,
+        },
+        {
+          key: '9',
+          value: 0,
+        },
+        {
+          key: '10',
+          value: 0.0033003300330033004,
+        },
+        {
+          key: '11',
+          value: 0,
+        },
+        {
+          key: '12',
+          value: 0,
+        },
+      ],
+    },
+  ],
+  yAxisOptions: {
+    maxYOverride: 1,
+  },
+};


### PR DESCRIPTION
## What does this implement/fix?

When bumping `polaris-viz` in `analytics-ui-components` we noticed that a previous change to the `useYScale` hook was causing the yScale to be way to high in certain situations.

![image](https://github.com/user-attachments/assets/4554ac26-d8e1-4552-a6e2-ccd984421b51)

This chart had a `maxYOverride: 1` but because the highest y value was `0.08` it was taking the `maxYOverride` value, but after taking a second look we only want to use the `maxYOverride` when a chart has no data.

## Does this close any currently open issues?

<!-- 🔗 Link to the issue/s that this PR solves, and use fix` or `solve` to close it automatically.  -->


## What do the changes look like?

![image](https://github.com/user-attachments/assets/0455c58a-283a-4180-b71a-13b9233f4c3c)
 
## Storybook link

https://6062ad4a2d14cd0021539c1b-yaodsyilfn.chromatic.com/?path=/story/polaris-viz-charts-linechart-playground--y-scale

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
