### PR TITLE
Allow ReactNode to be passed to annotation content

### DIFF
--- a/packages/polaris-viz/CHANGELOG.md
+++ b/packages/polaris-viz/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Changed `Annotation.content` type to allow `ReactNode` instead of just `string`.
 
 ## [16.15.5] - 2025-05-09
 

--- a/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
+++ b/packages/polaris-viz/src/components/Annotations/components/AnnotationContent/AnnotationContent.tsx
@@ -96,7 +96,7 @@ export function AnnotationContent({
         }}
         id={`annotation-content-${index}`}
         role="dialog"
-        aria-label={content}
+        aria-label={annotation.startKey.toString()}
       >
         {title != null && (
           <p

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -169,10 +169,10 @@ export interface Annotation {
   collapseButtonText?: string;
   expandButtonText?: string;
   content?: {
-    content: string;
+    content: ReactNode;
     linkText?: string;
     linkUrl?: string;
-    title?: string;
+    title?: ReactNode;
   };
 }
 


### PR DESCRIPTION
## What does this implement/fix?

We can render `ReactNode` for the annotation content but the type only expected a `string`. Until we can overhaul annotations, we'll change the type to `ReactNode`.