### PR TITLE
Add showPercentages option on FunnelChartNext for Live View Customer Behavior card

### DIFF
--- a/packages/polaris-viz/src/components/FunnelChartNext/Chart.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/Chart.tsx
@@ -50,6 +50,7 @@ export interface ChartProps {
     dropped: string;
   };
   showTooltip?: boolean;
+  showPercentages?: boolean;
   seriesNameFormatter: LabelFormatter;
   labelFormatter: LabelFormatter;
   percentageFormatter?: (value: number) => string;
@@ -60,6 +61,7 @@ export function Chart({
   data,
   tooltipLabels,
   showTooltip = true,
+  showPercentages = true,
   seriesNameFormatter,
   labelFormatter,
   percentageFormatter = (value: number) => {
@@ -175,6 +177,7 @@ export function Chart({
             shouldApplyScaling={shouldApplyScaling}
             renderScaleIconTooltipContent={renderScaleIconTooltipContent}
             trends={trends}
+            showPercentages={showPercentages}
           />
         </g>
 

--- a/packages/polaris-viz/src/components/FunnelChartNext/FunnelChartNext.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/FunnelChartNext.tsx
@@ -29,6 +29,7 @@ export type FunnelChartNextProps = {
   labelFormatter?: LabelFormatter;
   renderScaleIconTooltipContent?: () => ReactNode;
   percentageFormatter?: (value: number) => string;
+  showPercentages?: boolean;
 } & ChartProps;
 
 export function FunnelChartNext(props: FunnelChartNextProps) {
@@ -43,6 +44,7 @@ export function FunnelChartNext(props: FunnelChartNextProps) {
     errorText,
     tooltipLabels = DEFAULT_TOOLTIP_LABELS,
     showTooltip = true,
+    showPercentages = true,
     seriesNameFormatter = DEFAULT_LABEL_FORMATTER,
     labelFormatter = DEFAULT_LABEL_FORMATTER,
     percentageFormatter,
@@ -73,6 +75,7 @@ export function FunnelChartNext(props: FunnelChartNextProps) {
           data={data}
           tooltipLabels={tooltipLabels}
           showTooltip={showTooltip}
+          showPercentages={showPercentages}
           seriesNameFormatter={seriesNameFormatter}
           labelFormatter={labelFormatter}
           percentageFormatter={percentageFormatter}

--- a/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
@@ -158,8 +158,6 @@ export function FunnelChartLabels({
     showPercentages,
   ]);
 
-  console.log('layoutStrategy', layoutStrategy);
-
   function displayChartLabels(
     layoutStrategy: typeof LAYOUT_STRATEGY[keyof typeof LAYOUT_STRATEGY],
     index: number,

--- a/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/FunnelChartLabels.tsx
@@ -38,6 +38,7 @@ export interface FunnelChartLabelsProps {
   trends?: FunnelChartMetaData['trends'];
   xScale: ScaleBand<string>;
   shouldApplyScaling: boolean;
+  showPercentages?: boolean;
   renderScaleIconTooltipContent?: () => ReactNode;
 }
 
@@ -56,6 +57,7 @@ export function FunnelChartLabels({
   trends,
   xScale,
   shouldApplyScaling,
+  showPercentages = true,
   renderScaleIconTooltipContent,
 }: FunnelChartLabelsProps) {
   const {characterWidths, containerBounds} = useChartContext();
@@ -76,11 +78,13 @@ export function FunnelChartLabels({
       const currentTargetWidth = isLast
         ? barWidth - GROUP_OFFSET * 2
         : labelWidth - GROUP_OFFSET * 2;
-      const currentPercentWidth = estimateStringWidthWithOffset(
-        percentages[i],
-        VALUE_FONT_SIZE,
-        VALUE_FONT_WEIGHT,
-      );
+      const currentPercentWidth = showPercentages
+        ? estimateStringWidthWithOffset(
+            percentages[i],
+            VALUE_FONT_SIZE,
+            VALUE_FONT_WEIGHT,
+          )
+        : 0;
       const currentCountStringWidth = estimateStringWidthWithOffset(
         formattedValues[i],
         VALUE_FONT_SIZE,
@@ -151,7 +155,10 @@ export function FunnelChartLabels({
     labelWidth,
     barWidth,
     chartContainerWidth,
+    showPercentages,
   ]);
+
+  console.log('layoutStrategy', layoutStrategy);
 
   function displayChartLabels(
     layoutStrategy: typeof LAYOUT_STRATEGY[keyof typeof LAYOUT_STRATEGY],
@@ -161,22 +168,25 @@ export function FunnelChartLabels({
     countStringWidth: number,
     trendIndicatorProps: any,
     trendIndicatorWidth: number,
+    showPercentages: boolean,
   ) {
     if (layoutStrategy === LAYOUT_STRATEGY.ONE_LINE_ALL) {
       return (
         <Fragment>
-          <SingleTextLine
-            color={TEXT_COLOR}
-            text={percentages[index]}
-            targetWidth={percentWidth}
-            textAnchor="start"
-            fontSize={VALUE_FONT_SIZE}
-            fontWeight={VALUE_FONT_WEIGHT}
-          />
+          {showPercentages ? (
+            <SingleTextLine
+              color={TEXT_COLOR}
+              text={percentages[index]}
+              targetWidth={percentWidth}
+              textAnchor="start"
+              fontSize={VALUE_FONT_SIZE}
+              fontWeight={VALUE_FONT_WEIGHT}
+            />
+          ) : null}
           <SingleTextLine
             color={TEXT_COLOR}
             text={formattedValues[index]}
-            x={percentWidth + LINE_PADDING}
+            x={showPercentages ? percentWidth + LINE_PADDING : 0}
             targetWidth={
               currentTargetWidth -
               (percentWidth + LINE_PADDING) -
@@ -202,19 +212,22 @@ export function FunnelChartLabels({
     }
 
     if (layoutStrategy === LAYOUT_STRATEGY.ONE_LINE_COUNTS_AND_TRENDS) {
+      const formattedValueTransformY = showPercentages
+        ? LINE_HEIGHT + VERTICAL_STACK_SPACING
+        : 0;
       return (
         <Fragment>
-          <SingleTextLine
-            color={TEXT_COLOR}
-            text={percentages[index]}
-            targetWidth={currentTargetWidth}
-            textAnchor="start"
-            fontSize={VALUE_FONT_SIZE}
-            fontWeight={VALUE_FONT_WEIGHT}
-          />
-          <g
-            transform={`translate(0, ${LINE_HEIGHT + VERTICAL_STACK_SPACING})`}
-          >
+          {showPercentages ? (
+            <SingleTextLine
+              color={TEXT_COLOR}
+              text={percentages[index]}
+              targetWidth={currentTargetWidth}
+              textAnchor="start"
+              fontSize={VALUE_FONT_SIZE}
+              fontWeight={VALUE_FONT_WEIGHT}
+            />
+          ) : null}
+          <g transform={`translate(0, ${formattedValueTransformY})`}>
             <SingleTextLine
               color={TEXT_COLOR}
               text={formattedValues[index]}
@@ -240,19 +253,25 @@ export function FunnelChartLabels({
     }
 
     if (layoutStrategy === LAYOUT_STRATEGY.VERTICAL_STACKING) {
+      const formattedValueTransformY = showPercentages
+        ? LINE_HEIGHT + VERTICAL_STACK_SPACING
+        : 0;
+      const trendIndicatorTransformY = showPercentages
+        ? LINE_HEIGHT * 2 + VERTICAL_STACK_SPACING * 2
+        : LINE_HEIGHT + VERTICAL_STACK_SPACING * 2;
       return (
         <Fragment>
-          <SingleTextLine
-            color={TEXT_COLOR}
-            text={percentages[index]}
-            targetWidth={currentTargetWidth}
-            textAnchor="start"
-            fontSize={VALUE_FONT_SIZE}
-            fontWeight={VALUE_FONT_WEIGHT}
-          />
-          <g
-            transform={`translate(0, ${LINE_HEIGHT + VERTICAL_STACK_SPACING})`}
-          >
+          {showPercentages ? (
+            <SingleTextLine
+              color={TEXT_COLOR}
+              text={percentages[index]}
+              targetWidth={currentTargetWidth}
+              textAnchor="start"
+              fontSize={VALUE_FONT_SIZE}
+              fontWeight={VALUE_FONT_WEIGHT}
+            />
+          ) : null}
+          <g transform={`translate(0, ${formattedValueTransformY})`}>
             <SingleTextLine
               color={TEXT_COLOR}
               text={formattedValues[index]}
@@ -264,11 +283,7 @@ export function FunnelChartLabels({
             />
           </g>
           {trendIndicatorProps && (
-            <g
-              transform={`translate(0, ${
-                LINE_HEIGHT * 2 + VERTICAL_STACK_SPACING * 2
-              })`}
-            >
+            <g transform={`translate(0, ${trendIndicatorTransformY})`}>
               <g transform={`translate(0, ${-LABEL_VERTICAL_OFFSET})`}>
                 <TrendIndicator {...trendIndicatorProps} />
               </g>
@@ -307,6 +322,8 @@ export function FunnelChartLabels({
         const {trendIndicatorProps, trendIndicatorWidth} =
           getTrendIndicatorData(trends?.[index]?.reached);
 
+        const updatedPercentWidth = showPercentages ? percentWidth : 0;
+
         return (
           <g
             transform={`translate(${
@@ -344,10 +361,11 @@ export function FunnelChartLabels({
                 layoutStrategy,
                 index,
                 currentTargetWidth,
-                percentWidth,
+                updatedPercentWidth,
                 countStringWidth,
                 trendIndicatorProps,
                 trendIndicatorWidth,
+                showPercentages,
               )}
             </g>
           </g>

--- a/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/tests/FunnelChartLabels.test.tsx
+++ b/packages/polaris-viz/src/components/FunnelChartNext/components/FunnelChartLabels/tests/FunnelChartLabels.test.tsx
@@ -30,6 +30,7 @@ describe('<FunnelChartLabels />', () => {
     percentages: ['100%', '75%', '50%'],
     xScale: scaleBand().domain(['0', '1', '2']).range([0, 300]),
     shouldApplyScaling: false,
+    showPercentages: true,
     renderScaleIconTooltipContent: () => <div>Tooltip content</div>,
     trends: [
       {
@@ -106,6 +107,23 @@ describe('<FunnelChartLabels />', () => {
       });
       expect(component).toContainReactComponent(SingleTextLine, {
         text: '100%',
+      });
+    });
+
+    it('hides percentages when showPercentages is false', () => {
+      const component = wrapper({
+        ...mockProps,
+        showPercentages: false,
+      });
+
+      expect(component).toContainReactComponent(SingleTextLine, {
+        text: 'Step 1',
+      });
+      expect(component).not.toContainReactComponent(SingleTextLine, {
+        text: '100%',
+      });
+      expect(component).toContainReactComponent(SingleTextLine, {
+        text: '1,000',
       });
     });
   });


### PR DESCRIPTION
This is an urgent fix needed for [Live View fast follows](https://github.com/shop/issues-analytics/issues/1622) requested by multiple eng/product Directors in [#analytics-live-view](https://shopify.enterprise.slack.com/archives/C08P5BDSY5C)

## What does this implement/fix?

Adds a `showPercentages` option on `FunnelChartNext` to allow consumers to disable percentages between steps. 

This is required in order to show the Customer Behavior card on Live View.

| Before | After |
| <img width="775" alt="image" src="https://github.com/user-attachments/assets/6125d771-0e25-495c-a9a1-a4c12cc15c52" /> | ... |

## Does this close any currently open issues?

Resolves https://github.com/shop/issues-analytics/issues/1634

## What do the changes look like?

Visual walk through + code walkthrough
https://github.com/user-attachments/assets/bc783aa5-8953-4c24-96a6-6eddcb67a4e0

<img width="2928" alt="Polaris Viz Funnel Chart Updates" src="https://github.com/user-attachments/assets/27ec3b2e-584a-4644-8865-925cf78da301" />
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->
1. Look at `FunnelChartNext` default and trend indicator stories.
2. Disable `showPercentages`
3. Resize the page and ensure formatted value and trends are showing up correctly


### Before merging

- [x] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [x] Update relevant documentation, tests, and Storybook.

- [x] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
