### PR TITLE
Reduce spacing funnel trends

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## [16.15.5] - 2025-05-09
+
+### Changed
+
+- Reduce spacing between counts and trends in funnel.
+
 ## [16.15.4] - 2025-05-08
 
 - No updates. Transitive dependency bump.

--- a/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
@@ -18,11 +18,12 @@ const GROUP_OFFSET = 10;
 const LABEL_FONT_SIZE = 12;
 const VALUE_FONT_SIZE = 14;
 const VALUE_FONT_WEIGHT = 500;
+const VALUE_FONT_SIZE_SMALL = 12;
 const TREND_INDICATOR_SPACING = 20;
 const VERTICAL_STACK_SPACING = 3;
 const MIN_CHART_WIDTH_FOR_RULE_3_PRIORITY = 400;
 export const LABEL_VERTICAL_OFFSET = 2;
-const TREND_INDICATOR_SPACING_ADJUSTMENT = 20;
+const TREND_INDICATOR_SPACING_ADJUSTMENT = 35;
 
 const TEXT_COLOR = 'rgba(31, 33, 36, 1)';
 
@@ -221,15 +222,14 @@ export function FunnelChartLabels({
                 trendIndicatorProps ? countStringWidth : currentTargetWidth
               }
               textAnchor="start"
-              fontSize={VALUE_FONT_SIZE}
+              fontSize={VALUE_FONT_SIZE_SMALL}
               fontWeight={VALUE_FONT_WEIGHT}
               x={0}
+              y={2}
             />
             {trendIndicatorProps && (
               <g
-                transform={`translate(${
-                  countStringWidth + TREND_INDICATOR_SPACING
-                }, ${-LABEL_VERTICAL_OFFSET})`}
+                transform={`translate(${countStringWidth}, ${-LABEL_VERTICAL_OFFSET})`}
               >
                 <TrendIndicator {...trendIndicatorProps} />
               </g>


### PR DESCRIPTION
## What does this implement/fix?

We have to reduce the spacing between counts and trends when the funnel chart layouts display in the same line below the main percentage, so that we can delay having to wrap everything stacked. We also reduced the font size of the counts by 2px when in this layout.

## What do the changes look like?

https://github.com/user-attachments/assets/632a6db4-a177-4dbc-84fe-aa0c9cd390ee

 
## Storybook link

http://localhost:6006/?path=/story/polaris-viz-charts-funnelchartnext--with-trend-indicators


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [x] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
