### PR TITLE
Add new LineChartCumulative visualization

### DIFF
--- a/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
+++ b/packages/polaris-viz/src/components/Labels/hooks/useLabels.tsx
@@ -21,6 +21,8 @@ interface Props {
   targetWidth: number;
   onHeightChange?: Dispatch<SetStateAction<number>> | (() => void);
   align?: 'center' | 'left';
+  activeIndex?: number;
+  fillColor?: string;
 }
 
 export function useLabels({
@@ -29,6 +31,8 @@ export function useLabels({
   labels,
   onHeightChange = () => {},
   targetWidth,
+  activeIndex,
+  fillColor,
 }: Props) {
   const {characterWidths} = useChartContext();
 
@@ -77,6 +81,8 @@ export function useLabels({
           targetWidth,
           targetHeight: HORIZONTAL_LABEL_TARGET_HEIGHT,
           characterWidths,
+          activeIndex,
+          fillColor,
         });
       }
       case shouldDrawDiagonal: {
@@ -86,6 +92,8 @@ export function useLabels({
           longestLabelWidth,
           targetHeight: LINE_HEIGHT,
           targetWidth,
+          activeIndex,
+          fillColor,
         });
       }
       case shouldDrawVertical: {
@@ -94,6 +102,8 @@ export function useLabels({
           labels: preparedLabels,
           longestLabelWidth,
           targetWidth,
+          activeIndex,
+          fillColor,
         });
       }
       default: {
@@ -111,6 +121,8 @@ export function useLabels({
     characterWidths,
     preparedLabels,
     longestLabelWidth,
+    activeIndex,
+    fillColor,
   ]);
 
   useEffect(() => {

--- a/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getDiagonalLabels.ts
@@ -17,6 +17,8 @@ interface Props {
   targetHeight: number;
   targetWidth: number;
   characterWidths: CharacterWidths;
+  activeIndex?: number;
+  fillColor?: string;
 }
 
 export function getDiagonalLabels({
@@ -25,6 +27,8 @@ export function getDiagonalLabels({
   longestLabelWidth,
   targetHeight,
   targetWidth,
+  activeIndex,
+  fillColor,
 }: Props) {
   const clampedTargetWidth = clamp({
     amount: longestLabelWidth,
@@ -44,6 +48,7 @@ export function getDiagonalLabels({
   const centerPoint = targetWidth / 2 - LINE_HEIGHT / 2;
 
   for (let i = 0; i < labels.length; i++) {
+    const isActiveIndex = activeIndex === i;
     lines[i] = [];
     lines[i].push({
       truncatedText: truncatedLabels[i].truncatedName,
@@ -56,6 +61,8 @@ export function getDiagonalLabels({
       height: LINE_HEIGHT,
       textAnchor: 'end',
       transform: `rotate(-45)`,
+      style: isActiveIndex ? {fontWeight: '600'} : undefined,
+      fill: isActiveIndex ? fillColor : undefined,
     });
   }
 

--- a/packages/polaris-viz/src/components/Labels/utilities/getHorizontalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getHorizontalLabels.ts
@@ -16,6 +16,8 @@ interface Props {
   targetHeight: number;
   targetWidth: number;
   characterWidths: CharacterWidths;
+  activeIndex?: number;
+  fillColor?: string;
 }
 
 export function getHorizontalLabels({
@@ -25,6 +27,8 @@ export function getHorizontalLabels({
   targetHeight,
   targetWidth,
   characterWidths,
+  activeIndex,
+  fillColor,
 }: Props) {
   const truncatedLabels = truncateLabels({
     labels,
@@ -42,6 +46,7 @@ export function getHorizontalLabels({
     let line = '';
     let lineNumber = 0;
     const words = label.truncatedWords;
+    const isActiveIndex = activeIndex === index;
 
     // The reason we use a for loop here is we want
     // to be able to advance the loop below if we
@@ -84,6 +89,8 @@ export function getHorizontalLabels({
         height: LINE_HEIGHT,
         textAnchor: align === 'left' ? 'start' : 'middle',
         dominantBaseline: 'hanging',
+        style: isActiveIndex ? {fontWeight: '600'} : undefined,
+        fill: isActiveIndex ? fillColor : undefined,
       });
 
       lineNumber += 1;

--- a/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
+++ b/packages/polaris-viz/src/components/Labels/utilities/getVerticalLabels.ts
@@ -13,6 +13,8 @@ interface Props {
   longestLabelWidth: number;
   labels: PreparedLabels[];
   characterWidths: CharacterWidths;
+  activeIndex?: number;
+  fillColor?: string;
 }
 
 export function getVerticalLabels({
@@ -20,6 +22,8 @@ export function getVerticalLabels({
   characterWidths,
   longestLabelWidth,
   targetWidth,
+  activeIndex,
+  fillColor,
 }: Props) {
   const clampedTargetWidth = clamp({
     amount: longestLabelWidth,
@@ -38,6 +42,7 @@ export function getVerticalLabels({
   let longestString = 0;
 
   for (let i = 0; i < labels.length; i++) {
+    const isActiveIndex = activeIndex === i;
     lines[i] = [];
     lines[i].push({
       truncatedText: truncatedLabels[i].truncatedName,
@@ -49,6 +54,8 @@ export function getVerticalLabels({
       height: LINE_HEIGHT,
       textAnchor: 'end',
       transform: `translate(${targetWidth / 2}) rotate(-90)`,
+      style: isActiveIndex ? {fontWeight: '600'} : undefined,
+      fill: isActiveIndex ? fillColor : undefined,
     });
 
     if (truncatedLabels[i].truncatedWidth > longestString) {

--- a/packages/polaris-viz/src/components/LineChartCumulative/Chart.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/Chart.tsx
@@ -1,0 +1,180 @@
+import {useState, Fragment} from 'react';
+import {
+  useYScale,
+  LineSeries,
+  DEFAULT_THEME_NAME,
+  useChartPositions,
+  uniqueId,
+} from '@shopify/polaris-viz-core';
+import type {
+  XAxisOptions,
+  YAxisOptions,
+  LineChartDataSeriesWithDefaults,
+  LabelFormatter,
+} from '@shopify/polaris-viz-core';
+
+import {useIndexForLabels} from '../../hooks/useIndexForLabels';
+import {XAxis} from '../XAxis';
+import {useLegend} from '../LegendContainer';
+import {useTheme, useLinearLabelsAndDimensions} from '../../hooks';
+import {ChartElements} from '../ChartElements';
+
+import {PointsAndCrosshair} from './components';
+import {useFormatData, useFormattedLabels} from './hooks';
+import {yAxisMinMax} from './utilities';
+
+export interface ChartProps {
+  data: LineChartDataSeriesWithDefaults[];
+  emptyStateText?: string;
+  seriesNameFormatter: LabelFormatter;
+  theme?: string;
+  xAxisOptions: Required<XAxisOptions>;
+  yAxisOptions: Required<YAxisOptions>;
+  fixedActiveIndex: number;
+}
+
+export function Chart({
+  emptyStateText,
+  data,
+  seriesNameFormatter,
+  theme = DEFAULT_THEME_NAME,
+  xAxisOptions,
+  yAxisOptions,
+  fixedActiveIndex,
+}: ChartProps) {
+  const selectedTheme = useTheme(theme);
+
+  const [xAxisHeight, setXAxisHeight] = useState(0);
+
+  const {height, width} = useLegend({
+    data: [
+      {
+        shape: 'Line',
+        series: data,
+      },
+    ],
+    showLegend: false,
+    seriesNameFormatter,
+  });
+
+  const indexForLabels = useIndexForLabels(data);
+
+  const {formattedLabels} = useFormattedLabels({
+    data: [data[indexForLabels]],
+    labelFormatter: xAxisOptions.labelFormatter,
+    indexToKeep: [0, data[indexForLabels]?.data.length - 1],
+  });
+
+  const emptyState =
+    data.length === 0 || data.every((series) => series.data.length === 0);
+
+  const {minY, maxY} = yAxisMinMax(data);
+
+  const yScaleOptions = {
+    formatYAxisLabel: yAxisOptions.labelFormatter,
+    integersOnly: yAxisOptions.integersOnly,
+    fixedWidth: yAxisOptions.fixedWidth,
+    maxYOverride: yAxisOptions.maxYOverride,
+    max: maxY,
+    min: minY,
+    ticksOverride: yAxisOptions.ticksOverride,
+  };
+
+  const {longestSeriesLength, longestSeriesIndex} = useFormatData(data);
+
+  const {
+    drawableWidth,
+    drawableHeight,
+    chartXPosition,
+    chartYPosition,
+    xAxisBounds,
+  } = useChartPositions({
+    annotationsHeight: 0,
+    height,
+    width,
+    xAxisHeight,
+    yAxisWidth: 0,
+  });
+
+  const {xAxisDetails, xScale, labels} = useLinearLabelsAndDimensions({
+    data,
+    drawableWidth,
+    hideXAxis: false,
+    labels: formattedLabels,
+    longestSeriesLength,
+  });
+
+  const {yScale} = useYScale({
+    ...yScaleOptions,
+    drawableHeight,
+    verticalOverflow: selectedTheme.grid.verticalOverflow,
+  });
+
+  if (xScale == null || drawableWidth == null) {
+    return null;
+  }
+
+  const halfXAxisLabelWidth = xAxisDetails.labelWidth / 2;
+  const fillColor = data[data.length - 1].color as string;
+
+  return (
+    <Fragment>
+      <ChartElements.Svg
+        emptyState={emptyState}
+        emptyStateText={emptyStateText}
+        height={height}
+        role="table"
+        width={width}
+      >
+        <XAxis
+          allowLineWrap={xAxisOptions.allowLineWrap}
+          ariaHidden
+          labels={labels}
+          labelWidth={xAxisDetails.labelWidth}
+          onHeightChange={setXAxisHeight}
+          x={xAxisBounds.x - halfXAxisLabelWidth}
+          xScale={xScale}
+          y={xAxisBounds.y}
+          activeIndex={fixedActiveIndex}
+          fillColor={fillColor}
+        />
+
+        <line
+          x2={drawableWidth}
+          stroke={selectedTheme.crossHair.color}
+          transform={`translate(${xAxisBounds.x},${xAxisBounds.y - 10})`}
+        />
+
+        <g transform={`translate(${chartXPosition},${chartYPosition})`}>
+          {data.map((singleSeries, index) => {
+            return (
+              <LineSeries
+                activeLineIndex={-1}
+                data={singleSeries}
+                index={index}
+                key={`${name}-${index}`}
+                svgDimensions={{height: drawableHeight, width: drawableWidth}}
+                theme={theme}
+                xScale={xScale}
+                yScale={yScale}
+                type="default"
+              />
+            );
+          })}
+
+          <PointsAndCrosshair
+            activeIndex={fixedActiveIndex}
+            data={data}
+            drawableHeight={drawableHeight}
+            emptyState={emptyState}
+            longestSeriesIndex={longestSeriesIndex}
+            theme={theme}
+            tooltipId={uniqueId('lineChartCumulative')}
+            xScale={xScale}
+            yScale={yScale}
+          />
+        </g>
+      </ChartElements.Svg>
+    </Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/LineChartCumulative.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/LineChartCumulative.tsx
@@ -1,0 +1,93 @@
+import {Fragment} from 'react';
+import type {
+  XAxisOptions,
+  YAxisOptions,
+  ChartProps,
+  Color,
+} from '@shopify/polaris-viz-core';
+import {
+  InternalChartType,
+  ChartState,
+  DEFAULT_CHART_PROPS,
+  usePolarisVizContext,
+} from '@shopify/polaris-viz-core';
+
+import {fillMissingDataPoints} from '../../utilities/fillMissingDataPoints';
+import {getLineChartDataWithDefaults} from '../../utilities/getLineChartDataWithDefaults';
+import {ChartContainer} from '../ChartContainer';
+import {ChartSkeleton} from '../ChartSkeleton';
+import {
+  getXAxisOptionsWithDefaults,
+  getYAxisOptionsWithDefaults,
+} from '../../utilities';
+
+import {Chart} from './Chart';
+
+export type LineChartCumulativeProps = {
+  errorText?: string;
+  emptyStateText?: string;
+  xAxisOptions?: Partial<XAxisOptions>;
+  yAxisOptions?: Partial<YAxisOptions>;
+  scrollContainer?: Element | null;
+  fixedActiveIndex: number;
+  seriesColors: Color[];
+} & ChartProps;
+
+export function LineChartCumulative(props: LineChartCumulativeProps) {
+  const {defaultTheme} = usePolarisVizContext();
+
+  const {
+    data: dataSeries,
+    emptyStateText,
+    errorText,
+    id,
+    isAnimated,
+    onError,
+    seriesNameFormatter = (value) => `${value}`,
+    state,
+    theme = defaultTheme,
+    xAxisOptions,
+    yAxisOptions,
+    scrollContainer,
+    fixedActiveIndex,
+    seriesColors = ['#cbcbcf', '#cbcbcf', 'rgba(4, 123, 93, 1)'],
+  } = {
+    ...DEFAULT_CHART_PROPS,
+    ...props,
+  };
+
+  const data = fillMissingDataPoints(dataSeries, true);
+
+  const xAxisOptionsWithDefaults = getXAxisOptionsWithDefaults(xAxisOptions);
+  const yAxisOptionsWithDefaults = getYAxisOptionsWithDefaults(yAxisOptions);
+
+  const dataWithDefaults = getLineChartDataWithDefaults(data, seriesColors);
+
+  return (
+    <Fragment>
+      <ChartContainer
+        id={id}
+        data={data}
+        theme={theme}
+        isAnimated={isAnimated}
+        type={InternalChartType.Line}
+        onError={onError}
+        scrollContainer={scrollContainer}
+      >
+        {state !== ChartState.Success ? (
+          <ChartSkeleton state={state} errorText={errorText} theme={theme} />
+        ) : (
+          <Chart
+            data={dataWithDefaults}
+            emptyStateText={emptyStateText}
+            seriesNameFormatter={seriesNameFormatter}
+            theme={theme}
+            xAxisOptions={xAxisOptionsWithDefaults}
+            yAxisOptions={yAxisOptionsWithDefaults}
+            fixedActiveIndex={fixedActiveIndex}
+          />
+        )}
+      </ChartContainer>
+    </Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/components/Points/Points.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/components/Points/Points.tsx
@@ -1,0 +1,81 @@
+import {Fragment} from 'react';
+import type {ScaleLinear} from 'd3-scale';
+import {
+  isGradientType,
+  DataType,
+  changeColorOpacity,
+  useChartContext,
+} from '@shopify/polaris-viz-core';
+import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
+
+import {Point} from '../../../Point';
+
+interface PointsProps {
+  activeIndex: number | null;
+  data: LineChartDataSeriesWithDefaults[];
+  gradientId: string;
+  longestSeriesIndex: number;
+  tooltipId: string;
+  xScale: ScaleLinear<number, number>;
+  yScale: ScaleLinear<number, number>;
+}
+
+export function Points({
+  activeIndex,
+  data,
+  gradientId,
+  longestSeriesIndex,
+  tooltipId,
+  xScale,
+  yScale,
+}: PointsProps) {
+  const {shouldAnimate} = useChartContext();
+
+  return (
+    <Fragment>
+      {data.map((singleSeries, seriesIndex) => {
+        if (singleSeries?.metadata?.isVisuallyHidden === true) {
+          return null;
+        }
+
+        const index = singleSeries.metadata?.relatedIndex ?? seriesIndex;
+
+        const {data: singleData, name, color} = singleSeries;
+        const isLongestLine = index === longestSeriesIndex;
+        const pointGradientId = `${gradientId}-point-${index}`;
+
+        const pointColor = isGradientType(color)
+          ? `url(#${pointGradientId})`
+          : changeColorOpacity(color);
+
+        return (
+          <Fragment key={`${name}-${index}`}>
+            {singleData.map(({value}, dataIndex) => {
+              if (value == null) {
+                return null;
+              }
+
+              return (
+                <g key={`${name}-${index}-${dataIndex}`}>
+                  <Point
+                    dataType={DataType.Point}
+                    color={pointColor}
+                    cx={xScale(dataIndex)}
+                    cy={yScale(value)}
+                    active={activeIndex === dataIndex}
+                    index={dataIndex}
+                    tabIndex={isLongestLine ? 0 : -1}
+                    ariaLabelledby={tooltipId}
+                    isAnimated={false}
+                    ariaHidden={false}
+                    visuallyHidden={shouldAnimate}
+                  />
+                </g>
+              );
+            })}
+          </Fragment>
+        );
+      })}
+    </Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/components/Points/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/components/Points/index.ts
@@ -1,0 +1,1 @@
+export {Points} from './Points';

--- a/packages/polaris-viz/src/components/LineChartCumulative/components/PointsAndCrosshair/PointsAndCrosshair.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/components/PointsAndCrosshair/PointsAndCrosshair.tsx
@@ -1,0 +1,68 @@
+import {Fragment, useRef} from 'react';
+import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
+import {uniqueId, useTheme} from '@shopify/polaris-viz-core';
+import type {ScaleLinear} from 'd3-scale';
+
+import {CROSSHAIR_ID} from '../../../../constants';
+import {Crosshair} from '../../../Crosshair';
+import {Points} from '../Points';
+
+interface PointsAndCrosshairProps {
+  activeIndex: number | null;
+  data: LineChartDataSeriesWithDefaults[];
+  drawableHeight: number;
+  emptyState: boolean;
+  longestSeriesIndex: number;
+  theme: string;
+  tooltipId: string;
+  xScale: ScaleLinear<number, number>;
+  yScale: ScaleLinear<number, number>;
+}
+
+export function PointsAndCrosshair({
+  activeIndex,
+  data,
+  drawableHeight,
+  emptyState,
+  longestSeriesIndex,
+  theme,
+  tooltipId,
+  xScale,
+  yScale,
+}: PointsAndCrosshairProps) {
+  const selectedTheme = useTheme(theme);
+
+  const gradientId = useRef(uniqueId('lineChartGradient'));
+
+  const getXPosition = ({isCrosshair} = {isCrosshair: false}) => {
+    if (xScale == null) {
+      return 0;
+    }
+    const offset = isCrosshair ? selectedTheme.crossHair.width / 2 : 0;
+
+    return xScale(activeIndex == null ? 0 : activeIndex) - offset;
+  };
+
+  return (
+    <Fragment>
+      {emptyState ? null : (
+        <Crosshair
+          height={drawableHeight - 5}
+          id={`${tooltipId}-${CROSSHAIR_ID}`}
+          opacity={activeIndex == null ? 0 : 1}
+          theme={theme}
+          x={getXPosition({isCrosshair: true})}
+        />
+      )}
+      <Points
+        activeIndex={emptyState ? null : activeIndex}
+        data={data}
+        gradientId={gradientId.current}
+        longestSeriesIndex={longestSeriesIndex}
+        tooltipId={tooltipId}
+        xScale={xScale}
+        yScale={yScale}
+      />
+    </Fragment>
+  );
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/components/PointsAndCrosshair/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/components/PointsAndCrosshair/index.ts
@@ -1,0 +1,1 @@
+export {PointsAndCrosshair} from './PointsAndCrosshair';

--- a/packages/polaris-viz/src/components/LineChartCumulative/components/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/components/index.ts
@@ -1,0 +1,2 @@
+export {Points} from './Points';
+export {PointsAndCrosshair} from './PointsAndCrosshair';

--- a/packages/polaris-viz/src/components/LineChartCumulative/hooks/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/hooks/index.ts
@@ -1,0 +1,2 @@
+export {useFormatData} from './useFormatData';
+export {useFormattedLabels} from './useFormattedLabels';

--- a/packages/polaris-viz/src/components/LineChartCumulative/hooks/useFormatData.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/hooks/useFormatData.ts
@@ -1,0 +1,20 @@
+import {useMemo} from 'react';
+import type {LineChartDataSeriesWithDefaults} from '@shopify/polaris-viz-core';
+
+export function useFormatData(data: LineChartDataSeriesWithDefaults[]) {
+  const longestSeriesIndex = useMemo(
+    () =>
+      data.reduce((maxIndex, currentSeries, currentIndex) => {
+        return data[maxIndex].data.length < currentSeries.data.length
+          ? currentIndex
+          : maxIndex;
+      }, 0),
+    [data],
+  );
+
+  const longestSeriesLength = data[longestSeriesIndex]
+    ? data[longestSeriesIndex].data.length - 1
+    : 0;
+
+  return {longestSeriesLength, longestSeriesIndex};
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/hooks/useFormattedLabels.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/hooks/useFormattedLabels.ts
@@ -1,0 +1,34 @@
+import {useMemo} from 'react';
+import type {DataSeries, LabelFormatter} from '@shopify/polaris-viz-core';
+
+interface Props {
+  data: DataSeries[];
+  labelFormatter: LabelFormatter;
+  indexToKeep?: number[];
+}
+
+export function useFormattedLabels({data, labelFormatter, indexToKeep}: Props) {
+  return useMemo(() => {
+    const formattedLabels: string[] = [];
+    const unformattedLabels: string[] = [];
+
+    if (data == null || data.length === 0) {
+      return {formattedLabels, unformattedLabels};
+    }
+
+    data.forEach((series) => {
+      if (series == null || series.data == null) {
+        return;
+      }
+
+      series.data.forEach(({key}, index) => {
+        formattedLabels[index] = indexToKeep?.includes(index)
+          ? labelFormatter?.(`${key}`) ?? `${key}`
+          : '';
+        unformattedLabels[index] = indexToKeep?.includes(index) ? `${key}` : '';
+      });
+    });
+
+    return {formattedLabels, unformattedLabels};
+  }, [data, indexToKeep, labelFormatter]);
+}

--- a/packages/polaris-viz/src/components/LineChartCumulative/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/index.ts
@@ -1,0 +1,2 @@
+export {LineChartCumulative} from './LineChartCumulative';
+export type {LineChartCumulativeProps} from './LineChartCumulative';

--- a/packages/polaris-viz/src/components/LineChartCumulative/stories/Default.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/stories/Default.stories.tsx
@@ -1,0 +1,14 @@
+import type {Story} from '@storybook/react';
+
+export {META as default} from './meta';
+
+import type {LineChartCumulativeProps} from '../../../components';
+
+import {DEFAULT_DATA, DEFAULT_PROPS, Template} from './data';
+
+export const Default: Story<LineChartCumulativeProps> = Template.bind({});
+
+Default.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+};

--- a/packages/polaris-viz/src/components/LineChartCumulative/stories/ResizeableChart.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/stories/ResizeableChart.stories.tsx
@@ -1,0 +1,30 @@
+export {META as default} from './meta';
+
+import {
+  LineChartCumulative,
+  LineChartCumulativeProps,
+} from '../../../components';
+import type {Story} from '@storybook/react';
+import {DEFAULT_DATA, DEFAULT_PROPS} from './data';
+
+export const ResizeableChart: Story<LineChartCumulativeProps> = (
+  args: LineChartCumulativeProps,
+) => {
+  return (
+    <div
+      style={{
+        resize: 'both',
+        overflow: 'hidden',
+        maxHeight: '100%',
+        maxWidth: '100%',
+      }}
+    >
+      <LineChartCumulative {...args} />
+    </div>
+  );
+};
+
+ResizeableChart.args = {
+  ...DEFAULT_PROPS,
+  data: DEFAULT_DATA,
+};

--- a/packages/polaris-viz/src/components/LineChartCumulative/stories/data.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/stories/data.tsx
@@ -1,0 +1,78 @@
+import type {Story} from '@storybook/react';
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import type {LineChartCumulativeProps} from '../LineChartCumulative';
+import {LineChartCumulative} from '../LineChartCumulative';
+
+export const Template: Story<LineChartCumulativeProps> = (
+  args: LineChartCumulativeProps,
+) => {
+  return <LineChartCumulative {...args} />;
+};
+
+export const DEFAULT_PROPS: Partial<LineChartCumulativeProps> = {
+  fixedActiveIndex: 6,
+  isAnimated: false,
+  xAxisOptions: {
+    labelFormatter: (value: string) => {
+      const date = new Date(value);
+      if (isNaN(date.getTime())) {
+        return value;
+      }
+      return date.toLocaleDateString('en-CA', {
+        month: 'short',
+        day: 'numeric',
+      });
+    },
+  },
+};
+
+export const DEFAULT_DATA: DataSeries[] = [
+  {
+    name: 'Previous period',
+    data: [
+      {value: 159, key: '2020-03-01T12:00:00'},
+      {value: 188, key: '2020-03-02T12:00:00'},
+      {value: 268, key: '2020-03-03T12:00:00'},
+      {value: 300, key: '2020-03-04T12:00:00'},
+      {value: 420, key: '2020-03-05T12:00:00'},
+      {value: 489, key: '2020-03-07T12:00:00'},
+      {value: 521, key: 'Today'},
+      {value: 589, key: '2020-03-08T12:00:00'},
+      {value: 638, key: '2020-03-09T12:00:00'},
+      {value: 678, key: '2020-03-10T12:00:00'},
+      {value: 791, key: '2020-03-11T12:00:00'},
+      {value: 843, key: '2020-03-12T12:00:00'},
+      {value: 910, key: '2020-03-13T12:00:00'},
+      {value: 950, key: '2020-03-14T12:00:00'},
+    ],
+    isComparison: true,
+  },
+  {
+    name: 'Previous period',
+    data: [
+      {value: 159, key: '2020-03-01T12:00:00'},
+      {value: 188, key: '2020-03-02T12:00:00'},
+      {value: 268, key: '2020-03-03T12:00:00'},
+      {value: 300, key: '2020-03-04T12:00:00'},
+      {value: 420, key: '2020-03-05T12:00:00'},
+      {value: 489, key: '2020-03-07T12:00:00'},
+      {value: 521, key: 'Today'},
+    ],
+    metadata: {
+      isVisuallyHidden: true,
+    },
+  },
+  {
+    name: 'Apr 1 – Apr 14, 2020',
+    data: [
+      {value: 129, key: '2020-04-01T12:00:00'},
+      {value: 208, key: '2020-04-02T12:00:00'},
+      {value: 268, key: '2020-04-03T12:00:00'},
+      {value: 300, key: '2020-04-04T12:00:00'},
+      {value: 432, key: '2020-04-05T12:00:00'},
+      {value: 591, key: '2020-04-06T12:00:00'},
+      {value: 623, key: '2020-04-07T12:00:00'},
+    ],
+  },
+];

--- a/packages/polaris-viz/src/components/LineChartCumulative/stories/meta.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/stories/meta.tsx
@@ -1,0 +1,36 @@
+import type {Meta} from '@storybook/react';
+
+import {
+  CHART_STATE_CONTROL_ARGS,
+  CONTROLS_ARGS,
+  DATA_SERIES_ARGS,
+  EMPTY_STATE_TEXT_ARGS,
+  THEME_CONTROL_ARGS,
+  X_AXIS_OPTIONS_ARGS,
+  Y_AXIS_OPTIONS_ARGS,
+} from '../../../storybook/constants';
+import {PageWithSizingInfo} from '../../Docs/stories';
+import {LineChartCumulative} from '../LineChartCumulative';
+
+export const META: Meta = {
+  title: 'polaris-viz/Charts/LineChartCumulative',
+  component: LineChartCumulative,
+  decorators: [(Story: any) => <div style={{height: 400}}>{Story()}</div>],
+  parameters: {
+    controls: CONTROLS_ARGS,
+    docs: {
+      page: PageWithSizingInfo,
+      description: {
+        component: 'Used to show change over time, comparisons, and trends.',
+      },
+    },
+  },
+  argTypes: {
+    data: DATA_SERIES_ARGS,
+    emptyStateText: EMPTY_STATE_TEXT_ARGS,
+    xAxisOptions: X_AXIS_OPTIONS_ARGS,
+    yAxisOptions: Y_AXIS_OPTIONS_ARGS,
+    theme: THEME_CONTROL_ARGS,
+    state: CHART_STATE_CONTROL_ARGS,
+  },
+};

--- a/packages/polaris-viz/src/components/LineChartCumulative/stories/playground/Playground.stories.tsx
+++ b/packages/polaris-viz/src/components/LineChartCumulative/stories/playground/Playground.stories.tsx
@@ -1,0 +1,244 @@
+import type {Story} from '@storybook/react';
+
+import {
+  LineChartCumulative,
+  LineChartCumulativeProps,
+} from '../../LineChartCumulative';
+import {DEFAULT_PROPS} from '../data';
+import {META} from '../meta';
+
+export default {
+  ...META,
+  title: `${META.title}/Playground`,
+};
+
+const Template: Story<LineChartCumulativeProps> = (
+  args: LineChartCumulativeProps,
+) => {
+  return <LineChartCumulative {...args} />;
+};
+
+export const CumulativeLast: Story<LineChartCumulativeProps> = Template.bind(
+  {},
+);
+
+CumulativeLast.args = {
+  ...DEFAULT_PROPS,
+  fixedActiveIndex: 10,
+  data: [
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 589, key: '2020-03-08T12:00:00'},
+        {value: 638, key: '2020-03-09T12:00:00'},
+        {value: 678, key: '2020-03-10T12:00:00'},
+        {value: 791, key: '2020-03-11T12:00:00'},
+        {value: 843, key: 'Today'},
+        {value: 910, key: '2020-03-13T12:00:00'},
+      ],
+      isComparison: true,
+    },
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 589, key: '2020-03-08T12:00:00'},
+        {value: 638, key: '2020-03-09T12:00:00'},
+        {value: 678, key: '2020-03-10T12:00:00'},
+        {value: 791, key: '2020-03-11T12:00:00'},
+        {value: 843, key: 'Today'},
+      ],
+      metadata: {
+        isVisuallyHidden: true,
+      },
+    },
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 129, key: '2020-04-01T12:00:00'},
+        {value: 208, key: '2020-04-02T12:00:00'},
+        {value: 268, key: '2020-04-03T12:00:00'},
+        {value: 300, key: '2020-04-04T12:00:00'},
+        {value: 432, key: '2020-04-05T12:00:00'},
+        {value: 591, key: '2020-04-06T12:00:00'},
+        {value: 623, key: '2020-04-07T12:00:00'},
+        {value: 791, key: '2020-04-08T12:00:00'},
+        {value: 843, key: '2020-04-09T12:00:00'},
+        {value: 910, key: '2020-04-10T12:00:00'},
+        {value: 950, key: '2020-04-11T12:00:00'},
+      ],
+    },
+  ],
+};
+
+export const CumulativeShort: Story<LineChartCumulativeProps> = Template.bind(
+  {},
+);
+
+CumulativeShort.args = {
+  ...DEFAULT_PROPS,
+  fixedActiveIndex: 1,
+  data: [
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: 'Today'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 589, key: '2020-03-08T12:00:00'},
+        {value: 638, key: '2020-03-09T12:00:00'},
+        {value: 678, key: '2020-03-10T12:00:00'},
+        {value: 791, key: '2020-03-11T12:00:00'},
+        {value: 843, key: '2020-03-12T12:00:00'},
+        {value: 910, key: '2020-03-13T12:00:00'},
+        {value: 950, key: '2020-03-14T12:00:00'},
+      ],
+      isComparison: true,
+    },
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: 'Today'},
+      ],
+      metadata: {
+        isVisuallyHidden: true,
+      },
+    },
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 129, key: '2020-04-01T12:00:00'},
+        {value: 208, key: '2020-04-02T12:00:00'},
+      ],
+    },
+  ],
+};
+
+export const Cumulative: Story<LineChartCumulativeProps> = Template.bind({});
+
+Cumulative.args = {
+  ...DEFAULT_PROPS,
+  fixedActiveIndex: 6,
+  data: [
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 521, key: 'Today'},
+        {value: 589, key: '2020-03-08T12:00:00'},
+        {value: 638, key: '2020-03-09T12:00:00'},
+        {value: 678, key: '2020-03-10T12:00:00'},
+        {value: 791, key: '2020-03-11T12:00:00'},
+        {value: 843, key: '2020-03-12T12:00:00'},
+        {value: 910, key: '2020-03-13T12:00:00'},
+        {value: 950, key: '2020-03-14T12:00:00'},
+      ],
+      isComparison: true,
+    },
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 521, key: 'Today'},
+      ],
+      metadata: {
+        isVisuallyHidden: true,
+      },
+    },
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 129, key: '2020-04-01T12:00:00'},
+        {value: 208, key: '2020-04-02T12:00:00'},
+        {value: 268, key: '2020-04-03T12:00:00'},
+        {value: 300, key: '2020-04-04T12:00:00'},
+        {value: 432, key: '2020-04-05T12:00:00'},
+        {value: 591, key: '2020-04-06T12:00:00'},
+        {value: 623, key: '2020-04-07T12:00:00'},
+      ],
+    },
+  ],
+};
+
+export const CumulativeNegative: Story<LineChartCumulativeProps> =
+  Template.bind({});
+
+CumulativeNegative.args = {
+  ...DEFAULT_PROPS,
+  seriesColors: ['#cbcbcf', '#cbcbcf', '#545460'],
+  fixedActiveIndex: 6,
+  data: [
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 521, key: 'Today'},
+        {value: 589, key: '2020-03-08T12:00:00'},
+        {value: 638, key: '2020-03-09T12:00:00'},
+        {value: 678, key: '2020-03-10T12:00:00'},
+        {value: 791, key: '2020-03-11T12:00:00'},
+        {value: 843, key: '2020-03-12T12:00:00'},
+        {value: 910, key: '2020-03-13T12:00:00'},
+        {value: 950, key: '2020-03-14T12:00:00'},
+      ],
+      isComparison: true,
+    },
+    {
+      name: 'Previous period',
+      data: [
+        {value: 159, key: '2020-03-01T12:00:00'},
+        {value: 188, key: '2020-03-02T12:00:00'},
+        {value: 268, key: '2020-03-03T12:00:00'},
+        {value: 300, key: '2020-03-04T12:00:00'},
+        {value: 420, key: '2020-03-05T12:00:00'},
+        {value: 489, key: '2020-03-07T12:00:00'},
+        {value: 521, key: 'Today'},
+      ],
+      metadata: {
+        isVisuallyHidden: true,
+      },
+    },
+    {
+      name: 'Apr 1 – Apr 14, 2020',
+      data: [
+        {value: 129, key: '2020-04-01T12:00:00'},
+        {value: 208, key: '2020-04-02T12:00:00'},
+        {value: 268, key: '2020-04-03T12:00:00'},
+        {value: 300, key: '2020-04-04T12:00:00'},
+        {value: 389, key: '2020-04-05T12:00:00'},
+        {value: 391, key: '2020-04-06T12:00:00'},
+        {value: 463, key: '2020-04-07T12:00:00'},
+      ],
+    },
+  ],
+};

--- a/packages/polaris-viz/src/components/LineChartCumulative/utilities/index.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/utilities/index.ts
@@ -1,0 +1,1 @@
+export {yAxisMinMax} from './yAxisMinMax';

--- a/packages/polaris-viz/src/components/LineChartCumulative/utilities/yAxisMinMax.ts
+++ b/packages/polaris-viz/src/components/LineChartCumulative/utilities/yAxisMinMax.ts
@@ -1,0 +1,32 @@
+import type {DataSeries} from '@shopify/polaris-viz-core';
+
+import {EMPTY_STATE_CHART_MIN, EMPTY_STATE_CHART_MAX} from '../../../constants';
+
+export function yAxisMinMax(series: DataSeries[]) {
+  if (series.length === 0) {
+    return {minY: EMPTY_STATE_CHART_MIN, maxY: EMPTY_STATE_CHART_MAX};
+  }
+
+  let minY = Number.MAX_SAFE_INTEGER;
+  let maxY = -Number.MAX_SAFE_INTEGER;
+
+  series.forEach(({data}) => {
+    data.forEach(({value}) => {
+      if (value == null) {
+        return;
+      }
+
+      minY = Math.min(minY, value);
+      maxY = Math.max(maxY, value);
+    });
+  });
+
+  if (minY === Number.MAX_SAFE_INTEGER || maxY === -Number.MAX_SAFE_INTEGER) {
+    return {
+      minY: Math.min(minY, EMPTY_STATE_CHART_MIN),
+      maxY: Math.max(maxY, EMPTY_STATE_CHART_MAX),
+    };
+  }
+
+  return {minY, maxY};
+}

--- a/packages/polaris-viz/src/components/TextLine/TextLine.tsx
+++ b/packages/polaris-viz/src/components/TextLine/TextLine.tsx
@@ -28,6 +28,8 @@ export function TextLine({color, index, line}: TextLineProps) {
             width,
             x,
             y,
+            style,
+            fill,
           },
           textIndex,
         ) => {
@@ -42,10 +44,11 @@ export function TextLine({color, index, line}: TextLineProps) {
                 width={width}
                 x={x}
                 y={y}
-                fill={color ?? selectedTheme.xAxis.labelColor}
+                fill={color ?? fill ?? selectedTheme.xAxis.labelColor}
                 fontSize={fontSize}
                 fontFamily={FONT_FAMILY}
                 transform={transform}
+                style={style}
               >
                 {truncatedText}
               </text>

--- a/packages/polaris-viz/src/components/XAxis/XAxis.tsx
+++ b/packages/polaris-viz/src/components/XAxis/XAxis.tsx
@@ -16,6 +16,8 @@ interface XAxisProps {
   ariaHidden?: boolean;
   isLinearChart?: boolean;
   reducedLabelIndexes?: number[];
+  activeIndex?: number;
+  fillColor?: string;
 }
 
 export function XAxis({
@@ -29,12 +31,16 @@ export function XAxis({
   x,
   xScale,
   y,
+  activeIndex,
+  fillColor,
 }: XAxisProps) {
   const {lines} = useLabels({
     labels,
     onHeightChange,
     targetWidth: labelWidth,
     allowLineWrap,
+    activeIndex,
+    fillColor,
   });
 
   return (

--- a/packages/polaris-viz/src/components/index.ts
+++ b/packages/polaris-viz/src/components/index.ts
@@ -61,3 +61,5 @@ export {FunnelChartNext} from './FunnelChartNext';
 export type {FunnelChartNextProps} from './FunnelChartNext';
 export {SparkFunnelChart} from './SparkFunnelChart';
 export type {SparkFunnelChartProps} from './SparkFunnelChart';
+export {LineChartCumulative} from './LineChartCumulative';
+export type {LineChartCumulativeProps} from './LineChartCumulative';

--- a/packages/polaris-viz/src/index.ts
+++ b/packages/polaris-viz/src/index.ts
@@ -22,6 +22,7 @@ export {
   Grid,
   FunnelChartNext,
   SparkFunnelChart,
+  LineChartCumulative,
 } from './components';
 
 export type {
@@ -41,6 +42,7 @@ export type {
   GridProps,
   FunnelChartNextProps,
   SparkFunnelChartProps,
+  LineChartCumulativeProps,
 } from './components';
 
 export {

--- a/packages/polaris-viz/src/types.ts
+++ b/packages/polaris-viz/src/types.ts
@@ -139,6 +139,8 @@ export interface FormattedLine {
   y: number;
   dominantBaseline?: string;
   transform?: string;
+  style?: React.CSSProperties;
+  fill?: string;
 }
 
 export interface LegendData {


### PR DESCRIPTION
## What does this implement/fix?

<!-- 💡 Briefly describe what you want to achieve here.  Explain your approach and any other options you considered. -->

<!-- 🐛 For bugs: How can the original issue be recreated? How is your fix demonstrated? -->

<!-- 🎨 For new features: Have you reviewed your changes with UX? Is there a design that should be referenced? -->
Initial implementation for new `LineChartCumulative` visualization
Address this task: https://github.com/Shopify/merchant-analytics-issues/issues/617

For this first iteration this visualization will be rendered inside `HomeCards` so they are not interactive at the moment.

figma link: https://www.figma.com/design/9Sm7SuRkGTNTCgonxhXnWO/Push-insights-to-home-proposal?node-id=1105-5699&p=f&t=0qHDAS5ng3x6stIA-0

## What do the changes look like?

![image](https://github.com/user-attachments/assets/9eb2f513-7ca8-4b28-8135-3f516c1e046d)
 
 
## Storybook link

<!-- 🎩 Include links to help tophatting -->
- checkout current branch `passanelli/add_cumulative_line_chart`
- run `pnpm storybook`
- go to `Charts` -> `LineChartCumulative` 

### Before merging

- [ ] Check your changes on a variety of [browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) and devices.

- [ ] Update the Changelog's Unreleased section with your changes.

- [ ] Update relevant documentation, tests, and Storybook.

- [ ] Make sure you're exporting any new shared Components, Types and Utilities from the top level index file of the package
