### PR TITLE
Add padAngle to DonutChart

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Added padding between slices in `<DonutChart />` to improve visibility of small values.
 
 ## [16.15.2] - 2025-05-02
 

--- a/packages/polaris-viz/src/components/DonutChart/Chart.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/Chart.tsx
@@ -166,7 +166,8 @@ export function Chart({
 
   const createPie = pie<DataPoint>()
     .value(({value}) => value!)
-    .sort(null);
+    .sort(null)
+    .padAngle(0.05);
   const pieChartData = createPie(points);
   const isEveryValueZero = points.every(({value}) => value === 0);
   const emptyState = pieChartData.length === 0 || isEveryValueZero;

--- a/packages/polaris-viz/src/components/DonutChart/stories/TinySlices.stories.tsx
+++ b/packages/polaris-viz/src/components/DonutChart/stories/TinySlices.stories.tsx
@@ -1,0 +1,40 @@
+import type {Story} from '@storybook/react';
+
+import {META} from './meta';
+
+import type {DonutChartProps} from '../DonutChart';
+
+import {DEFAULT_PROPS, Template} from './data';
+
+export default {
+  ...META,
+  title: 'polaris-viz/Chromatic/Charts/DonutChart',
+  parameters: {
+    ...META.parameters,
+    chromatic: {disableSnapshot: false},
+  },
+};
+
+export const TinySlices: Story<DonutChartProps> = Template.bind({});
+
+TinySlices.args = {
+  ...DEFAULT_PROPS,
+  data: [
+    {
+      name: 'Shopify Payments',
+      data: [{key: 'april - march', value: 5000000}],
+    },
+    {
+      name: 'Paypal',
+      data: [{key: 'april - march', value: 250}],
+    },
+    {
+      name: 'Other',
+      data: [{key: 'april - march', value: 1000000}],
+    },
+    {
+      name: 'Amazon Pay',
+      data: [{key: 'april - march', value: 400}],
+    },
+  ],
+};


### PR DESCRIPTION
## What does this implement/fix?

Added `padAngle` to `DonutChart` so that all slices will render even when then min/max values are wildly different.

## Does this close any currently open issues?

Resolves https://github.com/Shopify/merchant-analytics-issues/issues/511

## What do the changes look like?

| Before  | After  |
|---|---|
|![image](https://github.com/user-attachments/assets/0cf1efc9-0802-4be2-9528-ddfb2b181ee4)|![image](https://github.com/user-attachments/assets/d84d7588-5928-4a38-9f17-616f3eff1736)|

## Storybook link

https://6062ad4a2d14cd0021539c1b-ntboeyaprp.chromatic.com/?path=/story/polaris-viz-chromatic-charts-donutchart--tiny-slices

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
